### PR TITLE
Harden App Console bridge activation to restore prompt/input

### DIFF
--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -678,6 +678,11 @@ export default function AppConsole() {
             (elem as any).context = ctxBridge;
             elem.addEventListener("pointerdown", activateConsoleContext);
             elem.addEventListener("focusin", activateConsoleContext);
+            // Some terminal events (for example selection/annotation updates)
+            // can be emitted before focus is moved to the element. Re-arming
+            // the bridge on keydown keeps AppConsole interactive even when
+            // another console recently replaced the shared renderer context.
+            elem.addEventListener("keydown", activateConsoleContext, true);
 
             elem.setAttribute("id", consoleId);
             elem.setAttribute("buttons", "false");
@@ -692,6 +697,9 @@ export default function AppConsole() {
             elem.setAttribute("scrollback", "4000");
 
             el.appendChild(elem);
+            // Re-apply once after attachment so the global messaging context is
+            // deterministic even if another component changed it during mount.
+            queueMicrotask(activateConsoleContext);
           }}
         ></div>
         <pre


### PR DESCRIPTION
### Motivation
- Fix a regression where the App Console showed no prompt and did not accept input due to `noopBridge` messages produced before the correct messaging bridge was active.
- Address a timing/race condition where the shared renderer context can be replaced during mount, causing early `console-view` events to be routed to the noop bridge.

### Description
- Re-apply the console messaging bridge after creating the `console-view` element by scheduling `queueMicrotask(activateConsoleContext)` to make the global context deterministic after mount. (file: `app/src/components/AppConsole/AppConsole.tsx`)
- Add a `keydown` listener on the `console-view` element in the capture phase (`elem.addEventListener("keydown", activateConsoleContext, true)`) so key events emitted before focus/pointer changes still re-arm the App Console bridge.
- Set the element-local `context` and keep existing `pointerdown`/`focusin` activation, with inline comments explaining the reasoning and failure mode.

### Testing
- Built the workspace with `pnpm run build` and the app build completed successfully. (build succeeded)
- Ran the package test suite with `CI=1 pnpm --filter @runmedev/react-console run test` and the `react-console` tests passed (7/7 tests).
- Ran `pnpm run build && pnpm run test` which completed the build and exercised the test runner (watch mode started); unit tests executed in CI mode reported passing results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990de362eac832a97672182d981b562)