### PR TITLE
[codex] Defend Drive sync against local overwrite

### DIFF
--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -876,6 +876,26 @@ export class LocalNotebooks extends Dexie {
     // prefer the local IndexedDB content because overwriting it risks data loss.
     if (!lastReadChecksum && currentRemoteChecksum) {
       if (serializedNotebookHasUserContent(localDoc)) {
+        const parseResult = parseSerializedNotebook(localDoc);
+        if (!parseResult.ok) {
+          appLogger.warn(
+            "Forking unparsable local notebook instead of overwriting Drive",
+            {
+              attrs: {
+                scope: "storage.drive.sync",
+                localUri,
+                remoteUri,
+                remoteChecksum: currentRemoteChecksum,
+                localChecksum,
+                error: String(parseResult.error),
+              },
+            },
+          );
+          await this.handleConflict(localUri, record, currentRemoteChecksum);
+          synced = true;
+          return;
+        }
+
         appLogger.warn(
           "Pushing local notebook to Drive without a baseline checksum",
           {
@@ -888,8 +908,7 @@ export class LocalNotebooks extends Dexie {
             },
           },
         );
-        const notebook = deserializeNotebook(localDoc);
-        await this.driveStore.save(remoteUri, notebook);
+        await this.driveStore.save(remoteUri, parseResult.notebook);
         const updatedChecksum =
           (await this.driveStore.getChecksum(remoteUri)) ?? "";
         await this.files.update(localUri, {
@@ -1101,13 +1120,29 @@ function deserializeNotebook(json: string): parser_pb.Notebook {
   if (!json) {
     return create(parser_pb.NotebookSchema, { cells: [] });
   }
+  const parsed = parseSerializedNotebook(json);
+  if (parsed.ok) {
+    return parsed.notebook;
+  }
+  console.error(
+    "Falling back to empty notebook due to parse failure",
+    parsed.error,
+  );
+  return create(parser_pb.NotebookSchema, { cells: [] });
+}
+
+function parseSerializedNotebook(json: string):
+  | { ok: true; notebook: parser_pb.Notebook }
+  | { ok: false; error: unknown } {
   try {
-    return fromJsonString(parser_pb.NotebookSchema, json, {
-      ignoreUnknownFields: true,
-    });
+    return {
+      ok: true,
+      notebook: fromJsonString(parser_pb.NotebookSchema, json, {
+        ignoreUnknownFields: true,
+      }),
+    };
   } catch (error) {
-    console.error("Falling back to empty notebook due to parse failure", error);
-    return create(parser_pb.NotebookSchema, { cells: [] });
+    return { ok: false, error };
   }
 }
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -876,28 +876,8 @@ export class LocalNotebooks extends Dexie {
     // prefer the local IndexedDB content because overwriting it risks data loss.
     if (!lastReadChecksum && currentRemoteChecksum) {
       if (serializedNotebookHasUserContent(localDoc)) {
-        const parseResult = parseSerializedNotebook(localDoc);
-        if (!parseResult.ok) {
-          appLogger.warn(
-            "Forking unparsable local notebook instead of overwriting Drive",
-            {
-              attrs: {
-                scope: "storage.drive.sync",
-                localUri,
-                remoteUri,
-                remoteChecksum: currentRemoteChecksum,
-                localChecksum,
-                error: String(parseResult.error),
-              },
-            },
-          );
-          await this.handleConflict(localUri, record, currentRemoteChecksum);
-          synced = true;
-          return;
-        }
-
         appLogger.warn(
-          "Pushing local notebook to Drive without a baseline checksum",
+          "Forking local notebook because Drive exists without a baseline checksum",
           {
             attrs: {
               scope: "storage.drive.sync",
@@ -908,14 +888,7 @@ export class LocalNotebooks extends Dexie {
             },
           },
         );
-        await this.driveStore.save(remoteUri, parseResult.notebook);
-        const updatedChecksum =
-          (await this.driveStore.getChecksum(remoteUri)) ?? "";
-        await this.files.update(localUri, {
-          lastRemoteChecksum: updatedChecksum,
-          md5Checksum: localChecksum,
-          lastSynced: nowIsoString(),
-        });
+        await this.handleConflict(localUri, record, currentRemoteChecksum);
         synced = true;
         return;
       }
@@ -1037,8 +1010,28 @@ export class LocalNotebooks extends Dexie {
     const newName = `${baseName}.${timestamp}.json`;
 
     const newFile = await this.driveStore.create(parentRemoteUri, newName);
-    const notebook = deserializeNotebook(record.doc ?? "");
-    await this.driveStore.save(newFile.uri, notebook);
+    const localDoc = record.doc ?? "";
+    const parseResult = parseSerializedNotebook(localDoc);
+    if (parseResult.ok) {
+      await this.driveStore.save(newFile.uri, parseResult.notebook);
+    } else {
+      appLogger.warn(
+        "Saving raw local notebook JSON to conflict file because parsing failed",
+        {
+          attrs: {
+            scope: "storage.drive.sync",
+            localUri,
+            newRemoteUri: newFile.uri,
+            error: String(parseResult.error),
+          },
+        },
+      );
+      await this.driveStore.saveContent(
+        newFile.uri,
+        localDoc,
+        "application/json",
+      );
+    }
 
     await this.files.update(localUri, {
       name: newName,

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -17,6 +17,10 @@ import {
 // Local folder URI is a special folder that contains all notebooks which are local (i.e. not synced to Drive)
 export const LOCAL_FOLDER_URI = "local://folder/local";
 
+const NOTEBOOK_JSON_WRITE_OPTIONS = {
+  emitDefaultValues: true,
+} as unknown as Parameters<typeof toJsonString>[2];
+
 /**
  * LocalFileRecord captures the information needed to persist a notebook locally.
  *
@@ -118,12 +122,12 @@ export class LocalNotebooks extends Dexie {
         folders: "&id, remoteId, name, lastSynced",
       })
       .upgrade(async (tx) => {
-        await tx.table("files").toCollection().modify((file: any) => {
+        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
           if (typeof file.lastSynced !== "string") {
             file.lastSynced = "";
           }
         });
-        await tx.table("folders").toCollection().modify((folder: any) => {
+        await tx.table("folders").toCollection().modify((folder: Partial<LocalFolderRecord>) => {
           if (typeof folder.lastSynced !== "string") {
             folder.lastSynced = "";
           }
@@ -135,7 +139,7 @@ export class LocalNotebooks extends Dexie {
         folders: "&id, remoteId, name, lastSynced",
       })
       .upgrade(async (tx) => {
-        await tx.table("files").toCollection().modify((file: any) => {
+        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
           if (typeof file.md5Checksum !== "string") {
             // Lazy backfill: keep migration cheap and compute missing checksums
             // when we evaluate whether a file needs syncing.
@@ -371,9 +375,11 @@ export class LocalNotebooks extends Dexie {
       );
     }
 
-    const serialized = toJsonString(parser_pb.NotebookSchema, notebook, {
-      emitDefaultValues: true,
-    });
+    const serialized = toJsonString(
+      parser_pb.NotebookSchema,
+      notebook,
+      NOTEBOOK_JSON_WRITE_OPTIONS,
+    );
     const checksum = checksumForSerializedNotebook(serialized);
 
     await this.files.update(uri, { doc: serialized, md5Checksum: checksum });
@@ -457,9 +463,43 @@ export class LocalNotebooks extends Dexie {
       void (async () => {
         try {
           const newFile = await this.driveStore.create(parent.remoteId as string, name);
+          let lastRemoteChecksum = "";
+          try {
+            lastRemoteChecksum =
+              (await this.driveStore.getChecksum(newFile.uri)) ?? "";
+          } catch (error) {
+            appLogger.warn("Failed to record checksum for new Drive notebook", {
+              attrs: {
+                scope: "storage.drive.sync",
+                localUri: fileUri,
+                remoteUri: newFile.uri,
+                error: String(error),
+              },
+            });
+          }
+          const currentRecord = await this.files.get(fileUri);
+          const hasLocalContent = serializedNotebookHasUserContent(
+            currentRecord?.doc ?? "",
+          );
           await this.files.update(fileUri, {
             remoteId: newFile.uri,
+            lastRemoteChecksum,
+            lastSynced: hasLocalContent ? "" : nowIsoString(),
           });
+          if (hasLocalContent) {
+            try {
+              await this.syncFile(fileUri);
+            } catch (error) {
+              appLogger.warn("Failed to sync local notebook after Drive create", {
+                attrs: {
+                  scope: "storage.drive.sync",
+                  localUri: fileUri,
+                  remoteUri: newFile.uri,
+                  error: String(error),
+                },
+              });
+            }
+          }
           if (typeof window !== "undefined") {
             window.dispatchEvent(
               new CustomEvent("local-notebook-updated", {
@@ -585,13 +625,16 @@ export class LocalNotebooks extends Dexie {
     try {
       const notebook = deserializeNotebook(record.doc ?? "");
       const client = runmeClientManager.get();
-      markdownBytes = await client.serializeNotebook(notebook, {
-        outputs: {
-          enabled: true,
-          // Summary controls information about execution. I don't think we need that.
-          summary: false,
-        },
-      });
+      markdownBytes = await client.serializeNotebook(
+        notebook,
+        create(parser_pb.SerializeRequestOptionsSchema, {
+          outputs: create(parser_pb.SerializeRequestOutputOptionsSchema, {
+            enabled: true,
+            // Summary controls information about execution. I don't think we need that.
+            summary: false,
+          }),
+        }),
+      );
     } catch (error) {
       console.error("Failed to serialize notebook to markdown", error);
       return;
@@ -829,17 +872,50 @@ export class LocalNotebooks extends Dexie {
 
     // Case 2: We have never read the remote file (the cache holds an empty
     // checksum) but Drive reports a concrete checksum. Download the remote
-    // copy and store it locally so future edits work against a consistent
-    // baseline.
+    // copy only if the local record has no user-authored content. Otherwise,
+    // prefer the local IndexedDB content because overwriting it risks data loss.
     if (!lastReadChecksum && currentRemoteChecksum) {
+      if (serializedNotebookHasUserContent(localDoc)) {
+        appLogger.warn(
+          "Pushing local notebook to Drive without a baseline checksum",
+          {
+            attrs: {
+              scope: "storage.drive.sync",
+              localUri,
+              remoteUri,
+              remoteChecksum: currentRemoteChecksum,
+              localChecksum,
+            },
+          },
+        );
+        const notebook = deserializeNotebook(localDoc);
+        await this.driveStore.save(remoteUri, notebook);
+        const updatedChecksum =
+          (await this.driveStore.getChecksum(remoteUri)) ?? "";
+        await this.files.update(localUri, {
+          lastRemoteChecksum: updatedChecksum,
+          md5Checksum: localChecksum,
+          lastSynced: nowIsoString(),
+        });
+        synced = true;
+        return;
+      }
+
       const remoteNotebook = await this.driveStore.load(remoteUri);
       const serialized = toJsonString(
         parser_pb.NotebookSchema,
         remoteNotebook,
-        {
-          emitDefaultValues: true,
-        },
+        NOTEBOOK_JSON_WRITE_OPTIONS,
       );
+      logRemoteOverwriteLocalDoc({
+        localUri,
+        remoteUri,
+        localChecksum,
+        remoteChecksum: currentRemoteChecksum,
+        reason: "no-local-baseline-checksum",
+        localDoc,
+        remoteDoc: serialized,
+      });
       await this.files.update(localUri, {
         doc: serialized,
         md5Checksum: checksumForSerializedNotebook(serialized),
@@ -859,10 +935,17 @@ export class LocalNotebooks extends Dexie {
         const serialized = toJsonString(
           parser_pb.NotebookSchema,
           remoteNotebook,
-          {
-            emitDefaultValues: true,
-          },
+          NOTEBOOK_JSON_WRITE_OPTIONS,
         );
+        logRemoteOverwriteLocalDoc({
+          localUri,
+          remoteUri,
+          localChecksum,
+          remoteChecksum: currentRemoteChecksum,
+          reason: "local-matches-previous-remote-baseline",
+          localDoc,
+          remoteDoc: serialized,
+        });
         await this.files.update(localUri, {
           doc: serialized,
           md5Checksum: checksumForSerializedNotebook(serialized),
@@ -969,9 +1052,10 @@ export class LocalNotebooks extends Dexie {
   private async findParentFolder(
     childUri: string,
   ): Promise<LocalFolderRecord | null> {
-    return this.folders
+    const folder = await this.folders
       .filter((folder) => folder.children.includes(childUri))
       .first();
+    return folder ?? null;
   }
 
   private async syncFolder(localUri: string): Promise<void> {
@@ -1025,6 +1109,63 @@ function deserializeNotebook(json: string): parser_pb.Notebook {
     console.error("Falling back to empty notebook due to parse failure", error);
     return create(parser_pb.NotebookSchema, { cells: [] });
   }
+}
+
+function serializedNotebookHasUserContent(json: string): boolean {
+  if (!json) {
+    return false;
+  }
+  try {
+    const notebook = fromJsonString(parser_pb.NotebookSchema, json, {
+      ignoreUnknownFields: true,
+    });
+    return (
+      notebook.cells.length > 0 ||
+      Object.keys(notebook.metadata ?? {}).length > 0
+    );
+  } catch (error) {
+    appLogger.warn("Preserving unparsable local notebook content", {
+      attrs: {
+        scope: "storage.drive.sync",
+        error: String(error),
+      },
+    });
+    return true;
+  }
+}
+
+function logRemoteOverwriteLocalDoc({
+  localUri,
+  remoteUri,
+  localChecksum,
+  remoteChecksum,
+  reason,
+  localDoc,
+  remoteDoc,
+}: {
+  localUri: string;
+  remoteUri: string;
+  localChecksum: string;
+  remoteChecksum: string;
+  reason: string;
+  localDoc: string;
+  remoteDoc: string;
+}): void {
+  if (localDoc === remoteDoc) {
+    return;
+  }
+  appLogger.warn("Overwriting local notebook content with Drive content", {
+    attrs: {
+      scope: "storage.drive.sync",
+      localUri,
+      remoteUri,
+      localChecksum,
+      remoteChecksum,
+      reason,
+      localBytes: new TextEncoder().encode(localDoc).byteLength,
+      remoteBytes: new TextEncoder().encode(remoteDoc).byteLength,
+    },
+  });
 }
 
 function formatTimestamp(date: Date): string {


### PR DESCRIPTION
Fixes #165

## Summary
- Preserve IndexedDB notebook content when a Drive-backed file has no remote checksum baseline but local content exists.
- Record the initial Drive checksum after async remote-file creation and immediately sync local edits if they already exist.
- Add appLogger warnings whenever Drive content overwrites local notebook content, including local and remote checksums and byte counts.
- Tighten local.ts migration/helper typing while touching the file so the file-level eslint check passes.

## Root Cause
The Drive sync path treated an empty lastRemoteChecksum as proof that the remote file should become the baseline. For newly-created Drive-backed notebooks, the app can create an initially empty Drive file and set remoteId before the first successful content sync records a checksum. If local edits existed at that point, a later reload or re-auth sync could download the empty remote notebook and overwrite the IndexedDB doc.

## Validation
- pnpm -C app exec eslint src/storage/local.ts
- git diff --check -- app/src/storage/local.ts
- pnpm -C app run typecheck (fails on existing repo-wide TypeScript errors outside this fix; no remaining local.ts errors in the latest run)
