### PR TITLE
Use a renderer registry to decouple Action(s) from input/output handling

### DIFF
--- a/packages/react-components/src/App.tsx
+++ b/packages/react-components/src/App.tsx
@@ -12,6 +12,7 @@ import NotFound from './components/NotFound'
 import Settings from './components/Settings/Settings'
 import { AgentClientProvider } from './contexts/AgentContext'
 import { CellProvider } from './contexts/CellContext'
+import { OutputProvider } from './contexts/OutputContext'
 import { SettingsProvider } from './contexts/SettingsContext'
 import './index.css'
 import Layout from './layout'
@@ -91,9 +92,11 @@ function App({ branding, initialState = {} }: AppProps) {
           webApp={initialState?.webApp}
         >
           <AgentClientProvider>
-            <CellProvider>
-              <AppRouter branding={branding} />
-            </CellProvider>
+            <OutputProvider>
+              <CellProvider>
+                <AppRouter branding={branding} />
+              </CellProvider>
+            </OutputProvider>
           </AgentClientProvider>
         </SettingsProvider>
       </Theme>

--- a/packages/react-components/src/components/Actions/CellConsole.tsx
+++ b/packages/react-components/src/components/Actions/CellConsole.tsx
@@ -101,8 +101,18 @@ const CellConsole = ({
   }, [cell.refId, runCode])
 
   const cellOutputs = useMemo(() => {
-    return createCellOutputs({ pid, exitCode }, stdout, stderr, mimeType)
-  }, [pid, exitCode, stdout, stderr, mimeType])
+    const statefulRunmeTerminalOutputs = cell.outputs.filter((o) =>
+      o.items.some((i) => i.mime === MimeType.StatefulRunmeTerminal)
+    )
+    const newOutputs = createCellOutputs(
+      { pid, exitCode },
+      stdout,
+      stderr,
+      mimeType
+    )
+
+    return [...statefulRunmeTerminalOutputs, ...newOutputs]
+  }, [pid, exitCode, stdout, stderr, mimeType, cell.outputs])
 
   useEffect(() => {
     if (startTime === null) {

--- a/packages/react-components/src/contexts/OutputContext.tsx
+++ b/packages/react-components/src/contexts/OutputContext.tsx
@@ -1,0 +1,83 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react'
+import { JSX } from 'react'
+
+import * as parser_pb from '@buf/stateful_runme.bufbuild_es/runme/parser/v1/parser_pb'
+
+export interface OutputRenderer {
+  onCellUpdate: (cell: parser_pb.Cell) => void
+  component: (props: any) => JSX.Element
+  props?: Record<string, any>
+}
+
+interface OutputContextType {
+  registerRenderer: (mimeType: string, renderer: OutputRenderer) => void
+  unregisterRenderer: (mimeType: string) => void
+  getRenderer: (mimeType: string) => OutputRenderer | undefined
+  getAllRenderers: () => Map<string, OutputRenderer>
+}
+
+const OutputContext = createContext<OutputContextType | undefined>(undefined)
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useOutput = () => {
+  const context = useContext(OutputContext)
+  if (!context) {
+    throw new Error('useOutput must be used within an OutputProvider')
+  }
+  return context
+}
+
+interface OutputProviderProps {
+  children: ReactNode
+}
+
+export const OutputProvider = ({ children }: OutputProviderProps) => {
+  const renderers = useMemo(() => new Map<string, OutputRenderer>(), [])
+
+  const registerRenderer = useCallback(
+    (mimeType: string, renderer: OutputRenderer) => {
+      renderers.set(mimeType, renderer)
+    },
+    [renderers]
+  )
+
+  const unregisterRenderer = useCallback(
+    (mimeType: string) => {
+      renderers.delete(mimeType)
+    },
+    [renderers]
+  )
+
+  const getRenderer = useCallback(
+    (mimeType: string) => {
+      return renderers.get(mimeType)
+    },
+    [renderers]
+  )
+
+  const getAllRenderers = useCallback(() => {
+    return renderers
+  }, [renderers])
+
+  const contextValue = useMemo(
+    () => ({
+      registerRenderer,
+      unregisterRenderer,
+      getRenderer,
+      getAllRenderers,
+    }),
+    [registerRenderer, unregisterRenderer, getRenderer, getAllRenderers]
+  )
+
+  return (
+    <OutputContext.Provider value={contextValue}>
+      {children}
+    </OutputContext.Provider>
+  )
+}

--- a/packages/react-components/src/contexts/index.tsx
+++ b/packages/react-components/src/contexts/index.tsx
@@ -4,3 +4,4 @@
 export { AgentClientProvider, useClient } from './AgentContext'
 export { CellProvider, useCell } from './CellContext'
 export { SettingsProvider, useSettings } from './SettingsContext'
+export { OutputProvider, useOutput } from './OutputContext'


### PR DESCRIPTION
We currently only have a single renderer, which is the Runme Console for shell-ish cells.