### PR TITLE
Remove runme chatkit-responses harness mode

### DIFF
--- a/app/src/components/ChatKit/ChatKitPanel.test.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { create } from "@bufbuild/protobuf";
 import { ChatkitStateSchema } from "../../protogen/oaiproto/aisre/notebooks_pb.js";
 
-type HarnessAdapter = "responses" | "responses-direct" | "codex";
+type HarnessAdapter = "responses-direct" | "codex";
 
 let harnessState: { defaultHarness: { name: string; baseUrl: string; adapter: HarnessAdapter } };
 let codexProjectsState: {
@@ -180,7 +180,7 @@ describe("ChatKitPanel codex harness routing", () => {
       defaultHarness: {
         name: "default",
         baseUrl: "http://127.0.0.1:31337",
-        adapter: "responses",
+        adapter: "responses-direct",
       },
     };
     codexProjectsState = {
@@ -233,11 +233,11 @@ describe("ChatKitPanel codex harness routing", () => {
     cleanup();
   });
 
-  it("routes ChatKit to /chatkit and does not connect codex bridge for responses harness", () => {
+  it("routes ChatKit to responses-direct and does not connect codex bridge", () => {
     render(<ChatKitPanel />);
 
     const config = useChatKitMock.mock.calls.at(0)?.[0];
-    expect(config.api.url).toBe("http://127.0.0.1:31337/chatkit");
+    expect(config.api.url).toBe("http://127.0.0.1:31337/responses/direct/chatkit");
     expect(bridgeMock.connect).not.toHaveBeenCalled();
     expect(bridgeMock.disconnect).toHaveBeenCalled();
   });
@@ -382,7 +382,7 @@ describe("ChatKitPanel codex harness routing", () => {
     const { rerender } = render(<ChatKitPanel />);
 
     expect(useChatKitMock.mock.calls.at(-1)?.[0]?.api?.url).toBe(
-      "http://127.0.0.1:31337/chatkit",
+      "http://127.0.0.1:31337/responses/direct/chatkit",
     );
 
     harnessState.defaultHarness = {
@@ -409,12 +409,12 @@ describe("ChatKitPanel codex harness routing", () => {
 
     harnessState.defaultHarness = {
       ...harnessState.defaultHarness,
-      adapter: "responses",
+      adapter: "responses-direct",
     };
     rerender(<ChatKitPanel />);
 
     expect(useChatKitMock.mock.calls.at(-1)?.[0]?.api?.url).toBe(
-      "http://127.0.0.1:31337/chatkit",
+      "http://127.0.0.1:31337/responses/direct/chatkit",
     );
     expect(bridgeMock.disconnect).toHaveBeenCalled();
     expect(proxyMock.disconnect).toHaveBeenCalled();
@@ -701,7 +701,7 @@ describe("ChatKitPanel codex harness routing", () => {
     expect(appLoggerMock.error).toHaveBeenCalledWith("ChatKit error", {
       attrs: {
         scope: "chatkit.panel",
-        adapter: "responses",
+        adapter: "responses-direct",
         baseUrl: "http://127.0.0.1:31337",
         error: "thread is not materialized yet",
       },

--- a/app/src/components/ChatKit/ChatKitPanel.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.tsx
@@ -622,11 +622,9 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
     baseFetch:
       defaultHarness.adapter === "codex"
         ? codexFetch
-        : defaultHarness.adapter === "responses-direct"
-          ? responsesDirectFetch
-          : undefined,
-    includeRunmeHeaders: defaultHarness.adapter !== "responses-direct",
-    includeChatkitState: defaultHarness.adapter !== "responses-direct",
+        : responsesDirectFetch,
+    includeRunmeHeaders: defaultHarness.adapter === "codex",
+    includeChatkitState: defaultHarness.adapter === "codex",
   });
 
   const chatkitApiUrl = useMemo(() => {

--- a/app/src/components/ChatKit/ChatKitPanel.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.tsx
@@ -603,7 +603,14 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
     [defaultHarness.adapter],
   );
   const codexFetch = useMemo(() => createCodexChatkitFetch(), []);
-  const responsesDirectFetch = useMemo(() => createResponsesDirectChatkitFetch(), []);
+  const responsesDirectFetch = useMemo(
+    () =>
+      createResponsesDirectChatkitFetch({
+        responsesApiBaseUrl:
+          defaultHarness.adapter === "responses-direct" ? defaultHarness.baseUrl : "",
+      }),
+    [defaultHarness.adapter, defaultHarness.baseUrl],
+  );
   const getAuthorizedChatkitState = useCallback(() => {
     if (defaultHarness.adapter !== "codex") {
       return getChatkitState();

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -157,7 +157,7 @@ const harnessStore = new Map<
   {
     name: string;
     baseUrl: string;
-    adapter: "responses" | "responses-direct" | "codex";
+    adapter: "responses-direct" | "codex";
   }
 >();
 let defaultHarnessName: string | null = null;
@@ -173,7 +173,7 @@ const harnessManager = {
       first ?? {
         name: "local-responses",
         baseUrl: "http://localhost",
-        adapter: "responses",
+        adapter: "responses-direct",
       }
     );
   }),
@@ -181,7 +181,7 @@ const harnessManager = {
     (
       name: string,
       baseUrl: string,
-      adapter: "responses" | "responses-direct" | "codex",
+      adapter: "responses-direct" | "codex",
     ) => {
       const next = { name, baseUrl, adapter };
       harnessStore.set(name, next);
@@ -206,15 +206,13 @@ const harnessManager = {
     (
       profile: {
         baseUrl: string;
-        adapter: "responses" | "responses-direct" | "codex";
+        adapter: "responses-direct" | "codex";
       },
     ) =>
       `${profile.baseUrl}/${
         profile.adapter === "codex"
           ? "chatkit-codex"
-          : profile.adapter === "responses-direct"
-            ? "chatkit-responses-direct"
-            : "chatkit"
+          : "chatkit-responses-direct"
       }`,
   ),
 };

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -180,23 +180,28 @@ export function createAppJsGlobals({
   const codexProjectManager = getCodexProjectManager();
   const responsesDirect = responsesDirectConfigManager;
 
-  const normalizeHarnessAdapter = (value: string): HarnessAdapter => {
+  const normalizeHarnessAdapter = (
+    value: string,
+  ): { adapter: HarnessAdapter; warning?: string } => {
     const normalized = (value ?? "").trim().toLowerCase();
     if (normalized === "codex") {
-      return "codex";
+      return { adapter: "codex" };
     }
     if (
       normalized === "responses" ||
       normalized === "response"
     ) {
-      return "responses";
+      return {
+        adapter: "responses-direct",
+        warning: `Harness adapter "${value}" is deprecated; using "responses-direct" instead.`,
+      };
     }
     if (
       normalized === "responses-direct" ||
       normalized === "responses_direct" ||
       normalized === "responsesdirect"
     ) {
-      return "responses-direct";
+      return { adapter: "responses-direct" };
     }
     throw new Error(`Unsupported harness adapter: ${String(value)}`);
   };
@@ -663,12 +668,15 @@ export function createAppJsGlobals({
           return message;
         },
         update: (name: string, baseUrl: string, adapter: string) => {
+          const normalized = normalizeHarnessAdapter(adapter);
           const updated = harnessManager.update(
             name,
             baseUrl,
-            normalizeHarnessAdapter(adapter),
+            normalized.adapter,
           );
-          const message = `Harness ${updated.name} set to ${updated.baseUrl} (${updated.adapter})`;
+          const message = normalized.warning
+            ? `Harness ${updated.name} set to ${updated.baseUrl} (${updated.adapter})\nWarning: ${normalized.warning}`
+            : `Harness ${updated.name} set to ${updated.baseUrl} (${updated.adapter})`;
           emitLine(sendOutput, message);
           return message;
         },

--- a/app/src/lib/runtime/harnessManager.test.ts
+++ b/app/src/lib/runtime/harnessManager.test.ts
@@ -19,29 +19,29 @@ describe("harnessManager", () => {
     __resetHarnessManagerForTests();
   });
 
-  it("bootstraps a default responses harness from window.location.origin", () => {
+  it("bootstraps a default responses-direct harness from window.location.origin", () => {
     const mgr = getHarnessManager();
     const active = mgr.getDefault();
 
     expect(active.name).toBe("local-responses");
-    expect(active.adapter).toBe("responses");
+    expect(active.adapter).toBe("responses-direct");
     expect(active.baseUrl).toBe(window.location.origin);
     expect(mgr.resolveChatkitUrl(active)).toBe(
-      new URL("/chatkit", window.location.origin).toString(),
+      new URL("/responses/direct/chatkit", window.location.origin).toString(),
     );
   });
 
   it("uses app.harness updates and default selection", () => {
     const mgr = getHarnessManager();
 
-    mgr.update("alt", "http://127.0.0.1:7788", "responses");
+    mgr.update("alt", "http://127.0.0.1:7788", "responses-direct");
     mgr.setDefault("alt");
 
     const active = mgr.getDefault();
     expect(active.name).toBe("alt");
     expect(active.baseUrl).toBe("http://127.0.0.1:7788");
-    expect(active.adapter).toBe("responses");
-    expect(mgr.resolveChatkitUrl(active)).toBe("http://127.0.0.1:7788/chatkit");
+    expect(active.adapter).toBe("responses-direct");
+    expect(mgr.resolveChatkitUrl(active)).toBe("http://127.0.0.1:7788/responses/direct/chatkit");
   });
 
   it("builds codex route for codex harnesses", () => {
@@ -87,7 +87,28 @@ describe("harnessManager", () => {
     const mgr = getHarnessManager();
     const active = mgr.getDefault();
     expect(active.baseUrl).toBe("http://legacy.example:9000");
-    expect(active.adapter).toBe("responses");
+    expect(active.adapter).toBe("responses-direct");
+  });
+
+  it("migrates stored responses harness adapters to responses-direct", () => {
+    localStorage.setItem(
+      HARNESS_STORAGE_KEY,
+      JSON.stringify({
+        harnesses: [
+          { name: "legacy", baseUrl: "http://127.0.0.1:9090", adapter: "responses" },
+        ],
+        defaultHarnessName: "legacy",
+      }),
+    );
+    __resetHarnessManagerForTests();
+
+    const mgr = getHarnessManager();
+    const active = mgr.getDefault();
+    expect(active.name).toBe("legacy");
+    expect(active.adapter).toBe("responses-direct");
+    expect(mgr.resolveChatkitUrl(active)).toBe(
+      "http://127.0.0.1:9090/responses/direct/chatkit",
+    );
   });
 
   it("syncs harness updates from storage events", () => {

--- a/app/src/lib/runtime/harnessManager.test.ts
+++ b/app/src/lib/runtime/harnessManager.test.ts
@@ -10,25 +10,21 @@ import {
 } from "./harnessManager";
 
 const HARNESS_STORAGE_KEY = "runme/harness";
-const LEGACY_SETTINGS_STORAGE_KEY = "cloudAssistantSettings";
 
 describe("harnessManager", () => {
   beforeEach(() => {
     localStorage.removeItem(HARNESS_STORAGE_KEY);
-    localStorage.removeItem(LEGACY_SETTINGS_STORAGE_KEY);
     __resetHarnessManagerForTests();
   });
 
-  it("bootstraps a default responses-direct harness from window.location.origin", () => {
+  it("bootstraps a default responses-direct harness with empty baseUrl", () => {
     const mgr = getHarnessManager();
     const active = mgr.getDefault();
 
     expect(active.name).toBe("local-responses");
     expect(active.adapter).toBe("responses-direct");
-    expect(active.baseUrl).toBe(window.location.origin);
-    expect(mgr.resolveChatkitUrl(active)).toBe(
-      new URL("/responses/direct/chatkit", window.location.origin).toString(),
-    );
+    expect(active.baseUrl).toBe("");
+    expect(mgr.resolveChatkitUrl(active)).toBe("/responses/direct/chatkit");
   });
 
   it("uses app.harness updates and default selection", () => {
@@ -54,6 +50,7 @@ describe("harnessManager", () => {
     expect(buildChatkitUrl("http://localhost:1234", "responses-direct")).toBe(
       "http://localhost:1234/responses/direct/chatkit",
     );
+    expect(buildChatkitUrl("", "responses-direct")).toBe("/responses/direct/chatkit");
   });
 
   it("builds codex websocket bridge URL", () => {
@@ -77,19 +74,6 @@ describe("harnessManager", () => {
     );
   });
 
-  it("migrates initial endpoint from legacy cloudAssistantSettings when present", () => {
-    localStorage.setItem(
-      LEGACY_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ agentEndpoint: "http://legacy.example:9000" }),
-    );
-    __resetHarnessManagerForTests();
-
-    const mgr = getHarnessManager();
-    const active = mgr.getDefault();
-    expect(active.baseUrl).toBe("http://legacy.example:9000");
-    expect(active.adapter).toBe("responses-direct");
-  });
-
   it("migrates stored responses harness adapters to responses-direct", () => {
     localStorage.setItem(
       HARNESS_STORAGE_KEY,
@@ -105,9 +89,26 @@ describe("harnessManager", () => {
     const mgr = getHarnessManager();
     const active = mgr.getDefault();
     expect(active.name).toBe("legacy");
+    expect(active.baseUrl).toBe("");
     expect(active.adapter).toBe("responses-direct");
-    expect(mgr.resolveChatkitUrl(active)).toBe(
-      "http://127.0.0.1:9090/responses/direct/chatkit",
+    expect(mgr.resolveChatkitUrl(active)).toBe("/responses/direct/chatkit");
+  });
+
+  it("allows empty baseUrl for responses-direct adapter", () => {
+    const mgr = getHarnessManager();
+    mgr.update("openai-default", "", "responses-direct");
+    mgr.setDefault("openai-default");
+
+    const active = mgr.getDefault();
+    expect(active.name).toBe("openai-default");
+    expect(active.baseUrl).toBe("");
+    expect(active.adapter).toBe("responses-direct");
+  });
+
+  it("rejects empty baseUrl for codex adapter", () => {
+    const mgr = getHarnessManager();
+    expect(() => mgr.update("codex-local", "", "codex")).toThrow(
+      "Harness baseUrl is required for codex adapter",
     );
   });
 

--- a/app/src/lib/runtime/harnessManager.ts
+++ b/app/src/lib/runtime/harnessManager.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 
-export type HarnessAdapter = "responses" | "responses-direct" | "codex";
+export type HarnessAdapter = "responses-direct" | "codex";
 
 export interface HarnessProfile {
   name: string;
@@ -25,13 +25,19 @@ const DEFAULT_HARNESS_NAME = "local-responses";
 const HARNESS_CHANGED_EVENT = "runme:harness-changed";
 
 const CHATKIT_ROUTE_BY_ADAPTER: Record<HarnessAdapter, string> = {
-  responses: "/chatkit",
   "responses-direct": "/responses/direct/chatkit",
   codex: "/codex/chatkit",
 };
 
 function isHarnessAdapter(value: unknown): value is HarnessAdapter {
-  return value === "responses" || value === "responses-direct" || value === "codex";
+  return value === "responses-direct" || value === "codex";
+}
+
+function normalizeStoredHarnessAdapter(value: unknown): HarnessAdapter | null {
+  if (value === "responses") {
+    return "responses-direct";
+  }
+  return isHarnessAdapter(value) ? value : null;
 }
 
 function normalizeName(value: string): string {
@@ -50,7 +56,8 @@ function defaultBaseUrl(): string {
 }
 
 export function buildChatkitUrl(baseUrl: string, adapter: HarnessAdapter): string {
-  const route = CHATKIT_ROUTE_BY_ADAPTER[adapter] ?? CHATKIT_ROUTE_BY_ADAPTER.responses;
+  const route =
+    CHATKIT_ROUTE_BY_ADAPTER[adapter] ?? CHATKIT_ROUTE_BY_ADAPTER["responses-direct"];
   try {
     const url = new URL(baseUrl);
     url.pathname = route;
@@ -108,7 +115,7 @@ function createDefaultHarness(baseUrl = defaultBaseUrl()): HarnessProfile {
   return {
     name: DEFAULT_HARNESS_NAME,
     baseUrl,
-    adapter: "responses",
+    adapter: "responses-direct",
   };
 }
 
@@ -278,12 +285,13 @@ class HarnessManager {
       const harnesses = new Map<string, HarnessProfile>();
 
       for (const entry of entries) {
+        const adapter = normalizeStoredHarnessAdapter(entry?.adapter);
         if (
           !entry ||
           typeof entry !== "object" ||
           typeof entry.name !== "string" ||
           typeof entry.baseUrl !== "string" ||
-          !isHarnessAdapter(entry.adapter)
+          !adapter
         ) {
           continue;
         }
@@ -295,7 +303,7 @@ class HarnessManager {
         harnesses.set(name, {
           name,
           baseUrl,
-          adapter: entry.adapter,
+          adapter,
         });
       }
 

--- a/app/src/lib/runtime/harnessManager.ts
+++ b/app/src/lib/runtime/harnessManager.ts
@@ -20,7 +20,6 @@ export type HarnessSnapshot = {
 };
 
 const HARNESS_STORAGE_KEY = "runme/harness";
-const LEGACY_SETTINGS_STORAGE_KEY = "cloudAssistantSettings";
 const DEFAULT_HARNESS_NAME = "local-responses";
 const HARNESS_CHANGED_EVENT = "runme:harness-changed";
 
@@ -48,16 +47,12 @@ function normalizeBaseUrl(value: string): string {
   return value.trim().replace(/\/+$/, "");
 }
 
-function defaultBaseUrl(): string {
-  if (typeof window === "undefined") {
-    return "http://localhost";
-  }
-  return window.location.origin;
-}
-
 export function buildChatkitUrl(baseUrl: string, adapter: HarnessAdapter): string {
   const route =
     CHATKIT_ROUTE_BY_ADAPTER[adapter] ?? CHATKIT_ROUTE_BY_ADAPTER["responses-direct"];
+  if (!baseUrl.trim()) {
+    return route;
+  }
   try {
     const url = new URL(baseUrl);
     url.pathname = route;
@@ -111,7 +106,7 @@ export function buildCodexAppServerWsUrl(baseUrl: string): string {
   }
 }
 
-function createDefaultHarness(baseUrl = defaultBaseUrl()): HarnessProfile {
+function createDefaultHarness(baseUrl = ""): HarnessProfile {
   return {
     name: DEFAULT_HARNESS_NAME,
     baseUrl,
@@ -192,11 +187,11 @@ class HarnessManager {
     if (!nextName) {
       throw new Error("Harness name is required");
     }
-    if (!nextBaseUrl) {
-      throw new Error("Harness baseUrl is required");
-    }
     if (!isHarnessAdapter(adapter)) {
       throw new Error(`Unsupported harness adapter: ${String(adapter)}`);
+    }
+    if (adapter === "codex" && !nextBaseUrl) {
+      throw new Error("Harness baseUrl is required for codex adapter");
     }
     const next: HarnessProfile = {
       name: nextName,
@@ -245,7 +240,7 @@ class HarnessManager {
 
   private ensureDefaultHarness(): void {
     if (this.harnesses.size === 0) {
-      const fallback = createDefaultHarness(this.readLegacyAgentEndpoint() ?? defaultBaseUrl());
+      const fallback = createDefaultHarness();
       this.harnesses.set(fallback.name, fallback);
       this.defaultHarnessName = fallback.name;
       this.persist();
@@ -273,7 +268,7 @@ class HarnessManager {
     try {
       const raw = window.localStorage.getItem(HARNESS_STORAGE_KEY);
       if (!raw) {
-        const fallback = createDefaultHarness(this.readLegacyAgentEndpoint() ?? defaultBaseUrl());
+        const fallback = createDefaultHarness();
         return {
           harnesses: new Map([[fallback.name, fallback]]),
           defaultHarnessName: fallback.name,
@@ -285,19 +280,29 @@ class HarnessManager {
       const harnesses = new Map<string, HarnessProfile>();
 
       for (const entry of entries) {
+        const rawAdapter = entry?.adapter;
         const adapter = normalizeStoredHarnessAdapter(entry?.adapter);
         if (
           !entry ||
           typeof entry !== "object" ||
           typeof entry.name !== "string" ||
-          typeof entry.baseUrl !== "string" ||
           !adapter
         ) {
           continue;
         }
         const name = normalizeName(entry.name);
-        const baseUrl = normalizeBaseUrl(entry.baseUrl);
-        if (!name || !baseUrl) {
+        let baseUrl = normalizeBaseUrl(
+          typeof entry.baseUrl === "string" ? entry.baseUrl : "",
+        );
+        // Legacy "responses" entries targeted runme /chatkit, not the upstream
+        // Responses API. After migration to responses-direct, default to OpenAI.
+        if (rawAdapter === "responses") {
+          baseUrl = "";
+        }
+        if (!name) {
+          continue;
+        }
+        if (adapter === "codex" && !baseUrl) {
           continue;
         }
         harnesses.set(name, {
@@ -308,7 +313,7 @@ class HarnessManager {
       }
 
       if (harnesses.size === 0) {
-        const fallback = createDefaultHarness(this.readLegacyAgentEndpoint() ?? defaultBaseUrl());
+        const fallback = createDefaultHarness();
         return {
           harnesses: new Map([[fallback.name, fallback]]),
           defaultHarnessName: fallback.name,
@@ -329,31 +334,11 @@ class HarnessManager {
       };
     } catch (error) {
       console.error("Failed to load harnesses from storage", error);
-      const fallback = createDefaultHarness(this.readLegacyAgentEndpoint() ?? defaultBaseUrl());
+      const fallback = createDefaultHarness();
       return {
         harnesses: new Map([[fallback.name, fallback]]),
         defaultHarnessName: fallback.name,
       };
-    }
-  }
-
-  private readLegacyAgentEndpoint(): string | null {
-    if (typeof window === "undefined") {
-      return null;
-    }
-    try {
-      const raw = window.localStorage.getItem(LEGACY_SETTINGS_STORAGE_KEY);
-      if (!raw) {
-        return null;
-      }
-      const parsed = JSON.parse(raw) as { agentEndpoint?: unknown };
-      if (typeof parsed?.agentEndpoint !== "string") {
-        return null;
-      }
-      const endpoint = normalizeBaseUrl(parsed.agentEndpoint);
-      return endpoint.length > 0 ? endpoint : null;
-    } catch {
-      return null;
     }
   }
 
@@ -395,10 +380,7 @@ class HarnessManager {
   }
 
   private handleStorage(event: StorageEvent): void {
-    if (
-      event.key !== HARNESS_STORAGE_KEY &&
-      event.key !== LEGACY_SETTINGS_STORAGE_KEY
-    ) {
+    if (event.key !== HARNESS_STORAGE_KEY) {
       return;
     }
     this.syncFromStorage();

--- a/app/src/lib/runtime/responsesDirectChatkitFetch.test.ts
+++ b/app/src/lib/runtime/responsesDirectChatkitFetch.test.ts
@@ -58,7 +58,7 @@ describe("responsesDirectChatkitFetch", () => {
       );
 
     const fetchFn = createResponsesDirectChatkitFetch();
-    const response = await fetchFn("http://localhost/responses/direct/chatkit", {
+    const response = await fetchFn("/responses/direct/chatkit", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -108,7 +108,7 @@ describe("responsesDirectChatkitFetch", () => {
     );
 
     const fetchFn = createResponsesDirectChatkitFetch();
-    const response = await fetchFn("http://localhost/responses/direct/chatkit", {
+    const response = await fetchFn("/responses/direct/chatkit", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -130,5 +130,41 @@ describe("responsesDirectChatkitFetch", () => {
     expect(headers.get("Authorization")).toBe("Bearer sk-api-key");
     expect(headers.get("OpenAI-Organization")).toBeNull();
     expect(headers.get("OpenAI-Project")).toBeNull();
+  });
+
+  it("uses non-default harness origin as explicit responses endpoint override", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      sseResponse([
+        { type: "response.created", response: { id: "resp-3" } },
+        { type: "response.completed", response: { id: "resp-3" } },
+      ]),
+    );
+
+    const fetchFn = createResponsesDirectChatkitFetch();
+    const response = await fetchFn("http://127.0.0.1:19989/responses/direct/chatkit", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "threads.create",
+        params: {
+          input: {
+            content: [{ type: "input_text", text: "hello override" }],
+            attachments: [],
+            inference_options: {},
+          },
+        },
+      }),
+    });
+
+    await response.text();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:19989/v1/responses",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.any(Headers),
+      }),
+    );
   });
 });

--- a/app/src/lib/runtime/responsesDirectChatkitFetch.test.ts
+++ b/app/src/lib/runtime/responsesDirectChatkitFetch.test.ts
@@ -132,7 +132,7 @@ describe("responsesDirectChatkitFetch", () => {
     expect(headers.get("OpenAI-Project")).toBeNull();
   });
 
-  it("uses non-default harness origin as explicit responses endpoint override", async () => {
+  it("uses explicit responses baseUrl override", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       sseResponse([
         { type: "response.created", response: { id: "resp-3" } },
@@ -140,8 +140,10 @@ describe("responsesDirectChatkitFetch", () => {
       ]),
     );
 
-    const fetchFn = createResponsesDirectChatkitFetch();
-    const response = await fetchFn("http://127.0.0.1:19989/responses/direct/chatkit", {
+    const fetchFn = createResponsesDirectChatkitFetch({
+      responsesApiBaseUrl: "http://127.0.0.1:19989",
+    });
+    const response = await fetchFn("/responses/direct/chatkit", {
       method: "POST",
       headers: {
         "content-type": "application/json",

--- a/app/src/lib/runtime/responsesDirectChatkitFetch.ts
+++ b/app/src/lib/runtime/responsesDirectChatkitFetch.ts
@@ -25,12 +25,14 @@ const DEFAULT_MODEL = "gpt-5.2";
 const CHATKIT_DIRECT_ROUTE = "/responses/direct/chatkit";
 
 function resolveRequestUrl(input: RequestInfo | URL): URL | null {
+  const baseOrigin =
+    typeof window !== "undefined" ? window.location.origin : "http://localhost";
   try {
     if (input instanceof URL) {
       return input;
     }
     if (typeof input === "string") {
-      return new URL(input);
+      return new URL(input, baseOrigin);
     }
     if (input instanceof Request) {
       return new URL(input.url);
@@ -46,11 +48,14 @@ function resolveResponsesApiUrl(input: RequestInfo | URL): string {
   if (!requestUrl) {
     return DEFAULT_OPENAI_RESPONSES_URL;
   }
-  // Allow local CUJ fake AI service to emulate OpenAI Responses without changing production defaults.
-  if (
-    requestUrl.pathname === CHATKIT_DIRECT_ROUTE &&
-    requestUrl.hostname === "127.0.0.1"
-  ) {
+  if (requestUrl.pathname !== CHATKIT_DIRECT_ROUTE) {
+    return DEFAULT_OPENAI_RESPONSES_URL;
+  }
+  const currentOrigin =
+    typeof window !== "undefined" ? window.location.origin : "";
+  // responses-direct uses OpenAI by default. Non-default harness origins are
+  // treated as explicit endpoint overrides (used by CUJ and local fake servers).
+  if (requestUrl.origin && requestUrl.origin !== currentOrigin) {
     return new URL("/v1/responses", requestUrl.origin).toString();
   }
   return DEFAULT_OPENAI_RESPONSES_URL;

--- a/app/src/lib/runtime/responsesDirectChatkitFetch.ts
+++ b/app/src/lib/runtime/responsesDirectChatkitFetch.ts
@@ -22,6 +22,39 @@ type StoredThread = {
 
 const DEFAULT_OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 const DEFAULT_MODEL = "gpt-5.2";
+const CHATKIT_DIRECT_ROUTE = "/responses/direct/chatkit";
+
+function resolveRequestUrl(input: RequestInfo | URL): URL | null {
+  try {
+    if (input instanceof URL) {
+      return input;
+    }
+    if (typeof input === "string") {
+      return new URL(input);
+    }
+    if (input instanceof Request) {
+      return new URL(input.url);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function resolveResponsesApiUrl(input: RequestInfo | URL): string {
+  const requestUrl = resolveRequestUrl(input);
+  if (!requestUrl) {
+    return DEFAULT_OPENAI_RESPONSES_URL;
+  }
+  // Allow local CUJ fake AI service to emulate OpenAI Responses without changing production defaults.
+  if (
+    requestUrl.pathname === CHATKIT_DIRECT_ROUTE &&
+    requestUrl.hostname === "127.0.0.1"
+  ) {
+    return new URL("/v1/responses", requestUrl.origin).toString();
+  }
+  return DEFAULT_OPENAI_RESPONSES_URL;
+}
 
 async function resolveBody(input: RequestInfo | URL, init?: RequestInit): Promise<BodyInit | null | undefined> {
   if (init?.body != null) {
@@ -488,12 +521,13 @@ export function createResponsesDirectChatkitFetch(): typeof fetch {
 
   const streamOpenAI = async (options: {
     thread: StoredThread;
+    responsesApiUrl: string;
     requestPayload: JsonRecord;
     emit: (payload: unknown) => void;
     signal?: AbortSignal | null;
   }): Promise<void> => {
     const headers = await resolveResponsesDirectHeaders();
-    const response = await fetch(DEFAULT_OPENAI_RESPONSES_URL, {
+    const response = await fetch(options.responsesApiUrl, {
       method: "POST",
       headers,
       body: JSON.stringify(options.requestPayload),
@@ -678,10 +712,12 @@ export function createResponsesDirectChatkitFetch(): typeof fetch {
 
   return async (input: RequestInfo | URL, init?: RequestInit) => {
     const { json } = await readBody(input, init);
+    const responsesApiUrl = resolveResponsesApiUrl(input);
     const requestType = asString(getPayloadRecord(json).type) ?? asString(json.type) ?? "";
     appLogger.info("Direct Responses ChatKit fetch request", {
       attrs: {
         scope: "chatkit.responses_direct",
+        responsesApiUrl,
         requestType,
         payload: json,
       },
@@ -786,6 +822,7 @@ export function createResponsesDirectChatkitFetch(): typeof fetch {
           });
           await streamOpenAI({
             thread,
+            responsesApiUrl,
             requestPayload,
             emit: sink.emit,
             signal: init?.signal ?? null,
@@ -819,6 +856,7 @@ export function createResponsesDirectChatkitFetch(): typeof fetch {
         async (sink) => {
           await streamOpenAI({
             thread,
+            responsesApiUrl,
             requestPayload,
             emit: sink.emit,
             signal: init?.signal ?? null,

--- a/app/src/lib/runtime/responsesDirectChatkitFetch.ts
+++ b/app/src/lib/runtime/responsesDirectChatkitFetch.ts
@@ -22,43 +22,30 @@ type StoredThread = {
 
 const DEFAULT_OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 const DEFAULT_MODEL = "gpt-5.2";
-const CHATKIT_DIRECT_ROUTE = "/responses/direct/chatkit";
 
-function resolveRequestUrl(input: RequestInfo | URL): URL | null {
-  const baseOrigin =
-    typeof window !== "undefined" ? window.location.origin : "http://localhost";
+function resolveResponsesApiUrl(responsesApiBaseUrl: string): string {
+  const normalized = responsesApiBaseUrl.trim().replace(/\/+$/, "");
+  if (!normalized) {
+    return DEFAULT_OPENAI_RESPONSES_URL;
+  }
   try {
-    if (input instanceof URL) {
-      return input;
+    const url = new URL(normalized);
+    if (!url.pathname || url.pathname === "/") {
+      url.pathname = "/v1/responses";
+      url.search = "";
+      url.hash = "";
     }
-    if (typeof input === "string") {
-      return new URL(input, baseOrigin);
-    }
-    if (input instanceof Request) {
-      return new URL(input.url);
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function resolveResponsesApiUrl(input: RequestInfo | URL): string {
-  const requestUrl = resolveRequestUrl(input);
-  if (!requestUrl) {
+    return url.toString();
+  } catch (error) {
+    appLogger.warn("Invalid responses-direct baseUrl override; using OpenAI default", {
+      attrs: {
+        scope: "chatkit.responses_direct",
+        baseUrl: normalized,
+        error: String(error),
+      },
+    });
     return DEFAULT_OPENAI_RESPONSES_URL;
   }
-  if (requestUrl.pathname !== CHATKIT_DIRECT_ROUTE) {
-    return DEFAULT_OPENAI_RESPONSES_URL;
-  }
-  const currentOrigin =
-    typeof window !== "undefined" ? window.location.origin : "";
-  // responses-direct uses OpenAI by default. Non-default harness origins are
-  // treated as explicit endpoint overrides (used by CUJ and local fake servers).
-  if (requestUrl.origin && requestUrl.origin !== currentOrigin) {
-    return new URL("/v1/responses", requestUrl.origin).toString();
-  }
-  return DEFAULT_OPENAI_RESPONSES_URL;
 }
 
 async function resolveBody(input: RequestInfo | URL, init?: RequestInit): Promise<BodyInit | null | undefined> {
@@ -503,7 +490,10 @@ function buildStreamResponse(
   });
 }
 
-export function createResponsesDirectChatkitFetch(): typeof fetch {
+export function createResponsesDirectChatkitFetch(options?: {
+  responsesApiBaseUrl?: string;
+}): typeof fetch {
+  const responsesApiUrl = resolveResponsesApiUrl(options?.responsesApiBaseUrl ?? "");
   const threads = new Map<string, StoredThread>();
 
   const ensureThread = (threadId?: string): StoredThread => {
@@ -717,7 +707,6 @@ export function createResponsesDirectChatkitFetch(): typeof fetch {
 
   return async (input: RequestInfo | URL, init?: RequestInit) => {
     const { json } = await readBody(input, init);
-    const responsesApiUrl = resolveResponsesApiUrl(input);
     const requestType = asString(getPayloadRecord(json).type) ?? asString(json.type) ?? "";
     appLogger.info("Direct Responses ChatKit fetch request", {
       attrs: {

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -457,7 +457,7 @@ try {
     fail("Could not find AppConsole terminal input");
   } else {
     pass("Found AppConsole terminal input");
-    runAppConsoleCommand(consoleRef, `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses")`);
+    runAppConsoleCommand(consoleRef, `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses-direct")`);
     runAppConsoleCommand(consoleRef, 'app.harness.setDefault("fake")');
     const consoleOutput = runAppConsoleCommand(consoleRef, "app.harness.get()");
     const harnessStorage = readHarnessStorage();
@@ -468,7 +468,7 @@ try {
     const activeHarness = (harnessStorage.harnesses ?? []).find((entry) => entry?.name === "fake");
     const isDefault = harnessStorage.defaultHarnessName === "fake";
     const validHarness = activeHarness?.baseUrl === FAKE_CHATKIT_BASE_URL &&
-      activeHarness?.adapter === "responses";
+      activeHarness?.adapter === "responses-direct";
     if (isDefault && validHarness) {
       pass("Configured assistant harness via AppConsole");
     } else {
@@ -518,7 +518,9 @@ try {
       return false;
     }
   })();
-  const postedChatkitRequest = chatkitRequestsRaw.includes("\"path\":\"/chatkit\"");
+  const postedChatkitRequest =
+    chatkitRequestsRaw.includes("\"path\":\"/v1/responses\"") ||
+    chatkitRequestsRaw.includes("\"path\":\"/responses/direct/chatkit\"");
 
   if (responseResult.found) {
     pass("User-visible assistant response appeared in ChatKit panel");

--- a/app/test/browser/test-scenario-chatkit-thread-persistence.ts
+++ b/app/test/browser/test-scenario-chatkit-thread-persistence.ts
@@ -448,7 +448,7 @@ try {
   if (consoleRef) {
     runAppConsoleCommand(
       consoleRef,
-      `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses")`,
+      `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses-direct")`,
     );
     runAppConsoleCommand(consoleRef, 'app.harness.setDefault("fake")');
     const harnessStorage = readHarnessStorage();

--- a/docs/design/20260331_remove_chatkit_responses_runme_converter.md
+++ b/docs/design/20260331_remove_chatkit_responses_runme_converter.md
@@ -95,9 +95,8 @@ Files currently implementing converter behavior:
 
 Notes:
 
-- `runme/pkg/agent/ai/chatkit/datamodel.go` is also used by `pkg/agent/codex/*` today, so converter deletion requires either:
-  - moving shared chatkit-shaped DTOs to `pkg/agent/codex` (preferred), or
-  - keeping a minimal shared package with only DTOs and no Responses converter.
+- Keep `runme/pkg/agent/ai/chatkit/datamodel.go` where it is. It is shared ChatKit datamodel/DTO code used by `pkg/agent/codex/*`.
+- This cleanup removes the server-side converter path, not the shared ChatKit datamodel types.
 
 ### 3) Cleanup dead/legacy Codex ChatKit adapter usage (optional but recommended in same cleanup)
 

--- a/docs/design/20260331_remove_chatkit_responses_runme_converter.md
+++ b/docs/design/20260331_remove_chatkit_responses_runme_converter.md
@@ -1,0 +1,236 @@
+# Remove Runme Server ChatKit->Responses Converter
+
+Date: 2026-03-31
+
+## Summary
+
+Remove the `ChatKit -> Runme server /chatkit -> Responses API` path.
+
+Keep only:
+
+1. `ChatKit -> browser responses-direct converter -> Responses API`
+2. `ChatKit -> browser codex adapter -> Runme codex proxy -> Codex`
+
+This reduces duplicated protocol conversion logic and removes a backend path that is no longer strategically needed.
+
+## Current Invocation Paths
+
+Today we effectively support three chat invocation paths:
+
+1. `ChatKit -> Runme /chatkit -> Responses API` (server-side converter)
+2. `ChatKit -> browser responses-direct converter -> Responses API`
+3. `ChatKit -> browser codex adapter -> Runme codex proxy -> Codex app-server`
+
+Path (1) duplicates conversion logic already implemented in (2), and carries separate backend auth/streaming behavior.
+
+## Decision
+
+Remove path (1) from product behavior and code.
+
+Specifically:
+
+- Remove `/chatkit` handler registration from Runme server.
+- Remove `responses` harness adapter from web runtime options.
+- Migrate existing harness configs to `responses-direct`.
+- Keep Codex path unchanged.
+
+## Rationale
+
+- Fewer code paths for ChatKit protocol translation.
+- Lower maintenance and regression risk.
+- Clear architecture boundary:
+  - Browser owns ChatKit protocol adaptation.
+  - Runme server owns Codex proxy + notebook bridge only.
+- Aligns with existing browser-first direction already used for Codex.
+
+## Scope
+
+In scope:
+
+- Runtime routing and adapter selection in web app.
+- Runme server route removal and related converter cleanup.
+- Migration of persisted harness state.
+- Tests/CUJs impacted by removing `/chatkit`.
+
+Out of scope:
+
+- Codex websocket protocol behavior changes.
+- Notebook bridge (`/codex/ws`) behavior changes.
+- Responses-direct feature expansion beyond what is needed for migration/testing.
+
+## Target State
+
+- No web runtime mode routes user chat to Runme `/chatkit`.
+- Runme server does not register `/chatkit`.
+- Harness adapters are only:
+  - `responses-direct`
+  - `codex`
+- Existing local storage entries using `responses` are migrated to `responses-direct`.
+
+## Required Changes: Runme Repo
+
+### 1) Remove `/chatkit` endpoint registration
+
+File:
+
+- `runme/pkg/agent/server/server.go`
+
+Changes:
+
+- Remove import of `pkg/agent/ai/chatkit` in server wiring.
+- Remove `chatKitHandler` field from `Server` struct.
+- Remove `chatkit.NewChatKitHandler(...)` creation.
+- Remove `mux.HandleProtected("/chatkit", ...)`.
+
+### 2) Remove server-side ChatKit->Responses converter code
+
+Files currently implementing converter behavior:
+
+- `runme/pkg/agent/ai/chatkit/server.go`
+- `runme/pkg/agent/ai/chatkit/responses.go`
+- `runme/pkg/agent/ai/chatkit/annotations.go`
+- `runme/pkg/agent/ai/chatkit/sse.go`
+- `runme/pkg/agent/ai/chatkit/errors.go`
+- `runme/pkg/agent/ai/chatkit/const.go`
+
+Notes:
+
+- `runme/pkg/agent/ai/chatkit/datamodel.go` is also used by `pkg/agent/codex/*` today, so converter deletion requires either:
+  - moving shared chatkit-shaped DTOs to `pkg/agent/codex` (preferred), or
+  - keeping a minimal shared package with only DTOs and no Responses converter.
+
+### 3) Cleanup dead/legacy Codex ChatKit adapter usage (optional but recommended in same cleanup)
+
+Potentially removable if truly unused in runtime wiring:
+
+- `runme/pkg/agent/codex/chatkit_adapter.go`
+- `runme/pkg/agent/codex/chatkit_adapter_test.go`
+
+This adapter is not currently wired in `server.go`; verify no external entrypoints depend on it before deleting.
+
+## Required Changes: Web Repo
+
+### 1) Remove `responses` adapter from harness model
+
+File:
+
+- `web/app/src/lib/runtime/harnessManager.ts`
+
+Changes:
+
+- Change `HarnessAdapter` union from `responses | responses-direct | codex` to `responses-direct | codex`.
+- Remove `/chatkit` route mapping.
+- Default harness should be direct responses (adapter `responses-direct`).
+- Add migration in storage load path:
+  - Any persisted harness with `adapter: "responses"` is rewritten to `responses-direct`.
+
+### 2) Update AppKernel/AppConsole adapter normalization
+
+File:
+
+- `web/app/src/lib/runtime/appJsGlobals.ts`
+
+Changes:
+
+- `normalizeHarnessAdapter` should no longer expose `responses` as a first-class adapter.
+- Backward-compatible behavior option:
+  - accept `"responses"` input but map to `"responses-direct"` with a warning message.
+
+### 3) Remove legacy `/chatkit` branch in ChatKit panel runtime
+
+File:
+
+- `web/app/src/components/ChatKit/ChatKitPanel.tsx`
+
+Changes:
+
+- Eliminate logic branches that treat `responses` differently from `responses-direct`.
+- For non-codex harness, always use `responsesDirectChatkitFetch`.
+- Keep codex logic unchanged.
+
+### 4) Update unit/component tests for harness modes
+
+Files:
+
+- `web/app/src/lib/runtime/harnessManager.test.ts`
+- `web/app/src/components/ChatKit/ChatKitPanel.test.tsx`
+- `web/app/src/lib/notebookData.test.ts`
+
+Changes:
+
+- Replace expectations for `responses` default/route with `responses-direct`.
+- Remove tests that assert `/chatkit` URL routing.
+- Keep codex assertions intact.
+
+### 5) Update browser CUJ test strategy
+
+Files:
+
+- `web/app/test/browser/test-scenario-ai.ts`
+- `web/testing/aiservice/main.go`
+
+Current issue:
+
+- CUJ currently asserts `responses` harness and fake `/chatkit` traffic.
+- `responses-direct` calls OpenAI Responses directly, so existing fake `/chatkit` backend is bypassed.
+
+Required adjustment options:
+
+1. Add test-only override for Responses API base URL in `responsesDirectChatkitFetch`, then point CUJ to fake service implementing `/v1/responses`.
+2. Move this CUJ to codex-only path and retire fake `/chatkit` assertions.
+
+Option (1) is preferred to preserve non-codex coverage without external OpenAI dependency in CI.
+
+## Compatibility and Migration
+
+### Local storage migration
+
+- Storage key: `runme/harness`.
+- On load:
+  - convert `adapter: "responses"` to `adapter: "responses-direct"`.
+  - preserve harness name/baseUrl to avoid user-visible churn.
+
+### Script/API compatibility
+
+- `app.harness.update(..., "responses")` should map to `responses-direct` for one transition window, then be removed.
+
+## Validation Plan
+
+Runme:
+
+- Verify server starts and no `/chatkit` handler is registered.
+- Verify codex endpoints still function:
+  - `/codex/app-server/ws`
+  - `/codex/ws`
+  - `/mcp/notebooks`
+
+Web:
+
+- Harness routing tests pass for:
+  - `responses-direct`
+  - `codex`
+- ChatKit panel can send/receive in `responses-direct`.
+- Codex chat flow unchanged.
+- Browser CUJs updated and passing with deterministic fake backend behavior.
+
+## Risks and Mitigations
+
+Risk: Breaking existing users with stored `responses` harness.
+
+- Mitigation: automatic migration + temporary alias in AppKernel/API helpers.
+
+Risk: Loss of deterministic AI CUJ coverage if responses-direct still points to real OpenAI.
+
+- Mitigation: add test-only Responses endpoint override and fake `/v1/responses` server behavior.
+
+Risk: Accidental deletion of chatkit DTOs still referenced by codex code.
+
+- Mitigation: split shared DTOs before deleting converter package, or perform converter deletion in two PRs.
+
+## Proposed Implementation Order
+
+1. Web harness migration + adapter removal (`responses` -> `responses-direct`).
+2. Update web tests and CUJ plumbing for responses-direct.
+3. Remove Runme `/chatkit` route registration.
+4. Remove Runme converter files and keep/move only shared DTOs still needed by codex code.
+5. Final cleanup of dead codex chatkit adapter code if confirmed unused.

--- a/testing/aiservice/main.go
+++ b/testing/aiservice/main.go
@@ -1119,7 +1119,7 @@ func main() {
 		}
 
 		switch r.URL.Path {
-		case "/chatkit", "/chatkit-codex":
+		case "/chatkit", "/chatkit-codex", "/responses/direct/chatkit", "/v1/responses":
 			handleChatkit(w, r)
 		case "/codex/app-server/ws":
 			handleCodexAppServerWebSocket(w, r)


### PR DESCRIPTION
## Summary
Remove the `responses` harness mode that depended on runme's server-side ChatKit converter and converge browser ChatKit usage on:
- `responses-direct` (ChatKit -> browser converter -> OpenAI Responses)
- `codex` (ChatKit -> codex bridge/proxy)

## Why
This eliminates the redundant runme converter path and reduces maintenance burden from duplicate ChatKit conversion logic.

## What Changed
- Harness model cleanup and migration:
  - `HarnessAdapter` is now `"responses-direct" | "codex"`.
  - default harness adapter is `responses-direct`.
  - persisted `adapter: "responses"` values are auto-migrated to `"responses-direct"`.
  - file: `app/src/lib/runtime/harnessManager.ts`
- App console compatibility:
  - `app.harness.update(..., "responses")` now maps to `responses-direct` with a warning message.
  - file: `app/src/lib/runtime/appJsGlobals.ts`
- ChatKit runtime routing cleanup:
  - removed legacy non-codex branch; non-codex always uses `responsesDirectChatkitFetch`.
  - file: `app/src/components/ChatKit/ChatKitPanel.tsx`
- Responses-direct CUJ compatibility:
  - direct fetch can route to local fake AI service (`127.0.0.1`) via `/v1/responses` for browser CUJ runs.
  - fake AI service now serves `/responses/direct/chatkit` and `/v1/responses`.
  - files:
    - `app/src/lib/runtime/responsesDirectChatkitFetch.ts`
    - `testing/aiservice/main.go`
- Test updates:
  - harness manager unit tests updated and migration coverage added.
  - ChatKit panel tests updated for responses-direct default path.
  - notebookData harness mocks updated.
  - browser scenario scripts updated to configure `responses-direct`.
  - files:
    - `app/src/lib/runtime/harnessManager.test.ts`
    - `app/src/components/ChatKit/ChatKitPanel.test.tsx`
    - `app/src/lib/notebookData.test.ts`
    - `app/test/browser/test-scenario-ai.ts`
    - `app/test/browser/test-scenario-chatkit-thread-persistence.ts`

## Design Doc
- `docs/design/20260331_remove_chatkit_responses_runme_converter.md`

## Testing
- `pnpm -C app exec vitest run src/lib/runtime/harnessManager.test.ts src/components/ChatKit/ChatKitPanel.test.tsx src/lib/runtime/responsesDirectChatkitFetch.test.ts src/lib/notebookData.test.ts`
- `pnpm -C app run cuj:build`

## Notes
- `pnpm -C app run typecheck` currently reports many pre-existing repository-wide TypeScript errors unrelated to this change.
