### PR TITLE
Rename JS console helpers from `aisre` to `app`

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -153,7 +153,7 @@ In the web app we need to configure a runner on which to execute cells
 In the app console.
 
 ```sh
-aisre.runners.update("localhost","ws://localhost:9977/ws")
+app.runners.update("localhost","ws://localhost:9977/ws")
 ```
 
 * Change the port to whatever port your runme agent is serving on


### PR DESCRIPTION
### Motivation
- Align the JS runtime helper namespace with the repo's intended `app` naming instead of `aisre` for configuration and console helpers.
- Avoid breaking existing snippets by providing a compatibility alias while updating the suggested usage and docs.

### Description
- Exposed an `app` helper object in the JS runtime globals and renamed the internal helper factory to `createAppHelpers` in `app/src/lib/runtime/jsKernel.ts`. 
- Kept `aisre` as a backward-compatible alias by assigning `aisre: app` in the injected globals. 
- Updated runtime help text and examples from `aisre.*` to `app.*` (including `app.clear`, `app.render`, and `app.runners.*`).
- Updated the README example to use `app.runners.update("localhost","ws://localhost:9977/ws")`.

### Testing
- Attempted `runme run build test` but it failed in this environment because `runme` is not installed. 
- Ran package-level validation with `pnpm -C app run build` which completed successfully. 
- Ran unit tests with `pnpm -C app run test` and observed one existing failing test (`bindStreamsToCell > appends stdout/stderr to existing outputs` in `src/lib/notebookData.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e036aee58832a86456b9d28a3cf95)