### PR TITLE
feat(app): cell execution state indicators + flush partial stdout

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, act, fireEvent } from "@testing-library/react";
 import { create } from "@bufbuild/protobuf";
 import React from "react";
 
-import { parser_pb } from "../../runme/client";
+import { parser_pb, RunmeMetadataKey } from "../../runme/client";
 import type { CellData } from "../../lib/notebookData";
 import { Action } from "./Actions";
 
@@ -60,6 +60,47 @@ vi.mock("@runmedev/renderers", () => ({
 
 vi.mock("../../contexts/CellContext", () => ({}));
 
+// Fake streams for testing PID/exitCode callbacks through CellConsole subscriptions.
+class FakeStreams {
+  private pidCbs = new Set<(pid: number) => void>();
+  private exitCbs = new Set<(code: number) => void>();
+  private stdoutCbs = new Set<(data: Uint8Array) => void>();
+  private stderrCbs = new Set<(data: Uint8Array) => void>();
+
+  stdout = {
+    subscribe: (cb: (data: Uint8Array) => void) => {
+      this.stdoutCbs.add(cb);
+      return { unsubscribe: () => this.stdoutCbs.delete(cb) };
+    },
+  };
+  stderr = {
+    subscribe: (cb: (data: Uint8Array) => void) => {
+      this.stderrCbs.add(cb);
+      return { unsubscribe: () => this.stderrCbs.delete(cb) };
+    },
+  };
+  pid = {
+    subscribe: (cb: (pid: number) => void) => {
+      this.pidCbs.add(cb);
+      return { unsubscribe: () => this.pidCbs.delete(cb) };
+    },
+  };
+  exitCode = {
+    subscribe: (cb: (code: number) => void) => {
+      this.exitCbs.add(cb);
+      return { unsubscribe: () => this.exitCbs.delete(cb) };
+    },
+  };
+
+  emitPid(pid: number) { this.pidCbs.forEach((cb) => cb(pid)); }
+  emitExitCode(code: number) { this.exitCbs.forEach((cb) => cb(code)); }
+  emitStdout(data: Uint8Array) { this.stdoutCbs.forEach((cb) => cb(data)); }
+
+  setCallback() {}
+  sendExecuteRequest() {}
+  close() {}
+}
+
 // Minimal stub CellData to drive runID changes.
 class StubCellData {
   snapshot: parser_pb.Cell;
@@ -103,13 +144,16 @@ class StubCellData {
     this.runListeners.forEach((l) => l(id));
   }
 
+  fakeStreams: FakeStreams | null = null;
+
   getStreams() {
-    return null;
+    return this.fakeStreams;
   }
   addBefore() {}
   addAfter() {}
   remove() {}
   run() {}
+  setRunner() {}
 }
 
 describe("Action component", () => {
@@ -188,5 +232,167 @@ describe("Action component", () => {
     const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell;
     expect(updatedCell.kind).toBe(parser_pb.CellKind.MARKUP);
     expect(updatedCell.languageId).toBe("markdown");
+  });
+
+  it("shows idle bracket [ ] before first run", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-idle",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "echo hello",
+    });
+    const stub = new StubCellData(cell);
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+
+    const bracket = screen.getByTestId("cell-bracket");
+    expect(bracket.textContent).toBe("[ ]");
+  });
+
+  it("shows pending state immediately on run click", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-pend",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "echo hello",
+    });
+    const stub = new StubCellData(cell);
+    stub.fakeStreams = new FakeStreams();
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+
+    const cellCard = document.getElementById("cell-card-cell-pend")!;
+    expect(cellCard.getAttribute("data-exec-state")).toBe("idle");
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Run code"));
+    });
+
+    expect(cellCard.getAttribute("data-exec-state")).toBe("pending");
+    const bracket = screen.getByTestId("cell-bracket");
+    expect(bracket.textContent).toBe("[*]");
+  });
+
+  it("transitions to running state on PID", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-run",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "echo hello",
+    });
+    const stub = new StubCellData(cell);
+    const streams = new FakeStreams();
+    stub.fakeStreams = streams;
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+
+    // Wait for CellConsole's useEffect to subscribe to streams
+    await act(async () => { await Promise.resolve(); });
+
+    // Click run to enter pending state
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Run code"));
+    });
+
+    const cellCard = document.getElementById("cell-card-cell-run")!;
+    expect(cellCard.getAttribute("data-exec-state")).toBe("pending");
+
+    // Emit PID to transition to running
+    await act(async () => {
+      streams.emitPid(42);
+    });
+
+    expect(cellCard.getAttribute("data-exec-state")).toBe("running");
+  });
+
+  it("transitions to success state on exitCode 0", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-ok",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "echo hello",
+    });
+    cell.metadata[RunmeMetadataKey.Sequence] = "1";
+    const stub = new StubCellData(cell);
+    const streams = new FakeStreams();
+    stub.fakeStreams = streams;
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    await act(async () => { await Promise.resolve(); });
+
+    // Run → PID → exit 0
+    await act(async () => { fireEvent.click(screen.getByLabelText("Run code")); });
+    await act(async () => { streams.emitPid(42); });
+    await act(async () => { streams.emitExitCode(0); });
+
+    const cellCard = document.getElementById("cell-card-cell-ok")!;
+    expect(cellCard.getAttribute("data-exec-state")).toBe("success");
+
+    const bracket = screen.getByTestId("cell-bracket");
+    expect(bracket.textContent).toBe("[1]");
+  });
+
+  it("transitions to error state on non-zero exitCode", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-err",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "exit 1",
+    });
+    const stub = new StubCellData(cell);
+    const streams = new FakeStreams();
+    stub.fakeStreams = streams;
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    await act(async () => { await Promise.resolve(); });
+
+    await act(async () => { fireEvent.click(screen.getByLabelText("Run code")); });
+    await act(async () => { streams.emitPid(42); });
+    await act(async () => { streams.emitExitCode(1); });
+
+    const cellCard = document.getElementById("cell-card-cell-err")!;
+    expect(cellCard.getAttribute("data-exec-state")).toBe("error");
+
+    const bracket = screen.getByTestId("cell-bracket");
+    expect(bracket.textContent).toBe("[!]");
+  });
+
+  it("resets to pending on re-run after success", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-rerun",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "echo hello",
+    });
+    const stub = new StubCellData(cell);
+    const streams = new FakeStreams();
+    stub.fakeStreams = streams;
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    await act(async () => { await Promise.resolve(); });
+
+    // First run → success
+    await act(async () => { fireEvent.click(screen.getByLabelText("Run code")); });
+    await act(async () => { streams.emitPid(42); });
+    await act(async () => { streams.emitExitCode(0); });
+
+    const cellCard = document.getElementById("cell-card-cell-rerun")!;
+    expect(cellCard.getAttribute("data-exec-state")).toBe("success");
+
+    // Re-run → should go back to pending
+    await act(async () => { fireEvent.click(screen.getByLabelText("Run code")); });
+    expect(cellCard.getAttribute("data-exec-state")).toBe("pending");
   });
 });

--- a/app/src/components/Actions/CellConsole.test.tsx
+++ b/app/src/components/Actions/CellConsole.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock runmedev/renderers to avoid registering the real web component,
 // which depends on adoptedStyleSheets and other browser-only APIs.
@@ -17,8 +17,50 @@ import { parser_pb, MimeType } from "../../contexts/CellContext";
 import { create } from "@bufbuild/protobuf";
 import CellConsole from "./CellConsole";
 
+// Fake streams for controlling stdout/pid/exitCode in tests.
+class FakeStreams {
+  private pidCbs = new Set<(pid: number) => void>();
+  private exitCbs = new Set<(code: number) => void>();
+  private stdoutCbs = new Set<(data: Uint8Array) => void>();
+  private stderrCbs = new Set<(data: Uint8Array) => void>();
+
+  stdout = {
+    subscribe: (cb: (data: Uint8Array) => void) => {
+      this.stdoutCbs.add(cb);
+      return { unsubscribe: () => this.stdoutCbs.delete(cb) };
+    },
+  };
+  stderr = {
+    subscribe: (cb: (data: Uint8Array) => void) => {
+      this.stderrCbs.add(cb);
+      return { unsubscribe: () => this.stderrCbs.delete(cb) };
+    },
+  };
+  pid = {
+    subscribe: (cb: (pid: number) => void) => {
+      this.pidCbs.add(cb);
+      return { unsubscribe: () => this.pidCbs.delete(cb) };
+    },
+  };
+  exitCode = {
+    subscribe: (cb: (code: number) => void) => {
+      this.exitCbs.add(cb);
+      return { unsubscribe: () => this.exitCbs.delete(cb) };
+    },
+  };
+
+  emitPid(pid: number) { this.pidCbs.forEach((cb) => cb(pid)); }
+  emitExitCode(code: number) { this.exitCbs.forEach((cb) => cb(code)); }
+  emitStdout(data: Uint8Array) { this.stdoutCbs.forEach((cb) => cb(data)); }
+
+  setCallback() {}
+  sendExecuteRequest() {}
+  close() {}
+}
+
 class FakeCellData {
   snapshot: parser_pb.Cell;
+  fakeStreams: FakeStreams | null = null;
 
   constructor(cell: parser_pb.Cell) {
     this.snapshot = cell;
@@ -29,7 +71,11 @@ class FakeCellData {
   }
 
   getStreams() {
-    return undefined;
+    return this.fakeStreams;
+  }
+
+  getRunID() {
+    return "run-test";
   }
 }
 
@@ -107,5 +153,108 @@ describe("CellConsole", () => {
     const spans = consoleEl?.querySelectorAll(".xterm-rows span") ?? [];
     const texts = Array.from(spans).map((s) => s.textContent);
     expect(texts.join("")).toContain("hello world");
+  });
+});
+
+describe("CellConsole stdout flush", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function getTerminalText(container: HTMLElement): string {
+    const consoleEl = container.querySelector("console-view") as FakeConsoleView | null;
+    const spans = consoleEl?.querySelectorAll(".xterm-rows span") ?? [];
+    return Array.from(spans).map((s) => s.textContent).join("");
+  }
+
+  async function renderWithStreams() {
+    if (!customElements.get("console-view")) {
+      customElements.define("console-view", FakeConsoleView);
+    }
+
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-flush",
+      kind: parser_pb.CellKind.CODE,
+      outputs: [],
+      metadata: {},
+    });
+
+    const streams = new FakeStreams();
+    const cellData = new FakeCellData(cell);
+    cellData.fakeStreams = streams;
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+
+    await act(async () => {
+      const root = ReactDOM.createRoot(div);
+      root.render(
+        <CellConsole cellData={cellData as any} onExitCode={() => {}} onPid={() => {}} />,
+      );
+      await Promise.resolve();
+    });
+
+    return { streams, div };
+  }
+
+  it("flushes partial stdout line after timeout", async () => {
+    vi.useFakeTimers();
+    const { streams, div } = await renderWithStreams();
+
+    // Emit partial line (no newline)
+    await act(async () => {
+      streams.emitStdout(new TextEncoder().encode("Password:"));
+    });
+
+    // Before timer fires, partial line should still be buffered
+    expect(getTerminalText(div)).not.toContain("Password:");
+
+    // Advance timer past 150ms flush threshold
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(getTerminalText(div)).toContain("Password:");
+    document.body.removeChild(div);
+  });
+
+  it("does not double-write when newline arrives after flush", async () => {
+    vi.useFakeTimers();
+    const { streams, div } = await renderWithStreams();
+
+    // Emit partial line
+    await act(async () => {
+      streams.emitStdout(new TextEncoder().encode("Password:"));
+    });
+
+    // Flush via timer
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // Now send the trailing newline
+    await act(async () => {
+      streams.emitStdout(new TextEncoder().encode("\n"));
+    });
+
+    // "Password:" should appear exactly once
+    const text = getTerminalText(div);
+    expect(text.match(/Password:/g)?.length).toBe(1);
+    document.body.removeChild(div);
+  });
+
+  it("complete lines are written immediately", async () => {
+    const { streams, div } = await renderWithStreams();
+
+    // Emit complete lines
+    await act(async () => {
+      streams.emitStdout(new TextEncoder().encode("hello\nworld\n"));
+    });
+
+    // Both lines should appear immediately without needing a timer
+    const text = getTerminalText(div);
+    expect(text).toContain("hello");
+    expect(text).toContain("world");
+    document.body.removeChild(div);
   });
 });

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -146,8 +146,23 @@
      while the output section manages its own overflow to keep scrollbars visible. */
   .cell-card {
     @apply rounded-nb-md border border-nb-border-strong bg-white shadow-paper;
+    @apply border-l-[3px] border-l-transparent;
     @apply transition-shadow duration-200;
     @apply focus-within:ring-1 focus-within:ring-nb-accent focus-within:ring-offset-1;
+  }
+
+  .cell-card[data-exec-state="pending"],
+  .cell-card[data-exec-state="running"] {
+    @apply border-l-amber-400;
+    animation: pulse-border 1.5s ease-in-out infinite;
+  }
+
+  .cell-card[data-exec-state="success"] {
+    @apply border-l-green-400;
+  }
+
+  .cell-card[data-exec-state="error"] {
+    @apply border-l-red-400;
   }
 
   /* Thin toolbar row inside a cell card (between editor and output) */
@@ -214,7 +229,15 @@
 }
 
 /* ═══════════════════════════════════════════════════════════════════
-   6. Vendor overrides
+   6. Animations
+   ═══════════════════════════════════════════════════════════════════ */
+@keyframes pulse-border {
+  0%, 100% { border-left-color: #fbbf24; }
+  50% { border-left-color: transparent; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   7. Vendor overrides
    ═══════════════════════════════════════════════════════════════════ */
 
 /* Monaco dark-theme: dark gutter with subtle right divider */

--- a/app/test/browser/test-notebook-ui.sh
+++ b/app/test/browser/test-notebook-ui.sh
@@ -301,6 +301,27 @@ fi
 screenshot "07-notebook-rendered"
 
 # ============================================================
+# Phase 8: Verify exec-state and bracket UI elements
+# ============================================================
+log ""
+log "=== Phase 8: Cell execution state UI ==="
+
+# Check that cell-card elements have the data-exec-state attribute
+page_html=$(agent-browser eval "document.documentElement.outerHTML" 2>/dev/null || true)
+if echo "$page_html" | grep -q 'data-exec-state'; then
+    pass "Cell card has data-exec-state attribute"
+else
+    fail "Cell card missing data-exec-state attribute"
+fi
+
+# Check that the bracket label element exists in the toolbar
+if echo "$page_html" | grep -q 'data-testid="cell-bracket"'; then
+    pass "Cell bracket label rendered in toolbar"
+else
+    fail "Cell bracket label NOT found in toolbar"
+fi
+
+# ============================================================
 # Cleanup and Summary
 # ============================================================
 

--- a/app/test/fixtures/notebooks/stdin-prompt-test.runme.md
+++ b/app/test/fixtures/notebooks/stdin-prompt-test.runme.md
@@ -1,0 +1,31 @@
+---
+runme:
+  id: stdin-prompt-test
+  version: v3
+---
+
+# Stdin Prompt Test
+
+## Echo then prompt
+
+```bash {"name":"echo-then-prompt"}
+echo "Before prompt"
+read -p "Enter your name: " name
+echo "Hello, $name"
+```
+
+## Password-style prompt (no echo)
+
+```bash {"name":"password-prompt"}
+read -sp "Password: " pass
+echo ""
+echo "Got password of length ${#pass}"
+```
+
+## Simple y/n confirmation
+
+```bash {"name":"yn-confirm"}
+echo "About to do something"
+read -p "Continue? [y/n] " answer
+echo "You said: $answer"
+```


### PR DESCRIPTION
## Summary

- **Execution state machine** (`idle → pending → running → success → error`) with colored left-border indicators on cell cards and bracket notation (`[ ]`, `[*]`, `[1]`, `[!]`) in the gutter — addresses #38
- **150ms timeout-based flush** for partial stdout lines (e.g. `Password:`, `[y/n]`) in both the React CellConsole component and the `bindStreamsToCell` data layer, with IOPub classification deferral preserved — addresses #99
- **13 unit tests** covering exec state transitions and stdout flush behavior
- **Browser integration test** fixture (`stdin-prompt-test.runme.md`) and Phase 8 in `test-notebook-ui.sh`

### Changes

| File | What changed |
|------|-------------|
| `Actions.tsx` | `CellExecState` type, rewrote `RunActionButton`, added `pending` state + `handlePid` + `execState` derivation, `data-exec-state` attribute, colored bracket |
| `CellConsole.tsx` | `flushTimerRef` with 150ms timeout for partial lines, cleanup on unmount |
| `notebookData.ts` | `flushTimer` in `bindStreamsToCell`, `appendStdoutChunk` returns boolean to preserve IOPub deferral, timer cleanup in exitCode/errors/dispose |
| `index.css` | Left-border indicators per exec state, `pulse-border` keyframe animation on border-left-color |
| `Actions.test.tsx` | 6 new tests: idle bracket, pending on click, running on PID, success/error on exitCode, re-run reset |
| `CellConsole.test.tsx` | 3 new tests: partial line flush, no double-write, complete lines immediate |
| `test-notebook-ui.sh` | Phase 8: verify `data-exec-state` and `cell-bracket` in page |
| `stdin-prompt-test.runme.md` | New fixture with echo+prompt, password prompt, y/n confirm cells |

## Test plan

- [x] `pnpm run build` passes
- [x] All 13 unit tests pass (`vitest run src/components/Actions/`)
- [ ] Browser smoke test (`test-smoke.sh`) with frontend running
- [ ] Manual verification: run a cell, observe pending → running → success/error transitions
- [ ] Manual verification: run a cell with `read -p "prompt: "`, confirm prompt appears within ~150ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)