### PR TITLE
Rudimentary export feature

### DIFF
--- a/packages/react-components/src/components/TopNavigation.tsx
+++ b/packages/react-components/src/components/TopNavigation.tsx
@@ -59,9 +59,32 @@ const UserAvatar = () => (
 )
 
 const TopNavigation = () => {
-  const { resetSession } = useCell()
+  const { resetSession, exportDocument } = useCell()
   return (
     <>
+      <Link
+        to="#"
+        onClick={(e) => {
+          e.preventDefault()
+          exportDocument()
+        }}
+      >
+        <Flex className="cursor-pointer" gap="1" align="center">
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 15 15"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.50005 1.04999C7.74858 1.04999 7.95005 1.25146 7.95005 1.49999V8.41359L10.1819 6.18179C10.3576 6.00605 10.6425 6.00605 10.8182 6.18179C10.994 6.35753 10.994 6.64245 10.8182 6.81819L7.81825 9.81819C7.64251 9.99392 7.35759 9.99392 7.18185 9.81819L4.18185 6.81819C4.00611 6.64245 4.00611 6.35753 4.18185 6.18179C4.35759 6.00605 4.64251 6.00605 4.81825 6.18179L7.05005 8.41359V1.49999C7.05005 1.25146 7.25152 1.04999 7.50005 1.04999ZM2.5 10C2.77614 10 3 10.2239 3 10.5V12C3 12.5539 3.44565 13 3.99635 13H11.0012C11.5529 13 12 12.5528 12 12V10.5C12 10.2239 12.2239 10 12.5 10C12.7761 10 13 10.2239 13 10.5V12C13 13.1041 12.1062 14 11.0012 14H3.99635C2.89019 14 2 13.103 2 12V10.5C2 10.2239 2.22386 10 2.5 10Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+          <Text>Export</Text>
+        </Flex>
+      </Link>
       <Link to="/" onClick={resetSession}>
         <Flex className="cursor-pointer" gap="1" align="center">
           <svg

--- a/packages/react-components/src/contexts/CellContext.tsx
+++ b/packages/react-components/src/contexts/CellContext.tsx
@@ -18,13 +18,38 @@ import {
   CellOutputSchema,
   CellRole,
   CellSchema,
+  NotebookSchema,
+  ParserService,
+  SerializeRequestSchema,
 } from '@buf/stateful_runme.bufbuild_es/runme/parser/v1/parser_pb'
 import { clone, create } from '@bufbuild/protobuf'
+import { createClient } from '@connectrpc/connect'
+import { createGrpcWebTransport } from '@connectrpc/connect-web'
 import { v4 as uuidv4 } from 'uuid'
 
-import { getAccessToken } from '../token'
+import { getAccessToken, getSessionToken } from '../token'
 import { useClient as useAgentClient } from './AgentContext'
 import { useSettings } from './SettingsContext'
+
+export type EditorClient = ReturnType<typeof createClient<typeof ParserService>>
+
+function createEditorClient(baseURL: string): EditorClient {
+  const transport = createGrpcWebTransport({
+    baseUrl: baseURL,
+    interceptors: [
+      (next) => (req) => {
+        const token = getSessionToken()
+        if (token) {
+          req.header.set('Authorization', `Bearer ${token}`)
+        }
+        return next(req).catch((e) => {
+          throw e // allow caller to handle the error
+        })
+      },
+    ],
+  })
+  return createClient(ParserService, transport)
+}
 
 type CellContextType = {
   // useColumns returns arrays of cells organized by their kind
@@ -39,6 +64,7 @@ type CellContextType = {
   // incrementSequence increments the sequence number
   incrementSequence: () => void
 
+  exportDocument: () => Promise<void>
   // Define additional functions to update the state
   // This way they can be set in the provider and passed down to the components
   sendOutputCell: (outputCell: Cell) => Promise<void>
@@ -267,12 +293,49 @@ export const CellProvider = ({ children }: { children: ReactNode }) => {
     }
   }
 
+  // todo(sebastian): quick and dirty export implementation
+  const exportDocument = async () => {
+    let cells = state.positions.map((id) => {
+      const c = state.cells[id]
+      c.languageId = 'sh'
+      return c
+    })
+    if (cells.length === 0) {
+      return
+    }
+
+    if (invertedOrder) {
+      cells = cells.reverse()
+    }
+
+    const notebook = create(NotebookSchema, {
+      cells: cells,
+    })
+
+    console.log(notebook)
+    const editorClient = createEditorClient(settings.agentEndpoint)
+    const req = create(SerializeRequestSchema, {
+      notebook: notebook,
+    })
+    const resp = await editorClient.serialize(req)
+    const blob = new Blob([resp.result], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `Session-${new Date().toISOString()}.md`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <CellContext.Provider
       value={{
         useColumns,
         sequence,
         incrementSequence,
+        exportDocument,
         sendOutputCell,
         createOutputCell,
         sendUserCell,

--- a/packages/react-components/src/contexts/CellContext.tsx
+++ b/packages/react-components/src/contexts/CellContext.tsx
@@ -20,6 +20,8 @@ import {
   CellSchema,
   NotebookSchema,
   ParserService,
+  SerializeRequestOptionsSchema,
+  SerializeRequestOutputOptionsSchema,
   SerializeRequestSchema,
 } from '@buf/stateful_runme.bufbuild_es/runme/parser/v1/parser_pb'
 import { clone, create } from '@bufbuild/protobuf'
@@ -316,6 +318,13 @@ export const CellProvider = ({ children }: { children: ReactNode }) => {
     const editorClient = createEditorClient(settings.agentEndpoint)
     const req = create(SerializeRequestSchema, {
       notebook: notebook,
+      options: create(SerializeRequestOptionsSchema, {
+        outputs: create(SerializeRequestOutputOptionsSchema, {
+          // todo(sebastian): will only work if we populate the outputs
+          enabled: false,
+          summary: false,
+        }),
+      }),
     })
     const resp = await editorClient.serialize(req)
     const blob = new Blob([resp.result], { type: 'text/plain' })


### PR DESCRIPTION
This PR introduces a "Export" button that will download a Runme notebook (markdown) without outputs.

While this is still overly simplistic, it does work. In order to include outputs we'd have to populate the cell types with respective outputs post-execution. This is for a separate PR.

Requires https://github.com/runmedev/runme/pull/857.