### PR TITLE
Fix terminal background color not reflecting theme

### DIFF
--- a/packages/renderers/src/components/console/view.ts
+++ b/packages/renderers/src/components/console/view.ts
@@ -832,8 +832,14 @@ export class ConsoleView extends LitElement {
 
   #updateTerminalTheme(): void {
     const foregroundColor = this.#getThemeHexColor(terminalCSS('foreground'))
+    const termBg = this.#getThemeHexColor(terminalCSS('background'))
+    const backgroundColor =
+      termBg && termBg.startsWith('#')
+        ? termBg
+        : this.#getThemeHexColor(vscodeCSS('editor', 'background'))
 
     const terminalTheme: ITheme = {
+      background: backgroundColor,
       foreground: foregroundColor,
       cursor:
         this.#getThemeHexColor(vscodeCSS('terminalCursor', 'foreground')) ||

--- a/packages/renderers/src/components/console/view.ts
+++ b/packages/renderers/src/components/console/view.ts
@@ -868,8 +868,9 @@ export class ConsoleView extends LitElement {
   #getThemeHexColor(variableName: string): string | undefined {
     const terminalContainer = this.shadowRoot?.querySelector('#terminal')
     return (
-      getComputedStyle(terminalContainer!).getPropertyValue(variableName) ??
-      undefined
+      getComputedStyle(terminalContainer!)
+        .getPropertyValue(variableName)
+        ?.trim() || undefined
     )
   }
 


### PR DESCRIPTION
## Summary
- Resolve the terminal background color from the `terminal.background` CSS variable in `#updateTerminalTheme()`
- Fall back to the VS Code `editor.background` color when the variable is missing or not a valid hex value
- Pass the resolved background into the xterm `ITheme` object so the terminal respects the active theme

## Test plan
- [x] Verify the terminal background matches the active theme in both light and dark modes
- [x] Confirm fallback to `editor.background` when no `terminal.background` variable is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)