### PR TITLE
docs: add app review guidelines to app/AGENTS.md

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -38,3 +38,11 @@ Here is an example of correct code.
             onClick={() => setContextMenu(null)}
           />
 ```
+
+## Review guidelines for app/
+
+* Ensure code changes are consistent with the design, practices, and styles defined in `docs-dev/architecture.md`.
+* Ensure that tests are properly updated to verify bug fixes and prevent regressions, including adding new tests where needed.
+  * Ensure CUJs as defined in `docs-dev/cujs` are updated if necessary.
+  * Ensure E2E tests and CUJs are in sync.
+* Ensure artifacts uploaded by tests confirm that the tests are validating what they claim to test.


### PR DESCRIPTION
### Motivation

- Add reviewer guidance to `app/AGENTS.md` so PR reviewers validate architecture/style alignment, test coverage (including CUJs/E2E), and that uploaded test artifacts actually validate the claimed behaviors.

### Description

- Add a new `## Review guidelines for app/` section to `app/AGENTS.md` with checks referencing `docs-dev/architecture.md`, `docs-dev/cujs`, synchronization of CUJs and E2E tests, and verification of test-uploaded artifacts.

### Testing

- This is a documentation-only change; I attempted `runme run build test` and `pnpm install` to validate the repo but both were blocked in this environment (`runme` failed to fetch its binary and `pnpm install` failed due to Buf registry auth), so no automated tests ran successfully for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d8a628f4832a9247b0cb21f358da)