### PR TITLE
Add Codex WASM ChatKit harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ packages/react-console/gen
 
 # CUJ generated outputs
 /app/.generated/
+/app/assets/generated/
 /app/test/browser/.generated/
 /app/test/browser/test-output/*
 

--- a/app/package.json
+++ b/app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "sync:codex-wasm": "node tools/sync_codex_wasm_assets.mjs",
     "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "build": "vite build",
     "cuj:build": "tsc --target es2020 --module nodenext --moduleResolution nodenext --esModuleInterop --skipLibCheck --outDir test/browser/.generated test/browser/run-cuj-scenarios.ts",

--- a/app/src/components/ChatKit/ChatKitPanel.test.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.test.tsx
@@ -6,7 +6,11 @@ import { ChatkitStateSchema } from "../../protogen/oaiproto/aisre/notebooks_pb.j
 
 type HarnessAdapter = "responses-direct" | "codex" | "codex-wasm";
 
-let harnessState: { defaultHarness: { name: string; baseUrl: string; adapter: HarnessAdapter } };
+let harnessState: {
+  harnesses: Array<{ name: string; baseUrl: string; adapter: HarnessAdapter }>;
+  defaultHarness: { name: string; baseUrl: string; adapter: HarnessAdapter };
+  defaultHarnessName: string;
+};
 let codexProjectsState: {
   projects: Array<{ id: string; name: string }>;
   defaultProject: { id: string; name: string };
@@ -24,6 +28,9 @@ let bridgeListener: (() => void) | null;
 let setThreadIdMock: ReturnType<typeof vi.fn>;
 let fetchUpdatesMock: ReturnType<typeof vi.fn>;
 const useChatKitMock = vi.fn();
+const harnessManagerMock = {
+  setDefault: vi.fn(),
+};
 const { appLoggerMock } = vi.hoisted(() => ({
   appLoggerMock: {
     info: vi.fn(),
@@ -171,6 +178,7 @@ vi.mock("../../lib/runtime/harnessManager", async () => {
   return {
     ...actual,
     useHarness: () => harnessState,
+    getHarnessManager: () => harnessManagerMock,
   };
 });
 
@@ -183,11 +191,29 @@ import ChatKitPanel from "./ChatKitPanel";
 describe("ChatKitPanel codex harness routing", () => {
   beforeEach(() => {
     harnessState = {
+      harnesses: [
+        {
+          name: "default",
+          baseUrl: "http://127.0.0.1:31337",
+          adapter: "responses-direct",
+        },
+        {
+          name: "local-codex",
+          baseUrl: "http://127.0.0.1:31337",
+          adapter: "codex",
+        },
+        {
+          name: "local-codex-wasm",
+          baseUrl: "",
+          adapter: "codex-wasm",
+        },
+      ],
       defaultHarness: {
         name: "default",
         baseUrl: "http://127.0.0.1:31337",
         adapter: "responses-direct",
       },
+      defaultHarnessName: "default",
     };
     codexProjectsState = {
       projects: [{ id: "project-1", name: "Runme Repo" }],
@@ -215,6 +241,7 @@ describe("ChatKitPanel codex harness routing", () => {
       setThreadId: setThreadIdMock,
       fetchUpdates: fetchUpdatesMock,
     });
+    harnessManagerMock.setDefault.mockClear();
     bridgeMock.connect.mockClear();
     bridgeMock.disconnect.mockClear();
     bridgeMock.setHandler.mockClear();
@@ -247,6 +274,22 @@ describe("ChatKitPanel codex harness routing", () => {
     expect(config.api.url).toBe("http://127.0.0.1:31337/responses/direct/chatkit");
     expect(bridgeMock.connect).not.toHaveBeenCalled();
     expect(bridgeMock.disconnect).toHaveBeenCalled();
+  });
+
+  it("renders a harness selector and switches the default harness", async () => {
+    render(<ChatKitPanel />);
+
+    const selector = screen.getByTestId("chatkit-harness-select") as HTMLSelectElement;
+    expect(selector.value).toBe("default");
+    expect(selector.options).toHaveLength(3);
+
+    await act(async () => {
+      fireEvent.change(selector, {
+        target: { value: "local-codex-wasm" },
+      });
+    });
+
+    expect(harnessManagerMock.setDefault).toHaveBeenCalledWith("local-codex-wasm");
   });
 
   it("routes ChatKit to responses-direct adapter URL and uses responses-direct fetch", async () => {

--- a/app/src/components/ChatKit/ChatKitPanel.test.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { create } from "@bufbuild/protobuf";
 import { ChatkitStateSchema } from "../../protogen/oaiproto/aisre/notebooks_pb.js";
 
-type HarnessAdapter = "responses-direct" | "codex";
+type HarnessAdapter = "responses-direct" | "codex" | "codex-wasm";
 
 let harnessState: { defaultHarness: { name: string; baseUrl: string; adapter: HarnessAdapter } };
 let codexProjectsState: {
@@ -78,6 +78,7 @@ const codexControllerMock = {
   })),
 };
 const codexFetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+const codexWasmFetchMock = vi.fn(async () => new Response(null, { status: 200 }));
 const responsesDirectFetchMock = vi.fn(async () => new Response(null, { status: 200 }));
 
 vi.mock("@openai/chatkit-react", () => ({
@@ -144,6 +145,10 @@ vi.mock("../../lib/runtime/codexAppServerProxyClient", () => ({
 
 vi.mock("../../lib/runtime/codexChatkitFetch", () => ({
   createCodexChatkitFetch: () => codexFetchMock,
+}));
+
+vi.mock("../../lib/runtime/codexWasmChatkitFetch", () => ({
+  createCodexWasmChatkitFetch: () => codexWasmFetchMock,
 }));
 
 vi.mock("../../lib/runtime/responsesDirectChatkitFetch", () => ({
@@ -224,6 +229,7 @@ describe("ChatKitPanel codex harness routing", () => {
     codexControllerMock.getSnapshot.mockClear();
     codexControllerMock.selectThread.mockClear();
     codexFetchMock.mockClear();
+    codexWasmFetchMock.mockClear();
     responsesDirectFetchMock.mockClear();
     approvalMgrMock.failAll.mockClear();
     appLoggerMock.info.mockClear();
@@ -269,6 +275,36 @@ describe("ChatKitPanel codex harness routing", () => {
     });
 
     expect(responsesDirectFetchMock).toHaveBeenCalled();
+    expect(codexFetchMock).not.toHaveBeenCalled();
+    expect(bridgeMock.connect).not.toHaveBeenCalled();
+  });
+
+  it("routes ChatKit to codex-wasm adapter URL and uses codex-wasm fetch", async () => {
+    harnessState.defaultHarness.adapter = "codex-wasm";
+
+    render(<ChatKitPanel />);
+
+    const config = useChatKitMock.mock.calls.at(0)?.[0];
+    expect(config.api.url).toBe("http://127.0.0.1:31337/codex/wasm/chatkit");
+
+    await act(async () => {
+      await config.api.fetch("http://127.0.0.1:31337/codex/wasm/chatkit", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          type: "threads.create",
+          params: {
+            input: {
+              content: [{ type: "input_text", text: "hello codex wasm" }],
+            },
+          },
+        }),
+      });
+    });
+
+    expect(codexWasmFetchMock).toHaveBeenCalled();
     expect(codexFetchMock).not.toHaveBeenCalled();
     expect(bridgeMock.connect).not.toHaveBeenCalled();
   });

--- a/app/src/components/ChatKit/ChatKitPanel.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.tsx
@@ -20,6 +20,7 @@ import { getCodexToolBridge } from '../../lib/runtime/codexToolBridge'
 import { getCodexExecuteApprovalManager } from '../../lib/runtime/codexExecuteApprovalManager'
 import { getCodexAppServerProxyClient } from '../../lib/runtime/codexAppServerProxyClient'
 import { createCodexChatkitFetch } from '../../lib/runtime/codexChatkitFetch'
+import { createCodexWasmChatkitFetch } from '../../lib/runtime/codexWasmChatkitFetch'
 import { createResponsesDirectChatkitFetch } from '../../lib/runtime/responsesDirectChatkitFetch'
 import {
   createCodeModeExecutor,
@@ -796,6 +797,13 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
     [defaultHarness.adapter]
   )
   const codexFetch = useMemo(() => createCodexChatkitFetch(), [])
+  const codexWasmFetch = useMemo(
+    () =>
+      createCodexWasmChatkitFetch({
+        codeModeExecutor,
+      }),
+    [codeModeExecutor]
+  )
   const responsesDirectFetch = useMemo(
     () =>
       createResponsesDirectChatkitFetch({
@@ -822,7 +830,11 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
   const authorizedFetch = useAuthorizedFetch(getAuthorizedChatkitState, {
     onSSEEvent: handleSseEvent,
     baseFetch:
-      defaultHarness.adapter === 'codex' ? codexFetch : responsesDirectFetch,
+      defaultHarness.adapter === 'codex'
+        ? codexFetch
+        : defaultHarness.adapter === 'codex-wasm'
+          ? codexWasmFetch
+          : responsesDirectFetch,
     includeRunmeHeaders: defaultHarness.adapter === 'codex',
     includeChatkitState: defaultHarness.adapter === 'codex',
   })

--- a/app/src/components/ChatKit/ChatKitPanel.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from 'react'
 import { ChatKit, useChatKit, ChatKitIcon } from '@openai/chatkit-react'
 import {
   parser_pb,
@@ -11,6 +18,7 @@ import { useCurrentDoc } from '../../contexts/CurrentDocContext'
 import { create, fromJsonString, toJson } from '@bufbuild/protobuf'
 import {
   useHarness,
+  getHarnessManager,
   buildChatkitUrl,
   buildCodexAppServerWsUrl,
   buildCodexBridgeWsUrl,
@@ -1750,13 +1758,51 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
 }
 
 function ChatKitPanel() {
-  const { defaultHarness } = useHarness()
+  const { harnesses, defaultHarness } = useHarness()
+  const harnessManager = useMemo(() => getHarnessManager(), [])
   const harnessSessionKey = `${defaultHarness.name}:${defaultHarness.baseUrl}:${defaultHarness.adapter}`
+
+  const handleHarnessChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const nextHarnessName = event.target.value
+      if (!nextHarnessName || nextHarnessName === defaultHarness.name) {
+        return
+      }
+      harnessManager.setDefault(nextHarnessName)
+    },
+    [defaultHarness.name, harnessManager]
+  )
+
   return (
-    <ChatKitPanelInner
-      key={harnessSessionKey}
-      defaultHarness={defaultHarness}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1">
+        <ChatKitPanelInner
+          key={harnessSessionKey}
+          defaultHarness={defaultHarness}
+        />
+      </div>
+      <div className="border-t border-nb-cell-border bg-white px-3 py-2">
+        <label
+          htmlFor="chatkit-harness-select"
+          className="mb-1 block text-xs font-medium text-nb-text-muted"
+        >
+          Harness
+        </label>
+        <select
+          id="chatkit-harness-select"
+          data-testid="chatkit-harness-select"
+          className="w-full rounded border border-nb-cell-border bg-white px-2 py-1 text-sm text-nb-text"
+          value={defaultHarness.name}
+          onChange={handleHarnessChange}
+        >
+          {harnesses.map((harness) => (
+            <option key={harness.name} value={harness.name}>
+              {`${harness.name} (${harness.adapter})`}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
   )
 }
 

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -157,7 +157,7 @@ const harnessStore = new Map<
   {
     name: string;
     baseUrl: string;
-    adapter: "responses-direct" | "codex";
+    adapter: "responses-direct" | "codex" | "codex-wasm";
   }
 >();
 let defaultHarnessName: string | null = null;
@@ -181,7 +181,7 @@ const harnessManager = {
     (
       name: string,
       baseUrl: string,
-      adapter: "responses-direct" | "codex",
+      adapter: "responses-direct" | "codex" | "codex-wasm",
     ) => {
       const next = { name, baseUrl, adapter };
       harnessStore.set(name, next);
@@ -206,13 +206,15 @@ const harnessManager = {
     (
       profile: {
         baseUrl: string;
-        adapter: "responses-direct" | "codex";
+        adapter: "responses-direct" | "codex" | "codex-wasm";
       },
     ) =>
       `${profile.baseUrl}/${
         profile.adapter === "codex"
           ? "chatkit-codex"
-          : "chatkit-responses-direct"
+          : profile.adapter === "codex-wasm"
+            ? "chatkit-codex-wasm"
+            : "chatkit-responses-direct"
       }`,
   ),
 };

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -188,6 +188,13 @@ export function createAppJsGlobals({
       return { adapter: "codex" };
     }
     if (
+      normalized === "codex-wasm" ||
+      normalized === "codex_wasm" ||
+      normalized === "codexwasm"
+    ) {
+      return { adapter: "codex-wasm" };
+    }
+    if (
       normalized === "responses" ||
       normalized === "response"
     ) {

--- a/app/src/lib/runtime/codexWasmChatkitFetch.test.ts
+++ b/app/src/lib/runtime/codexWasmChatkitFetch.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createCodexWasmChatkitFetch } from './codexWasmChatkitFetch'
+
+const submitTurnMock = vi.fn<
+  (args: { prompt: string; onEvent: (event: Record<string, unknown>) => void }) => Promise<string>
+>()
+
+vi.mock('./codexWasmSession', () => ({
+  createCodexWasmSession: () => ({
+    submitTurn: submitTurnMock,
+  }),
+}))
+
+describe('codexWasmChatkitFetch', () => {
+  beforeEach(() => {
+    submitTurnMock.mockReset()
+  })
+
+  it('maps a threads.create request into ChatKit stream events', async () => {
+    submitTurnMock.mockImplementationOnce(async ({ onEvent }) => {
+      onEvent({
+        id: 'event-1',
+        msg: {
+          type: 'task_started',
+        },
+      })
+      onEvent({
+        id: 'event-2',
+        msg: {
+          type: 'agent_message_delta',
+          delta: 'hello from codex wasm',
+        },
+      })
+      onEvent({
+        id: 'event-3',
+        msg: {
+          type: 'task_complete',
+          last_agent_message: 'hello from codex wasm',
+        },
+      })
+      return 'submission-1'
+    })
+
+    const fetchFn = createCodexWasmChatkitFetch({
+      codeModeExecutor: {
+        execute: vi.fn(async () => ({ output: '' })),
+      },
+    })
+
+    const response = await fetchFn('/codex/wasm/chatkit', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        type: 'threads.create',
+        params: {
+          input: {
+            content: [{ type: 'input_text', text: 'say hello' }],
+          },
+        },
+      }),
+    })
+
+    const body = await response.text()
+    expect(body).toContain('"type":"thread.created"')
+    expect(body).toContain('"type":"thread.item.added"')
+    expect(body).toContain('"type":"thread.item.updated"')
+    expect(body).toContain('hello from codex wasm')
+    expect(body).toContain('"type":"aisre.chatkit.state"')
+    expect(body).toContain('"type":"response.completed"')
+  })
+
+  it('returns an unsupported response for client tool output requests', async () => {
+    const fetchFn = createCodexWasmChatkitFetch({
+      codeModeExecutor: {
+        execute: vi.fn(async () => ({ output: '' })),
+      },
+    })
+
+    const response = await fetchFn('/codex/wasm/chatkit', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        type: 'threads.add_client_tool_output',
+        params: {
+          thread_id: 'thread-1',
+        },
+      }),
+    })
+
+    const payload = JSON.parse(await response.text()) as { error?: string }
+    expect(payload.error).toBe('client_tool_output_not_supported_for_codex_wasm')
+  })
+})

--- a/app/src/lib/runtime/codexWasmChatkitFetch.ts
+++ b/app/src/lib/runtime/codexWasmChatkitFetch.ts
@@ -1,0 +1,557 @@
+import { appLogger } from '../logging/runtime'
+import type { CodeModeExecutor } from './codeModeExecutor'
+import { createCodexWasmSession } from './codexWasmSession'
+import type { ChatKitThreadDetail } from './chatkitProtocol'
+
+type JsonRecord = Record<string, unknown>
+
+type BodyPayload = {
+  raw: unknown
+  json: JsonRecord
+}
+
+type StoredThread = {
+  id: string
+  title: string
+  createdAt: string
+  updatedAt: string
+  previousResponseId?: string
+  items: JsonRecord[]
+}
+
+function randomId(prefix: string): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return `${prefix}_${crypto.randomUUID()}`
+  }
+  return `${prefix}_${Math.random().toString(36).slice(2, 12)}`
+}
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  return value as JsonRecord
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value
+    : undefined
+}
+
+async function resolveBody(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<BodyInit | null | undefined> {
+  if (init?.body != null) {
+    return init.body
+  }
+  if (!(input instanceof Request)) {
+    return init?.body
+  }
+  const clone = input.clone()
+  const contentType = clone.headers.get('content-type')?.toLowerCase() ?? ''
+  if (contentType.includes('multipart/form-data')) {
+    try {
+      return await clone.formData()
+    } catch {
+      return null
+    }
+  }
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    try {
+      return new URLSearchParams(await clone.text())
+    } catch {
+      return null
+    }
+  }
+  try {
+    return await clone.text()
+  } catch {
+    return null
+  }
+}
+
+async function readBody(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<BodyPayload> {
+  const body = await resolveBody(input, init)
+  if (typeof body === 'string') {
+    try {
+      const parsed = JSON.parse(body) as JsonRecord
+      return { raw: parsed, json: parsed }
+    } catch {
+      return { raw: body, json: {} }
+    }
+  }
+  if (body instanceof FormData) {
+    const json: JsonRecord = {}
+    body.forEach((value, key) => {
+      if (typeof value === 'string') {
+        try {
+          json[key] = JSON.parse(value)
+        } catch {
+          json[key] = value
+        }
+      }
+    })
+    return { raw: json, json }
+  }
+  if (body instanceof URLSearchParams) {
+    const json: JsonRecord = {}
+    body.forEach((value, key) => {
+      json[key] = value
+    })
+    return { raw: json, json }
+  }
+  return { raw: null, json: {} }
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+    },
+  })
+}
+
+function getPayloadRecord(payload: JsonRecord): JsonRecord {
+  const params =
+    payload.params &&
+    typeof payload.params === 'object' &&
+    !Array.isArray(payload.params)
+      ? (payload.params as JsonRecord)
+      : null
+  return params ?? payload
+}
+
+function extractInput(payload: JsonRecord): { text: string } {
+  const root = getPayloadRecord(payload)
+  const input = asRecord(root.input)
+  const content = Array.isArray(input.content) ? input.content : []
+  const text = content
+    .map((entry) => {
+      const part = asRecord(entry)
+      return asString(part.text) ?? ''
+    })
+    .join('')
+    .trim()
+  return { text }
+}
+
+function readThreadId(payload: JsonRecord): string | undefined {
+  const root = getPayloadRecord(payload)
+  return (
+    asString(root.thread_id) ??
+    asString(root.threadId) ??
+    asString(asRecord(root.thread).id)
+  )
+}
+
+function buildThreadDetail(thread: StoredThread): ChatKitThreadDetail {
+  return {
+    id: thread.id,
+    title: thread.title,
+    created_at: thread.createdAt,
+    updated_at: thread.updatedAt,
+    status: { type: 'active' },
+    metadata: {},
+    items: {
+      data: thread.items,
+      has_more: false,
+    },
+    messages: {
+      data: thread.items.filter((item) => {
+        const type = asString(asRecord(item).type)
+        return type === 'assistant_message' || type === 'user_message'
+      }),
+      has_more: false,
+    },
+  }
+}
+
+function buildStreamResponse(
+  producer: (sink: { emit: (payload: unknown) => void }) => Promise<void>,
+  options?: {
+    signal?: AbortSignal | null
+    logContext?: Record<string, unknown>
+  }
+): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false
+      const emit = (payload: unknown) => {
+        if (closed) {
+          return
+        }
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`))
+      }
+
+      void producer({ emit })
+        .catch((error) => {
+          appLogger.error('Codex WASM ChatKit stream failed', {
+            attrs: {
+              scope: 'chatkit.codex_wasm',
+              error: String(error),
+              ...options?.logContext,
+            },
+          })
+          emit({
+            type: 'response.failed',
+            error: {
+              message: String(error),
+            },
+          })
+        })
+        .finally(() => {
+          if (closed) {
+            return
+          }
+          closed = true
+          controller.close()
+        })
+
+      options?.signal?.addEventListener(
+        'abort',
+        () => {
+          if (closed) {
+            return
+          }
+          closed = true
+          controller.close()
+        },
+        { once: true }
+      )
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    },
+  })
+}
+
+function withUpdatedThreadTitle(thread: StoredThread, text: string): void {
+  const trimmed = text.trim()
+  if (!trimmed || thread.title !== 'New conversation') {
+    return
+  }
+  thread.title = trimmed.slice(0, 80)
+}
+
+export function createCodexWasmChatkitFetch(options: {
+  codeModeExecutor: CodeModeExecutor
+}): typeof fetch {
+  const threads = new Map<string, StoredThread>()
+  const session = createCodexWasmSession({
+    codeModeExecutor: options.codeModeExecutor,
+  })
+
+  const ensureThread = (threadId?: string): StoredThread => {
+    const normalized = threadId?.trim() ?? ''
+    if (normalized && threads.has(normalized)) {
+      return threads.get(normalized)!
+    }
+    const now = new Date().toISOString()
+    const created: StoredThread = {
+      id: normalized || randomId('thread'),
+      title: 'New conversation',
+      createdAt: now,
+      updatedAt: now,
+      items: [],
+    }
+    threads.set(created.id, created)
+    return created
+  }
+
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const { json } = await readBody(input, init)
+    const requestType =
+      asString(getPayloadRecord(json).type) ?? asString(json.type) ?? ''
+
+    if (requestType === 'threads.list') {
+      return jsonResponse({
+        data: [...threads.values()].map((thread) => ({
+          id: thread.id,
+          title: thread.title,
+          updated_at: thread.updatedAt,
+        })),
+        has_more: false,
+      })
+    }
+
+    if (requestType === 'threads.get_by_id' || requestType === 'threads.get') {
+      const threadId = readThreadId(json)
+      const thread = threadId ? threads.get(threadId) : undefined
+      if (!thread) {
+        return new Response(JSON.stringify({ error: 'thread_not_found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return jsonResponse(buildThreadDetail(thread))
+    }
+
+    if (requestType === 'items.list' || requestType === 'messages.list') {
+      const threadId = readThreadId(json)
+      const thread = threadId ? threads.get(threadId) : undefined
+      return jsonResponse({
+        data: thread?.items ?? [],
+        has_more: false,
+      })
+    }
+
+    if (
+      requestType === 'threads.create' ||
+      requestType === 'threads.add_user_message'
+    ) {
+      const { text } = extractInput(json)
+      if (!text) {
+        return jsonResponse({
+          data: null,
+          error: 'missing_user_input',
+        })
+      }
+
+      const requestedThreadId =
+        requestType === 'threads.add_user_message'
+          ? readThreadId(json)
+          : undefined
+      const thread = ensureThread(requestedThreadId)
+      withUpdatedThreadTitle(thread, text)
+
+      const userItem: JsonRecord = {
+        id: randomId('msg'),
+        type: 'user_message',
+        thread_id: thread.id,
+        created_at: new Date().toISOString(),
+        content: [
+          {
+            type: 'input_text',
+            text,
+          },
+        ],
+        attachments: [],
+        inference_options: {},
+      }
+      thread.items.push(userItem)
+      thread.updatedAt = new Date().toISOString()
+
+      return buildStreamResponse(
+        async (sink) => {
+          if (requestType === 'threads.create') {
+            sink.emit({
+              type: 'thread.created',
+              thread: {
+                id: thread.id,
+                title: thread.title,
+                created_at: thread.createdAt,
+              },
+            })
+          }
+          sink.emit({
+            type: 'thread.item.added',
+            item: userItem,
+          })
+          sink.emit({
+            type: 'thread.item.done',
+            item: userItem,
+          })
+
+          let assistantItemId = ''
+          let assistantText = ''
+          let assistantCreatedAt = new Date().toISOString()
+          let failureMessage = ''
+
+          const ensureAssistantItem = () => {
+            if (assistantItemId) {
+              return assistantItemId
+            }
+            assistantItemId = randomId('assistant')
+            assistantCreatedAt = new Date().toISOString()
+            sink.emit({
+              type: 'thread.item.added',
+              item: {
+                id: assistantItemId,
+                type: 'assistant_message',
+                thread_id: thread.id,
+                created_at: assistantCreatedAt,
+                status: 'in_progress',
+                content: [],
+              },
+            })
+            sink.emit({
+              type: 'thread.item.updated',
+              item_id: assistantItemId,
+              update: {
+                type: 'assistant_message.content_part.added',
+                content_index: 0,
+                content: {
+                  type: 'output_text',
+                  text: '',
+                  annotations: [],
+                },
+              },
+            })
+            return assistantItemId
+          }
+
+          const finalizeAssistant = (finalText: string) => {
+            const normalized = finalText.trim() ? finalText : assistantText
+            if (!normalized && !assistantItemId) {
+              return
+            }
+            const itemId = ensureAssistantItem()
+            sink.emit({
+              type: 'thread.item.updated',
+              item_id: itemId,
+              update: {
+                type: 'assistant_message.content_part.done',
+                content_index: 0,
+                content: {
+                  type: 'output_text',
+                  text: normalized,
+                  annotations: [],
+                },
+              },
+            })
+            const assistantItem: JsonRecord = {
+              id: itemId,
+              type: 'assistant_message',
+              thread_id: thread.id,
+              created_at: assistantCreatedAt,
+              status: 'completed',
+              content: [
+                {
+                  type: 'output_text',
+                  text: normalized,
+                  annotations: [],
+                },
+              ],
+            }
+            thread.items.push(assistantItem)
+            thread.updatedAt = new Date().toISOString()
+            sink.emit({
+              type: 'thread.item.done',
+              item: assistantItem,
+            })
+          }
+
+          const submissionId = await session.submitTurn({
+            prompt: text,
+            onEvent: (event) => {
+              const root = asRecord(event)
+              const msg = asRecord(root.msg)
+              const msgType = asString(msg.type)
+              switch (msgType) {
+                case 'session_configured':
+                  return
+                case 'task_started':
+                case 'turn_started':
+                  ensureAssistantItem()
+                  return
+                case 'agent_message_delta': {
+                  const delta = asString(msg.delta) ?? ''
+                  if (!delta) {
+                    return
+                  }
+                  const itemId = ensureAssistantItem()
+                  assistantText = `${assistantText}${delta}`
+                  sink.emit({
+                    type: 'thread.item.updated',
+                    item_id: itemId,
+                    update: {
+                      type: 'assistant_message.content_part.text_delta',
+                      content_index: 0,
+                      delta,
+                    },
+                  })
+                  return
+                }
+                case 'agent_message': {
+                  const message = asString(msg.message) ?? ''
+                  if (message && !assistantText) {
+                    assistantText = message
+                  }
+                  return
+                }
+                case 'error':
+                  failureMessage = asString(msg.message) ?? 'Codex WASM turn failed'
+                  return
+                case 'task_complete':
+                case 'turn_complete':
+                  finalizeAssistant(asString(msg.last_agent_message) ?? '')
+                  return
+                default:
+                  return
+              }
+            },
+          })
+
+          thread.previousResponseId = submissionId
+          thread.updatedAt = new Date().toISOString()
+          sink.emit({
+            type: 'aisre.chatkit.state',
+            item: {
+              state: {
+                threadId: thread.id,
+                previousResponseId: submissionId,
+              },
+            },
+          })
+
+          if (failureMessage) {
+            sink.emit({
+              type: 'response.failed',
+              error: {
+                message: failureMessage,
+              },
+            })
+            return
+          }
+
+          const endOfTurn: JsonRecord = {
+            id: randomId('end'),
+            type: 'end_of_turn',
+            thread_id: thread.id,
+            created_at: new Date().toISOString(),
+          }
+          thread.items.push(endOfTurn)
+          thread.updatedAt = new Date().toISOString()
+          sink.emit({
+            type: 'thread.item.done',
+            item: endOfTurn,
+          })
+          sink.emit({
+            type: 'response.completed',
+            response: { id: submissionId || randomId('resp') },
+          })
+        },
+        { signal: init?.signal ?? null }
+      )
+    }
+
+    if (requestType === 'threads.add_client_tool_output') {
+      return jsonResponse({
+        data: null,
+        error: 'client_tool_output_not_supported_for_codex_wasm',
+      })
+    }
+
+    return jsonResponse({
+      data: null,
+      error: requestType
+        ? `unsupported_request_type:${requestType}`
+        : 'unsupported_request',
+    })
+  }
+}

--- a/app/src/lib/runtime/codexWasmHarnessLoader.ts
+++ b/app/src/lib/runtime/codexWasmHarnessLoader.ts
@@ -1,0 +1,51 @@
+import { resolveAppUrl } from '../appBase'
+
+export type BrowserCodexInstance = {
+  set_api_key(apiKey: string): void
+  set_code_executor(executor: (input: string) => string | Promise<string>): void
+  clear_code_executor(): void
+  submit_turn(
+    prompt: string,
+    onEvent: (event: unknown) => void
+  ): Promise<unknown>
+}
+
+export type BrowserCodexConstructor = new (
+  apiKey: string
+) => BrowserCodexInstance
+
+export type CodexWasmGeneratedModule = {
+  default: (moduleOrPath?: string | URL | Request) => Promise<unknown>
+  BrowserCodex: BrowserCodexConstructor
+}
+
+let modulePromise: Promise<CodexWasmGeneratedModule> | null = null
+
+export function getCodexWasmAssetUrls(): { moduleUrl: string; wasmUrl: URL } {
+  return {
+    moduleUrl: resolveAppUrl(
+      'generated/codex-wasm/codex_wasm_harness.js'
+    ).toString(),
+    wasmUrl: resolveAppUrl(
+      'generated/codex-wasm/codex_wasm_harness_bg.wasm'
+    ),
+  }
+}
+
+export async function loadCodexWasmModule(): Promise<CodexWasmGeneratedModule> {
+  if (!modulePromise) {
+    modulePromise = (async () => {
+      const { moduleUrl, wasmUrl } = getCodexWasmAssetUrls()
+      const generated = (await import(
+        /* @vite-ignore */ moduleUrl
+      )) as unknown as CodexWasmGeneratedModule
+      await generated.default(wasmUrl)
+      return generated
+    })()
+  }
+  return modulePromise
+}
+
+export function __resetCodexWasmHarnessLoaderForTests(): void {
+  modulePromise = null
+}

--- a/app/src/lib/runtime/codexWasmSession.ts
+++ b/app/src/lib/runtime/codexWasmSession.ts
@@ -1,0 +1,121 @@
+import {
+  type CodeModeExecutor,
+  getCodeModeErrorOutput,
+} from './codeModeExecutor'
+import {
+  loadCodexWasmModule,
+  type BrowserCodexInstance,
+} from './codexWasmHarnessLoader'
+import { responsesDirectConfigManager } from './responsesDirectConfigManager'
+
+export type CodexWasmSessionEvent = Record<string, unknown>
+
+export type CodexWasmSession = {
+  submitTurn(args: {
+    prompt: string
+    onEvent: (event: CodexWasmSessionEvent) => void
+  }): Promise<string>
+}
+
+const RUNME_CODE_MODE_PROMPT_PREFIX = [
+  'You are operating inside the Runme app ChatKit panel in a browser.',
+  'When you need to inspect or modify notebooks, use Codex code mode.',
+  'Executed JavaScript runs in the Runme browser sandbox.',
+  'The runtime inside executed code exposes helpers named runme, notebooks, and help.',
+  'Always await helper calls before reading or logging their results.',
+  'Use concise JavaScript snippets and report concrete notebook-visible results.',
+].join('\n')
+
+function buildPrompt(prompt: string): string {
+  return `${RUNME_CODE_MODE_PROMPT_PREFIX}\n\nUser request:\n${prompt}`
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value : String(value ?? '')
+}
+
+export function createCodexWasmSession(options: {
+  codeModeExecutor: CodeModeExecutor
+}): CodexWasmSession {
+  let browserCodexPromise: Promise<BrowserCodexInstance> | null = null
+
+  const getBrowserCodex = async (): Promise<BrowserCodexInstance> => {
+    const apiKey = responsesDirectConfigManager.getSnapshot().apiKey.trim()
+    if (!apiKey) {
+      throw new Error(
+        'Codex WASM requires an OpenAI API key. Run app.responsesDirect.setAPIKey(...).'
+      )
+    }
+
+    if (!browserCodexPromise) {
+      browserCodexPromise = (async () => {
+        const generated = await loadCodexWasmModule()
+        return new generated.BrowserCodex(apiKey)
+      })()
+    }
+
+    const browserCodex = await browserCodexPromise
+    browserCodex.set_api_key(apiKey)
+    browserCodex.set_code_executor(async (input: string) => {
+      let request: {
+        source?: unknown
+        stored_values?: unknown
+      } = {}
+      try {
+        request = JSON.parse(input) as {
+          source?: unknown
+          stored_values?: unknown
+        }
+      } catch (error) {
+        return JSON.stringify({
+          output: '',
+          stored_values: {},
+          error_text: `Invalid code executor request: ${error}`,
+        })
+      }
+
+      try {
+        const result = await options.codeModeExecutor.execute({
+          code: normalizeString(request.source),
+          source: 'codex',
+        })
+        return JSON.stringify({
+          output: result.output,
+          stored_values:
+            request.stored_values &&
+            typeof request.stored_values === 'object' &&
+            !Array.isArray(request.stored_values)
+              ? request.stored_values
+              : {},
+        })
+      } catch (error) {
+        return JSON.stringify({
+          output: getCodeModeErrorOutput(error),
+          stored_values:
+            request.stored_values &&
+            typeof request.stored_values === 'object' &&
+            !Array.isArray(request.stored_values)
+              ? request.stored_values
+              : {},
+          error_text: String(error),
+        })
+      }
+    })
+    return browserCodex
+  }
+
+  return {
+    async submitTurn(args) {
+      const browserCodex = await getBrowserCodex()
+      const submissionId = await browserCodex.submit_turn(
+        buildPrompt(args.prompt),
+        (event: unknown) => {
+          if (event && typeof event === 'object' && !Array.isArray(event)) {
+            args.onEvent(event as CodexWasmSessionEvent)
+          }
+        }
+      )
+      return String(submissionId ?? '')
+    },
+  }
+}

--- a/app/src/lib/runtime/harnessManager.test.ts
+++ b/app/src/lib/runtime/harnessManager.test.ts
@@ -46,6 +46,13 @@ describe("harnessManager", () => {
     );
   });
 
+  it("builds codex-wasm route for local codex wasm harnesses", () => {
+    expect(buildChatkitUrl("http://localhost:1234", "codex-wasm")).toBe(
+      "http://localhost:1234/codex/wasm/chatkit",
+    );
+    expect(buildChatkitUrl("", "codex-wasm")).toBe("/codex/wasm/chatkit");
+  });
+
   it("builds responses-direct route for direct OpenAI harnesses", () => {
     expect(buildChatkitUrl("http://localhost:1234", "responses-direct")).toBe(
       "http://localhost:1234/responses/direct/chatkit",
@@ -103,6 +110,18 @@ describe("harnessManager", () => {
     expect(active.name).toBe("openai-default");
     expect(active.baseUrl).toBe("");
     expect(active.adapter).toBe("responses-direct");
+  });
+
+  it("allows empty baseUrl for codex-wasm adapter", () => {
+    const mgr = getHarnessManager();
+    mgr.update("local-codex-wasm", "", "codex-wasm");
+    mgr.setDefault("local-codex-wasm");
+
+    const active = mgr.getDefault();
+    expect(active.name).toBe("local-codex-wasm");
+    expect(active.baseUrl).toBe("");
+    expect(active.adapter).toBe("codex-wasm");
+    expect(mgr.resolveChatkitUrl(active)).toBe("/codex/wasm/chatkit");
   });
 
   it("rejects empty baseUrl for codex adapter", () => {

--- a/app/src/lib/runtime/harnessManager.ts
+++ b/app/src/lib/runtime/harnessManager.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 
-export type HarnessAdapter = "responses-direct" | "codex";
+export type HarnessAdapter = "responses-direct" | "codex" | "codex-wasm";
 
 export interface HarnessProfile {
   name: string;
@@ -26,10 +26,11 @@ const HARNESS_CHANGED_EVENT = "runme:harness-changed";
 const CHATKIT_ROUTE_BY_ADAPTER: Record<HarnessAdapter, string> = {
   "responses-direct": "/responses/direct/chatkit",
   codex: "/codex/chatkit",
+  "codex-wasm": "/codex/wasm/chatkit",
 };
 
 function isHarnessAdapter(value: unknown): value is HarnessAdapter {
-  return value === "responses-direct" || value === "codex";
+  return value === "responses-direct" || value === "codex" || value === "codex-wasm";
 }
 
 function normalizeStoredHarnessAdapter(value: unknown): HarnessAdapter | null {
@@ -280,7 +281,7 @@ class HarnessManager {
       const harnesses = new Map<string, HarnessProfile>();
 
       for (const entry of entries) {
-        const rawAdapter = entry?.adapter;
+        const wasLegacyResponses = entry?.adapter === "responses";
         const adapter = normalizeStoredHarnessAdapter(entry?.adapter);
         if (
           !entry ||
@@ -296,7 +297,7 @@ class HarnessManager {
         );
         // Legacy "responses" entries targeted runme /chatkit, not the upstream
         // Responses API. After migration to responses-direct, default to OpenAI.
-        if (rawAdapter === "responses") {
+        if (wasLegacyResponses) {
           baseUrl = "";
         }
         if (!name) {

--- a/app/tools/sync_codex_wasm_assets.mjs
+++ b/app/tools/sync_codex_wasm_assets.mjs
@@ -1,0 +1,36 @@
+import { copyFile, mkdir, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_SOURCE_DIR = path.join(
+  os.homedir(),
+  "code",
+  "codex",
+  "codex-rs",
+  "wasm-harness",
+  "examples",
+  "pkg",
+);
+
+const sourceDir = process.env.CODEX_WASM_PKG_DIR || DEFAULT_SOURCE_DIR;
+const targetDir = path.resolve("assets/generated/codex-wasm");
+const files = ["codex_wasm_harness.js", "codex_wasm_harness_bg.wasm"];
+
+async function ensureDirectoryExists(dir) {
+  const info = await stat(dir).catch(() => null);
+  if (!info?.isDirectory()) {
+    throw new Error(`missing source directory: ${dir}`);
+  }
+}
+
+await ensureDirectoryExists(sourceDir);
+await mkdir(targetDir, { recursive: true });
+
+for (const file of files) {
+  const source = path.join(sourceDir, file);
+  const target = path.join(targetDir, file);
+  await copyFile(source, target);
+  console.log(`synced ${file}`);
+}
+
+console.log(`copied Codex WASM assets into ${targetDir}`);

--- a/docs-dev/design/20260403_drive_agentic_search.md
+++ b/docs-dev/design/20260403_drive_agentic_search.md
@@ -1,0 +1,466 @@
+# 20260403 Drive Agentic Search
+
+## Status
+
+Draft proposal.
+
+## Problem
+
+The Runme agent should be able to search notebooks stored in Google Drive and
+open the relevant documents for read-only inspection, regardless of whether the
+active harness is Codex app-server or the browser-direct Responses API path.
+
+Today Drive-backed notebooks are stored as JSON notebook files, and the local
+notebook mirror best-effort syncs a Markdown sidecar (`<basename>.index.md`) to
+Drive. Those sidecars are much better search targets than raw JSON notebooks
+because Drive can index their full text directly.
+
+We want an agent-facing Drive interface that:
+
+- exposes Google Drive's native query syntax instead of hiding it behind a
+  custom keyword search DSL,
+- lets the agent open and read documents returned by search,
+- uses Markdown sidecars to make notebook contents searchable,
+- does not expose any write, copy, rename, share, or delete capability.
+
+## Goals
+
+- Add a read-only Drive search/open interface suitable for Runme agent flows in
+  both harnesses (`codex` and `responses-direct`).
+- Preserve Drive's native query expressiveness (`q`, corpora, shared-drive
+  options, ordering, pagination).
+- Make notebook full-text search work well by querying Markdown sidecars.
+- Return stable, ID-backed Drive URIs so follow-up opens are unambiguous.
+- Keep authorization and access control identical to what the user already has
+  in Drive.
+
+## Non-Goals
+
+- No Drive mutation APIs in the agent surface.
+- No semantic/vector retrieval system in v0.
+- No attempt to bypass Drive ACLs or search only within unshared content.
+- No broad redesign of the existing notebook storage model in this document.
+
+## Existing Implementation Context
+
+The web app already has three useful building blocks:
+
+- `DriveNotebookStore` can `load`, `list`, and `getMetadata` Drive items by
+  stable Drive IDs/URLs.
+- `LocalNotebooks.syncMarkdownFile()` writes a Markdown sidecar next to each
+  Drive-backed notebook and names it `<basename>.index.md`.
+- Existing Drive design notes already prefer stable ID-backed URIs over
+  path-like names because duplicate folder/file names are ambiguous.
+
+Current sidecar behavior has one important limitation for search: the Markdown
+sidecar is stored as a separate Drive file, but there is no explicit Drive
+metadata link from the sidecar back to the canonical notebook JSON file. In v0
+we can infer that relation from same-folder sibling naming conventions, but a
+better v1 design is to store stable linkage metadata in Drive `appProperties`.
+
+## Prior Art
+
+I inspected a local read-only Google Drive connector implementation and found
+three ideas worth carrying over:
+
+- A small tool surface is enough: `search` plus `fetch/open` covers most agent
+  workflows.
+- Read-only enforcement is done at the API registry layer by exposing only
+  read tools and leaving share/copy operations disabled.
+- Search results should include both metadata and an opaque document URL/ID that
+  can be passed to `open` without making the model reconstruct identifiers.
+
+That prior implementation is less suitable for this repo in two ways:
+
+- It hides native Drive query syntax behind a lexical search box, which makes
+  it hard for the agent to use Drive's full `q` language.
+- It is not notebook-sidecar-aware, so it cannot preferentially search Markdown
+  sidecars and then resolve back to the corresponding notebook.
+
+## Google Drive Query Semantics We Should Preserve
+
+The Drive API's `files.list` endpoint accepts a `q` string with the grammar
+`query_term operator value`, and supports operators like `contains`, `=`,
+`!=`, `<`, `<=`, `>`, `>=`, `in`, `and`, `or`, and `not`. Search can combine
+metadata constraints (`name`, `mimeType`, `modifiedTime`, parent IDs, labels,
+etc.) with full-text constraints via `fullText contains '...'`. It also supports
+pagination, ordering, field masks, and shared-drive-specific options.
+
+References:
+
+- [Search for files and folders](https://developers.google.com/workspace/drive/api/guides/search-files)
+- [Search query terms and operators](https://developers.google.com/workspace/drive/api/guides/ref-search-terms)
+
+## Proposed Agent Interface
+
+Expose a read-only `drive` namespace to AppKernel / code mode with two
+functions:
+
+```ts
+type DriveQueryRequest = {
+  q: string;
+  pageSize?: number;
+  pageToken?: string;
+  orderBy?: string;
+  corpora?: "user" | "drive" | "domain" | "allDrives";
+  driveId?: string;
+  includeItemsFromAllDrives?: boolean;
+  supportsAllDrives?: boolean;
+  spaces?: string;
+};
+
+type DriveQueryMatch = {
+  uri: string;
+  id: string;
+  name: string;
+  mimeType: string;
+  modifiedTime?: string;
+  parents: string[];
+  webViewLink?: string;
+};
+
+type DriveQueryResponse = {
+  matches: DriveQueryMatch[];
+  nextPageToken?: string;
+  incompleteSearch?: boolean;
+};
+
+type DriveOpenRequest = {
+  uri: string;
+  format?: "text" | "notebookJson" | "metadata";
+  maxBytes?: number;
+};
+
+type DriveOpenResponse = {
+  uri: string;
+  id: string;
+  name: string;
+  mimeType: string;
+  parents: string[];
+  modifiedTime?: string;
+  webViewLink?: string;
+  text?: string;
+  truncated?: boolean;
+};
+
+interface DriveAgentApi {
+  query(request: DriveQueryRequest): Promise<DriveQueryResponse>;
+  open(request: DriveOpenRequest): Promise<DriveOpenResponse>;
+}
+```
+
+### `drive.query`
+
+`drive.query` should pass the caller's `q` expression directly to Drive
+`files.list` after applying only safety guardrails that do not reduce query
+expressiveness.
+
+Recommended behavior:
+
+- Always use a fixed response field mask that returns only read-only metadata
+  needed by `open` and UI/debugging.
+- Cap `pageSize` to a safe maximum (for example 100).
+- Default `supportsAllDrives=true` and `includeItemsFromAllDrives=true` so
+  shared-drive notebooks are discoverable.
+- Preserve caller-supplied `corpora`, `driveId`, `spaces`, and `orderBy`.
+- Return stable canonical Drive URIs built from file IDs, not path-like names.
+
+### Query builder helpers
+
+Instead of a `mode` argument, query shaping should happen before calling
+`drive.query(...)` using composable helpers that return native Drive `q`
+strings.
+
+This keeps `drive.query` itself aligned with Drive's API while still making
+common query patterns easy to express and chain.
+
+Example helper API:
+
+```ts
+const q = drive.q
+  .raw("fullText contains 'SLO burn rate'")
+  .and("modifiedTime >= '2026-01-01T00:00:00'")
+  .restrictToMarkdownSidecars()
+  .build();
+
+const result = await drive.query({
+  q,
+  orderBy: "modifiedTime desc",
+  pageSize: 20,
+});
+```
+
+Equivalent functional style:
+
+```ts
+const result = await drive.query({
+  q: drive.q.restrictToMarkdownSidecars(
+    "fullText contains 'SLO burn rate' and modifiedTime >= '2026-01-01T00:00:00'",
+  ),
+  orderBy: "modifiedTime desc",
+  pageSize: 20,
+});
+```
+
+Recommended helper surface:
+
+```ts
+interface DriveQueryBuilder {
+  raw(clause: string): DriveQueryBuilder;
+  and(clause: string): DriveQueryBuilder;
+  or(clause: string): DriveQueryBuilder;
+  not(clause: string): DriveQueryBuilder;
+  inParents(folderId: string): DriveQueryBuilder;
+  nameContains(value: string): DriveQueryBuilder;
+  mimeTypeEquals(value: string): DriveQueryBuilder;
+  fullTextContains(value: string): DriveQueryBuilder;
+  modifiedAfter(value: string): DriveQueryBuilder;
+  modifiedBefore(value: string): DriveQueryBuilder;
+  restrictToMarkdownSidecars(): DriveQueryBuilder;
+  build(): string;
+}
+
+interface DriveQueryHelpers {
+  builder(): DriveQueryBuilder;
+  raw(query: string): DriveQueryBuilder;
+  restrictToMarkdownSidecars(query: string): string;
+}
+```
+
+Example folder-scoped search:
+
+```ts
+const q = drive.q
+  .builder()
+  .inParents("<folder-id>")
+  .fullTextContains("incident review")
+  .restrictToMarkdownSidecars()
+  .build();
+
+const result = await drive.query({
+  q,
+  corpora: "drive",
+  driveId: "<shared-drive-id>",
+  pageSize: 25,
+});
+```
+
+`restrictToMarkdownSidecars(...)` should only append Drive-native clauses such
+as:
+
+```ts
+mimeType = 'text/markdown' and name contains '.index.md'
+```
+
+It should not fetch notebook JSON files or reshape response objects. That work
+belongs in a separate result-resolution helper.
+
+### `drive.open`
+
+`drive.open` should fetch a Drive document by stable URI/ID and return only
+readable content and metadata. It must not mutate notebook state or local
+selection state as a side effect.
+
+Recommended behavior:
+
+- Accept canonical Drive file URLs or raw file IDs and normalize them through
+  the existing Drive URI parser.
+- For `format: "metadata"`, return metadata only.
+- For `format: "text"`, fetch media bytes and return decoded text for text-like
+  MIME types (`text/markdown`, `text/plain`, `application/json`), with a byte
+  limit and `truncated=true` when clipped.
+- For `format: "notebookJson"`, return notebook JSON text for the canonical
+  notebook file.
+- Reject folders for content reads but still allow metadata opens on folders.
+
+## Sidecar Resolution Design
+
+Query result post-processing should also be separate from `drive.query(...)`.
+That avoids mixing "what Drive should search" with "how Runme interprets the
+matches".
+
+Proposed helper:
+
+```ts
+type DriveNotebookMatch = {
+  notebook: DriveQueryMatch;
+  sidecar: DriveQueryMatch;
+  resolution: "resolved" | "missing" | "ambiguous";
+  candidates?: DriveQueryMatch[];
+};
+
+interface DriveResultResolvers {
+  resolveNotebookSidecars(matches: DriveQueryMatch[]): Promise<DriveNotebookMatch[]>;
+}
+```
+
+Example:
+
+```ts
+const sidecarMatches = await drive.query({
+  q: drive.q.restrictToMarkdownSidecars(
+    "fullText contains 'feature flag cleanup'",
+  ),
+  pageSize: 10,
+});
+
+const notebookMatches = await drive.results.resolveNotebookSidecars(
+  sidecarMatches.matches,
+);
+
+for (const match of notebookMatches) {
+  if (match.resolution !== "resolved") {
+    continue;
+  }
+  const notebook = await drive.open({
+    uri: match.notebook.uri,
+    format: "notebookJson",
+    maxBytes: 512_000,
+  });
+  console.log(notebook.text);
+}
+```
+
+### v0: naming-based resolution
+
+For each Markdown sidecar hit named `<basename>.index.md`:
+
+- read its parent folder IDs from Drive metadata,
+- derive candidate notebook filename `<basename>.json`,
+- query siblings in the same parent folder for that exact name and notebook
+  MIME type,
+- if exactly one notebook match exists, return that notebook URI as `uri` and
+  the sidecar URI as `matchedSidecarUri`,
+- if zero or multiple notebook matches exist, return the sidecar itself as
+  `uri` and leave notebook resolution to a follow-up `open`.
+
+This is easy to implement with today's storage model but can be ambiguous when
+duplicate sibling names exist.
+
+### v1: explicit linkage with `appProperties`
+
+When writing sidecars, also set Drive app properties such as:
+
+```ts
+// On notebook JSON file
+appProperties: {
+  runmeRole: "notebook",
+  runmeMarkdownSidecarId: "<sidecar-file-id>",
+}
+
+// On Markdown sidecar file
+appProperties: {
+  runmeRole: "markdownSidecar",
+  runmeNotebookId: "<notebook-file-id>",
+}
+```
+
+Then `drive.results.resolveNotebookSidecars(...)` can resolve sidecar hits to
+notebook files deterministically without relying on sibling-name inference.
+
+## Alternatives Considered
+
+### Use the built-in Google Drive connector in the Responses API
+
+OpenAI's Responses API supports first-party connectors, including Google Drive,
+as documented in the
+[Connectors and MCP guide](https://developers.openai.com/api/docs/guides/tools-connectors-mcp?quickstart-panels=connector#connectors).
+
+In that design, the `responses-direct` harness would delegate Drive search and
+document fetch to the model's connector tool calls instead of exposing a
+Runme-owned `drive` API in AppKernel.
+
+Why this is likely not the right default for Runme:
+
+- Less control over the agent-facing API surface. We are limited to the
+  connector functions OpenAI exposes, which is enough for basic search/fetch but
+  harder to extend with Runme-specific notebook semantics, sidecar resolution,
+  or future write workflows.
+- We already plan to give the agent a JavaScript execution environment in
+  AppKernel / code mode. A Drive JS library is a richer and more extensible
+  interface than a fixed connector tool set, especially once the agent needs to
+  compose Drive search, notebook inspection, and Runme-specific helper logic in
+  one program.
+- A connector-centric design helps only the `responses-direct` harness. A
+  Runme-owned JS API can be made harness-independent and reused by both
+  `responses-direct` and `codex`.
+
+Main downside of the Runme-owned JS API approach:
+
+- We may need to build and maintain more of the agentic loop/tool orchestration
+  ourselves instead of relying on the connector stack to provide that behavior.
+
+Current recommendation:
+
+- Prefer the Runme-owned `drive.query`, `drive.q`, `drive.results`, and
+  `drive.open` AppKernel API as the primary design.
+- Keep the built-in Responses Google Drive connector as a fallback or future
+  implementation option if we discover that maintaining a custom agentic Drive
+  loop is more costly than expected.
+
+## Safety and Policy
+
+This interface should be intentionally read-only.
+
+- Do not expose `create`, `save`, `saveContent`, `rename`, `copy`, `share`, or
+  `delete` through the agent-facing `drive` namespace.
+- Use the user's existing Drive auth context and request only read scopes for
+  agent search/open.
+- Do not let `open` fetch arbitrary URLs; only Drive file IDs/URLs accepted by
+  the existing Drive parser should be allowed.
+- Cap `pageSize`, response bytes, and `open.maxBytes` so a broad search or a
+  large notebook cannot flood the tool response.
+- Keep a fixed metadata field mask so the model cannot use `fields` to ask for
+  unexpected Drive resource fields.
+- Emit structured errors for malformed `q`, unsupported MIME types, folder
+  content reads, missing files, and permission-denied responses.
+
+## Implementation Plan
+
+1. Add a small read-only Drive client method layer around the existing
+   Drive files client:
+   - `queryFiles(request)` -> `files.list`
+   - `openFileMetadata(uri)` -> `files.get(fields=...)`
+   - `openFileText(uri, maxBytes)` -> `files.get(alt=media)`
+2. Add sidecar-aware query resolution:
+   - implement `drive.q.restrictToMarkdownSidecars(...)`,
+   - implement `drive.results.resolveNotebookSidecars(...)`,
+   - start with naming-based sidecar-to-notebook resolution.
+3. Expose a read-only `drive.query` and `drive.open` AppKernel API for
+   code-mode agent flows.
+4. Update agent instructions/tool docs to teach this pattern:
+   - use Drive `q` directly,
+   - search Markdown sidecars for notebook text,
+   - open canonical notebook files for final inspection.
+5. Add tests against the fake Drive server and at least one manual Drive CUJ
+   notebook covering sidecar search and notebook open.
+6. Consider a v1 sidecar schema migration to persist reciprocal Drive
+   `appProperties` links and remove naming-based ambiguity.
+
+## Test Plan
+
+- Unit test Drive query parameter forwarding and response normalization.
+- Unit test sidecar-to-notebook resolution for unique, missing, and duplicate
+  sibling matches.
+- Unit test `open` truncation, MIME filtering, and folder rejection.
+- Integration test fake Drive search over `.index.md` sidecars and opening the
+  resolved notebook JSON file.
+- Manual CUJ test against real Drive:
+  - create/save a Drive notebook,
+  - wait for sidecar sync,
+  - search by notebook body text through `drive.query`,
+  - open the returned notebook through `drive.open`,
+  - verify no write operation is available from the agent API.
+
+## Open Questions
+
+- Should `drive.open(format: "notebookJson")` return raw notebook JSON text,
+  parsed notebook objects, or both?
+- Should `drive.results.resolveNotebookSidecars(...)` hide sidecars completely
+  when notebook resolution fails, or return sidecar hits with explicit
+  ambiguity metadata?
+- Do we want a dedicated `drive.queryNotebookText(...)` convenience wrapper, or
+  is `drive.query(...)` plus `drive.results.resolveNotebookSidecars(...)`
+  enough?
+- Should AppKernel expose this as direct JS helpers only, or also generate
+  first-class MCP tools from a proto contract?

--- a/docs-dev/design/20260414_codex_wasm.md
+++ b/docs-dev/design/20260414_codex_wasm.md
@@ -1,0 +1,858 @@
+# 20260414 Codex WASM Harness
+
+## Status
+
+Draft proposal.
+
+## Summary
+
+Add a third browser harness adapter, `codex-wasm`, alongside
+`responses-direct` and `codex`.
+
+`codex-wasm` runs the Codex browser harness inside the web app via WASM, uses
+Codex code mode, and binds Codex tool execution to the existing Runme browser
+sandbox kernel. For v0, the goal is parity with the current browser-direct
+Responses harness for code execution and other browser-owned tools, without
+bringing over heavier Codex runtime features such as Recorder.
+
+## Problem
+
+Today we have two harness shapes:
+
+- `responses-direct`: a browser-local turn loop in
+  [responsesDirectChatkitFetch.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/responsesDirectChatkitFetch.ts)
+  that talks directly to the Responses API and executes browser tools locally.
+- `codex`: a remote Codex app-server path that depends on `/codex/chatkit`,
+  `/codex/ws`, and `/codex/app-server/ws`.
+
+The `responses-direct` path gave us a fast way to ship browser-native tool
+execution, but it is still our own small harness. As we add more tools and more
+agent behaviors, continuing to grow that custom loop in this repo is the wrong
+direction. We want to build on the Codex harness instead.
+
+Separately, the Codex branch in `~/code/codex` now contains a browser harness
+prototype under `codex-rs/wasm-harness`. That branch establishes the right seam
+for embedding a Codex harness in a downstream browser app, but it still needs a
+few integration-oriented changes before Runme can use it as its primary browser
+harness.
+
+## Background
+
+Runme's ChatKit integration already routes through a harness-selected custom
+`fetch` implementation.
+
+At a high level:
+
+1. `ChatKitPanel` builds an authorized fetch wrapper.
+2. That wrapper delegates to a harness-specific `baseFetch`.
+3. The selected `baseFetch` is responsible for handling ChatKit protocol
+   requests and returning normal `Response` objects, including SSE streams for
+   turn output.
+
+Today the main browser-visible fetch implementations are:
+
+- `createResponsesDirectChatkitFetch(...)` for the browser-local
+  `responses-direct` harness,
+- `createCodexChatkitFetch(...)` for the remote `codex` harness.
+
+This is why the `codex-wasm` design introduces
+`createCodexWasmChatkitFetch(...)` rather than a new ChatKit integration
+mechanism. The existing integration seam is already "ChatKit speaks `fetch`,
+and the web app chooses which harness-backed fetch handler receives the
+request."
+
+For `codex-wasm`, that means:
+
+- ChatKit still uses the same request/response path,
+- the app still selects a harness-specific fetch implementation,
+- but the selected handler runs the Codex WASM harness locally in the browser
+  instead of proxying to the remote app-server stack.
+
+### Current Browser API
+
+The current Codex WASM implementation exposes a browser-facing API through
+`BrowserCodex. It wraps
+`codex-core::CodexThread` and calls `submit(Op::UserTurn { ... })`.
+
+Today the browser API works like this:
+
+- JavaScript creates a harness instance with `new BrowserCodex(apiKey)`.
+- JavaScript may later update the API key with `set_api_key(...)`.
+- JavaScript registers one host-side code-mode callback with
+  `set_code_executor(...)`.
+- JavaScript starts a turn with `submit_turn(prompt, on_event)`.
+- Rust lazily creates a real Codex session/thread if needed, emits a
+  `SessionConfigured` event, submits `Op::UserTurn`, then forwards real Codex
+  `Event` objects back to JavaScript by invoking the supplied `on_event`
+  callback.
+- `submit_turn(...)` resolves with the submission id once the matching turn
+  reaches `TurnComplete`, `TurnAborted`, or `Error`.
+
+The important consequence is that the browser-facing shim is now thin, but it
+is still a shim:
+
+- JavaScript does not currently pass a full thread/session object into Rust.
+- JavaScript passes the prompt string for the new turn.
+- JavaScript passes a callback for streamed Codex protocol events.
+- JavaScript configures browser-specific host state such as the API key and code
+  executor out of band.
+
+The code executor callback also has a richer contract than the older
+`exec_js(code: string)` prototype. The Rust side serializes a request that
+includes:
+
+- `source` for the code to run,
+- `stored_values` for code-mode state continuity,
+- `enabled_tools` describing code-mode capabilities,
+
+and expects a response containing:
+
+- `output`,
+- updated `stored_values`,
+- optional `error_text`.
+
+This is the API surface we should assume for v0.
+
+TODO: revisit this section as the Codex WASM API continues to settle. The crate
+now uses the true Codex submit path, but the browser-facing `BrowserCodex`
+wrapper may still evolve as upstream Codex exposes a more native browser/session
+boundary.
+
+### Current Codex-to-ChatKit Mapping
+
+The existing remote `codex` harness path already contains an event translation
+layer that converts Codex-side activity into ChatKit stream events.
+
+Today that logic lives primarily in
+[codexConversationController.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/codexConversationController.ts).
+That controller:
+
+- receives Codex-side notifications from the current app-server/proxy path,
+- tracks thread and turn state,
+- emits ChatKit stream events such as:
+  - `thread.item.added`
+  - `thread.item.updated`
+  - `assistant_message.content_part.text_delta`
+  - `thread.item.done`
+  - `response.completed`
+  - `aisre.chatkit.state`
+
+So we do already have a working "Codex events -> ChatKit events" adapter in the
+repo.
+
+However, the current implementation is tightly coupled to the remote Codex
+app-server protocol and its notification shapes. Those notifications are derived
+from upstream Codex `EventMsg`, but they are not the same wire shape.
+
+In the WASM case, the browser callback now receives real Codex `Event` /
+`EventMsg` protocol objects rather than app-server `thread/*`, `turn/*`, and
+`item/*` notifications. That means the exact code in
+`codexConversationController.ts` is not directly reusable as-is.
+
+What we should reuse is:
+
+- the existing ChatKit event vocabulary,
+- the existing mapping patterns for assistant-message lifecycle and state
+  updates,
+- the current tests and fixtures that validate those emitted ChatKit events.
+
+What we should likely refactor is:
+
+- extracting the generic "normalized Codex lifecycle -> ChatKit stream events"
+  logic into a smaller shared adapter,
+- with one input adapter for remote app-server notifications and another for
+  raw Codex `Event` / `EventMsg` from WASM.
+
+## Goals
+
+- Add `codex-wasm` as a first-class harness adapter in Runme web.
+- Run Codex in the browser through the WASM harness rather than through the
+  remote `codex` websocket/app-server stack.
+- Use Codex code mode and wire its code-execution tool to
+  [codeModeExecutor.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/codeModeExecutor.ts)
+  in sandbox mode.
+- Reuse the existing ChatKit thread/item streaming shape already used by
+  `responses-direct`.
+- Keep v0 narrow: parity with the current browser harness for local tool
+  execution, not full parity with every Codex desktop or app-server feature.
+
+## Non-Goals
+
+- Porting full `codex-core` to `wasm32` in this design.
+- Supporting Recorder, memories, sub-agents, or the full app-server protocol in
+  v0.
+- Replacing the existing `codex` adapter immediately.
+- Redesigning the notebook tool contract in this document.
+
+## Current State
+
+### Runme web
+
+The current harness split is hard-coded around two adapters:
+
+- [harnessManager.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/harnessManager.ts)
+  defines `HarnessAdapter = "responses-direct" | "codex"`.
+- [ChatKitPanel.tsx](/Users/jlewi/code/runmecodex/web/app/src/components/ChatKit/ChatKitPanel.tsx)
+  selects either `createResponsesDirectChatkitFetch(...)` or
+  `createCodexChatkitFetch(...)`.
+- `responses-direct` already has a browser-local thread store, direct Responses
+  API streaming, and local tool execution.
+- Code execution already has a clean browser host seam in
+  [codeModeExecutor.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/codeModeExecutor.ts),
+  backed by the sandbox iframe kernel in
+  [sandboxJsKernel.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/sandboxJsKernel.ts).
+
+This is good news for `codex-wasm`: most of the host-side capability we need is
+already present.
+
+### Codex branch
+
+The Codex branch has a new crate:
+
+- [codex-rs/wasm-harness/Cargo.toml](/Users/jlewi/code/codex/codex-rs/wasm-harness/Cargo.toml)
+- [codex-rs/wasm-harness/README.md](/Users/jlewi/code/codex/codex-rs/wasm-harness/README.md)
+- [codex-rs/wasm-harness/src/harness.rs](/Users/jlewi/code/codex/codex-rs/wasm-harness/src/harness.rs)
+- [codex-rs/wasm-harness/src/browser.rs](/Users/jlewi/code/codex/codex-rs/wasm-harness/src/browser.rs)
+- [codex-rs/wasm-harness/src/responses.rs](/Users/jlewi/code/codex/codex-rs/wasm-harness/src/responses.rs)
+
+The important architectural point has changed from the earlier prototype. The
+active downstream boundary is now the browser-facing `BrowserCodex` wrapper in
+`src/browser.rs`, and that wrapper drives a real `codex-core::CodexThread`.
+
+The current exported surface is effectively:
+
+- `BrowserCodex` as the `wasm_bindgen` entrypoint,
+- `submit_turn(prompt, on_event)` to call `CodexThread::submit(Op::UserTurn {
+  ... })`,
+- `set_code_executor(...)` to inject the host code-mode runtime callback,
+- real upstream Codex `Event` / `EventMsg` objects streamed back to JavaScript.
+
+There are still older Rust files in the crate such as `src/harness.rs`, but
+they are no longer the active embedding surface for the browser integration.
+Runme should plan against `BrowserCodex` and the real Codex protocol event
+stream, not the earlier `EmbeddedHarness` path.
+
+## Gaps In The Current Codex WASM Browser Wrapper
+
+The current browser wrapper is close enough to plan against, but not yet the exact
+shape Runme needs.
+
+### 1. Browser transport is API-key oriented
+
+`BrowserCodex` currently owns a direct browser `fetch` to
+`https://api.openai.com/v1/responses` and takes a raw API key.
+
+For v0, we explicitly accept that limitation. A user must supply an API key to
+use the `codex-wasm` ChatKit harness.
+
+Runme already has a user-facing browser API for this through the existing
+Responses-direct configuration path:
+
+- `app.responsesDirect.setAPIKey(...)`
+- `credentials.openai.setAPIKey(...)`
+
+Both feed the persisted `responsesDirectConfigManager`, which already stores the
+OpenAI API key in browser localStorage for the current direct Responses
+integration.
+
+For v0, `codex-wasm` should reuse that same stored key rather than introducing a
+second Codex-specific credential flow. In practice that means the Runme-side
+`codex-wasm` loader/session code should read
+`responsesDirectConfigManager.getSnapshot().apiKey` and pass it into
+`new BrowserCodex(apiKey)` / `set_api_key(...)`.
+
+This is not the long-term browser auth model we want, but it is acceptable for
+the first integration because it lets us prove the harness architecture without
+blocking on upstream transport abstraction work.
+
+### 2. V0 does not require hosted Responses tools
+
+The current browser harness path is centered on Codex code mode and a
+browser-injected code executor. That is sufficient for the v0 Runme goal.
+
+For this proposal, we make the v0 decision explicitly: `codex-wasm` parity only
+includes browser-executed tools. We do not require hosted Responses tools such
+as `file_search`.
+
+That is consistent with the broader Runme direction. We are moving away from
+`file_search` for notebook workflows because it does not work well enough for
+notebooks. The intended search direction is the Drive-native agentic search path
+described in
+[20260403_drive_agentic_search.md](/Users/jlewi/code/runmecodex/web/docs-dev/design/20260403_drive_agentic_search.md),
+which is one of the motivations for adopting the Codex harness rather than
+continuing to extend the current lightweight browser loop.
+
+### 3. Browser facade is code-mode oriented
+
+The current WASM boundary exposes one injected host capability: the code-mode
+runtime callback registered through `set_code_executor(...)`.
+
+That is actually aligned with the current Runme browser direction. Per
+[20260331_code_mode.md](/Users/jlewi/code/runmecodex/web/docs-dev/design/20260331_code_mode.md)
+and PR #160, the browser harness is moving to a single code-mode tool design:
+
+- one model-facing tool (`ExecuteCode` in Runme terms, `exec_js` in the current
+  Codex WASM prototype),
+- with richer host functionality made available inside the executed JavaScript
+  environment rather than as separate model-facing tools.
+
+So the real distinction here is not "many browser tools vs one browser tool."
+It is:
+
+- one model-facing tool, and
+- a richer host environment behind that tool.
+
+For Runme, that richer host environment today is the sandbox AppKernel surface
+exposed through `runme`, `notebooks`, and `help`, with future expansion likely
+to come from browser-side APIs such as Drive-native agentic search rather than a
+return to many notebook CRUD tools.
+
+For v0, `codex-wasm` should follow that same single-tool design. We do not need
+additional model-facing browser tools to unblock v0 as long as the WASM harness
+can bind its code-mode execution path to Runme's existing `CodeModeExecutor`.
+
+### 4. Browser services are still degraded relative to desktop Codex
+
+The README is explicit that this is still a minimal browser port, not full
+desktop Codex.
+
+What is true today:
+
+- it uses the real `CodexThread` turn path,
+- it emits real upstream Codex protocol events,
+- code mode runs through one injected browser callback,
+- native shell, PTY, MCP, plugin runtime, and filesystem-backed persistence are
+  not available in the browser prototype.
+
+That is acceptable for v0. Our goal here is not "full Codex desktop in the
+browser." Our goal is "stop growing a custom TypeScript harness, and switch the
+browser harness boundary to the Codex implementation."
+
+### 5. Session lifetime is still browser-wrapper specific
+
+Today `BrowserCodex.submit_turn(...)` resets its cached session after the turn
+finishes, so the browser wrapper currently behaves more like "fresh Codex
+session per submission" than a long-lived in-page thread.
+
+That does not block the design doc, but it is important to call out because
+Runme's current browser harnesses preserve local thread continuity. We need to
+decide whether v0 accepts this wrapper behavior or whether upstream Codex needs
+to preserve the session across turns.
+
+## Proposal
+
+Add a new harness adapter, `codex-wasm`, which behaves like this:
+
+1. ChatKit selects a local `fetch` implementation,
+   `createCodexWasmChatkitFetch(...)`.
+2. That fetch implementation keeps the same local thread/item model used by
+   `responses-direct`.
+3. Instead of building the turn loop in TypeScript, it instantiates the Codex
+   WASM harness and submits the prompt to it.
+4. The Codex WASM harness talks directly to the Responses API using the current
+   Codex browser facade and an OpenAI API key supplied through Runme's existing
+   `responsesDirectConfigManager` path.
+5. When Codex emits a code-execution tool call, the Codex harness invokes the
+   Runme-provided tool handler for that tool.
+6. That Runme-provided tool handler executes the request via
+   `CodeModeExecutor.execute({ code, source: "codex" })` using the existing
+   sandbox-mode executor instance.
+7. The WASM harness emits Codex-shaped events; the local fetch adapter
+   translates them into ChatKit stream events and thread items.
+
+In short: `responses-direct` stays the UI transport pattern, but the actual turn
+loop moves into the Codex WASM crate.
+
+## Why A Third Harness
+
+We should keep all three adapters for now:
+
+- `responses-direct`: current stable browser harness.
+- `codex`: remote websocket/app-server Codex integration.
+- `codex-wasm`: browser-local Codex harness.
+
+`codex-wasm` is not a drop-in replacement for the current `codex` adapter,
+because it intentionally avoids the remote app-server features. It is also not
+the same as `responses-direct`, because the harness loop and prompting live in
+Codex rather than in Runme TypeScript.
+
+## Detailed Design
+
+### Harness routing
+
+Update
+[harnessManager.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/harnessManager.ts)
+to support:
+
+```ts
+type HarnessAdapter = "responses-direct" | "codex" | "codex-wasm";
+```
+
+`codex-wasm` should resolve to a local ChatKit route, for example:
+
+```ts
+"/codex/wasm/chatkit"
+```
+
+Like `responses-direct`, this route only exists as a logical endpoint consumed
+by a browser `fetch` interceptor. It does not require a backend handler.
+
+`baseUrl` should be optional for `codex-wasm`, because the harness runs in the
+page and should use the same browser auth/config path as `responses-direct`.
+
+### ChatKitPanel changes
+
+[ChatKitPanel.tsx](/Users/jlewi/code/runmecodex/web/app/src/components/ChatKit/ChatKitPanel.tsx)
+should select among three local/remote fetch implementations:
+
+- `responses-direct` -> `createResponsesDirectChatkitFetch(...)`
+- `codex` -> `createCodexChatkitFetch(...)`
+- `codex-wasm` -> `createCodexWasmChatkitFetch(...)`
+
+`codex-wasm` should behave like `responses-direct` in these respects:
+
+- no `/codex/ws` bridge,
+- no `/codex/app-server/ws` proxy bootstrap,
+- no codex thread-history bootstrap through the remote app server.
+
+Instead, thread state remains browser-local in the `codex-wasm` fetch adapter.
+
+### Browser host services
+
+We should introduce a Runme-side browser host wrapper around the Codex crate.
+The exact file names are flexible, but the responsibilities are not:
+
+- `codexWasmHarnessLoader.ts`
+  - live under committed app source in `web/app/src/...`,
+  - resolve generated artifact URLs with `resolveAppUrl(...)`,
+  - lazy-load and initialize the generated WASM module,
+  - cache a singleton module instance.
+- `codexWasmSession.ts`
+  - create or manage a harness instance,
+  - inject transport and tool callbacks,
+  - expose `submitTurn(...)`.
+- `codexWasmChatkitFetch.ts`
+  - keep the browser-local ChatKit thread model,
+  - translate Codex WASM events into ChatKit SSE events.
+
+### Proposed Runme integration
+
+Given the current `BrowserCodex` API, the Runme-side integration should work in
+four layers:
+
+1. **WASM loading**
+   - use a small handwritten Runme loader in `src/` rather than importing
+     Cargo output directly,
+   - resolve the generated artifact URLs from the app base path,
+   - lazily load and initialize the generated `codex_wasm_harness.js`
+     wrapper and companion `.wasm`,
+   - create a `BrowserCodex` instance,
+   - configure `set_api_key(...)` and `set_code_executor(...)`.
+
+2. **Host tool binding**
+   - register a Runme host callback for the Codex code-execution tool,
+   - implement that callback with `CodeModeExecutor` in sandbox mode,
+   - keep tool implementation ownership in Runme while leaving tool-call
+     orchestration in Codex.
+
+3. **Event translation**
+   - call `submit_turn(prompt, onEvent)`,
+   - receive streamed upstream Codex `Event` objects from WASM,
+   - translate those `Event` / `EventMsg` values into ChatKit stream events.
+
+4. **ChatKit fetch integration**
+   - wrap the above in `createCodexWasmChatkitFetch(...)`,
+   - return normal `Response` objects and SSE payloads to ChatKit,
+   - keep browser-local thread state and `previousResponseId` continuity.
+
+In practice, `codexWasmChatkitFetch.ts` is the integration point that ties all
+four layers together.
+
+### Reusing the current Codex adapter
+
+We should reuse the existing Codex adapter patterns, but probably not the
+current controller implementation wholesale.
+
+The existing remote `codex` path proves that we already know how to:
+
+- represent assistant-message lifecycle in ChatKit,
+- emit `aisre.chatkit.state` updates,
+- handle text deltas and final message completion,
+- synthesize end-of-turn markers and response completion events.
+
+That makes the current remote Codex adapter the right reference
+implementation for `codex-wasm`.
+
+The likely reuse strategy is:
+
+- keep using the same ChatKit event shapes and test expectations,
+- extract shared helpers for:
+  - state emission,
+  - assistant item creation,
+  - delta application,
+  - completion/end-of-turn synthesis,
+- add a new mapper from raw Codex `Event` / `EventMsg` to those shared helpers.
+
+The current remote controller is still useful as a source of truth for the
+ChatKit-side contract, even if the WASM path ends up with a smaller and cleaner
+adapter module.
+
+### Transport seam
+
+For v0, we will not block on a custom transport seam. `codex-wasm` will use the
+current `BrowserCodex` model:
+
+- direct browser `fetch` to the Responses API,
+- user-supplied API key,
+- Codex-owned request construction and response parsing.
+
+That keeps the first integration simple and minimizes upstream changes required
+before Runme can try the harness in-browser.
+
+The recommended follow-on direction for the Codex crate is still to support a
+host-provided Responses transport, but that is explicitly post-v0 work.
+
+### Instruction injection
+
+The instruction path needs to be updated to match the new Codex submit-based
+browser wrapper.
+
+Today `BrowserCodex` builds a real Codex config/thread internally and submits
+`Op::UserTurn`, but it does not yet expose an explicit Runme-facing API for
+passing extra user/developer instructions into that session configuration.
+
+So the v0 design requirement is:
+
+- add or confirm a `BrowserCodex` configuration seam for Runme-specific
+  instructions,
+- use that seam to describe the browser runtime available behind the single
+  code-mode tool.
+
+The injected guidance should cover at least:
+
+- the model-facing tool is code mode (`ExecuteCode` in Runme terms),
+- executed JavaScript runs inside the Runme browser sandbox,
+- the runtime inside executed code exposes `runme`, `notebooks`, and `help`,
+- browser-only constraints or workflow guidance that the model needs in order to
+  use those helpers correctly.
+
+This keeps the behavior aligned with the current `responses-direct` design,
+which already relies on detailed browser-specific instructions in
+[responsesDirectChatkitFetch.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/responsesDirectChatkitFetch.ts).
+
+TODO: revisit this section once the Codex WASM browser API settles. The wrapper
+now uses the true Codex submit path, but the exact configuration surface for
+instruction injection may still change as upstream Codex removes remaining
+browser-specific shims and exposes a more native embedded configuration model.
+
+### Tool execution
+
+For v0, `codex-wasm` should wire Codex code mode to the existing sandbox code
+executor:
+
+```ts
+createCodeModeExecutor({
+  mode: "sandbox",
+  resolveNotebook,
+  listNotebooks,
+})
+```
+
+The first mapped tool should be the Codex-side code-execution tool. Today the
+browser wrapper exposes that through the code-mode runtime callback rather than
+through a separate Runme-defined function tool. That is acceptable for v0 as an
+internal Codex detail.
+
+The important requirement is that Codex code-mode execution in the WASM harness
+routes to the same sandbox runtime already used by Runme code mode.
+
+Ownership should be explicit:
+
+- the Codex WASM harness owns the turn loop and decides when a tool call is
+  needed,
+- the Codex WASM harness invokes the registered browser code executor,
+- the Runme host implementation of that executor uses
+  `CodeModeExecutor.execute({ code, source: "codex" })` to run the code inside
+  the browser sandbox,
+- the host callback maps Runme's `{ output }` result back into the JSON shape
+  expected by `BrowserCodeModeRuntime`, including `stored_values` and optional
+  `error_text`.
+
+That gives us:
+
+- the existing AppKernel helper surface,
+- notebook APIs,
+- existing timeouts and output limits,
+- the existing browser sandbox boundary.
+
+### Event mapping
+
+The Codex WASM harness now emits real upstream Codex `Event` objects. Those
+wrap `EventMsg` variants such as:
+
+- `SessionConfigured`
+- `TurnStarted`
+- `AgentMessageDelta`
+- `AgentMessage`
+- code-mode and tool-call lifecycle events
+- `TurnComplete`
+- `TurnAborted`
+- `Error`
+
+`codexWasmChatkitFetch.ts` should translate those raw Codex events into the
+same ChatKit stream shapes already used by `responses-direct`:
+
+- thread creation and thread state updates,
+- assistant message placeholder creation,
+- assistant text deltas,
+- client tool call items,
+- end-of-turn items.
+
+This is another reason to keep the local `fetch` shim: ChatKit already expects
+those stream events, and the existing Codex/Responses adapters give us a proven
+template for the target shape even though the WASM input stream is different.
+
+### Thread persistence
+
+For v0, thread persistence should remain browser-local, just like
+`responses-direct`.
+
+We do not need to integrate Codex Recorder or any stateful app-server storage in
+this phase. A simple local in-memory thread store is enough to validate the
+browser harness architecture.
+
+## V0 Scope
+
+V0 should include:
+
+- new harness type `codex-wasm`,
+- browser-local Codex harness execution through WASM,
+- API-key-based authentication for the `codex-wasm` harness,
+- Codex code mode tool wired to the sandbox kernel,
+- ChatKit streaming and thread behavior equivalent to `responses-direct`,
+- direct Responses API calls through the current Codex browser facade.
+
+V0 should explicitly defer:
+
+- Recorder,
+- remote thread history,
+- app-server protocol support,
+- sub-agents and long-running task controls,
+- any feature that requires full `codex-core` parity rather than browser harness
+  parity.
+
+## Concrete Changes In Runme Web
+
+### Routing and config
+
+- Update
+  [harnessManager.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/harnessManager.ts)
+  for `codex-wasm`.
+- Update
+  [appJsGlobals.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/appJsGlobals.ts)
+  so `app.harness.update(..., "codex-wasm")` works.
+- Reuse the existing OpenAI API key setters exposed through
+  `app.responsesDirect.setAPIKey(...)` and `credentials.openai.setAPIKey(...)`
+  instead of adding a new Codex-specific API key API for v0.
+- Add tests in
+  [harnessManager.test.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/harnessManager.test.ts)
+  and
+  [ChatKitPanel.test.tsx](/Users/jlewi/code/runmecodex/web/app/src/components/ChatKit/ChatKitPanel.test.tsx)
+  for the new adapter.
+
+### Runtime
+
+- Add `codexWasmHarnessLoader.ts`.
+- Add `codexWasmChatkitFetch.ts`.
+- Potentially add `codexWasmHost.ts` or `codexWasmSession.ts` to keep the
+  WASM-specific state out of `ChatKitPanel.tsx`.
+- Read the v0 API key from `responsesDirectConfigManager.getSnapshot().apiKey`
+  and pass it through to `BrowserCodex`.
+- Reuse
+  [codeModeExecutor.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/codeModeExecutor.ts)
+  and
+  [sandboxJsKernel.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/sandboxJsKernel.ts)
+  unchanged except for any small adapter glue.
+
+### Dependency management
+
+For v0, we should consume the Codex WASM harness from source via a **git
+dependency on the Codex branch** and compile it in the `runmedev/web` repo
+build flow rather than reimplementing its logic locally.
+
+This fits the current Codex crate structure. `codex-rs/wasm-harness` is part of
+the Codex Rust workspace and uses workspace-managed metadata and dependency
+resolution. By pulling it in as a git dependency, Cargo resolves the crate in
+the context of the original Codex workspace instead of forcing us to vendor the
+whole workspace into the Runme repo.
+
+The expected build shape becomes:
+
+1. Add a small Runme-side Rust wrapper or helper workspace in `web/wasm/`.
+2. Declare a pinned git dependency on `codex-wasm-harness` from the Codex repo
+   and branch/revision.
+3. Run `cargo build --target wasm32-unknown-unknown`.
+4. Run `wasm-bindgen --target web ...`.
+5. Stage the generated JS/WASM output into the app's static asset directory.
+6. Load those generated assets from a small handwritten loader in the Vite app.
+
+This changes a few things in a useful way:
+
+- packaging is now reproducible against a pinned Codex revision,
+- we no longer need to make `codex-wasm-harness` standalone before trying the
+  integration,
+- Runme does not need to vendor Codex Rust sources directly,
+- upstream API stability matters more because Runme will be pinned to and built
+  against a real Codex branch revision.
+
+For local development we may still want an override path to a local Codex
+checkout, but the documented v0 default should be a pinned git dependency.
+
+### Build layout
+
+With the git dependency decision made, the recommended Runme-side layout is:
+
+- `web/wasm/`
+  - small Rust helper workspace or wrapper crate,
+  - `Cargo.toml` with git dependency on `codex-wasm-harness`,
+  - build script that produces browser artifacts.
+- generated output staged into the app's existing Vite static asset directory:
+  - `web/app/assets/generated/codex-wasm/`
+  - for example:
+    - `web/app/assets/generated/codex-wasm/codex_wasm_harness.js`
+    - `web/app/assets/generated/codex-wasm/codex_wasm_harness_bg.wasm`
+- handwritten integration code committed under app source:
+  - `web/app/src/lib/runtime/codexWasmHarnessLoader.ts`
+  - `web/app/src/lib/runtime/codexWasmSession.ts`
+  - `web/app/src/lib/runtime/codexWasmChatkitFetch.ts`
+
+This matches the current app's Vite setup. The app already uses
+`publicDir: "assets"` and serves files such as
+`configs/app-configs.yaml` from that static asset tree.
+
+The intended split is:
+
+- generated `wasm-bindgen` artifacts are build outputs and should not be
+  committed to git,
+- handwritten Runme loader code lives in `src/` and is bundled with the app,
+- the loader resolves the generated asset URLs with `resolveAppUrl(...)` and
+  initializes the generated wrapper at runtime.
+
+This is preferable to placing generated artifacts under `src/` because it keeps
+generated code out of the Vite module graph while still using the repo's
+existing static-asset serving path.
+
+## Concrete Changes Needed In Codex
+
+The current Codex branch is close, but we should make these upstream changes to
+support Runme cleanly:
+
+1. Keep the exported WASM/browser API stable enough for downstream consumption
+   as a pinned git dependency.
+2. Expose or stabilize a configuration seam for Runme-specific instructions in
+   the real Codex session path.
+3. Keep the current code-execution binding simple enough to wire into Runme's
+   single-tool code-mode design.
+4. Keep the raw `Event` / `EventMsg` surface stable enough for downstream UI
+   adapters to translate it into ChatKit events.
+5. Decide whether `BrowserCodex` should preserve a session across turns instead
+   of resetting after each submission.
+
+None of those changes require full `codex-core` in WASM. They are boundary
+changes, not a runtime port.
+
+## Phased Plan
+
+### Phase 1: Boundary hardening in Codex
+
+- Keep the exported WASM/browser API stable enough to consume from a pinned git
+  revision.
+- Stabilize the code executor request/response contract used by
+  `BrowserCodeModeRuntime`.
+- Add or confirm a configuration path for Runme-specific instructions.
+- Keep v0 scoped to browser-executed tools; do not block on hosted Responses
+  tools such as `file_search`.
+- Decide whether the browser wrapper should preserve session continuity across
+  turns.
+
+### Phase 2: Runme adapter integration
+
+- Add `codex-wasm` harness routing.
+- Add the local ChatKit fetch shim backed by the Codex WASM harness.
+- Wire the Codex browser code executor to `CodeModeExecutor` in sandbox mode.
+- Add tests for adapter selection and tool execution.
+
+### Phase 3: Cutover experiments
+
+- Exercise notebook workflows under `codex-wasm`.
+- Compare behavior with `responses-direct`.
+- Decide whether `responses-direct` remains as a fallback or is eventually
+  retired.
+
+## Risks
+
+- The current Codex WASM crate is still a prototype. If we integrate directly
+  against demo-oriented APIs, we will create churn on both sides.
+- Git-dependency consumption means upstream Codex API churn directly affects the
+  Runme build until we pin and update revisions carefully.
+- The WASM callback emits raw Codex `Event` / `EventMsg`, while the existing
+  remote controller consumes app-server notifications derived from those
+  events. A clean normalization layer is needed to avoid duplicating mapping
+  logic.
+- If `BrowserCodex` continues to reset session state after each turn, we may
+  get behavior drift relative to the browser-local thread continuity that
+  Runme's current harnesses expect.
+- Prompt and event-shape differences between `responses-direct` and Codex may
+  surface UX drift in ChatKit even when tool execution works.
+- WASM packaging and asset loading can become more work than the harness logic
+  itself if we do not settle the build artifact story early.
+
+## Test Plan
+
+Unit:
+
+- `HarnessAdapter` accepts `codex-wasm`.
+- `buildChatkitUrl(..., "codex-wasm")` resolves to the local browser route.
+- `app.harness.update(..., "codex-wasm")` stores and formats correctly.
+
+Integration:
+
+- `ChatKitPanel` selects `createCodexWasmChatkitFetch(...)` for
+  `codex-wasm`.
+- A prompt under `codex-wasm` triggers a Codex WASM turn, streams assistant
+  deltas, executes Codex code mode, and completes the turn.
+- The browser code executor runs through `CodeModeExecutor` with
+  `mode: "sandbox"` and `source: "codex"`.
+
+Browser E2E:
+
+- switch harness to `codex-wasm`,
+- ask for a notebook inspection or mutation that requires code mode,
+- verify the output and notebook-visible side effects match the current
+  `responses-direct` experience for the same task,
+- verify the API-key-only setup path is clear and functional.
+
+## Open Questions
+
+- Is API-key-only authentication for `codex-wasm` acceptable beyond local/dev
+  usage, or should we treat it as strictly temporary from the outset?
+- Should `codex-wasm` use browser-local thread persistence only, or should we
+  persist threads in localStorage from day one?
+- Should `BrowserCodex` preserve the underlying Codex session across turns, or
+  is the current "fresh session per submission" wrapper behavior acceptable for
+  the first integration?
+- What is the exact instruction-injection API that Runme should target once the
+  browser wrapper settles?
+- What is the exact Runme-side Rust wrapper layout for building the git-pinned
+  Codex WASM dependency and staging its generated assets into the web app?
+
+## References
+
+- User-referenced design doc:
+  [Codex harness in browser Google doc](https://docs.google.com/document/d/1ukACcrfmLvJAuqR7ZR9EYVE5SyvXpnDMhfyqCSqnDn8/edit?tab=t.0#heading=h.74vvbahro6wf)
+- Codex WASM harness README:
+  [README.md](/Users/jlewi/code/codex/codex-rs/wasm-harness/README.md)
+- Current browser-direct harness:
+  [responsesDirectChatkitFetch.ts](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/responsesDirectChatkitFetch.ts)
+- Current code mode design:
+  [20260331_code_mode.md](/Users/jlewi/code/runmecodex/web/docs-dev/design/20260331_code_mode.md)


### PR DESCRIPTION
## Summary
- add a `codex-wasm` ChatKit harness path that runs the Codex WASM browser harness locally and routes Codex code mode into Runme's sandbox executor
- reuse the existing browser-side OpenAI API key configuration path and add a local asset sync helper for the generated `wasm-bindgen` JS/WASM bundle
- add a harness selector at the bottom of the Chat side panel so users can switch harnesses and refresh the ChatKit panel immediately
- document the v0 design and packaging plan for pulling the Codex WASM harness into `runmedev/web`

## What changed
- extend the harness manager to support a third adapter, `codex-wasm`, with local ChatKit routing at `/codex/wasm/chatkit`
- add `codexWasmHarnessLoader`, `codexWasmSession`, and `codexWasmChatkitFetch` to:
  - load the generated browser wrapper and `.wasm`
  - initialize `BrowserCodex`
  - provide the existing Responses-direct API key to Codex
  - execute Codex code mode requests through Runme's browser sandbox
  - translate upstream Codex events into ChatKit SSE events
- update `ChatKitPanel` to choose between `responses-direct`, `codex`, and `codex-wasm`
- add a footer harness selector in the Chat side panel that switches the default harness and remounts ChatKit on change
- add `pnpm run sync:codex-wasm` to copy generated Codex WASM artifacts into the Vite-served asset directory
- add and update tests for harness routing, the Codex WASM fetch bridge, and the harness selector
- add the design doc updates in `docs-dev/design/20260414_codex_wasm.md`

## Testing
- `pnpm -C /Users/jlewi/code/runmecodex/web/app exec vitest run src/lib/runtime/harnessManager.test.ts src/lib/runtime/codexWasmChatkitFetch.test.ts src/components/ChatKit/ChatKitPanel.test.tsx`
- `pnpm -C /Users/jlewi/code/runmecodex/web/app exec vitest run src/components/ChatKit/ChatKitPanel.test.tsx src/lib/runtime/harnessManager.test.ts`
- browser smoke test with Vite + Agent Browser:
  - verified `/generated/codex-wasm/codex_wasm_harness.js` is served
  - verified `/generated/codex-wasm/codex_wasm_harness_bg.wasm` is served as `application/wasm`
  - verified the browser can import the generated wrapper, initialize the module, and construct `BrowserCodex`

## Follow-ups / known limitations
- this v0 path assumes the user provides an OpenAI API key through the existing browser config helpers
- full end-to-end Codex turn execution with a live key was not exercised in this branch
- upstream session continuity and the long-term instruction injection seam are still called out in the design doc as follow-up work
