### PR TITLE
Expose lower level components and types

### DIFF
--- a/packages/react-components/src/components/index.tsx
+++ b/packages/react-components/src/components/index.tsx
@@ -1,4 +1,5 @@
 export { default as Actions } from './Actions/Actions'
+export { default as CellConsole } from './Actions/CellConsole'
 export { default as Chat } from './Chat/Chat'
 export { default as FilesViewer } from './Files/Viewer'
 export { default as Login } from './Login/Login'

--- a/packages/react-components/src/index.tsx
+++ b/packages/react-components/src/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 export * from './components'
 export * from './contexts'
+export * from './runme/client'
 
 // Export layout
 export { default as Layout } from './layout'
@@ -8,3 +9,8 @@ export { default as Layout } from './layout'
 // Export App
 export { default as App } from './App'
 export type { AppProps } from './App'
+
+// Export protobuf types
+export type { WebAppConfig } from '@buf/stateful_runme.bufbuild_es/agent/v1/webapp_pb'
+export * from '@buf/stateful_runme.bufbuild_es/runme/parser/v1/parser_pb'
+export type { DocResult } from '@buf/stateful_runme.bufbuild_es/runme/parser/v1/docresult_pb'


### PR DESCRIPTION
We would like to use the lower-level components /types while having control of our layout.