### PR TITLE
Track Drive sync state

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -50,6 +50,7 @@ import {
   useDriveLinkCoordinatorSnapshot,
 } from "../../lib/driveLinkCoordinator";
 import { parseDriveItem } from "../../storage/drive";
+import type { NotebookSyncState } from "../../storage/local";
 import { NotebookStoreItemType } from "../../storage/notebook";
 import DriveLinkStatusTab from "../DriveLinkStatusTab";
 import React from "react";
@@ -86,6 +87,149 @@ TabPanel.displayName = "TabPanel";
 // (preserving scroll/Monaco layout) while hiding inactive tabs without stacking
 // them. Inactive tabs are taken out of flow via absolute positioning and hidden
 // visibility so they don't visually overlap yet retain their state.
+
+function syncIndicatorPresentation(state: NotebookSyncState | null): {
+  label: string;
+  className: string;
+  clickable: boolean;
+} {
+  switch (state?.status) {
+    case "synced":
+      return {
+        label: "Notebook is synced",
+        className: "bg-emerald-500",
+        clickable: false,
+      };
+    case "pending":
+      return {
+        label: "Notebook has local changes pending upstream sync. Click to sync now.",
+        className: "bg-red-500",
+        clickable: true,
+      };
+    case "pending-upstream-create":
+      return {
+        label: "Notebook is waiting for its upstream file to be created. Click to sync now.",
+        className: "bg-amber-500",
+        clickable: true,
+      };
+    case "syncing":
+      return {
+        label: "Notebook is syncing",
+        className: "bg-sky-500 animate-pulse",
+        clickable: false,
+      };
+    case "error":
+      return {
+        label: state.lastError
+          ? `Notebook sync failed: ${state.lastError}. Click to retry.`
+          : "Notebook sync failed. Click to retry.",
+        className: "bg-red-700",
+        clickable: true,
+      };
+    case "local-only":
+      return {
+        label: "Notebook is stored only in this browser",
+        className: "border border-nb-text-faint bg-transparent",
+        clickable: false,
+      };
+    default:
+      return {
+        label: "Notebook sync state is loading",
+        className: "border border-nb-text-faint bg-transparent",
+        clickable: false,
+      };
+  }
+}
+
+function NotebookSyncIndicator({ docUri }: { docUri: string }) {
+  const { store } = useNotebookStore();
+  const [syncState, setSyncState] = useState<NotebookSyncState | null>(null);
+
+  useEffect(() => {
+    if (!store || !docUri.startsWith("local://file/")) {
+      setSyncState(null);
+      return;
+    }
+
+    let cancelled = false;
+    const refresh = () => {
+      void (async () => {
+        try {
+          const next = await store.getSyncState(docUri);
+          if (!cancelled) {
+            setSyncState(next);
+          }
+        } catch (error) {
+          if (!cancelled) {
+            setSyncState({
+              status: "error",
+              localUri: docUri,
+              remoteId: "",
+              lastError: String(error),
+            });
+          }
+        }
+      })();
+    };
+
+    refresh();
+    const unsubscribe = store.subscribeSync(docUri, refresh);
+    const onSyncUpdated = (event: Event) => {
+      const detail = (event as CustomEvent<{ uri?: string }>).detail;
+      if (detail?.uri === docUri) {
+        refresh();
+      }
+    };
+    window.addEventListener("local-notebook-sync-updated", onSyncUpdated);
+    window.addEventListener("local-notebook-updated", onSyncUpdated);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      window.removeEventListener("local-notebook-sync-updated", onSyncUpdated);
+      window.removeEventListener("local-notebook-updated", onSyncUpdated);
+    };
+  }, [docUri, store]);
+
+  const presentation = syncIndicatorPresentation(syncState);
+  const handleClick = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!store || !presentation.clickable) {
+        return;
+      }
+      void store.sync(docUri).catch((error) => {
+        appLogger.warn("Notebook tab immediate sync failed", {
+          attrs: {
+            scope: "storage.local.sync",
+            localUri: docUri,
+            error: String(error),
+          },
+        });
+      });
+    },
+    [docUri, presentation.clickable, store],
+  );
+
+  if (!store || !docUri.startsWith("local://file/")) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={presentation.label}
+      title={presentation.label}
+      className="inline-flex h-5 w-5 items-center justify-center rounded-full"
+      onClick={handleClick}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <span
+        className={`block h-2.5 w-2.5 rounded-full ${presentation.className}`}
+      />
+    </button>
+  );
+}
 
 /** Compact icon-only run button that sits in the cell toolbar.
  *  Shows a spinner while running, otherwise always shows the play icon. */
@@ -1623,7 +1767,7 @@ export default function Actions() {
               </Tabs.Trigger>
             </div>
           )}
-          {openNotebooks.map((doc) => {              
+          {openNotebooks.map((doc) => {
             const displayName =
               doc.name ||
               doc.uri.split("/").filter(Boolean).pop() ||
@@ -1638,19 +1782,20 @@ export default function Actions() {
                 >
                   <span className="truncate max-w-[140px]">{displayName}</span>
                 </Tabs.Trigger>
-                  <button
-                    type="button"
-                    className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-nb-xs text-nb-text-faint transition-all duration-150 hover:text-nb-text hover:bg-nb-surface-2"
-                    aria-label={`Close ${displayName}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleCloseTab(doc.uri);
-                    }}
-                    onMouseDown={(event) => event.stopPropagation()}
-                  >
-                    <XMarkIcon className="h-3 w-3" />
-                  </button>
-                </div>
+                <NotebookSyncIndicator docUri={doc.uri} />
+                <button
+                  type="button"
+                  className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-nb-xs text-nb-text-faint transition-all duration-150 hover:text-nb-text hover:bg-nb-surface-2"
+                  aria-label={`Close ${displayName}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleCloseTab(doc.uri);
+                  }}
+                  onMouseDown={(event) => event.stopPropagation()}
+                >
+                  <XMarkIcon className="h-3 w-3" />
+                </button>
+              </div>
               );
             })}
           </Tabs.List>

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -10,9 +10,9 @@ import {
 
 const GAPI_SCRIPT_SRC = "https://apis.google.com/js/api.js";
 
-// VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file version
+// VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file content version.
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
-const VERSION_FIELDS = "md5Checksum,headRevisionId,version";
+const VERSION_FIELDS = "md5Checksum,headRevisionId";
 
 let gapiScriptPromise: Promise<void> | null = null;
 let clientPromise: Promise<GapiDriveFilesClient> | null = null;
@@ -528,6 +528,11 @@ type DriveFileMetadata = {
   parents?: string[];
 };
 
+export interface DriveVersionMetadata {
+  md5Checksum?: string;
+  headRevisionId?: string;
+}
+
 export function parseDriveItem(uri: string): DriveItem {
   if (!uri) {
     throw new Error("Google Drive URI must be provided");
@@ -811,21 +816,22 @@ export class DriveNotebookStore {
   }
 
   async getChecksum(uri: string): Promise<string | null> {
+    return (await this.getVersionMetadata(uri))?.md5Checksum ?? null;
+  }
+
+  async getVersionMetadata(uri: string): Promise<DriveVersionMetadata | null> {
     const { id, type } = parseDriveItem(uri);
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.getChecksum expects a file URI");
+      throw new Error("DriveNotebookStore.getVersionMetadata expects a file URI");
     }
     const client = await this.getFilesClient();
     const metadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
-      //fields: "md5Checksum",
       fields: VERSION_FIELDS,
     });
-    return (
-      (metadataResponse.result as { md5Checksum?: string } | undefined)
-        ?.md5Checksum ?? null
-    );
+    const result = metadataResponse.result as DriveVersionMetadata | undefined;
+    return result ?? null;
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1,0 +1,214 @@
+/// <reference types="vitest" />
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+import LocalNotebooks, {
+  type LocalFileRecord,
+  type LocalFolderRecord,
+} from "./local";
+import { NotebookStoreItemType } from "./notebook";
+
+function createMockTable<T extends { id: string }>() {
+  const store = new Map<string, T>();
+  return {
+    _store: store,
+    get: vi.fn(async (id: string) => store.get(id) ?? undefined),
+    put: vi.fn(async (record: T) => {
+      store.set(record.id, record);
+      return record.id;
+    }),
+    update: vi.fn(async (id: string, changes: Partial<T>) => {
+      const existing = store.get(id);
+      if (!existing) {
+        return 0;
+      }
+      store.set(id, { ...existing, ...changes });
+      return 1;
+    }),
+    where: vi.fn((field: keyof T) => ({
+      equals: vi.fn((value: unknown) => ({
+        first: vi.fn(async () =>
+          [...store.values()].find((record) => record[field] === value),
+        ),
+      })),
+    })),
+    filter: vi.fn((predicate: (record: T) => boolean) => ({
+      toArray: vi.fn(async () => [...store.values()].filter(predicate)),
+      first: vi.fn(async () => [...store.values()].find(predicate)),
+    })),
+  };
+}
+
+function createTestStore(driveStore: unknown) {
+  const localStore = Object.create(LocalNotebooks.prototype) as any;
+  localStore.files = createMockTable<LocalFileRecord>();
+  localStore.folders = createMockTable<LocalFolderRecord>();
+  localStore.driveStore = driveStore;
+  localStore.filesystemStore = null;
+  localStore.inFlightSyncs = new Set();
+  localStore.syncListeners = new Map();
+  localStore.syncSubjects = new Map();
+  localStore.markdownSyncSubjects = new Map();
+  return localStore as LocalNotebooks;
+}
+
+describe("LocalNotebooks pending Drive create", () => {
+  it("persists pending upstream parent when Drive create fails", async () => {
+    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
+    const driveStore = {
+      create: vi.fn(async () => {
+        throw new Error("Google Drive authorization is required.");
+      }),
+    };
+    const store = createTestStore(driveStore);
+    await store.folders.put({
+      id: "local://folder/drive",
+      name: "Drive",
+      remoteId: parentRemoteUri,
+      children: [],
+      lastSynced: "",
+    });
+
+    const item = await store.create("local://folder/drive", "draft.json");
+
+    expect(item.type).toBe(NotebookStoreItemType.File);
+    const record = await store.files.get(item.uri);
+    expect(record?.remoteId).toBe("");
+    expect(record?.parentRemoteIdWhenCreated).toBe(parentRemoteUri);
+    expect(
+      (await store.folders.get("local://folder/drive"))?.children,
+    ).toContain(item.uri);
+  });
+
+  it("reports pending upstream creation in sync state", async () => {
+    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
+    const store = createTestStore({});
+    await store.files.put({
+      id: "local://file/pending",
+      name: "draft.json",
+      remoteId: "",
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      lastRemoteChecksum: "",
+      lastSynced: "",
+      doc: "",
+      md5Checksum: "",
+    });
+
+    await expect(
+      store.getSyncState("local://file/pending"),
+    ).resolves.toMatchObject({
+      status: "pending-upstream-create",
+      parentRemoteIdWhenCreated: parentRemoteUri,
+    });
+  });
+
+  it("creates the Drive file on sync and clears pending parent", async () => {
+    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const driveStore = {
+      create: vi.fn(async () => ({
+        uri: remoteUri,
+        name: "draft.json",
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: "checksum-1",
+        headRevisionId: "revision-1",
+      })),
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: "draft.json",
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      save: vi.fn(async () => ({ conflicted: false })),
+    };
+    const store = createTestStore(driveStore);
+    await store.files.put({
+      id: "local://file/pending",
+      name: "draft.json",
+      remoteId: "",
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      lastRemoteChecksum: "",
+      lastSynced: "",
+      doc: "",
+      md5Checksum: "",
+    });
+
+    await store.sync("local://file/pending");
+
+    const record = await store.files.get("local://file/pending");
+    expect(record?.remoteId).toBe(remoteUri);
+    expect(record?.parentRemoteIdWhenCreated).toBeUndefined();
+    expect(record?.lastRemoteChecksum).toBe("checksum-1");
+    expect(record?.lastUpstreamVersion).toEqual({
+      checksum: "checksum-1",
+      revisionId: "revision-1",
+    });
+    expect(driveStore.create).toHaveBeenCalledWith(
+      parentRemoteUri,
+      "draft.json",
+    );
+  });
+
+  it("does not duplicate a pending Drive file if initial metadata recording fails", async () => {
+    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const driveStore = {
+      create: vi.fn(async () => ({
+        uri: remoteUri,
+        name: "draft.json",
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      getVersionMetadata: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("metadata unavailable"))
+        .mockResolvedValueOnce({
+          md5Checksum: "remote-created",
+          headRevisionId: "revision-2",
+        })
+        .mockResolvedValueOnce({
+          md5Checksum: "local-saved",
+          headRevisionId: "revision-3",
+        }),
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: "draft.json",
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      save: vi.fn(async () => ({ conflicted: false })),
+      saveContent: vi.fn(async () => undefined),
+    };
+    const store = createTestStore(driveStore);
+    await store.files.put({
+      id: "local://file/pending",
+      name: "draft.json",
+      remoteId: "",
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      lastRemoteChecksum: "",
+      lastSynced: "",
+      doc: "{malformed-json",
+      md5Checksum: "local-checksum",
+    });
+
+    await store.sync("local://file/pending");
+
+    const record = await store.files.get("local://file/pending");
+    expect(record?.remoteId).toBe(remoteUri);
+    expect(record?.parentRemoteIdWhenCreated).toBeUndefined();
+    expect(record?.lastRemoteChecksum).toBe("local-saved");
+    expect(driveStore.create).toHaveBeenCalledTimes(1);
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      remoteUri,
+      "{malformed-json",
+      "application/json",
+    );
+  });
+});

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -45,7 +45,7 @@ function createTestStore(driveStore: unknown) {
   localStore.folders = createMockTable<LocalFolderRecord>();
   localStore.driveStore = driveStore;
   localStore.filesystemStore = null;
-  localStore.inFlightSyncs = new Set();
+  localStore.inFlightSyncs = new Map();
   localStore.syncListeners = new Map();
   localStore.syncSubjects = new Map();
   localStore.markdownSyncSubjects = new Map();
@@ -210,5 +210,65 @@ describe("LocalNotebooks pending Drive create", () => {
       "{malformed-json",
       "application/json",
     );
+  });
+
+  it("serializes overlapping sync calls for the same pending Drive file", async () => {
+    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    let releaseCreate!: () => void;
+    let createStarted!: () => void;
+    const createStartedPromise = new Promise<void>((resolve) => {
+      createStarted = resolve;
+    });
+    const releaseCreatePromise = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const driveStore = {
+      create: vi.fn(async () => {
+        createStarted();
+        await releaseCreatePromise;
+        return {
+          uri: remoteUri,
+          name: "draft.json",
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [parentRemoteUri],
+        };
+      }),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: "checksum-1",
+        headRevisionId: "revision-1",
+      })),
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: "draft.json",
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      save: vi.fn(async () => ({ conflicted: false })),
+    };
+    const store = createTestStore(driveStore);
+    await store.files.put({
+      id: "local://file/pending",
+      name: "draft.json",
+      remoteId: "",
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      lastRemoteChecksum: "",
+      lastSynced: "",
+      doc: "",
+      md5Checksum: "",
+    });
+
+    const firstSync = store.sync("local://file/pending");
+    await createStartedPromise;
+    const secondSync = store.sync("local://file/pending");
+    releaseCreate();
+    await Promise.all([firstSync, secondSync]);
+
+    const record = await store.files.get("local://file/pending");
+    expect(record?.remoteId).toBe(remoteUri);
+    expect(record?.parentRemoteIdWhenCreated).toBeUndefined();
+    expect(driveStore.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -139,7 +139,7 @@ export class LocalNotebooks extends Dexie {
 
   private readonly syncSubjects = new Map<string, Subject<void>>();
   private readonly markdownSyncSubjects = new Map<string, Subject<void>>();
-  private readonly inFlightSyncs = new Set<string>();
+  private readonly inFlightSyncs = new Map<string, Promise<void>>();
   private readonly syncListeners = new Map<string, Set<() => void>>();
 
   constructor(
@@ -1008,18 +1008,32 @@ export class LocalNotebooks extends Dexie {
   }
 
   private async syncFile(localUri: string): Promise<void> {
-    this.inFlightSyncs.add(localUri);
+    const existingSync = this.inFlightSyncs.get(localUri);
+    if (existingSync) {
+      return existingSync;
+    }
+
+    const operation = Promise.resolve().then(async () => {
+      try {
+        await this.syncFileInner(localUri);
+        await this.files.update(localUri, { lastSyncError: undefined });
+      } catch (error) {
+        await this.files.update(localUri, { lastSyncError: String(error) });
+        throw error;
+      }
+    });
+    this.inFlightSyncs.set(localUri, operation);
     this.notifySync(localUri);
-    try {
-      await this.syncFileInner(localUri);
-      await this.files.update(localUri, { lastSyncError: undefined });
-    } catch (error) {
-      await this.files.update(localUri, { lastSyncError: String(error) });
-      throw error;
-    } finally {
+
+    const cleanup = () => {
+      if (this.inFlightSyncs.get(localUri) !== operation) {
+        return;
+      }
       this.inFlightSyncs.delete(localUri);
       this.notifySync(localUri);
-    }
+    };
+    void operation.then(cleanup, cleanup);
+    return operation;
   }
 
   private async syncFileInner(localUri: string): Promise<void> {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -8,7 +8,11 @@ import { parser_pb } from "../runme/client";
 import { aisreClientManager as runmeClientManager } from "../lib/aisreClientManager";
 import { appState } from "../lib/runtime/AppState";
 import { appLogger } from "../lib/logging/runtime";
-import { DriveNotebookStore, isDriveItemUri } from "./drive";
+import {
+  DriveNotebookStore,
+  type DriveVersionMetadata,
+  isDriveItemUri,
+} from "./drive";
 import type { FilesystemNotebookStore } from "./fs";
 import {
   NotebookStoreItem,
@@ -36,6 +40,8 @@ export interface LocalFileRecord {
   name: string;
   /** Upstream URI. Browser-only notebooks use the same local://file/... URI. */
   remoteId: string;
+  /** Creation-time upstream parent URI used to finish a pending remote create. */
+  parentRemoteIdWhenCreated?: string;
   /** Remote Drive URI of the Markdown sidecar (e.g. *.index.md) if present. */
   markdownUri?: string;
   /**
@@ -45,6 +51,10 @@ export interface LocalFileRecord {
   lastRemoteChecksum: string;
   /** ISO timestamp of the last successful sync with Drive (empty if never). */
   lastSynced: string;
+  /** Last successfully observed upstream revision/checksum metadata. */
+  lastUpstreamVersion?: UpstreamVersion;
+  /** Last sync failure, if any. Cleared after successful sync. */
+  lastSyncError?: string;
   /**
    * JSON serialized notebook document. Using a string keeps the IndexedDB
    * representation simple and defers parsing to the caller.
@@ -55,6 +65,31 @@ export interface LocalFileRecord {
    * changes without re-hashing every file on each pass.
    */
   md5Checksum: string;
+}
+
+export interface UpstreamVersion {
+  checksum?: string;
+  revisionId?: string;
+  modifiedTime?: string;
+  sizeBytes?: number;
+}
+
+export type NotebookSyncStatus =
+  | "local-only"
+  | "synced"
+  | "pending"
+  | "pending-upstream-create"
+  | "syncing"
+  | "error";
+
+export interface NotebookSyncState {
+  status: NotebookSyncStatus;
+  localUri: string;
+  remoteId: string;
+  parentRemoteIdWhenCreated?: string;
+  lastSynced?: string;
+  lastUpstreamVersion?: UpstreamVersion;
+  lastError?: string;
 }
 
 /**
@@ -104,6 +139,8 @@ export class LocalNotebooks extends Dexie {
 
   private readonly syncSubjects = new Map<string, Subject<void>>();
   private readonly markdownSyncSubjects = new Map<string, Subject<void>>();
+  private readonly inFlightSyncs = new Set<string>();
+  private readonly syncListeners = new Map<string, Set<() => void>>();
 
   constructor(
     driveStore: DriveNotebookStore,
@@ -158,6 +195,18 @@ export class LocalNotebooks extends Dexie {
           if (typeof file.remoteId !== "string" || file.remoteId === "") {
             file.remoteId = file.id ?? "";
           }
+        });
+      });
+    this.version(5)
+      .stores({
+        files: "&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced",
+        folders: "&id, remoteId, name, lastSynced",
+      })
+      .upgrade(async (tx) => {
+        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
+          delete file.lastUpstreamVersion;
+          delete file.lastSyncError;
+          delete file.parentRemoteIdWhenCreated;
         });
       });
 
@@ -264,7 +313,9 @@ export class LocalNotebooks extends Dexie {
           doc: serialized,
           md5Checksum: checksum,
           lastRemoteChecksum: checksum,
+          lastUpstreamVersion: { checksum },
           lastSynced: nowIsoString(),
+          lastSyncError: undefined,
         });
       }
       return existing.id;
@@ -276,6 +327,7 @@ export class LocalNotebooks extends Dexie {
       name,
       remoteId: upstreamUri,
       lastRemoteChecksum: checksum,
+      lastUpstreamVersion: { checksum },
       lastSynced: nowIsoString(),
       doc: serialized,
       md5Checksum: checksum,
@@ -354,6 +406,20 @@ export class LocalNotebooks extends Dexie {
       }
     }
 
+    const existingChildren = existingFolder?.children ?? [];
+    for (const childUri of existingChildren) {
+      const childRecord = childUri.startsWith("local://file/")
+        ? await this.files.get(childUri)
+        : null;
+      if (
+        childRecord?.remoteId === "" &&
+        childRecord.parentRemoteIdWhenCreated === remoteUri &&
+        !childUris.includes(childUri)
+      ) {
+        childUris.push(childUri);
+      }
+    }
+
     await this.folders.update(folderId, {
       name: resolvedName,
       children: childUris,
@@ -374,6 +440,67 @@ export class LocalNotebooks extends Dexie {
     }
 
     throw new Error(`Unsupported local URI format: ${localUri}`);
+  }
+
+  subscribeSync(localUri: string, listener: () => void): () => void {
+    let listeners = this.syncListeners.get(localUri);
+    if (!listeners) {
+      listeners = new Set();
+      this.syncListeners.set(localUri, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      const current = this.syncListeners.get(localUri);
+      if (!current) {
+        return;
+      }
+      current.delete(listener);
+      if (current.size === 0) {
+        this.syncListeners.delete(localUri);
+      }
+    };
+  }
+
+  async getSyncState(localUri: string): Promise<NotebookSyncState> {
+    const record = await this.files.get(localUri);
+    if (!record) {
+      return {
+        status: "error",
+        localUri,
+        remoteId: "",
+        lastError: `Local notebook record not found for ${localUri}`,
+      };
+    }
+
+    if (this.inFlightSyncs.has(localUri)) {
+      return syncStateForRecord(record, "syncing");
+    }
+
+    if (record.remoteId === "" && record.parentRemoteIdWhenCreated) {
+      return syncStateForRecord(
+        record,
+        record.lastSyncError ? "error" : "pending-upstream-create",
+      );
+    }
+
+    if (record.remoteId === "") {
+      return syncStateForRecord(record, "error", "Missing upstream URI");
+    }
+
+    if (isLocalFileUpstream(record.remoteId, record.id)) {
+      return syncStateForRecord(record, "local-only");
+    }
+
+    if (record.lastSyncError) {
+      return syncStateForRecord(record, "error");
+    }
+
+    const localChecksum = await this.getOrBackfillLocalChecksum(localUri, record);
+    const upstreamChecksum = record.lastRemoteChecksum ?? "";
+    return syncStateForRecord(
+      { ...record, md5Checksum: localChecksum },
+      localChecksum === upstreamChecksum ? "synced" : "pending",
+    );
   }
 
   async getMetadata(uri: string): Promise<NotebookStoreItem | null> {
@@ -462,6 +589,7 @@ export class LocalNotebooks extends Dexie {
     const checksum = checksumForSerializedNotebook(serialized);
 
     await this.files.update(uri, { doc: serialized, md5Checksum: checksum });
+    this.notifySync(uri);
   }
 
   async load(uri: string): Promise<parser_pb.Notebook> {
@@ -480,7 +608,17 @@ export class LocalNotebooks extends Dexie {
     if (shouldSync) {
       // Best-effort attempt to ensure the local cache reflects the latest remote state
       // before we hydrate the notebook for the caller.
-      await this.syncFile(uri);
+      try {
+        await this.syncFile(uri);
+      } catch (error) {
+        appLogger.warn("Continuing with local notebook after sync-on-load failed", {
+          attrs: {
+            scope: "storage.local.sync",
+            localUri: uri,
+            error: String(error),
+          },
+        });
+      }
 
       const refreshed = await this.files.get(uri);
       if (!refreshed) {
@@ -514,12 +652,14 @@ export class LocalNotebooks extends Dexie {
     }
 
     const fileUri = this.generateLocalUri("file");
+    const isDriveBackedParent = isDriveUri(parent.remoteId);
     const record: LocalFileRecord = {
       id: fileUri,
       name,
-      remoteId: fileUri,
+      remoteId: isDriveBackedParent ? "" : fileUri,
+      parentRemoteIdWhenCreated: isDriveBackedParent ? parent.remoteId : undefined,
       lastRemoteChecksum: "",
-      lastSynced: nowIsoString(),
+      lastSynced: isDriveBackedParent ? "" : nowIsoString(),
       doc: "",
       md5Checksum: "",
     };
@@ -530,7 +670,7 @@ export class LocalNotebooks extends Dexie {
       lastSynced: nowIsoString(),
     });
 
-    if (typeof window !== "undefined") {
+    if (canDispatchWindowEvents()) {
       window.dispatchEvent(
         new CustomEvent("local-notebook-updated", {
           detail: { uri: fileUri, name, remoteUri: undefined },
@@ -538,60 +678,19 @@ export class LocalNotebooks extends Dexie {
       );
     }
 
-    if (isDriveUri(parent.remoteId)) {
+    if (isDriveBackedParent) {
       void (async () => {
         try {
-          const newFile = await this.driveStore.create(parent.remoteId as string, name);
-          let lastRemoteChecksum = "";
-          try {
-            lastRemoteChecksum =
-              (await this.driveStore.getChecksum(newFile.uri)) ?? "";
-          } catch (error) {
-            appLogger.warn("Failed to record checksum for new Drive notebook", {
-              attrs: {
-                scope: "storage.drive.sync",
-                localUri: fileUri,
-                remoteUri: newFile.uri,
-                error: String(error),
-              },
-            });
-          }
-          const currentRecord = await this.files.get(fileUri);
-          const hasLocalContent = serializedNotebookHasUserContent(
-            currentRecord?.doc ?? "",
-          );
-          await this.files.update(fileUri, {
-            remoteId: newFile.uri,
-            lastRemoteChecksum,
-            lastSynced: hasLocalContent ? "" : nowIsoString(),
-          });
-          if (hasLocalContent) {
-            try {
-              await this.syncFile(fileUri);
-            } catch (error) {
-              appLogger.warn("Failed to sync local notebook after Drive create", {
-                attrs: {
-                  scope: "storage.drive.sync",
-                  localUri: fileUri,
-                  remoteUri: newFile.uri,
-                  error: String(error),
-                },
-              });
-            }
-          }
-          if (typeof window !== "undefined") {
-            window.dispatchEvent(
-              new CustomEvent("local-notebook-updated", {
-                detail: {
-                  uri: fileUri,
-                  name: newFile.name ?? name,
-                  remoteUri: newFile.uri,
-                },
-              }),
-            );
-          }
+          await this.syncFile(fileUri);
         } catch (error) {
-          console.error("Failed to create remote Drive notebook", error);
+          appLogger.warn("Pending Drive notebook creation did not complete", {
+            attrs: {
+              scope: "storage.drive.sync",
+              localUri: fileUri,
+              parentRemoteUri: parent.remoteId,
+              error: String(error),
+            },
+          });
         }
       })();
     }
@@ -620,7 +719,7 @@ export class LocalNotebooks extends Dexie {
 
     const parentFolder = await this.findParentFolder(uri);
 
-    if (typeof window !== "undefined") {
+    if (canDispatchWindowEvents()) {
       window.dispatchEvent(
         new CustomEvent("local-notebook-updated", {
           detail: { uri, name, remoteUri: publicRemoteUri(record) },
@@ -745,11 +844,18 @@ export class LocalNotebooks extends Dexie {
    */
   async listDriveBackedFilesNeedingSync(): Promise<string[]> {
     const driveBackedFiles = await this.files
-      .filter((record) => isDriveUri(record.remoteId))
+      .filter((record) =>
+        isDriveUri(record.remoteId) ||
+        Boolean(record.parentRemoteIdWhenCreated),
+      )
       .toArray();
     const pending: string[] = [];
 
     for (const record of driveBackedFiles) {
+      if (record.remoteId === "" && record.parentRemoteIdWhenCreated) {
+        pending.push(record.id);
+        continue;
+      }
       const localChecksum = await this.getOrBackfillLocalChecksum(record.id, record);
       const lastRemoteChecksum = record.lastRemoteChecksum ?? "";
       if (localChecksum !== lastRemoteChecksum) {
@@ -803,6 +909,26 @@ export class LocalNotebooks extends Dexie {
       this.syncSubjects.set(uri, subject);
     }
     subject.next();
+  }
+
+  private notifySync(uri: string): void {
+    const listeners = this.syncListeners.get(uri);
+    if (listeners) {
+      for (const listener of listeners) {
+        try {
+          listener();
+        } catch (error) {
+          console.error("Local notebook sync listener failed", error);
+        }
+      }
+    }
+    if (canDispatchWindowEvents()) {
+      window.dispatchEvent(
+        new CustomEvent("local-notebook-sync-updated", {
+          detail: { uri },
+        }),
+      );
+    }
   }
 
   private enqueueMarkdownSync(uri: string): void {
@@ -882,7 +1008,22 @@ export class LocalNotebooks extends Dexie {
   }
 
   private async syncFile(localUri: string): Promise<void> {
-    const record = await this.files.get(localUri);
+    this.inFlightSyncs.add(localUri);
+    this.notifySync(localUri);
+    try {
+      await this.syncFileInner(localUri);
+      await this.files.update(localUri, { lastSyncError: undefined });
+    } catch (error) {
+      await this.files.update(localUri, { lastSyncError: String(error) });
+      throw error;
+    } finally {
+      this.inFlightSyncs.delete(localUri);
+      this.notifySync(localUri);
+    }
+  }
+
+  private async syncFileInner(localUri: string): Promise<void> {
+    let record = await this.files.get(localUri);
     if (!record) {
       throw new Error(`Local notebook record not found for ${localUri}`);
     }
@@ -890,17 +1031,26 @@ export class LocalNotebooks extends Dexie {
     // Files that do not have a remote counterpart live exclusively in
     // IndexedDB. There is nothing to synchronise for those entries, so we can
     // exit early once we've confirmed the local metadata exists.
+    let completedPendingCreate = false;
     if (!record.remoteId) {
-      await this.files.update(localUri, {
-        remoteId: localUri,
-        lastSynced: nowIsoString(),
-      });
-      return;
+      if (!record.parentRemoteIdWhenCreated) {
+        throw new Error(
+          `Local notebook ${localUri} is missing remoteId and pending parent`,
+        );
+      }
+      await this.completePendingDriveCreate(localUri, record);
+      completedPendingCreate = true;
+      const updated = await this.files.get(localUri);
+      if (!updated?.remoteId) {
+        throw new Error(`Failed to create Drive file for pending notebook ${localUri}`);
+      }
+      record = updated;
     }
 
     if (isLocalFileUpstream(record.remoteId, localUri)) {
       await this.files.update(localUri, {
         lastSynced: nowIsoString(),
+        lastSyncError: undefined,
       });
       return;
     }
@@ -931,10 +1081,13 @@ export class LocalNotebooks extends Dexie {
 
     // Fetch the current checksum from Drive. We treat "missing" as an empty
     // string so downstream comparisons remain simple string equality checks.
+    let currentVersion: UpstreamVersion = {};
     let currentRemoteChecksum = "";
     try {
-      currentRemoteChecksum =
-        (await this.driveStore.getChecksum(remoteUri)) ?? "";
+      currentVersion = driveMetadataToUpstreamVersion(
+        await this.driveStore.getVersionMetadata(remoteUri),
+      );
+      currentRemoteChecksum = currentVersion.checksum ?? "";
     } catch (error) {
       console.error(
         "Failed to retrieve remote checksum while synchronising",
@@ -954,14 +1107,17 @@ export class LocalNotebooks extends Dexie {
     // the local content is authoritative. We can safely push our data back to
     // Drive without risking data loss.
     if (currentRemoteChecksum === lastReadChecksum) {
-      const notebook = deserializeNotebook(localDoc);
-      await this.driveStore.save(remoteUri, notebook);
-      const updatedChecksum =
-        (await this.driveStore.getChecksum(remoteUri)) ?? "";
+      await this.saveLocalDocToDrive(localUri, remoteUri, localDoc);
+      const updatedVersion = driveMetadataToUpstreamVersion(
+        await this.driveStore.getVersionMetadata(remoteUri),
+      );
+      const updatedChecksum = updatedVersion.checksum ?? "";
       await this.files.update(localUri, {
         lastRemoteChecksum: updatedChecksum,
+        lastUpstreamVersion: updatedVersion,
         md5Checksum: localChecksum,
         lastSynced: nowIsoString(),
+        lastSyncError: undefined,
       });
       synced = true;
       return;
@@ -972,6 +1128,23 @@ export class LocalNotebooks extends Dexie {
     // copy only if the local record has no user-authored content. Otherwise,
     // prefer the local IndexedDB content because overwriting it risks data loss.
     if (!lastReadChecksum && currentRemoteChecksum) {
+      if (completedPendingCreate && serializedNotebookHasUserContent(localDoc)) {
+        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc);
+        const updatedVersion = driveMetadataToUpstreamVersion(
+          await this.driveStore.getVersionMetadata(remoteUri),
+        );
+        const updatedChecksum = updatedVersion.checksum ?? "";
+        await this.files.update(localUri, {
+          lastRemoteChecksum: updatedChecksum,
+          lastUpstreamVersion: updatedVersion,
+          md5Checksum: localChecksum,
+          lastSynced: nowIsoString(),
+          lastSyncError: undefined,
+        });
+        synced = true;
+        return;
+      }
+
       if (serializedNotebookHasUserContent(localDoc)) {
         appLogger.warn(
           "Forking local notebook because Drive exists without a baseline checksum",
@@ -1000,12 +1173,16 @@ export class LocalNotebooks extends Dexie {
         reason: "no-local-baseline-checksum",
         localDoc,
         remoteDoc: serialized,
+        previousUpstreamRevisionId: record.lastUpstreamVersion?.revisionId,
+        upstreamRevisionId: currentVersion.revisionId,
       });
       await this.files.update(localUri, {
         doc: serialized,
         md5Checksum: checksumForSerializedNotebook(serialized),
         lastRemoteChecksum: currentRemoteChecksum,
+        lastUpstreamVersion: currentVersion,
         lastSynced: nowIsoString(),
+        lastSyncError: undefined,
       });
       synced = true;
       return;
@@ -1026,12 +1203,16 @@ export class LocalNotebooks extends Dexie {
           reason: "local-matches-previous-remote-baseline",
           localDoc,
           remoteDoc: serialized,
+          previousUpstreamRevisionId: record.lastUpstreamVersion?.revisionId,
+          upstreamRevisionId: currentVersion.revisionId,
         });
         await this.files.update(localUri, {
           doc: serialized,
           md5Checksum: checksumForSerializedNotebook(serialized),
           lastRemoteChecksum: currentRemoteChecksum,
+          lastUpstreamVersion: currentVersion,
           lastSynced: nowIsoString(),
+          lastSyncError: undefined,
         });
         synced = true;
         return;
@@ -1050,21 +1231,26 @@ export class LocalNotebooks extends Dexie {
     // keep the baseline empty.
     if (!currentRemoteChecksum) {
       if (localDoc) {
-        const notebook = deserializeNotebook(localDoc);
-        await this.driveStore.save(remoteUri, notebook);
-        const updatedChecksum =
-          (await this.driveStore.getChecksum(remoteUri)) ?? "";
+        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc);
+        const updatedVersion = driveMetadataToUpstreamVersion(
+          await this.driveStore.getVersionMetadata(remoteUri),
+        );
+        const updatedChecksum = updatedVersion.checksum ?? "";
         await this.files.update(localUri, {
           lastRemoteChecksum: updatedChecksum,
+          lastUpstreamVersion: updatedVersion,
           md5Checksum: localChecksum,
           lastSynced: nowIsoString(),
+          lastSyncError: undefined,
         });
         synced = true;
       } else if (lastReadChecksum) {
         await this.files.update(localUri, {
           lastRemoteChecksum: "",
+          lastUpstreamVersion: currentVersion,
           md5Checksum: localChecksum,
           lastSynced: nowIsoString(),
+          lastSyncError: undefined,
         });
         synced = true;
       }
@@ -1073,7 +1259,106 @@ export class LocalNotebooks extends Dexie {
     if (!synced) {
       await this.files.update(localUri, {
         lastSynced: nowIsoString(),
+        lastSyncError: undefined,
       });
+    }
+  }
+
+  private async saveLocalDocToDrive(
+    localUri: string,
+    remoteUri: string,
+    localDoc: string,
+  ): Promise<void> {
+    if (!localDoc) {
+      await this.driveStore.save(
+        remoteUri,
+        create(parser_pb.NotebookSchema, { cells: [] }),
+      );
+      return;
+    }
+
+    const parseResult = parseSerializedNotebook(localDoc);
+    if (parseResult.ok) {
+      await this.driveStore.save(remoteUri, parseResult.notebook);
+      return;
+    }
+
+    appLogger.warn("Saving raw local notebook JSON because parsing failed", {
+      attrs: {
+        scope: "storage.drive.sync",
+        localUri,
+        remoteUri,
+        error: String(parseResult.error),
+      },
+    });
+    await this.driveStore.saveContent(remoteUri, localDoc, "application/json");
+  }
+
+  private async completePendingDriveCreate(
+    localUri: string,
+    record: LocalFileRecord,
+  ): Promise<void> {
+    const parentRemoteUri = record.parentRemoteIdWhenCreated;
+    if (!parentRemoteUri) {
+      throw new Error(`Missing pending Drive parent for ${localUri}`);
+    }
+    if (!isDriveUri(parentRemoteUri)) {
+      throw new Error(
+        `Pending upstream parent is not a Drive folder for ${localUri}: ${parentRemoteUri}`,
+      );
+    }
+
+    const newFile = await this.driveStore.create(parentRemoteUri, record.name);
+    let version: UpstreamVersion = {};
+    try {
+      version = driveMetadataToUpstreamVersion(
+        await this.driveStore.getVersionMetadata(newFile.uri),
+      );
+    } catch (error) {
+      appLogger.warn("Failed to record version metadata for new Drive notebook", {
+        attrs: {
+          scope: "storage.drive.sync",
+          localUri,
+          remoteUri: newFile.uri,
+          error: String(error),
+        },
+      });
+    }
+    const currentRecord = await this.files.get(localUri);
+    const localDoc = currentRecord?.doc ?? record.doc ?? "";
+    const hasLocalContent = serializedNotebookHasUserContent(localDoc);
+
+    await this.files.update(localUri, {
+      name: newFile.name ?? record.name,
+      remoteId: newFile.uri,
+      parentRemoteIdWhenCreated: undefined,
+      lastRemoteChecksum: version.checksum ?? "",
+      lastUpstreamVersion: version,
+      lastSynced: hasLocalContent ? "" : nowIsoString(),
+      lastSyncError: undefined,
+    });
+
+    appLogger.info("Created pending Drive notebook upstream file", {
+      attrs: {
+        scope: "storage.drive.sync",
+        localUri,
+        parentRemoteUri,
+        remoteUri: newFile.uri,
+        upstreamChecksum: version.checksum,
+        upstreamRevisionId: version.revisionId,
+      },
+    });
+
+    if (canDispatchWindowEvents()) {
+      window.dispatchEvent(
+        new CustomEvent("local-notebook-updated", {
+          detail: {
+            uri: localUri,
+            name: newFile.name ?? record.name,
+            remoteUri: newFile.uri,
+          },
+        }),
+      );
     }
   }
 
@@ -1115,7 +1400,11 @@ export class LocalNotebooks extends Dexie {
         doc: upstreamDoc,
         md5Checksum: checksumForSerializedNotebook(upstreamDoc),
         lastRemoteChecksum: checksumForSerializedNotebook(upstreamDoc),
+        lastUpstreamVersion: {
+          checksum: checksumForSerializedNotebook(upstreamDoc),
+        },
         lastSynced: nowIsoString(),
+        lastSyncError: undefined,
       });
       return;
     }
@@ -1139,7 +1428,11 @@ export class LocalNotebooks extends Dexie {
           doc: upstreamDoc,
           md5Checksum: upstreamChecksum,
           lastRemoteChecksum: upstreamChecksum,
+          lastUpstreamVersion: {
+            checksum: upstreamChecksum,
+          },
           lastSynced: nowIsoString(),
+          lastSyncError: undefined,
         });
         return;
       }
@@ -1173,8 +1466,12 @@ export class LocalNotebooks extends Dexie {
     await upstreamStore.save(upstreamUri, parseResult.notebook);
     await this.files.update(localUri, {
       lastRemoteChecksum: localChecksum,
+      lastUpstreamVersion: {
+        checksum: localChecksum,
+      },
       md5Checksum: localChecksum,
       lastSynced: nowIsoString(),
+      lastSyncError: undefined,
     });
   }
 
@@ -1223,11 +1520,30 @@ export class LocalNotebooks extends Dexie {
       );
     }
 
+    let newFileVersion: UpstreamVersion = {};
+    try {
+      newFileVersion = driveMetadataToUpstreamVersion(
+        await this.driveStore.getVersionMetadata(newFile.uri),
+      );
+    } catch (error) {
+      appLogger.warn("Failed to record version metadata for conflict Drive notebook", {
+        attrs: {
+          scope: "storage.drive.sync",
+          localUri,
+          remoteUri: newFile.uri,
+          error: String(error),
+        },
+      });
+    }
+
     await this.files.update(localUri, {
       name: newName,
       remoteId: newFile.uri,
-      lastRemoteChecksum: "",
+      parentRemoteIdWhenCreated: undefined,
+      lastRemoteChecksum: newFileVersion.checksum ?? "",
+      lastUpstreamVersion: newFileVersion,
       lastSynced: nowIsoString(),
+      lastSyncError: undefined,
     });
 
     console.warn("Notebook conflict resolved by creating a new file", {
@@ -1238,7 +1554,7 @@ export class LocalNotebooks extends Dexie {
       remoteChecksum,
     });
 
-    if (typeof window !== "undefined") {
+    if (canDispatchWindowEvents()) {
       window.dispatchEvent(
         new CustomEvent("local-notebook-updated", {
           detail: {
@@ -1360,11 +1676,38 @@ function serializedNotebookHasUserContent(json: string): boolean {
   }
 }
 
+function driveMetadataToUpstreamVersion(
+  metadata: DriveVersionMetadata | null,
+): UpstreamVersion {
+  return {
+    checksum: metadata?.md5Checksum,
+    revisionId: metadata?.headRevisionId,
+  };
+}
+
+function syncStateForRecord(
+  record: LocalFileRecord,
+  status: NotebookSyncStatus,
+  fallbackError?: string,
+): NotebookSyncState {
+  return {
+    status,
+    localUri: record.id,
+    remoteId: record.remoteId,
+    parentRemoteIdWhenCreated: record.parentRemoteIdWhenCreated,
+    lastSynced: record.lastSynced || undefined,
+    lastUpstreamVersion: record.lastUpstreamVersion,
+    lastError: record.lastSyncError || fallbackError,
+  };
+}
+
 function logRemoteOverwriteLocalDoc({
   localUri,
   remoteUri,
   localChecksum,
   remoteChecksum,
+  previousUpstreamRevisionId,
+  upstreamRevisionId,
   reason,
   localDoc,
   remoteDoc,
@@ -1373,6 +1716,8 @@ function logRemoteOverwriteLocalDoc({
   remoteUri: string;
   localChecksum: string;
   remoteChecksum: string;
+  previousUpstreamRevisionId?: string;
+  upstreamRevisionId?: string;
   reason: string;
   localDoc: string;
   remoteDoc: string;
@@ -1380,13 +1725,15 @@ function logRemoteOverwriteLocalDoc({
   if (localDoc === remoteDoc) {
     return;
   }
-  appLogger.warn("Overwriting local notebook content with Drive content", {
+  appLogger.warn("Overwriting local notebook content with upstream content", {
     attrs: {
-      scope: "storage.drive.sync",
+      scope: "storage.local.sync",
       localUri,
       remoteUri,
       localChecksum,
       remoteChecksum,
+      previousUpstreamRevisionId,
+      upstreamRevisionId,
       reason,
       localBytes: new TextEncoder().encode(localDoc).byteLength,
       remoteBytes: new TextEncoder().encode(remoteDoc).byteLength,
@@ -1415,6 +1762,13 @@ function stripTimestampSuffix(name: string): string {
 
 function nowIsoString(): string {
   return new Date().toISOString();
+}
+
+function canDispatchWindowEvents(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  );
 }
 
 function needsSync(lastSynced: string | undefined, maxAgeMs: number): boolean {

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -261,8 +261,6 @@ attrs:
   upstreamChecksum
   previousUpstreamRevisionId
   upstreamRevisionId
-  previousUpstreamObjectVersion
-  upstreamObjectVersion
   localBytes
   upstreamBytes
   reason
@@ -278,7 +276,6 @@ attrs:
   remoteId
   uploadedChecksum
   uploadedRevisionId
-  uploadedObjectVersion
 ```
 
 This gives support/debugging enough information to compare IndexedDB state,
@@ -525,16 +522,11 @@ old blob revision forever.
 - Modify local and upstream concurrently; verify conflict path still preserves
   local content.
 
-## Open Questions
+## Resolved Decisions
 
-- Should the sync indicator live in the tab, the notebook toolbar, or both?
-  - Decision: tab should be sufficient to start with
-- Should successful immediate sync show a toast, or is the indicator transition
-  sufficient?
-  - Decision: Don't show a toast
-- Should we keep a bounded local recovery snapshot for every upstream-to-local
-  overwrite?
-  - Decision: not right now
-- Should we mark the current Drive revision `keepForever` when a user explicitly
-  asks to preserve or restore it?
-  - Decision: not right now
+- The sync indicator should live in the tab to start.
+- Successful immediate sync should use the indicator transition; do not add a
+  toast in the first implementation.
+- Do not keep a bounded local recovery snapshot for every upstream-to-local
+  overwrite in this pass.
+- Do not mark the current Drive revision `keepForever` in this pass.

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -7,7 +7,12 @@ Issues:
 - https://github.com/runmedev/web/issues/165
 - https://github.com/runmedev/web/issues/157
 
-Depends on: `docs-dev/design/20260408a_refactor_notebooks.md`
+Builds on:
+
+- `docs-dev/design/20260408a_refactor_notebooks.md`
+- PR #168, which removed the old `NotebookStore` routing path, made
+  `LocalNotebooks` the app-facing notebook store, and removed the unused
+  contents-service storage path.
 
 ## Summary
 
@@ -16,19 +21,22 @@ local-vs-upstream state explicit to the user.
 
 Recommended changes:
 
-1. Track optional upstream revision metadata alongside content checksums.
+1. Track optional upstream revision metadata alongside content checksums in
+   `LocalFileRecord`.
 2. Adapt Google Drive revision metadata into that generic upstream-version
-   model.
-3. Add generic logging for every sync transition that can replace local mirror
-   content.
+   model without making notebook tabs Drive-specific.
+3. Generalize the existing overwrite logging so every upstream-to-local
+   replacement includes revision/checksum context.
 4. Add a small per-notebook sync-state indicator in the tab bar.
-5. Let users click the indicator to force immediate sync.
+5. Let users click the indicator to force immediate sync through
+   `LocalNotebooks.sync(localUri)`.
 6. Reject new Drive-file creation while Drive auth is unavailable until we have
    a durable pending-upstream-creation queue.
 
-Keep using content checksum (`md5Checksum`) as the sync/conflict predicate where
-possible. Upstream revision IDs should be persisted as provenance and diagnostic
-metadata, not as the only proof that two notebook payloads are equal.
+Keep using content checksum (`md5Checksum`) and upstream content checksum
+(`lastRemoteChecksum`) as the sync/conflict predicate where possible. Upstream
+revision IDs should be persisted as provenance and diagnostic metadata, not as
+the only proof that two notebook payloads are equal.
 
 ## Background
 
@@ -41,10 +49,57 @@ reproduced the loss, but investigation found two risky areas:
    can produce a browser-only local notebook instead of a Drive-backed mirror.
 
 PR #167 added conservative Drive sync guards and logging. This document captures
-follow-up work that should happen after the #157 / local-mirror cleanup.
+follow-up work that should happen after the #157 / local-mirror cleanup. PR
+#168 has now landed that cleanup.
 
 The UI should render "is my local notebook mirror synced to its upstream?", not
 "is my Google Drive file synced?".
+
+## Current Refactored Code State
+
+The app-facing notebook path is now:
+
+```text
+NotebookData / editor tabs
+  -> local://file/<id>
+  -> LocalNotebooks / IndexedDB
+  -> optional upstream selected by LocalFileRecord.remoteId
+```
+
+`LocalFileRecord` currently stores:
+
+```ts
+interface LocalFileRecord {
+  id: string;                 // local://file/<uuid>
+  name: string;
+  remoteId: string;           // local://file/<uuid> | fs://... | Drive HTTPS URL
+  markdownUri?: string;
+  lastRemoteChecksum: string;
+  lastSynced: string;
+  doc: string;
+  md5Checksum: string;
+}
+```
+
+`lastRemoteChecksum` is a legacy field name. After the refactor it is the last
+observed upstream content checksum for Drive and File System Access, not only
+Google Drive.
+
+The supported upstreams after PR #168 are:
+
+| Upstream | `remoteId` shape | Notes |
+| --- | --- | --- |
+| Browser-only IndexedDB | `remoteId === id` (`local://file/<uuid>`) | No external sync target. |
+| Google Drive | `https://drive.google.com/...` | Drive-only flows must use `isDriveItemUri`, not permissive `parseDriveItem`. |
+| File System Access | `fs://workspace/<workspace-id>/file/<path>` | Browser handle-backed upstream; do not document this as `file://`. |
+
+The contents-service path has been removed. Do not design new sync/version
+state around `contents://...` unless a real backend service and product entry
+point are reintroduced.
+
+`StorageBrowser` is now the narrow workspace-tree contract used by
+`WorkspaceExplorer`. It is not the editor persistence API and deliberately does
+not include notebook content load/save.
 
 ## Proposal 1: Model Upstream Versions as Optional Metadata
 
@@ -64,15 +119,21 @@ interface UpstreamVersion {
 
 interface LocalFileRecord {
   lastUpstreamVersion?: UpstreamVersion;
+  lastSyncError?: string;
 }
 ```
+
+Adding these fields requires a new Dexie migration after schema version 4.
+Backfill should leave `lastUpstreamVersion` undefined for existing records and
+clear `lastSyncError`.
 
 Backend examples:
 
 - Google Drive fills `checksum = files.md5Checksum`,
   `revisionId = files.headRevisionId`, and `objectVersion = files.version`.
-- Local filesystem can fill `checksum` by hashing file contents. It may also
-  fill `modifiedTime` and `sizeBytes`, but it does not need a `revisionId`.
+- File System Access fills `checksum` by hashing the serialized file contents.
+  It may later fill `modifiedTime` and `sizeBytes` from `File` metadata, but it
+  does not need a `revisionId`.
 - Browser-only IndexedDB notebooks can omit upstream revision metadata, or use
   the local checksum as the only version signal.
 
@@ -135,16 +196,48 @@ Update the Drive store to fetch and return this object in metadata paths that
 currently fetch `md5Checksum,headRevisionId,version` but keep only
 `md5Checksum`.
 
+Current code detail: `DriveNotebookStore` already defines:
+
+```ts
+const VERSION_FIELDS = "md5Checksum,headRevisionId,version";
+```
+
+It requests those fields in `load`, `save`, and `getChecksum`, but it only
+reads/persists `md5Checksum`. Add a typed metadata adapter rather than adding
+new ad hoc `getHeadRevisionId` calls:
+
+```ts
+interface DriveVersionMetadata {
+  md5Checksum?: string;
+  headRevisionId?: string;
+  version?: string;
+}
+
+class DriveNotebookStore {
+  getVersion(uri: string): Promise<UpstreamVersion | null>;
+}
+```
+
+Then `LocalNotebooks.syncFile(...)` can update both `lastRemoteChecksum` and
+`lastUpstreamVersion` from the same metadata read.
+
 ## Proposal 3: Structured Logging for Overwrites and Revision Transitions
 
 Use `appLogger` for sync events that are important for data-loss diagnosis.
+
+Current code already logs upstream-to-local replacement via
+`logRemoteOverwriteLocalDoc(...)`, but the event is still named
+"Overwriting local notebook content with Drive content" and only includes
+checksums/byte counts. Because the same helper is used by the filesystem
+upstream path, rename the event and scope to be upstream-generic when adding
+version metadata.
 
 Log before replacing local notebook JSON with upstream JSON:
 
 ```text
 event: Overwriting local notebook content with upstream content
 attrs:
-  scope: storage.notebook.sync
+  scope: storage.local.sync
   localUri
   remoteId
   localChecksum
@@ -164,7 +257,7 @@ Log after successful upload:
 ```text
 event: Uploaded local notebook content to upstream
 attrs:
-  scope: storage.notebook.sync
+  scope: storage.local.sync
   localUri
   remoteId
   uploadedChecksum
@@ -201,9 +294,9 @@ Clicking it should bypass the existing debounce and try to save now.
 
 ## Proposal 5: Add Generic Mirror Sync State
 
-After the Issue 157 refactor, expose sync state in terms of the local mirror and
-its optional upstream. Do not expose a Google-Drive-specific status object to
-notebook tabs.
+With the Issue 157 refactor landed, expose sync state in terms of the local
+mirror and its optional upstream. Do not expose a Google-Drive-specific status
+object to notebook tabs.
 
 Illustrative shape:
 
@@ -230,13 +323,25 @@ Then expose these through the local mirror service:
 ```ts
 class LocalNotebooks {
   getSyncState(localUri: string): Promise<NotebookSyncState>;
-  syncNow(localUri: string): Promise<void>;
   subscribeSync(localUri: string, listener: () => void): () => void;
 }
 ```
 
-`syncNow` should call the same synchronization state machine as the debounced
-background sync; it should not create a second upload path.
+Do not add a second upload path. The class already exposes
+`sync(localUri: string): Promise<void>`; the UI click handler can call that
+method directly or through a thin `syncNow` alias if a clearer UI-facing name is
+needed.
+
+`getSyncState` can be derived from the existing fields at first:
+
+- `remoteId === id` or `remoteId` is empty: `local-only`
+- upstream is Drive or `fs://...` and `md5Checksum === lastRemoteChecksum`:
+  `synced`
+- upstream is Drive or `fs://...` and `md5Checksum !== lastRemoteChecksum`:
+  `pending`
+- current in-memory sync subject is running: `syncing`
+- last sync attempt failed: `error` once we add `lastSyncError` or equivalent
+  metadata
 
 The first implementation can omit `subscribeSync` and poll/recompute when
 NotebookData emits, if that is enough for the tab indicator. Add a subscription
@@ -248,6 +353,15 @@ Start with the simpler UX:
 
 If the user is creating a new file from a mounted Google Drive folder, require
 Drive auth before creating any local notebook record.
+
+Current gap after PR #168: `WorkspaceExplorer` calls `LocalNotebooks.create`
+for local mirrored Drive folders. `LocalNotebooks.create` creates a
+`local://file/...` record first, then asynchronously calls
+`DriveNotebookStore.create(parent.remoteId, name)` if the parent folder has a
+Drive `remoteId`. Because `DriveNotebookStore` uses non-interactive
+`ensureAccessToken({ interactive: false })`, expired auth can make that async
+Drive create fail and leave the notebook as browser-only. This is exactly the
+case we should remove.
 
 Flow:
 
@@ -308,17 +422,19 @@ old blob revision forever.
 ## Rollout Plan
 
 1. Land the Issue 165 defensive overwrite fix.
-2. Implement the Issue 157 local-mirror consolidation described in
+2. Done: implement the Issue 157 local-mirror consolidation described in
    `20260408a_refactor_notebooks.md`.
 3. Add optional `UpstreamVersion` metadata to local mirror records.
 4. Adapt Drive metadata into `UpstreamVersion`.
-5. Add structured appLogger events for uploads, downloads, conflicts, and
-   local-overwrite.
-6. Add generic `syncNow` and sync-state API on the local mirror service.
+5. Generalize structured appLogger events for uploads, downloads, conflicts,
+   and local-overwrite, preserving the existing overwrite logging but adding
+   revision metadata.
+6. Add generic sync-state API on the local mirror service; use the existing
+   `LocalNotebooks.sync(localUri)` method for immediate sync.
 7. Add tab-level sync indicator using the sync-state API.
 8. Wire red/failed indicator clicks to immediate sync or required auth/reconnect.
-9. Change Explorer "new Drive file" flow to require auth before creating the
-   local mirror.
+9. Change Explorer/LocalNotebooks "new Drive file" flow to require auth before
+   creating the local mirror.
 10. Add tests for expired-auth new-file creation.
 
 ## Test Plan
@@ -326,7 +442,7 @@ old blob revision forever.
 - Create a Drive-backed notebook and verify IndexedDB records checksum,
   head revision ID, and Drive version after initial upload.
 - Create a browser-only notebook and verify sync state is IndexedDB-only.
-- Open/mirror a filesystem notebook and verify sync state uses `file://...`.
+- Open/mirror a filesystem notebook and verify sync state uses `fs://...`.
 - Edit a Drive-backed notebook while auth is unavailable; verify tab indicator
   turns red.
 - Click red indicator after restoring auth; verify upload happens immediately

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -181,19 +181,14 @@ checksum comparison.
 
 ## Proposal 2: Persist Drive Revision Provenance
 
-Drive metadata should be adapted into `UpstreamVersion`, not exposed to tab UI
-as a Google-specific state object.
+`LocalNotebooks` remains the app-facing API. Notebook tabs and other UI should
+ask `LocalNotebooks` for sync/version state; they should not import
+`DriveNotebookStore`, call Drive APIs, or receive a Google-specific status
+object.
 
-Illustrative shape:
-
-```ts
-function toUpstreamVersion(metadata: DriveFileMetadata): UpstreamVersion {
-  return {
-    checksum: metadata.md5Checksum,
-    revisionId: metadata.headRevisionId,
-  };
-}
-```
+The Drive-specific work in this proposal is only an internal adapter step:
+capture the Drive metadata that `LocalNotebooks` needs to persist
+`lastRemoteChecksum` and `lastUpstreamVersion`.
 
 Update the Drive store to fetch and return this object in metadata paths that
 currently fetch `md5Checksum,headRevisionId,version` but keep only
@@ -207,8 +202,8 @@ const VERSION_FIELDS = "md5Checksum,headRevisionId,version";
 ```
 
 It requests those fields in `load`, `save`, and `getChecksum`, but it only
-reads/persists `md5Checksum`. Add a typed metadata adapter rather than adding
-new ad hoc `getHeadRevisionId` calls:
+reads/persists `md5Checksum`. Add a typed metadata return value rather than
+adding new ad hoc `getHeadRevisionId` calls:
 
 ```ts
 interface DriveVersionMetadata {
@@ -217,12 +212,23 @@ interface DriveVersionMetadata {
 }
 
 class DriveNotebookStore {
-  getVersion(uri: string): Promise<UpstreamVersion | null>;
+  getVersionMetadata(uri: string): Promise<DriveVersionMetadata | null>;
 }
 ```
 
-Then `LocalNotebooks.syncFile(...)` can update both `lastRemoteChecksum` and
-`lastUpstreamVersion` from the same metadata read.
+Then `LocalNotebooks.syncFile(...)` can translate that Drive metadata into the
+generic `LocalFileRecord` fields:
+
+```ts
+lastRemoteChecksum = metadata.md5Checksum ?? "";
+lastUpstreamVersion = {
+  checksum: metadata.md5Checksum,
+  revisionId: metadata.headRevisionId,
+};
+```
+
+This translation belongs inside `LocalNotebooks` or a private storage helper,
+not in the tab UI.
 
 ## Proposal 3: Structured Logging for Overwrites and Revision Transitions
 

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -375,6 +375,14 @@ Drive `remoteId`. Because `DriveNotebookStore` uses non-interactive
 Drive create fail and leave the notebook as browser-only. This is exactly the
 case we should remove.
 
+`LocalFileRecord` does not currently store its parent folder ID. Parent
+membership is persisted on `LocalFolderRecord.children`, and `LocalNotebooks`
+can recover a file's parent by scanning folders. That means a reload after the
+local file insert but before the async Drive create completes leaves a durable
+local file whose `remoteId` looks browser-only. We can infer that it sits under a
+Drive-backed local folder, but there is no explicit "pending Drive create for
+parent X" state on the file.
+
 Flow:
 
 1. User clicks "new file" in a Drive folder.
@@ -406,6 +414,14 @@ local mirror already has a Drive `remoteId`: the save should move into
 avoid here is the initial-create failure mode where the notebook is accidentally
 left as browser-only because Drive creation failed after the local record was
 already inserted.
+
+If we decide to keep a local-first create flow, we should make that state
+explicit instead of relying on folder-child inference. That would require adding
+fields such as `pendingUpstreamParentId`, `pendingUpstreamName`, and
+`lastSyncError`, then a startup reconciler that resumes or surfaces pending
+Drive creates. That is effectively the pending-upstream-creation queue described
+below, so the simpler first step should be remote-first create for Drive-backed
+folders.
 
 ## Deferred Option: Pending Upstream Creation Queue
 

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -112,7 +112,6 @@ Illustrative shape:
 interface UpstreamVersion {
   checksum?: string;
   revisionId?: string;
-  objectVersion?: string;
   modifiedTime?: string;
   sizeBytes?: number;
 }
@@ -130,7 +129,8 @@ clear `lastSyncError`.
 Backend examples:
 
 - Google Drive fills `checksum = files.md5Checksum`,
-  `revisionId = files.headRevisionId`, and `objectVersion = files.version`.
+  `revisionId = files.headRevisionId`, and may later fill `modifiedTime` or
+  `sizeBytes` if those help diagnostics.
 - File System Access fills `checksum` by hashing the serialized file contents.
   It may later fill `modifiedTime` and `sizeBytes` from `File` metadata, but it
   does not need a `revisionId`.
@@ -151,6 +151,10 @@ The Drive `files.get` response has several version-like fields:
 Drive `files.version` is deliberately broader than content. Google documents it
 as a monotonically increasing number reflecting every server-side file change,
 including changes that are not visible to the user.
+
+Do not persist `files.version` as part of `UpstreamVersion` unless we add a
+separate diagnostics-only use case. It is too broad for sync correctness and is
+not the user-visible revision identity we need for restore/version UI.
 
 Drive `headRevisionId` corresponds to the current content revision for our JSON
 blob files. It is the API-level identity closest to the "Current version" row in
@@ -187,14 +191,14 @@ function toUpstreamVersion(metadata: DriveFileMetadata): UpstreamVersion {
   return {
     checksum: metadata.md5Checksum,
     revisionId: metadata.headRevisionId,
-    objectVersion: metadata.version,
   };
 }
 ```
 
 Update the Drive store to fetch and return this object in metadata paths that
 currently fetch `md5Checksum,headRevisionId,version` but keep only
-`md5Checksum`.
+`md5Checksum`. As part of this change, stop requesting `version` from
+`VERSION_FIELDS` unless a concrete diagnostics-only use case is added.
 
 Current code detail: `DriveNotebookStore` already defines:
 
@@ -210,7 +214,6 @@ new ad hoc `getHeadRevisionId` calls:
 interface DriveVersionMetadata {
   md5Checksum?: string;
   headRevisionId?: string;
-  version?: string;
 }
 
 class DriveNotebookStore {

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -30,8 +30,9 @@ Recommended changes:
 4. Add a small per-notebook sync-state indicator in the tab bar.
 5. Let users click the indicator to force immediate sync through
    `LocalNotebooks.sync(localUri)`.
-6. Reject new Drive-file creation while Drive auth is unavailable until we have
-   a durable pending-upstream-creation queue.
+6. Persist pending Drive-file creation state so users can create locally while
+   Drive auth is unavailable, then complete upstream creation after auth
+   recovers.
 
 Keep using content checksum (`md5Checksum`) and upstream content checksum
 (`lastRemoteChecksum`) as the sync/conflict predicate where possible. Upstream
@@ -93,6 +94,11 @@ The supported upstreams after PR #168 are:
 | Google Drive | `https://drive.google.com/...` | Drive-only flows must use `isDriveItemUri`, not permissive `parseDriveItem`. |
 | File System Access | `fs://workspace/<workspace-id>/file/<path>` | Browser handle-backed upstream; do not document this as `file://`. |
 
+Current PR #168 code normalizes empty `remoteId` values to `id` for existing
+records. Introducing `remoteId === ""` as a pending-upstream-create state would
+therefore be a new explicit state, not the current browser-only representation.
+Proposal 6 describes that new state.
+
 The contents-service path has been removed. Do not design new sync/version
 state around `contents://...` unless a real backend service and product entry
 point are reintroduced.
@@ -119,12 +125,13 @@ interface UpstreamVersion {
 interface LocalFileRecord {
   lastUpstreamVersion?: UpstreamVersion;
   lastSyncError?: string;
+  parentRemoteIdWhenCreated?: string;
 }
 ```
 
 Adding these fields requires a new Dexie migration after schema version 4.
 Backfill should leave `lastUpstreamVersion` undefined for existing records and
-clear `lastSyncError`.
+clear `lastSyncError` and `parentRemoteIdWhenCreated`.
 
 Backend examples:
 
@@ -314,6 +321,7 @@ type NotebookSyncStatus =
   | "local-only"
   | "synced"
   | "pending"
+  | "pending-upstream-create"
   | "syncing"
   | "error";
 
@@ -321,6 +329,7 @@ interface NotebookSyncState {
   status: NotebookSyncStatus;
   localUri: string;
   remoteId: string;
+  parentRemoteIdWhenCreated?: string;
   lastSynced?: string;
   lastUpstreamVersion?: UpstreamVersion;
   lastError?: string;
@@ -343,7 +352,10 @@ needed.
 
 `getSyncState` can be derived from the existing fields at first:
 
-- `remoteId === id` or `remoteId` is empty: `local-only`
+- `remoteId === id`: `local-only`
+- `remoteId === "" && parentRemoteIdWhenCreated`:
+  `pending-upstream-create`
+- `remoteId === ""` without `parentRemoteIdWhenCreated`: `error`
 - upstream is Drive or `fs://...` and `md5Checksum === lastRemoteChecksum`:
   `synced`
 - upstream is Drive or `fs://...` and `md5Checksum !== lastRemoteChecksum`:
@@ -356,15 +368,12 @@ The first implementation can omit `subscribeSync` and poll/recompute when
 NotebookData emits, if that is enough for the tab indicator. Add a subscription
 only when we need tabs to update immediately after metadata-only sync events.
 
-## Proposal 6: Block Drive New-File Creation While Drive Auth Is Unavailable
+## Proposal 6: Persist Pending Drive New-File Creation
 
-Start with the simpler UX, but do not rely on a preflight auth check as the
-correctness mechanism. A token that is valid before creation can still expire
-before the network request finishes. The invariant should be stronger:
-
-If the user is creating a new file from a mounted Google Drive folder, do not
-create the local notebook mirror until the Drive file has been created
-successfully and we have its Drive URI.
+Allow local document creation even when Drive auth is unavailable, but make the
+missing upstream creation state explicit and durable. Do not rely on a preflight
+auth check; a token that is valid before creation can still expire before the
+network request finishes.
 
 Current gap after PR #168: `WorkspaceExplorer` calls `LocalNotebooks.create`
 for local mirrored Drive folders. `LocalNotebooks.create` creates a
@@ -383,29 +392,47 @@ local file whose `remoteId` looks browser-only. We can infer that it sits under 
 Drive-backed local folder, but there is no explicit "pending Drive create for
 parent X" state on the file.
 
+Add a transitory parent snapshot to `LocalFileRecord`, for example:
+
+```ts
+interface LocalFileRecord {
+  remoteId: string; // "" while pending upstream creation
+  parentRemoteIdWhenCreated?: string;
+}
+```
+
+`parentRemoteIdWhenCreated` should contain the parent's upstream URI at the time
+the local file was created, for example the Drive folder URL. It is deliberately
+not a live parent pointer and should not be kept up to date if the remote file or
+folder is later moved in Google Drive. Once the Drive file is created and
+`remoteId` is set to the Drive file URL, clear `parentRemoteIdWhenCreated`.
+
 Flow:
 
 1. User clicks "new file" in a Drive folder.
 2. `LocalNotebooks.create(...)` detects that the parent is Drive-backed.
-3. It awaits `DriveNotebookStore.create(parent.remoteId, name)`.
-4. If Drive auth is missing, expired, or fails during the request, the awaited
-   Drive create rejects.
-5. On rejection, do not create a local notebook record; surface auth-required
-   or create-failed UI.
-6. On success, create the IndexedDB mirror using the returned Drive URI as
-   `remoteId`.
-7. Persist the same initial notebook content locally and store checksum/revision
-   metadata.
+3. It creates the local record with `remoteId = ""` and
+   `parentRemoteIdWhenCreated = parent.remoteId`.
+4. It adds the local file URI to the local folder's `children`.
+5. It attempts `DriveNotebookStore.create(parent.remoteId, name)` immediately if
+   auth is available.
+6. If Drive create succeeds, set `remoteId` to the Drive file URL, clear
+   `parentRemoteIdWhenCreated`, and store checksum/revision metadata.
+7. If Drive auth is missing, expired, or the app reloads before the async create
+   completes, keep the local file and show it as pending upstream creation.
 
 If auth is unavailable:
 
-1. Do not create a local notebook.
-2. Start login flow or show an auth-required error.
-3. Keep the user in the same Explorer location.
-4. Ask the user to retry creation after auth completes.
+1. Keep the local notebook.
+2. Surface a pending/error sync state on the notebook tab.
+3. On explicit sync or the next background sync after auth is restored, create
+   the Drive file under `parentRemoteIdWhenCreated`.
+4. After successful creation, clear `parentRemoteIdWhenCreated` and continue
+   normal sync using the assigned Drive `remoteId`.
 
-This avoids creating an IndexedDB-only notebook when the user intended to create
-a Drive-backed notebook.
+This avoids silently converting a Drive-intended notebook into a browser-only
+notebook. The local record is allowed to exist first, but it carries enough
+state to complete the upstream creation later.
 
 This does not eliminate all token-expiry races. A token can still expire after
 the Drive file is created and before a later autosave. That is acceptable if the
@@ -415,18 +442,17 @@ avoid here is the initial-create failure mode where the notebook is accidentally
 left as browser-only because Drive creation failed after the local record was
 already inserted.
 
-If we decide to keep a local-first create flow, we should make that state
-explicit instead of relying on folder-child inference. That would require adding
-fields such as `pendingUpstreamParentId`, `pendingUpstreamName`, and
-`lastSyncError`, then a startup reconciler that resumes or surfaces pending
-Drive creates. That is effectively the pending-upstream-creation queue described
-below, so the simpler first step should be remote-first create for Drive-backed
-folders.
+The reconciler should treat `remoteId === "" && parentRemoteIdWhenCreated` as
+"pending upstream creation". If `remoteId === ""` without
+`parentRemoteIdWhenCreated`, treat it as malformed/legacy state and surface an
+error instead of guessing a parent from `LocalFolderRecord.children`.
 
-## Deferred Option: Pending Upstream Creation Queue
+## Deferred Option: General Pending Upstream Creation Queue
 
-Offline upstream-file creation can be supported later, but only with an explicit
-pending creation model.
+The `parentRemoteIdWhenCreated` approach is the smallest durable fix for Drive
+new-file creation. A more general queue can be supported later if we need
+multi-backend offline creation, richer retry state, or multiple pending upstream
+operations per local notebook.
 
 That model would need to persist:
 
@@ -474,22 +500,26 @@ old blob revision forever.
    `LocalNotebooks.sync(localUri)` method for immediate sync.
 7. Add tab-level sync indicator using the sync-state API.
 8. Wire red/failed indicator clicks to immediate sync or required auth/reconnect.
-9. Change Explorer/LocalNotebooks "new Drive file" flow to require auth before
-   creating the local mirror.
-10. Add tests for expired-auth new-file creation.
+9. Change Explorer/LocalNotebooks "new Drive file" flow to persist pending
+   upstream creation state when Drive create cannot complete immediately.
+10. Add tests for expired-auth new-file creation and retry.
 
 ## Test Plan
 
-- Create a Drive-backed notebook and verify IndexedDB records checksum,
-  head revision ID, and Drive version after initial upload.
+- Create a Drive-backed notebook and verify IndexedDB records checksum and head
+  revision ID after initial upload.
 - Create a browser-only notebook and verify sync state is IndexedDB-only.
 - Open/mirror a filesystem notebook and verify sync state uses `fs://...`.
 - Edit a Drive-backed notebook while auth is unavailable; verify tab indicator
   turns red.
 - Click red indicator after restoring auth; verify upload happens immediately
   and indicator turns green.
-- Create new notebook from a Drive folder while auth is unavailable; verify no
-  local file record is created and the UI prompts for login.
+- Create new notebook from a Drive folder while auth is unavailable; verify a
+  local file record is created with `remoteId === ""` and
+  `parentRemoteIdWhenCreated` set to the Drive folder URL.
+- Restore auth and sync the pending notebook; verify the Drive file is created,
+  `remoteId` is set to the Drive file URL, and `parentRemoteIdWhenCreated` is
+  cleared.
 - Modify upstream Drive content from another browser session; verify local
   overwrite is logged with previous and current revision metadata.
 - Modify local and upstream concurrently; verify conflict path still preserves

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -358,10 +358,13 @@ only when we need tabs to update immediately after metadata-only sync events.
 
 ## Proposal 6: Block Drive New-File Creation While Drive Auth Is Unavailable
 
-Start with the simpler UX:
+Start with the simpler UX, but do not rely on a preflight auth check as the
+correctness mechanism. A token that is valid before creation can still expire
+before the network request finishes. The invariant should be stronger:
 
-If the user is creating a new file from a mounted Google Drive folder, require
-Drive auth before creating any local notebook record.
+If the user is creating a new file from a mounted Google Drive folder, do not
+create the local notebook mirror until the Drive file has been created
+successfully and we have its Drive URI.
 
 Current gap after PR #168: `WorkspaceExplorer` calls `LocalNotebooks.create`
 for local mirrored Drive folders. `LocalNotebooks.create` creates a
@@ -375,11 +378,16 @@ case we should remove.
 Flow:
 
 1. User clicks "new file" in a Drive folder.
-2. UI checks Drive auth.
-3. If auth is available, create the Drive file first.
-4. Create the IndexedDB mirror only after Drive returns the file ID.
-5. Persist initial notebook content locally.
-6. Upload that same content and store checksum/revision metadata.
+2. `LocalNotebooks.create(...)` detects that the parent is Drive-backed.
+3. It awaits `DriveNotebookStore.create(parent.remoteId, name)`.
+4. If Drive auth is missing, expired, or fails during the request, the awaited
+   Drive create rejects.
+5. On rejection, do not create a local notebook record; surface auth-required
+   or create-failed UI.
+6. On success, create the IndexedDB mirror using the returned Drive URI as
+   `remoteId`.
+7. Persist the same initial notebook content locally and store checksum/revision
+   metadata.
 
 If auth is unavailable:
 
@@ -390,6 +398,14 @@ If auth is unavailable:
 
 This avoids creating an IndexedDB-only notebook when the user intended to create
 a Drive-backed notebook.
+
+This does not eliminate all token-expiry races. A token can still expire after
+the Drive file is created and before a later autosave. That is acceptable if the
+local mirror already has a Drive `remoteId`: the save should move into
+`pending` or `error` sync state and retry after auth is restored. The bug to
+avoid here is the initial-create failure mode where the notebook is accidentally
+left as browser-only because Drive creation failed after the local record was
+already inserted.
 
 ## Deferred Option: Pending Upstream Creation Queue
 

--- a/docs-dev/design/20260408b_track_drive_versions.md
+++ b/docs-dev/design/20260408b_track_drive_versions.md
@@ -198,14 +198,13 @@ capture the Drive metadata that `LocalNotebooks` needs to persist
 `lastRemoteChecksum` and `lastUpstreamVersion`.
 
 Update the Drive store to fetch and return this object in metadata paths that
-currently fetch `md5Checksum,headRevisionId,version` but keep only
-`md5Checksum`. As part of this change, stop requesting `version` from
+currently fetch only the checksum. As part of this change, keep `version` out of
 `VERSION_FIELDS` unless a concrete diagnostics-only use case is added.
 
 Current code detail: `DriveNotebookStore` already defines:
 
 ```ts
-const VERSION_FIELDS = "md5Checksum,headRevisionId,version";
+const VERSION_FIELDS = "md5Checksum,headRevisionId";
 ```
 
 It requests those fields in `load`, `save`, and `getChecksum`, but it only


### PR DESCRIPTION
## Summary
- track optional upstream version metadata on local notebook records
- persist pending Google Drive create state with `parentRemoteIdWhenCreated` and complete it on later sync
- add a tab sync-state indicator with click-to-sync for pending/error states
- preserve malformed local JSON by saving raw content instead of falling back to an empty notebook
- update the Drive version-tracking design doc to keep `files.version` out of sync metadata

## Why
This makes Drive sync state observable and more defensive around expired auth and unknown baseline states. Pending Drive file creation now survives failed auth/metadata fetches and local content is not silently downgraded to an empty notebook if parsing fails.

Refs #165
Refs #157

## Validation
- `pnpm exec vitest run src/storage/local.test.ts src/storage/drive.test.ts src/storage/fs.test.ts src/components/Actions/Actions.test.tsx`
- `git diff --cached --check`

`pnpm run typecheck` still fails on existing repo-wide diagnostics in `Actions.test.tsx`, `Actions.tsx`, `drive.ts`, WorkspaceExplorer, ChatKit, Datadog, and related files; no new `local.ts` or `local.test.ts` diagnostics remain after the test helper fix.
