### PR TITLE
fix: default new cell type to markdown instead of code

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -819,24 +819,12 @@ function NotebookTabContent({ docUri }: { docUri: string }) {
             if (!data) {
               return;
             }
-            // Default to inserting a code cell when notebook is empty.
+            // Insert a markup (markdown) cell at the top of the notebook.
             const firstCell = cellDatas[0]?.snapshot;
             if (firstCell) {
-              data.addCodeCellBefore(firstCell.refId);
+              data.addMarkupCellBefore(firstCell.refId);
             } else {
-              const newCell = data.addCodeCellAfter("");
-              if (!newCell) {
-                // Fallback: create and persist a new code cell at the end.
-                const cell = create(parser_pb.CellSchema, {
-                  metadata: {},
-                  refId: `code_${crypto.randomUUID().replace(/-/g, "")}`,
-                  languageId: "bash",
-                  role: parser_pb.CellRole.USER,
-                  kind: parser_pb.CellKind.CODE,
-                  value: "",
-                });
-                data.updateCell(cell);
-              }
+              data.appendMarkupCell();
             }
           }}
         >


### PR DESCRIPTION
## Summary
- Changed the default cell type when adding a cell to an empty notebook from JavaScript/code to markdown
- Added `addMarkupCellBefore()`, `appendMarkupCell()`, and `createMarkupCell()` methods to `NotebookData`
- Simplified the empty-notebook fallback in `Actions.tsx` by removing the inline cell creation

Closes #72

## Test plan
- [ ] Open a new/empty notebook and click "Add cell" — verify a markdown cell is created (not JS)
- [ ] Add a cell before the first cell in an existing notebook — verify it's a markdown cell
- [ ] Existing "Add cell above/below" buttons on cells still create code cells (unchanged behavior)
- [ ] Run `npx vitest run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)