### PR TITLE
Default new notebook cells to markdown

### DIFF
--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -216,3 +216,21 @@ describe("NotebookData.getActiveStream", () => {
     expect(model.getActiveStream(cell.refId)).toBeUndefined();
   });
 });
+
+describe("NotebookData cell defaults", () => {
+  it("creates markdown cells by default for new notebooks", () => {
+    const notebook = create(parser_pb.NotebookSchema, { cells: [] });
+    const model = new NotebookData({
+      notebook,
+      uri: "nb://new",
+      name: "new",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    const cell = model.appendCodeCell();
+
+    expect(cell.languageId).toBe("markdown");
+    expect(cell.kind).toBe(parser_pb.CellKind.CODE);
+  });
+});

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -636,7 +636,9 @@ export class NotebookData {
     const refID = `code_${crypto.randomUUID().replace(/-/g, "")}`;
     const normalizedLanguage = languageId?.trim().toLowerCase();
     const resolvedLanguage =
-      normalizedLanguage && normalizedLanguage.length > 0 ? normalizedLanguage : "js";
+      normalizedLanguage && normalizedLanguage.length > 0
+        ? normalizedLanguage
+        : "markdown";
     return create(parser_pb.CellSchema, {
       metadata: {},
       refId: refID,


### PR DESCRIPTION
### Motivation
- New notebooks were created with the first cell defaulting to JavaScript (`js`) which is unexpected for prose-first workflows, so the default should be `markdown`.

### Description
- Change `NotebookData.createCodeCell` to default the resolved language to `"markdown"` when no `languageId` is provided (updated `app/src/lib/notebookData.ts`).
- Add a regression test that verifies `appendCodeCell()` creates a markdown cell by default (added `app/src/lib/notebookData.test.ts`).

### Testing
- Ran a full build with `pnpm run build` which completed successfully. 
- Ran unit tests with `pnpm run test:run` which succeeded (`1 test file` ran and all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfe8ec058832a80d10407d0882c4e)