### PR TITLE
Fix infinite login if principal is unauthorized

### DIFF
--- a/packages/react-components/src/contexts/CellContext.tsx
+++ b/packages/react-components/src/contexts/CellContext.tsx
@@ -485,7 +485,7 @@ export const CellProvider = ({ children, getAccessToken }: CellProviderProps) =>
     }
 
     const resp = await c.serialize(req)
-    const blob = new Blob([resp.result], { type: 'text/plain' })
+    const blob = new Blob([new Uint8Array(resp.result)], { type: 'text/plain' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url

--- a/packages/react-components/src/contexts/CellContext.tsx
+++ b/packages/react-components/src/contexts/CellContext.tsx
@@ -314,7 +314,7 @@ export const CellProvider = ({ children, getAccessToken }: CellProviderProps) =>
 
     req.openaiAccessToken = accessToken
     if (!accessToken) {
-      console.error('No access token found')
+      console.warn('No access token found (expected if oauth is disabled)')
     }
 
     try {

--- a/packages/react-components/src/contexts/SettingsContext.tsx
+++ b/packages/react-components/src/contexts/SettingsContext.tsx
@@ -136,8 +136,12 @@ export const SettingsProvider = ({
   const defaultCreateAuthInterceptors = useCallback(
     (redirect: boolean): Interceptor[] => {
       const redirectOnUnauthError = (error: unknown) => {
+        const currentPath = window.location.pathname
         const connectErr = ConnectError.from(error)
-        if (connectErr.code === Code.Unauthenticated) {
+        if (
+          currentPath !== '/login' &&
+          connectErr.code === Code.Unauthenticated
+        ) {
           window.location.href = `/login?error=${encodeURIComponent(connectErr.name)}&error_description=${encodeURIComponent(connectErr.message)}`
         }
       }

--- a/packages/react-components/src/layout.tsx
+++ b/packages/react-components/src/layout.tsx
@@ -40,10 +40,9 @@ function Layout({
     const loginUrl = settings.requireAuth ? '/oidc/login' : '/login'
 
     if (!(runnerError instanceof Error) && !(runnerError instanceof Event)) {
-      const isAuthError =
-        runnerError.code === Code.UNAUTHENTICATED ||
-        runnerError.code === Code.PERMISSION_DENIED
-      if (isAuthError) {
+      // only do this for unauthenticated errors, unauthorized is not an IdP-related error
+      const isAuthnError = runnerError.code === Code.UNAUTHENTICATED
+      if (isAuthnError && window.location.pathname !== loginUrl) {
         window.location.href = loginUrl
       } else {
         navigate(settingsPath)

--- a/packages/react-components/src/storage.ts
+++ b/packages/react-components/src/storage.ts
@@ -43,6 +43,10 @@ export class SessionStorage extends Dexie {
     this.saveSubject
       .pipe(debounceTime(200))
       .subscribe(async ({ id, notebook }) => {
+        if (!id) {
+          console.warn(new Date().toISOString(), 'no id to save notebook')
+          return
+        }
         const record: SessionNotebook = {
           id,
           principal: this.principal,
@@ -147,7 +151,7 @@ export class SessionStorage extends Dexie {
       return resp.session?.id
     } catch (e) {
       console.error('Error creating session', e)
-      return undefined
+      throw e
     }
   }
 }


### PR DESCRIPTION
This isn't a login issue per se. Usually this means that, e.g. a `user@domain.com` is not allowed in the role bindings. Re-login would only fix this if the "wrong user" was logged in. This is for a user to determine which is why we surface the error message instead of forcing a re-login.