### PR TITLE
Trigger Codex postsubmit on merged PRs and post request to the PR thread

### DIFF
--- a/.github/workflows/codex-cuj.yaml
+++ b/.github/workflows/codex-cuj.yaml
@@ -2,7 +2,7 @@ name: Codex CUJ Automation
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
   push:
     branches: [main]
   workflow_dispatch:
@@ -50,46 +50,20 @@ jobs:
             });
 
   postsubmit-codex-request:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Create or find postsubmit CUJ tracking issue
-        id: issue
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            const title = 'Codex postsubmit CUJ runs';
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const existing = issues.find((i) => i.title === title);
-            if (existing) {
-              return String(existing.number);
-            }
-            const created = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body: 'Tracking issue for Codex postsubmit CUJ execution artifacts (screenshots/videos).',
-            });
-            return String(created.data.number);
-
       - name: Ask Codex to run CUJ scenarios for main
         uses: actions/github-script@v7
-        env:
-          ISSUE_NUMBER: ${{ steps.issue.outputs.result }}
         with:
           script: |
-            const issueNumber = Number(process.env.ISSUE_NUMBER);
-            const marker = `[codex-cuj-postsubmit][sha:${context.sha}]`;
+            const prNumber = context.payload.pull_request.number;
+            const mergedSha = context.payload.pull_request.merge_commit_sha ?? context.sha;
+            const marker = `[codex-cuj-postsubmit][sha:${mergedSha}]`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issueNumber,
+              issue_number: prNumber,
               per_page: 100,
             });
             if (comments.some((c) => c.body && c.body.includes(marker))) {
@@ -98,16 +72,16 @@ jobs:
             }
             const body = [
               marker,
-              `@codex Please run all scenarios in docs-dev/cujs against main at ${context.sha}.`,
+              `@codex Please run all scenarios in docs-dev/cujs against main at ${mergedSha}.`,
               '',
               'Required outputs:',
               '- pass/fail summary per CUJ from `app/test/browser/run-cuj-scenarios.ts`',
               '- screenshots and logs attached in the comment',
-              '- a short end-to-end CUJ video uploaded to this issue',
+              '- a short end-to-end CUJ video uploaded to this PR thread',
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issueNumber,
+              issue_number: prNumber,
               body,
             });


### PR DESCRIPTION
### Motivation
- The existing postsubmit flow posted `@codex` to a separate tracking issue on `push` to `main`, which caused missed PR-centric follow-up handling. 
- Postsubmit requests should be posted on the merged PR conversation so Codex can run CUJs tied to the specific PR merge and upload artifacts to that thread.

### Description
- Added `closed` to the `pull_request_target` event types in `.github/workflows/codex-cuj.yaml` so PR-closure events are delivered to the workflow. 
- Changed the `postsubmit-codex-request` job to run when a PR is `closed` and `merged == true` instead of running on `push` to `main`. 
- Removed the tracking-issue creation logic and updated the postsubmit flow to comment directly on the merged PR thread using the PR number. 
- Use `merge_commit_sha` (falling back to `context.sha`) as the dedupe key in the marker and updated the comment text to request artifacts be uploaded to the PR thread.

### Testing
- Confirmed workflow file changes with `git diff` and inspected the updated file at `.github/workflows/codex-cuj.yaml`. 
- Verified GitHub Actions event docs locally via `curl`/search to ensure `pull_request_target` supports the required activity types. 
- Attempted to run `runme run build test` as required by repository guidance but the runme binary download failed due to environment network reachability (`ENETUNREACH`), so build/test could not complete in this environment. 
- Other local validation steps (workflow file inspection and grep checks) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990fdda01e0832aaede70ced3cc9ae2)