### PR TITLE
Redesign notebook UI with Colab-inspired styling

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 
 import { create } from "@bufbuild/protobuf";
-import { Box, Button, Card, ScrollArea, Tabs, Text } from "@radix-ui/themes";
+import { Box, ScrollArea, Tabs, Text } from "@radix-ui/themes";
 import { useParams } from "react-router-dom";
 
 import { Cross2Icon } from "@radix-ui/react-icons";
@@ -93,17 +93,35 @@ function RunActionButton({
     return "Run code";
   };
 
+  const isRunning = exitCode === null && pid !== null;
+  const isSuccess = exitCode !== null && exitCode === 0;
+  const isError = exitCode !== null && exitCode > 0;
+  const isIdle = exitCode === null && pid === null;
+
   return (
-    <Button variant="soft" onClick={onClick} aria-label={getButtonLabel()}>
-      {exitCode === null && pid === null && <PlayIcon />}
-      {exitCode === null && pid !== null && (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={getButtonLabel()}
+      className={`flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ${
+        isRunning
+          ? "bg-amber-100 text-amber-600"
+          : isSuccess
+            ? "bg-green-100 text-green-600"
+            : isError
+              ? "bg-red-100 text-red-600"
+              : "bg-gray-100 text-gray-500 hover:bg-amber-50 hover:text-amber-600"
+      }`}
+    >
+      {isIdle && <PlayIcon />}
+      {isRunning && (
         <div className="animate-spin">
           <SpinnerIcon />
         </div>
       )}
-      {exitCode !== null && exitCode === 0 && <SuccessIcon />}
-      {exitCode !== null && exitCode > 0 && <ErrorIcon exitCode={exitCode} />}
-    </Button>
+      {isSuccess && <SuccessIcon />}
+      {isError && <ErrorIcon exitCode={exitCode} />}
+    </button>
   );
 }
 
@@ -535,16 +553,16 @@ export function Action({ cellData, isFirst }: { cellData: CellData; isFirst: boo
 
   return (
     <div
-      className="relative py-2 flex flex-col gap-2"
+      className="group relative py-4 flex flex-col gap-3 border-l-[3px] border-transparent hover:border-amber-400 transition-colors duration-150 pl-2"
       onContextMenu={handleContextMenu}
     >
       {!isFirst && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-center">
+        <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150">
           <div className="pointer-events-auto flex h-8 w-8 -translate-y-1/2 items-center justify-center">
             <button
               type="button"
               aria-label="Add cell above"
-              className="flex h-6 w-6 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 shadow-sm transition-colors hover:border-gray-400 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+              className="flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all hover:border-amber-300 hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
               onClick={handleAddCodeCellBefore}
             >
               <PlusIcon width={12} height={12} />
@@ -554,17 +572,18 @@ export function Action({ cellData, isFirst }: { cellData: CellData; isFirst: boo
       )}
       <Box className="relative w-full px-2 py-1">
         <div className="flex justify-between items-top">
-          <div className="flex flex-col items-center">
+          <div className="flex flex-col items-center pt-1">
             <RunActionButton pid={pid} exitCode={exitCode} onClick={runCode} />
-            <Text
-              size="2"
-              className="mt-1 p-2 font-bold text-gray-400 font-mono"
-              data-testid="sequence-label"
-            >
-              [{sequenceLabel}]
-            </Text>
+            {sequenceLabel.trim() && (
+              <span
+                className="mt-1 text-[10px] text-gray-400 font-mono"
+                data-testid="sequence-label"
+              >
+                {sequenceLabel}
+              </span>
+            )}
           </div>
-      <Card className="flex flex-col flex-1 ml-2 overflow-hidden">
+      <div className="flex flex-col flex-1 ml-3 overflow-hidden rounded-lg bg-white">
         <div id="editor-toolbar" className="relative flex flex-col gap-0">
               <Editor
                 key={`editor-${cell.refId}-${selectedLanguage}`}
@@ -583,13 +602,13 @@ export function Action({ cellData, isFirst }: { cellData: CellData; isFirst: boo
               />
               <div
                 id="toolbar"
-                className="-mt-px flex items-center justify-start gap-4 border border-sky-200/70 bg-[#111111] px-3 py-0.5 text-[10px] leading-tight text-gray-200 rounded-b-md"
+                className="flex items-center justify-start gap-4 border-t border-gray-100 bg-gray-50 px-3 py-1.5 text-xs opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-150"
               >
                 <div className="flex items-center gap-2">
                   <Text
                     size="1"
                     as="span"
-                    className="text-[9px] uppercase tracking-wide text-gray-300"
+                    className="text-[11px] text-gray-500"
                   >
                     Language
                   </Text>
@@ -597,7 +616,7 @@ export function Action({ cellData, isFirst }: { cellData: CellData; isFirst: boo
                     id={languageSelectId}
                     value={selectedLanguage}
                     onChange={handleLanguageChange}
-                    className="cursor-pointer rounded border border-sky-200/70 bg-[#111111] px-2 py-0.5 text-[10px] font-mono text-gray-100 focus:outline-none focus:ring-2 focus:ring-sky-200/50"
+                    className="cursor-pointer rounded border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-amber-300/50 focus:border-amber-300"
                   >
                     {LANGUAGE_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -610,22 +629,22 @@ export function Action({ cellData, isFirst }: { cellData: CellData; isFirst: boo
                   <Text
                     size="1"
                     as="span"
-                    className="text-[9px] uppercase tracking-wide text-gray-300"
+                    className="text-[11px] text-gray-500"
                   >
                     Runner
                   </Text>
                   <select
                     id={runnerSelectId}
                     value={initialRunnerName}
-                    onChange={(event) => {                      
+                    onChange={(event) => {
                       const nextName = event.target.value;
                       const names = new Set(listRunners().map((r) => r.name));
                       if (!names.has(nextName) && nextName !== DEFAULT_RUNNER_PLACEHOLDER) {
                         return;
                       }
-                      cellData.setRunner(nextName);           
+                      cellData.setRunner(nextName);
                     }}
-                    className="cursor-pointer rounded border border-sky-200/70 bg-[#111111] px-2 py-0.5 text-[10px] font-mono text-gray-100 focus:outline-none focus:ring-2 focus:ring-sky-200/50"
+                    className="cursor-pointer rounded border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-amber-300/50 focus:border-amber-300"
                   >
                     <option value="<default>">
                       {defaultRunnerName ? `<default: ${defaultRunnerName}>` : "<default>"}
@@ -641,15 +660,15 @@ export function Action({ cellData, isFirst }: { cellData: CellData; isFirst: boo
           </div>
             {renderedOutputs}
             {renderedOutputItems}
-          </Card>
+          </div>
         </div> 
       </Box>
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center">
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150">
         <div className="pointer-events-auto flex h-8 w-8 translate-y-1/2 items-center justify-center">
           <button
             type="button"
             aria-label="Add cell below"
-            className="flex h-6 w-6 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 shadow-sm transition-colors hover:border-gray-400 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+            className="flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all hover:border-amber-300 hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
             onClick={handleAddCodeCellAfter}
           >
             <PlusIcon width={12} height={12} />
@@ -712,14 +731,14 @@ function NotebookTabContent({ docUri }: { docUri: string }) {
       key={`scroll-${docUri}`}
       type="auto"
       scrollbars="vertical"
-      className="flex-1 h-full p-1"
+      className="flex-1 h-full p-4"
       data-document-id={docUri}
     >
-      <div className="mb-2 flex justify-center">
+      <div className="mb-4 flex justify-center">
         <button
           type="button"
           aria-label="Add cell"
-          className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 shadow-sm transition-colors hover:border-gray-400 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all hover:border-amber-300 hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
           onClick={() => {
             if (!data) {
               return;
@@ -912,20 +931,20 @@ export default function Actions() {
       ) : (
         <Tabs.Root
           value={currentDocUri ?? openNotebooks[0]?.uri ?? ""}
-          className="flex flex-col flex-1 min-h-0 border border-gray-200 rounded-md overflow-hidden bg-white"
+          className="flex flex-col flex-1 min-h-0 rounded-lg overflow-hidden bg-gray-50"
         >
-          <Tabs.List className="flex items-center gap-0 border-b border-gray-300 bg-gray-100 px-1">
-          {openNotebooks.map((doc) => {              
+          <Tabs.List className="flex items-center gap-1 border-b border-gray-200 bg-white px-2 pt-2">
+          {openNotebooks.map((doc) => {
             const displayName =
               doc.name ||
               doc.uri.split("/").filter(Boolean).pop() ||
               "This is a bug; this should not happen";
             return (
-              <div key={`tab-${doc.uri}`} className="flex items-center gap-1">
+              <div key={`tab-${doc.uri}`} className="flex items-center">
                 <Tabs.Trigger
                   value={doc.uri}
                   title={doc.name}
-                  className="group flex items-center gap-2 px-3 py-1 text-sm font-medium text-gray-600 border border-gray-300 border-b-0 border-t-transparent data-[state=active]:border-t-2 data-[state=active]:border-t-sky-400 data-[state=active]:border-l-gray-400 data-[state=active]:border-r-gray-400 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=inactive]:bg-gray-100 focus:outline-none"
+                  className="group flex items-center gap-2 px-3 py-2 text-sm text-gray-500 rounded-t-lg transition-colors data-[state=active]:bg-gray-50 data-[state=active]:text-gray-900 data-[state=active]:border-b-2 data-[state=active]:border-amber-400 data-[state=inactive]:hover:text-gray-700 data-[state=inactive]:hover:bg-gray-50 focus:outline-none"
                   onClick={() => {
                     if (doc.uri !== currentDocUri) {
                       setMountedTabs((prev) => {
@@ -944,7 +963,7 @@ export default function Actions() {
                 </Tabs.Trigger>
                   <button
                     type="button"
-                    className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-700"
+                    className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-gray-400 transition-all hover:text-gray-700 hover:bg-gray-200"
                     aria-label={`Close ${displayName}`}
                     onClick={(event) => {
                       event.stopPropagation();

--- a/app/src/components/Actions/Editor.tsx
+++ b/app/src/components/Actions/Editor.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import MonacoEditor from "@monaco-editor/react";
 import useResizeObserver from "use-resize-observer";
 
-const theme = "vs-dark";
+const theme = "vs";
 
 // Editor component for editing code which won't re-render unless the value changes
 const Editor = memo(
@@ -128,7 +128,7 @@ const Editor = memo(
 
     return (
       <div className="w-full" ref={setContainerRef}>
-        <div className="rounded-t-md overflow-hidden">
+        <div className="rounded-md overflow-hidden border border-gray-200">
           <MonacoEditor
             key={id}
             height={`${height}px`}

--- a/app/src/components/MainPage/MainPage.tsx
+++ b/app/src/components/MainPage/MainPage.tsx
@@ -12,25 +12,25 @@ export default function MainPage() {
   const sidePanelVisible = Boolean(activePanel);
 
   return (
-    <div className="flex h-screen w-screen bg-white">
+    <div className="flex h-screen w-screen bg-gray-50">
       <CurrentDocInitializer />
       <div className="flex h-full min-h-0 w-full">
         <div
-          className="flex h-full flex-col border-r border-gray-200 bg-gray-50"
+          className="flex h-full flex-col bg-white"
           style={{ width: TOOLBAR_WIDTH }}
         >
           <SidePanelToolbar />
         </div>
         <div
           id="sidepanel-column"
-          className={`h-full border-r border-gray-200 transition-[width] duration-150`}
+          className={`h-full border-r border-gray-100 bg-white transition-[width] duration-150`}
           style={{ width: sidePanelVisible ? SIDE_PANEL_WIDTH : 0 }}
         >
-          {sidePanelVisible && (    
+          {sidePanelVisible && (
             <SidePanelContent />
           )}
         </div>
-        <div className="flex h-full flex-1 min-w-0 flex-col gap-3 p-4">
+        <div className="flex h-full flex-1 min-w-0 flex-col gap-4 p-4">
           <div className="flex-1 min-h-0">
             <Actions />
           </div>

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -7,7 +7,7 @@ import { useSidePanel } from "../../contexts/SidePanelContext";
 import Settings from "../Settings/Settings";
 
 const sideButtonBase =
-  "relative flex h-10 w-10 items-center justify-center rounded-md border border-transparent text-gray-700 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-800";
+  "relative flex h-10 w-10 items-center justify-center rounded-lg border border-transparent text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400";
 
 const tooltipBase =
   "pointer-events-none absolute left-11 top-1/2 z-50 -translate-y-1/2 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-xs font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100";
@@ -18,12 +18,12 @@ export function SidePanelToolbar() {
   const browserAdapter = getBrowserAdapter();
 
   return (
-    <div className="flex h-full w-12 flex-col items-center justify-between bg-gray-50">
+    <div className="flex h-full w-12 flex-col items-center justify-between bg-white border-r border-gray-100">
       <div className="flex flex-col items-center gap-2 pt-2">
         <button
           type="button"
           className={`group ${sideButtonBase} ${
-            activePanel === "explorer" ? "bg-gray-200 text-gray-800 hover:bg-gray-200" : ""
+            activePanel === "explorer" ? "bg-amber-50 text-amber-600 hover:bg-amber-50" : ""
           }`}
           aria-pressed={activePanel === "explorer"}
           aria-label="Toggle Explorer panel"
@@ -45,7 +45,7 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`group ${sideButtonBase} ${
-            activePanel === "chatkit" ? "bg-gray-200 text-gray-800 hover:bg-gray-200" : ""
+            activePanel === "chatkit" ? "bg-amber-50 text-amber-600 hover:bg-amber-50" : ""
           }`}
           aria-pressed={activePanel === "chatkit"}
           aria-label="Toggle ChatKit panel"
@@ -83,7 +83,7 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`group ${sideButtonBase} ${
-            activePanel === "settings" ? "bg-gray-200 text-gray-800 hover:bg-gray-200" : ""
+            activePanel === "settings" ? "bg-amber-50 text-amber-600 hover:bg-amber-50" : ""
           }`}
           aria-pressed={activePanel === "settings"}
           aria-label="Toggle settings panel"

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -169,7 +169,7 @@ function EditableTreeNode({
       <input
         ref={inputRef}
         defaultValue={node.data.name}
-        className="w-full rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+        className="w-full rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-400"
         onBlur={() => node.reset()}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
@@ -602,7 +602,7 @@ function formatShortTimestamp(date: Date): string {
           {data.type === NotebookStoreItemType.File ? (
             <button
               type="button"
-              className="block w-full bg-transparent p-0 text-left text-blue-600 leading-4 hover:bg-transparent hover:underline focus:outline-none border-0"
+              className="block w-full bg-transparent p-0 text-left text-amber-600 leading-4 hover:bg-transparent hover:text-amber-700 hover:underline focus:outline-none border-0"
               onClick={(event) => {
                 event.stopPropagation();
                 void handleFileOpen(data);


### PR DESCRIPTION
## Summary
- Change Monaco editor from dark to light theme
- Add left border accent on cell hover (amber)
- Make toolbar hidden by default, visible on hover
- Simplify run button to circular design with state colors
- Update tabs to flatter design with amber bottom border
- Increase whitespace and padding throughout
- Add warm amber accent color palette
- Update sidebar buttons with amber active states
- Change file links to amber color