### PR TITLE
fix: use distinct cloud icon for Google Drive button

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -14,6 +14,7 @@ import useResizeObserver from "use-resize-observer";
 
 import { GoogleDrivePickerButton } from "./GoogleDrivePickerButton";
 import { FolderPlusIcon } from "../icons/FolderPlusIcon";
+import { CloudFolderIcon } from "../icons/CloudFolderIcon";
 import { useWorkspace } from "../../contexts/WorkspaceContext";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
@@ -838,10 +839,10 @@ function formatShortTimestamp(date: Date): string {
             </button>
           )}
           <GoogleDrivePickerButton
-            label="Add Folder"
+            label="Add Google Drive folder"
             className="btn btn-soft h-8 w-8 justify-center rounded-full p-0"
           >
-            <FolderPlusIcon width={20} height={20} />
+            <CloudFolderIcon width={20} height={20} />
           </GoogleDrivePickerButton>
         </div>
       </div>

--- a/app/src/components/icons/CloudFolderIcon.tsx
+++ b/app/src/components/icons/CloudFolderIcon.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+/**
+ * Cloud icon with an overlaid plus sign, used for adding folders from
+ * cloud storage (e.g. Google Drive).
+ */
+export function CloudFolderIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M6.5 19a4.5 4.5 0 0 1-.42-8.98A7 7 0 0 1 19.32 13 4.5 4.5 0 0 1 18.5 22H6.5Z" />
+      <path d="M12 13v4" />
+      <path d="M10 15h4" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- The Explorer toolbar had two identical folder-plus icons for "Open local folder" and "Add Google Drive folder", making them indistinguishable
- Added a new `CloudFolderIcon` (cloud with plus sign) and use it for the Google Drive picker button
- Updated the Google Drive button label to "Add Google Drive folder" for clarity

## Test plan
- [ ] Verify both icons render correctly in the Explorer toolbar
- [ ] Verify the local folder button still opens the File System Access picker
- [ ] Verify the cloud icon button still opens the Google Drive picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)