### PR TITLE
Add agentic search runtime hooks for Codex WASM

### DIFF
--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -1,13 +1,15 @@
-import { jwtDecode } from "jwt-decode";
+import { jwtDecode } from 'jwt-decode'
 
-import { OidcConfig, oidcConfigManager } from "../../auth/oidcConfig";
-import { parser_pb } from "../../runme/client";
-import { LOCAL_FOLDER_URI } from "../../storage/local";
+import { OidcConfig, oidcConfigManager } from '../../auth/oidcConfig'
+import { parser_pb } from '../../runme/client'
 import {
   FilesystemNotebookStore,
   isFileSystemAccessSupported,
-} from "../../storage/fs";
-import { getAuthData } from "../../token";
+} from '../../storage/fs'
+import { LOCAL_FOLDER_URI } from '../../storage/local'
+import { getAuthData } from '../../token'
+import { agentEndpointManager } from '../agentEndpointManager'
+import { aisreClientManager } from '../aisreClientManager'
 import {
   disableAppConfigOverridesOnLoad,
   enableAppConfigOverridesOnLoad,
@@ -16,9 +18,15 @@ import {
   setAppConfig,
   setAppConfigFromYaml,
   setLocalConfigPreferredOnLoad,
-} from "../appConfig";
-import { agentEndpointManager } from "../agentEndpointManager";
-import { aisreClientManager } from "../aisreClientManager";
+} from '../appConfig'
+import {
+  copyDriveNotebookFile,
+  createDriveFile,
+  listDriveFolderItems,
+  saveNotebookAsDriveCopy,
+  updateDriveFileBytes,
+} from '../driveTransfer'
+import { googleClientManager } from '../googleClientManager'
 import {
   deserializeMarkdownToNotebook,
   getImportedFileBytes,
@@ -27,95 +35,94 @@ import {
   pickMarkdownSource,
   registerImportedMarkdownForUri,
   toImportedNotebookName,
-} from "../markdownImport";
-import { googleClientManager } from "../googleClientManager";
-import type { Runner } from "../runner";
+} from '../markdownImport'
+import type { Runner } from '../runner'
+import { appState } from './AppState'
+import type {
+  AppKernelNetworkApi,
+  AppKernelOpfsApi,
+} from './appKernelLowLevelApis'
 import {
-  copyDriveNotebookFile,
-  createDriveFile,
-  listDriveFolderItems,
-  saveNotebookAsDriveCopy,
-  updateDriveFileBytes,
-} from "../driveTransfer";
-import { appState } from "./AppState";
-import { getCodexProjectManager, type CodexProject } from "./codexProjectManager";
-import { type HarnessAdapter, getHarnessManager } from "./harnessManager";
-import { responsesDirectConfigManager } from "./responsesDirectConfigManager";
+  type CodexProject,
+  getCodexProjectManager,
+} from './codexProjectManager'
+import { type HarnessAdapter, getHarnessManager } from './harnessManager'
+import { getJupyterManager } from './jupyterManager'
+import { responsesDirectConfigManager } from './responsesDirectConfigManager'
 import {
-  createNotebooksApi,
   type NotebookDataLike,
   type RunmeConsoleApi,
-} from "./runmeConsole";
-import { getRunnersManager } from "./runnersManager";
-import { getJupyterManager } from "./jupyterManager";
+  createNotebooksApi,
+} from './runmeConsole'
+import { getRunnersManager } from './runnersManager'
 
-type SendOutput = (data: string) => void;
+type SendOutput = (data: string) => void
 
 type RuntimeNotebookStore = {
-  create: (parentUri: string, name: string) => Promise<{ uri: string }>;
-  save: (uri: string, notebook: parser_pb.Notebook) => Promise<unknown>;
-};
+  create: (parentUri: string, name: string) => Promise<{ uri: string }>
+  save: (uri: string, notebook: parser_pb.Notebook) => Promise<unknown>
+}
 
 type WorkspaceApi = {
-  getItems?: () => string[];
-  addItem?: (uri: string) => void;
-  removeItem?: (uri: string) => void;
-};
+  getItems?: () => string[]
+  addItem?: (uri: string) => void
+  removeItem?: (uri: string) => void
+}
 
 type RunnerSync = {
-  onUpdated?: (runner: Runner) => void;
-  onDeleted?: (name: string) => void;
-  onDefaultSet?: (name: string) => void;
-};
+  onUpdated?: (runner: Runner) => void
+  onDeleted?: (name: string) => void
+  onDefaultSet?: (name: string) => void
+}
 
 function emitLine(sendOutput: SendOutput | undefined, message: string): void {
-  sendOutput?.(`${message}\r\n`);
+  sendOutput?.(`${message}\r\n`)
 }
 
 function createRunmeApi(
   runme: RunmeConsoleApi,
-  sendOutput: SendOutput | undefined,
+  sendOutput: SendOutput | undefined
 ): RunmeConsoleApi {
   return {
     getCurrentNotebook: () => runme.getCurrentNotebook(),
     clear: (target?: unknown) => {
-      const message = runme.clear(target);
-      emitLine(sendOutput, message);
-      return message;
+      const message = runme.clear(target)
+      emitLine(sendOutput, message)
+      return message
     },
     clearOutputs: (target?: unknown) => {
-      const message = runme.clearOutputs(target);
-      emitLine(sendOutput, message);
-      return message;
+      const message = runme.clearOutputs(target)
+      emitLine(sendOutput, message)
+      return message
     },
     runAll: (target?: unknown) => {
-      const message = runme.runAll(target);
-      emitLine(sendOutput, message);
-      return message;
+      const message = runme.runAll(target)
+      emitLine(sendOutput, message)
+      return message
     },
     rerun: (target?: unknown) => {
-      const message = runme.rerun(target);
-      emitLine(sendOutput, message);
-      return message;
+      const message = runme.rerun(target)
+      emitLine(sendOutput, message)
+      return message
     },
     help: () => {
-      const message = runme.help();
-      emitLine(sendOutput, message);
-      return message;
+      const message = runme.help()
+      emitLine(sendOutput, message)
+      return message
     },
-  };
+  }
 }
 
 function defaultEnsureFilesystemStore(): FilesystemNotebookStore | null {
   if (appState.filesystemStore) {
-    return appState.filesystemStore;
+    return appState.filesystemStore
   }
   if (!isFileSystemAccessSupported()) {
-    return null;
+    return null
   }
-  const store = new FilesystemNotebookStore();
-  appState.setFilesystemStore(store);
-  return store;
+  const store = new FilesystemNotebookStore()
+  appState.setFilesystemStore(store)
+  return store
 }
 
 export function createAppJsGlobals({
@@ -128,279 +135,374 @@ export function createAppJsGlobals({
   runnerSync,
   resolveNotebook,
   listNotebooks,
+  opfsApi,
+  networkApi,
 }: {
-  runme: RunmeConsoleApi;
-  sendOutput?: SendOutput;
-  resolveNotebookStore?: () => RuntimeNotebookStore | null;
-  ensureFilesystemStore?: () => FilesystemNotebookStore | null;
-  workspace?: WorkspaceApi;
-  openNotebook?: (uri: string) => void | Promise<void>;
-  runnerSync?: RunnerSync;
-  resolveNotebook?: (target?: unknown) => NotebookDataLike | null;
-  listNotebooks?: () => NotebookDataLike[];
+  runme: RunmeConsoleApi
+  sendOutput?: SendOutput
+  resolveNotebookStore?: () => RuntimeNotebookStore | null
+  ensureFilesystemStore?: () => FilesystemNotebookStore | null
+  workspace?: WorkspaceApi
+  openNotebook?: (uri: string) => void | Promise<void>
+  runnerSync?: RunnerSync
+  resolveNotebook?: (target?: unknown) => NotebookDataLike | null
+  listNotebooks?: () => NotebookDataLike[]
+  opfsApi?: AppKernelOpfsApi
+  networkApi?: AppKernelNetworkApi
 }) {
   const getWorkspaceItems = () =>
-    workspace?.getItems?.() ?? appState.getWorkspaceItems();
+    workspace?.getItems?.() ?? appState.getWorkspaceItems()
   const addWorkspaceItem = (uri: string) => {
     if (workspace?.addItem) {
-      workspace.addItem(uri);
-      return;
+      workspace.addItem(uri)
+      return
     }
-    appState.addWorkspaceItem(uri);
-  };
+    appState.addWorkspaceItem(uri)
+  }
   const removeWorkspaceItem = (uri: string) => {
     if (workspace?.removeItem) {
-      workspace.removeItem(uri);
-      return;
+      workspace.removeItem(uri)
+      return
     }
-    appState.removeWorkspaceItem(uri);
-  };
-  const resolveStore = () => resolveNotebookStore?.() ?? appState.localNotebooks;
+    appState.removeWorkspaceItem(uri)
+  }
+  const resolveStore = () => resolveNotebookStore?.() ?? appState.localNotebooks
   const openNotebookForRuntime = async (uri: string) => {
     if (openNotebook) {
-      await openNotebook(uri);
-      return;
+      await openNotebook(uri)
+      return
     }
-    await appState.openNotebook(uri);
-  };
+    await appState.openNotebook(uri)
+  }
   const resolveLocalMirrorStore = () => {
     if (!appState.localNotebooks) {
-      throw new Error("Local notebook mirror store is not initialized yet.");
+      throw new Error('Local notebook mirror store is not initialized yet.')
     }
-    return appState.localNotebooks;
-  };
+    return appState.localNotebooks
+  }
 
-  const runmeApi = createRunmeApi(runme, sendOutput);
+  const runmeApi = createRunmeApi(runme, sendOutput)
   const notebooksApi = createNotebooksApi({
     resolveNotebook: resolveNotebook ?? (() => runme.getCurrentNotebook()),
     listNotebooks,
-  });
-  const jupyterManager = getJupyterManager();
-  const harnessManager = getHarnessManager();
-  const codexProjectManager = getCodexProjectManager();
-  const responsesDirect = responsesDirectConfigManager;
+  })
+  const jupyterManager = getJupyterManager()
+  const harnessManager = getHarnessManager()
+  const codexProjectManager = getCodexProjectManager()
+  const responsesDirect = responsesDirectConfigManager
 
   const normalizeHarnessAdapter = (
-    value: string,
+    value: string
   ): { adapter: HarnessAdapter; warning?: string } => {
-    const normalized = (value ?? "").trim().toLowerCase();
-    if (normalized === "codex") {
-      return { adapter: "codex" };
+    const normalized = (value ?? '').trim().toLowerCase()
+    if (normalized === 'codex') {
+      return { adapter: 'codex' }
     }
     if (
-      normalized === "codex-wasm" ||
-      normalized === "codex_wasm" ||
-      normalized === "codexwasm"
+      normalized === 'codex-wasm' ||
+      normalized === 'codex_wasm' ||
+      normalized === 'codexwasm'
     ) {
-      return { adapter: "codex-wasm" };
+      return { adapter: 'codex-wasm' }
     }
-    if (
-      normalized === "responses" ||
-      normalized === "response"
-    ) {
+    if (normalized === 'responses' || normalized === 'response') {
       return {
-        adapter: "responses-direct",
+        adapter: 'responses-direct',
         warning: `Harness adapter "${value}" is deprecated; using "responses-direct" instead.`,
-      };
+      }
     }
     if (
-      normalized === "responses-direct" ||
-      normalized === "responses_direct" ||
-      normalized === "responsesdirect"
+      normalized === 'responses-direct' ||
+      normalized === 'responses_direct' ||
+      normalized === 'responsesdirect'
     ) {
-      return { adapter: "responses-direct" };
+      return { adapter: 'responses-direct' }
     }
-    throw new Error(`Unsupported harness adapter: ${String(value)}`);
-  };
+    throw new Error(`Unsupported harness adapter: ${String(value)}`)
+  }
 
   const formatHarness = (
     harness: { name: string; baseUrl: string; adapter: HarnessAdapter },
-    options?: { includeDefaultMarker?: boolean },
+    options?: { includeDefaultMarker?: boolean }
   ): string => {
     const isDefault =
       options?.includeDefaultMarker === true &&
-      harness.name === harnessManager.getDefaultName();
+      harness.name === harnessManager.getDefaultName()
     return `${harness.name}: ${harness.baseUrl} (${harness.adapter})${
-      isDefault ? " (default)" : ""
-    }`;
-  };
+      isDefault ? ' (default)' : ''
+    }`
+  }
 
-  const formatDefaultHarness = (
-    harness: { name: string; baseUrl: string; adapter: HarnessAdapter },
-  ): string => {
-    return `Default harness: ${harness.name} (${harness.baseUrl}, ${harness.adapter})`;
-  };
+  const formatDefaultHarness = (harness: {
+    name: string
+    baseUrl: string
+    adapter: HarnessAdapter
+  }): string => {
+    return `Default harness: ${harness.name} (${harness.baseUrl}, ${harness.adapter})`
+  }
 
   const parseVectorStores = (value: string[] | string): string[] => {
     if (Array.isArray(value)) {
       return value
-        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-        .filter((entry): entry is string => entry.length > 0);
+        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+        .filter((entry): entry is string => entry.length > 0)
     }
-    if (typeof value === "string") {
+    if (typeof value === 'string') {
       return value
-        .split(",")
+        .split(',')
         .map((entry) => entry.trim())
-        .filter((entry) => entry.length > 0);
+        .filter((entry) => entry.length > 0)
     }
-    return [];
-  };
+    return []
+  }
 
   const openWorkspaceAndAdd = () => {
-    const store = ensureFilesystemStore();
+    const store = ensureFilesystemStore()
     if (!store) {
-      const message = "File System Access API is not supported in this browser.";
-      emitLine(sendOutput, message);
-      return message;
+      const message = 'File System Access API is not supported in this browser.'
+      emitLine(sendOutput, message)
+      return message
     }
 
     void store
       .openWorkspace()
       .then((workspaceRootUri) => {
         if (!getWorkspaceItems().includes(workspaceRootUri)) {
-          addWorkspaceItem(workspaceRootUri);
+          addWorkspaceItem(workspaceRootUri)
         }
-        emitLine(sendOutput, `Added local folder: ${workspaceRootUri}`);
+        emitLine(sendOutput, `Added local folder: ${workspaceRootUri}`)
       })
       .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          emitLine(sendOutput, "Picker cancelled.");
-          return;
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          emitLine(sendOutput, 'Picker cancelled.')
+          return
         }
-        emitLine(sendOutput, `Failed to open folder: ${String(error)}`);
-      });
+        emitLine(sendOutput, `Failed to open folder: ${String(error)}`)
+      })
 
-    return "Opening directory picker...";
-  };
+    return 'Opening directory picker...'
+  }
 
   const importMarkdownAndOpen = async () => {
-    const store = resolveStore();
+    const store = resolveStore()
     if (!store) {
-      emitLine(sendOutput, "Notebook store is not initialized yet.");
-      return "Notebook store unavailable.";
+      emitLine(sendOutput, 'Notebook store is not initialized yet.')
+      return 'Notebook store unavailable.'
     }
 
-    let picked;
+    let picked
     try {
-      picked = await pickMarkdownSource();
+      picked = await pickMarkdownSource()
     } catch (error) {
-      const message = `Failed to open markdown picker: ${String(error)}`;
-      emitLine(sendOutput, message);
-      return message;
+      const message = `Failed to open markdown picker: ${String(error)}`
+      emitLine(sendOutput, message)
+      return message
     }
 
     if (!picked) {
-      emitLine(sendOutput, "Markdown import cancelled.");
-      return "Import cancelled.";
+      emitLine(sendOutput, 'Markdown import cancelled.')
+      return 'Import cancelled.'
     }
 
     try {
-      const selection = getPickedMarkdownSelection(picked.sourceUri);
-      const notebook = await deserializeMarkdownToNotebook(selection);
-      const fileName = toImportedNotebookName(picked.name);
-      const created = await store.create(LOCAL_FOLDER_URI, fileName);
-      await store.save(created.uri, notebook);
+      const selection = getPickedMarkdownSelection(picked.sourceUri)
+      const notebook = await deserializeMarkdownToNotebook(selection)
+      const fileName = toImportedNotebookName(picked.name)
+      const created = await store.create(LOCAL_FOLDER_URI, fileName)
+      await store.save(created.uri, notebook)
       if (!getWorkspaceItems().includes(LOCAL_FOLDER_URI)) {
-        addWorkspaceItem(LOCAL_FOLDER_URI);
+        addWorkspaceItem(LOCAL_FOLDER_URI)
       }
-      await openNotebookForRuntime(created.uri);
-      const message = `Imported ${picked.name} as ${fileName}`;
-      emitLine(sendOutput, message);
-      return message;
+      await openNotebookForRuntime(created.uri)
+      const message = `Imported ${picked.name} as ${fileName}`
+      emitLine(sendOutput, message)
+      return message
     } catch (error) {
-      const message = `Failed to import markdown file: ${String(error)}`;
-      emitLine(sendOutput, message);
-      return message;
+      const message = `Failed to import markdown file: ${String(error)}`
+      emitLine(sendOutput, message)
+      return message
     }
-  };
+  }
 
   return {
     runme: runmeApi,
     notebooks: notebooksApi,
+    opfs: {
+      exists: (path: string) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.exists(path)
+      },
+      readText: (path: string) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.readText(path)
+      },
+      writeText: (path: string, text: string) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.writeText(path, text)
+      },
+      readBytes: (path: string) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.readBytes(path)
+      },
+      writeBytes: (path: string, bytes: Uint8Array) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.writeBytes(path, bytes)
+      },
+      list: (path: string) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.list(path)
+      },
+      mkdir: (path: string, options?: { recursive?: boolean }) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.mkdir(path, options)
+      },
+      stat: (path: string) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.stat(path)
+      },
+      remove: (path: string, options?: { recursive?: boolean }) => {
+        if (!opfsApi) {
+          throw new Error('opfs API is not available in this runtime.')
+        }
+        return opfsApi.remove(path, options)
+      },
+      help: () => {
+        return [
+          'opfs.exists(path)                - Return true if the path exists',
+          'opfs.readText(path)              - Read a UTF-8 text file',
+          'opfs.writeText(path, text)       - Write a UTF-8 text file',
+          'opfs.readBytes(path)             - Read a file as Uint8Array',
+          'opfs.writeBytes(path, bytes)     - Write a Uint8Array file',
+          'opfs.list(path)                  - List directory entries',
+          'opfs.mkdir(path, { recursive? }) - Create a directory',
+          'opfs.stat(path)                  - Return file or directory metadata',
+          'opfs.remove(path, { recursive? }) - Remove a file or directory',
+          'opfs.help()                      - Show this help',
+        ].join('\n')
+      },
+    },
+    net: {
+      get: (
+        url: string,
+        options?: {
+          headers?: Record<string, string>
+          responseType?: 'text' | 'bytes' | 'json'
+        }
+      ) => {
+        if (!networkApi) {
+          throw new Error('net API is not available in this runtime.')
+        }
+        return networkApi.get(url, options)
+      },
+      help: () => {
+        return [
+          'net.get(url, { headers?, responseType? }) - Perform an HTTP GET request',
+          "  responseType: 'text' | 'bytes' | 'json' (default: 'text')",
+          'net.help()                                - Show this help',
+        ].join('\n')
+      },
+    },
     runmeRunners: {
       get: () => {
-        const mgr = getRunnersManager();
-        const runners = mgr.list();
+        const mgr = getRunnersManager()
+        const runners = mgr.list()
         if (runners.length === 0) {
-          return "No runners configured.";
+          return 'No runners configured.'
         }
         return runners
           .map((runner) => {
-            const isDefault = runner.name === mgr.getDefaultRunnerName();
+            const isDefault = runner.name === mgr.getDefaultRunnerName()
             const endpoint =
-              typeof runner.endpoint === "string" && runner.endpoint.trim() !== ""
+              typeof runner.endpoint === 'string' &&
+              runner.endpoint.trim() !== ''
                 ? runner.endpoint
-                : "<endpoint not set>";
-            return `${runner.name}: ${endpoint}${isDefault ? " (default)" : ""}`;
+                : '<endpoint not set>'
+            return `${runner.name}: ${endpoint}${isDefault ? ' (default)' : ''}`
           })
-          .join("\n");
+          .join('\n')
       },
       update: (name: string, endpoint: string) => {
-        const mgr = getRunnersManager();
-        const updated = mgr.update(name, endpoint);
+        const mgr = getRunnersManager()
+        const updated = mgr.update(name, endpoint)
         if (runnerSync?.onUpdated) {
-          runnerSync.onUpdated(updated);
+          runnerSync.onUpdated(updated)
         } else {
-          appState.syncRunnerUpdate(updated);
+          appState.syncRunnerUpdate(updated)
         }
-        return `Runner ${name} set to ${endpoint}`;
+        return `Runner ${name} set to ${endpoint}`
       },
       delete: (name: string) => {
-        const mgr = getRunnersManager();
-        mgr.delete(name);
+        const mgr = getRunnersManager()
+        mgr.delete(name)
         if (runnerSync?.onDeleted) {
-          runnerSync.onDeleted(name);
+          runnerSync.onDeleted(name)
         } else {
-          appState.syncRunnerDelete(name);
+          appState.syncRunnerDelete(name)
         }
-        return `Runner ${name} deleted`;
+        return `Runner ${name} deleted`
       },
       getDefault: () => {
-        const mgr = getRunnersManager();
-        const defaultName = mgr.getDefaultRunnerName();
+        const mgr = getRunnersManager()
+        const defaultName = mgr.getDefaultRunnerName()
         if (!defaultName) {
-          return "No default runner set.";
+          return 'No default runner set.'
         }
-        const runner = mgr.get(defaultName);
+        const runner = mgr.get(defaultName)
         const endpoint =
-          runner && typeof runner.endpoint === "string"
+          runner && typeof runner.endpoint === 'string'
             ? runner.endpoint
-            : "<endpoint not set>";
-        return `Default runner: ${defaultName} (${endpoint})`;
+            : '<endpoint not set>'
+        return `Default runner: ${defaultName} (${endpoint})`
       },
       setDefault: (name: string) => {
-        const mgr = getRunnersManager();
-        const runner = mgr.get(name);
+        const mgr = getRunnersManager()
+        const runner = mgr.get(name)
         if (!runner) {
-          return `Runner ${name} not found`;
+          return `Runner ${name} not found`
         }
-        mgr.setDefault(name);
+        mgr.setDefault(name)
         if (runnerSync?.onDefaultSet) {
-          runnerSync.onDefaultSet(name);
+          runnerSync.onDefaultSet(name)
         } else {
-          appState.syncRunnerDefault(name);
+          appState.syncRunnerDefault(name)
         }
-        return `Default runner set to ${name}`;
+        return `Default runner set to ${name}`
       },
     },
     jupyter: {
       servers: {
         get: async (runnerName: string) => {
           if (!runnerName?.trim()) {
-            throw new Error("Usage: jupyter.servers.get(runnerName)");
+            throw new Error('Usage: jupyter.servers.get(runnerName)')
           }
           try {
-            const servers = await jupyterManager.listServers(runnerName);
+            const servers = await jupyterManager.listServers(runnerName)
             const message =
               servers.length === 0
-                ? "No Jupyter servers configured."
-                : JSON.stringify(servers, null, 2);
-            emitLine(sendOutput, message);
-            return servers;
+                ? 'No Jupyter servers configured.'
+                : JSON.stringify(servers, null, 2)
+            emitLine(sendOutput, message)
+            return servers
           } catch (error) {
-            const message = `Failed to list Jupyter servers: ${String(error)}`;
-            emitLine(sendOutput, message);
-            throw error;
+            const message = `Failed to list Jupyter servers: ${String(error)}`
+            emitLine(sendOutput, message)
+            throw error
           }
         },
       },
@@ -408,118 +510,143 @@ export function createAppJsGlobals({
         start: async (
           runnerName: string,
           serverName: string,
-          options?: { kernelSpec?: string; name?: string; path?: string },
+          options?: { kernelSpec?: string; name?: string; path?: string }
         ) => {
           if (!runnerName?.trim() || !serverName?.trim()) {
-            throw new Error("Usage: jupyter.kernels.start(runnerName, serverName, options?)");
+            throw new Error(
+              'Usage: jupyter.kernels.start(runnerName, serverName, options?)'
+            )
           }
           try {
-            const kernel = await jupyterManager.startKernel(runnerName, serverName, options);
-            const message = `Started kernel ${kernel.id} on ${runnerName}/${serverName} (${kernel.name})`;
-            emitLine(sendOutput, message);
-            emitLine(sendOutput, JSON.stringify(kernel, null, 2));
-            return kernel;
+            const kernel = await jupyterManager.startKernel(
+              runnerName,
+              serverName,
+              options
+            )
+            const message = `Started kernel ${kernel.id} on ${runnerName}/${serverName} (${kernel.name})`
+            emitLine(sendOutput, message)
+            emitLine(sendOutput, JSON.stringify(kernel, null, 2))
+            return kernel
           } catch (error) {
-            const message = `Failed to start Jupyter kernel: ${String(error)}`;
-            emitLine(sendOutput, message);
-            throw error;
+            const message = `Failed to start Jupyter kernel: ${String(error)}`
+            emitLine(sendOutput, message)
+            throw error
           }
         },
         get: async (runnerName: string, serverName: string) => {
           if (!runnerName?.trim() || !serverName?.trim()) {
-            throw new Error("Usage: jupyter.kernels.get(runnerName, serverName)");
+            throw new Error(
+              'Usage: jupyter.kernels.get(runnerName, serverName)'
+            )
           }
           try {
-            const kernels = await jupyterManager.listKernels(runnerName, serverName);
+            const kernels = await jupyterManager.listKernels(
+              runnerName,
+              serverName
+            )
             const message =
               kernels.length === 0
                 ? `No kernels running on ${runnerName}/${serverName}.`
-                : JSON.stringify(kernels, null, 2);
-            emitLine(sendOutput, message);
-            return kernels;
+                : JSON.stringify(kernels, null, 2)
+            emitLine(sendOutput, message)
+            return kernels
           } catch (error) {
-            const message = `Failed to list Jupyter kernels: ${String(error)}`;
-            emitLine(sendOutput, message);
-            throw error;
+            const message = `Failed to list Jupyter kernels: ${String(error)}`
+            emitLine(sendOutput, message)
+            throw error
           }
         },
-        stop: async (runnerName: string, serverName: string, kernelNameOrId: string) => {
-          if (!runnerName?.trim() || !serverName?.trim() || !kernelNameOrId?.trim()) {
-            throw new Error("Usage: jupyter.kernels.stop(runnerName, serverName, kernelNameOrId)");
+        stop: async (
+          runnerName: string,
+          serverName: string,
+          kernelNameOrId: string
+        ) => {
+          if (
+            !runnerName?.trim() ||
+            !serverName?.trim() ||
+            !kernelNameOrId?.trim()
+          ) {
+            throw new Error(
+              'Usage: jupyter.kernels.stop(runnerName, serverName, kernelNameOrId)'
+            )
           }
           try {
-            await jupyterManager.stopKernel(runnerName, serverName, kernelNameOrId);
-            const message = `Stopped kernel ${kernelNameOrId} on ${runnerName}/${serverName}`;
-            emitLine(sendOutput, message);
-            return message;
+            await jupyterManager.stopKernel(
+              runnerName,
+              serverName,
+              kernelNameOrId
+            )
+            const message = `Stopped kernel ${kernelNameOrId} on ${runnerName}/${serverName}`
+            emitLine(sendOutput, message)
+            return message
           } catch (error) {
-            const message = `Failed to stop Jupyter kernel: ${String(error)}`;
-            emitLine(sendOutput, message);
-            throw error;
+            const message = `Failed to stop Jupyter kernel: ${String(error)}`
+            emitLine(sendOutput, message)
+            throw error
           }
         },
       },
     },
     agent: {
       get: () => {
-        const snapshot = agentEndpointManager.getSnapshot();
-        const current = snapshot.endpoint?.trim() || "<not set>";
-        const defaultEndpoint = snapshot.defaultEndpoint?.trim() || "<not set>";
-        const message = `Agent endpoint: ${current}\nDefault agent endpoint: ${defaultEndpoint}`;
-        emitLine(sendOutput, message);
-        return message;
+        const snapshot = agentEndpointManager.getSnapshot()
+        const current = snapshot.endpoint?.trim() || '<not set>'
+        const defaultEndpoint = snapshot.defaultEndpoint?.trim() || '<not set>'
+        const message = `Agent endpoint: ${current}\nDefault agent endpoint: ${defaultEndpoint}`
+        emitLine(sendOutput, message)
+        return message
       },
       update: (endpoint: string) => {
-        const trimmed = endpoint?.trim();
+        const trimmed = endpoint?.trim()
         if (!trimmed) {
-          const message = "Usage: agent.update(endpoint)";
-          emitLine(sendOutput, message);
-          return message;
+          const message = 'Usage: agent.update(endpoint)'
+          emitLine(sendOutput, message)
+          return message
         }
-        agentEndpointManager.set(trimmed);
-        aisreClientManager.setDefault({ baseUrl: trimmed });
-        const message = `Agent endpoint set to ${trimmed}`;
-        emitLine(sendOutput, message);
-        return message;
+        agentEndpointManager.set(trimmed)
+        aisreClientManager.setDefault({ baseUrl: trimmed })
+        const message = `Agent endpoint set to ${trimmed}`
+        emitLine(sendOutput, message)
+        return message
       },
       setDefault: () => {
-        const defaultEndpoint = agentEndpointManager.reset();
+        const defaultEndpoint = agentEndpointManager.reset()
         if (!defaultEndpoint) {
-          const message = "Default agent endpoint is not configured.";
-          emitLine(sendOutput, message);
-          return message;
+          const message = 'Default agent endpoint is not configured.'
+          emitLine(sendOutput, message)
+          return message
         }
-        aisreClientManager.setDefault({ baseUrl: defaultEndpoint });
-        const message = `Agent endpoint reset to default (${defaultEndpoint})`;
-        emitLine(sendOutput, message);
-        return message;
+        aisreClientManager.setDefault({ baseUrl: defaultEndpoint })
+        const message = `Agent endpoint reset to default (${defaultEndpoint})`
+        emitLine(sendOutput, message)
+        return message
       },
       help: () => {
         const message = [
-          "agent.get()                 - Show current and default agent endpoint",
-          "agent.update(endpoint)      - Set the active agent endpoint",
-          "agent.setDefault()          - Reset agent endpoint to app default",
-          "agent.help()                - Show this help",
-        ].join("\n");
-        emitLine(sendOutput, message);
-        return message;
+          'agent.get()                 - Show current and default agent endpoint',
+          'agent.update(endpoint)      - Set the active agent endpoint',
+          'agent.setDefault()          - Reset agent endpoint to app default',
+          'agent.help()                - Show this help',
+        ].join('\n')
+        emitLine(sendOutput, message)
+        return message
       },
     },
     googleClientManager: {
       get: () => googleClientManager.getOAuthClient(),
       setOAuthClient: (config: {
-        clientId?: string;
-        clientSecret?: string;
-        authFlow?: "implicit" | "pkce";
-        authUxMode?: "popup" | "redirect";
+        clientId?: string
+        clientSecret?: string
+        authFlow?: 'implicit' | 'pkce'
+        authUxMode?: 'popup' | 'redirect'
       }) => googleClientManager.setOAuthClient(config),
       setClientId: (clientId: string) =>
         googleClientManager.setOAuthClient({ clientId }),
       setClientSecret: (clientSecret: string) =>
         googleClientManager.setClientSecret(clientSecret),
-      setAuthFlow: (authFlow: "implicit" | "pkce") =>
+      setAuthFlow: (authFlow: 'implicit' | 'pkce') =>
         googleClientManager.setAuthFlow(authFlow),
-      setAuthUxMode: (authUxMode: "popup" | "redirect") =>
+      setAuthUxMode: (authUxMode: 'popup' | 'redirect') =>
         googleClientManager.setAuthUxMode(authUxMode),
       setFromJson: (raw: string) =>
         googleClientManager.setOAuthClientFromJson(raw),
@@ -529,7 +656,8 @@ export function createAppJsGlobals({
       getRedirectURI: () => oidcConfigManager.getRedirectURI(),
       getScope: () => oidcConfigManager.getScope(),
       set: (config: Partial<OidcConfig>) => oidcConfigManager.setConfig(config),
-      setClientId: (clientId: string) => oidcConfigManager.setClientId(clientId),
+      setClientId: (clientId: string) =>
+        oidcConfigManager.setClientId(clientId),
       setClientSecret: (clientSecret: string) =>
         oidcConfigManager.setClientSecret(clientSecret),
       setDiscoveryURL: (discoveryUrl: string) =>
@@ -538,24 +666,27 @@ export function createAppJsGlobals({
       setScope: (scope: string) => oidcConfigManager.setScope(scope),
       setGoogleDefaults: () => oidcConfigManager.setGoogleDefaults(),
       getStatus: async () => {
-        const authData = await getAuthData();
+        const authData = await getAuthData()
         if (!authData) {
-          emitLine(sendOutput, "Is Authenticated: No");
-          return { isAuthenticated: false };
+          emitLine(sendOutput, 'Is Authenticated: No')
+          return { isAuthenticated: false }
         }
-        let decodedAccessToken: unknown = null;
-        let decodedIdToken: unknown = null;
+        let decodedAccessToken: unknown = null
+        let decodedIdToken: unknown = null
         try {
-          decodedAccessToken = jwtDecode(authData.accessToken);
+          decodedAccessToken = jwtDecode(authData.accessToken)
         } catch (error) {
-          emitLine(sendOutput, `Failed to decode access token: ${String(error)}`);
+          emitLine(
+            sendOutput,
+            `Failed to decode access token: ${String(error)}`
+          )
         }
         try {
           if (authData.idToken) {
-            decodedIdToken = jwtDecode(authData.idToken);
+            decodedIdToken = jwtDecode(authData.idToken)
           }
         } catch (error) {
-          emitLine(sendOutput, `Failed to decode ID token: ${String(error)}`);
+          emitLine(sendOutput, `Failed to decode ID token: ${String(error)}`)
         }
         const status = {
           isAuthenticated: true,
@@ -565,11 +696,11 @@ export function createAppJsGlobals({
           decodedIdToken,
           tokenType: authData.tokenType,
           scope: authData.scope,
-        };
-        emitLine(sendOutput, "Is Authenticated: Yes");
-        emitLine(sendOutput, `Is Expired: ${status.isExpired ? "Yes" : "No"}`);
-        emitLine(sendOutput, JSON.stringify(status, null, 2));
-        return status;
+        }
+        emitLine(sendOutput, 'Is Authenticated: Yes')
+        emitLine(sendOutput, `Is Expired: ${status.isExpired ? 'Yes' : 'No'}`)
+        emitLine(sendOutput, JSON.stringify(status, null, 2))
+        return status
       },
     },
     credentials: {
@@ -578,22 +709,24 @@ export function createAppJsGlobals({
       openai: {
         get: () => responsesDirect.getSnapshot(),
         setAuthMethod: (authMethod: string) => {
-          return responsesDirect.setAuthMethod(authMethod);
+          return responsesDirect.setAuthMethod(authMethod)
         },
         setOpenAIOrganization: (openaiOrganization: string) => {
-          return responsesDirect.setOpenAIOrganization(openaiOrganization);
+          return responsesDirect.setOpenAIOrganization(openaiOrganization)
         },
         setOpenAIProject: (openaiProject: string) => {
-          return responsesDirect.setOpenAIProject(openaiProject);
+          return responsesDirect.setOpenAIProject(openaiProject)
         },
         setVectorStores: (vectorStores: string[] | string) => {
-          return responsesDirect.setVectorStores(parseVectorStores(vectorStores));
+          return responsesDirect.setVectorStores(
+            parseVectorStores(vectorStores)
+          )
         },
         setAPIKey: (apiKey: string) => {
-          return responsesDirect.setAPIKey(apiKey);
+          return responsesDirect.setAPIKey(apiKey)
         },
         clearAPIKey: () => {
-          return responsesDirect.clearAPIKey();
+          return responsesDirect.clearAPIKey()
         },
       },
     },
@@ -601,137 +734,137 @@ export function createAppJsGlobals({
       getDefaultConfigUrl: () => getDefaultAppConfigUrl(),
       isLocalConfigPreferredOnLoad: () => isLocalConfigPreferredOnLoad(),
       setLocalConfigPreferredOnLoad: (preferLocal: boolean) => {
-        const applied = setLocalConfigPreferredOnLoad(Boolean(preferLocal));
-        const message = `App config load precedence set to ${applied ? "local storage" : "app-config"}`;
-        emitLine(sendOutput, message);
-        return applied;
+        const applied = setLocalConfigPreferredOnLoad(Boolean(preferLocal))
+        const message = `App config load precedence set to ${applied ? 'local storage' : 'app-config'}`
+        emitLine(sendOutput, message)
+        return applied
       },
       disableConfigOverridesOnLoad: () => {
-        const applied = disableAppConfigOverridesOnLoad();
-        emitLine(sendOutput, "App config overrides on load disabled.");
-        return applied;
+        const applied = disableAppConfigOverridesOnLoad()
+        emitLine(sendOutput, 'App config overrides on load disabled.')
+        return applied
       },
       enableConfigOverridesOnLoad: () => {
-        const applied = enableAppConfigOverridesOnLoad();
-        emitLine(sendOutput, "App config overrides on load enabled.");
-        return applied;
+        const applied = enableAppConfigOverridesOnLoad()
+        emitLine(sendOutput, 'App config overrides on load enabled.')
+        return applied
       },
       openNotebook: async (uri: string) => {
         if (!uri?.trim()) {
-          throw new Error("Usage: app.openNotebook(localUri)");
+          throw new Error('Usage: app.openNotebook(localUri)')
         }
-        await openNotebookForRuntime(uri);
-        emitLine(sendOutput, `Opened notebook ${uri}`);
-        return uri;
+        await openNotebookForRuntime(uri)
+        emitLine(sendOutput, `Opened notebook ${uri}`)
+        return uri
       },
       setConfig: async (url?: string) => {
-        emitLine(sendOutput, "Fetching app config...");
+        emitLine(sendOutput, 'Fetching app config...')
         try {
-          const applied = await setAppConfig(url);
+          const applied = await setAppConfig(url)
           if (applied.warnings.length > 0) {
             applied.warnings.forEach((warning) => {
-              emitLine(sendOutput, `Warning: ${warning}`);
-            });
+              emitLine(sendOutput, `Warning: ${warning}`)
+            })
           }
-          emitLine(sendOutput, "App config applied.");
-          return applied;
+          emitLine(sendOutput, 'App config applied.')
+          return applied
         } catch (error) {
-          const message = `Failed to apply app config: ${String(error)}`;
-          emitLine(sendOutput, message);
-          throw error;
+          const message = `Failed to apply app config: ${String(error)}`
+          emitLine(sendOutput, message)
+          throw error
         }
       },
       setConfigFromYaml: async (yamlText: string, source?: string) => {
-        emitLine(sendOutput, "Applying app config YAML...");
+        emitLine(sendOutput, 'Applying app config YAML...')
         try {
-          const applied = setAppConfigFromYaml(yamlText, source);
+          const applied = setAppConfigFromYaml(yamlText, source)
           if (applied.warnings.length > 0) {
             applied.warnings.forEach((warning) => {
-              emitLine(sendOutput, `Warning: ${warning}`);
-            });
+              emitLine(sendOutput, `Warning: ${warning}`)
+            })
           }
-          emitLine(sendOutput, "App config applied.");
-          return applied;
+          emitLine(sendOutput, 'App config applied.')
+          return applied
         } catch (error) {
-          const message = `Failed to apply app config YAML: ${String(error)}`;
-          emitLine(sendOutput, message);
-          throw error;
+          const message = `Failed to apply app config YAML: ${String(error)}`
+          emitLine(sendOutput, message)
+          throw error
         }
       },
       harness: {
         get: () => {
-          const harnesses = harnessManager.list();
+          const harnesses = harnessManager.list()
           if (harnesses.length === 0) {
-            const message = "No harnesses configured.";
-            emitLine(sendOutput, message);
-            return message;
+            const message = 'No harnesses configured.'
+            emitLine(sendOutput, message)
+            return message
           }
           const message = harnesses
             .map((harness) =>
-              formatHarness(harness, { includeDefaultMarker: true }),
+              formatHarness(harness, { includeDefaultMarker: true })
             )
-            .join("\n");
-          emitLine(sendOutput, message);
-          return message;
+            .join('\n')
+          emitLine(sendOutput, message)
+          return message
         },
         update: (name: string, baseUrl: string, adapter: string) => {
-          const normalized = normalizeHarnessAdapter(adapter);
+          const normalized = normalizeHarnessAdapter(adapter)
           const updated = harnessManager.update(
             name,
             baseUrl,
-            normalized.adapter,
-          );
+            normalized.adapter
+          )
           const message = normalized.warning
             ? `Harness ${updated.name} set to ${updated.baseUrl} (${updated.adapter})\nWarning: ${normalized.warning}`
-            : `Harness ${updated.name} set to ${updated.baseUrl} (${updated.adapter})`;
-          emitLine(sendOutput, message);
-          return message;
+            : `Harness ${updated.name} set to ${updated.baseUrl} (${updated.adapter})`
+          emitLine(sendOutput, message)
+          return message
         },
         delete: (name: string) => {
-          harnessManager.delete(name);
-          const message = `Harness ${name} deleted`;
-          emitLine(sendOutput, message);
-          return message;
+          harnessManager.delete(name)
+          const message = `Harness ${name} deleted`
+          emitLine(sendOutput, message)
+          return message
         },
         getDefault: () => {
-          const message = formatDefaultHarness(harnessManager.getDefault());
-          emitLine(sendOutput, message);
-          return message;
+          const message = formatDefaultHarness(harnessManager.getDefault())
+          emitLine(sendOutput, message)
+          return message
         },
         setDefault: (name: string) => {
-          harnessManager.setDefault(name);
-          const message = `Default harness set to ${name}`;
-          emitLine(sendOutput, message);
-          return message;
+          harnessManager.setDefault(name)
+          const message = `Default harness set to ${name}`
+          emitLine(sendOutput, message)
+          return message
         },
         getActiveChatkitUrl: () => {
-          const active = harnessManager.getDefault();
-          const chatkitUrl = harnessManager.resolveChatkitUrl(active);
-          const message = `Active ChatKit URL: ${chatkitUrl} (${active.name}, ${active.adapter})`;
-          emitLine(sendOutput, message);
-          return message;
+          const active = harnessManager.getDefault()
+          const chatkitUrl = harnessManager.resolveChatkitUrl(active)
+          const message = `Active ChatKit URL: ${chatkitUrl} (${active.name}, ${active.adapter})`
+          emitLine(sendOutput, message)
+          return message
         },
       },
       codex: {
         project: {
           list: () => {
-            const projects = codexProjectManager.list();
+            const projects = codexProjectManager.list()
             if (projects.length === 0) {
-              const message = "No codex projects configured.";
-              emitLine(sendOutput, message);
-              return message;
+              const message = 'No codex projects configured.'
+              emitLine(sendOutput, message)
+              return message
             }
-            const defaultProjectId = codexProjectManager.getDefaultId();
+            const defaultProjectId = codexProjectManager.getDefaultId()
             const message = projects
               .map((project) => {
-                const isDefault = project.id === defaultProjectId;
+                const isDefault = project.id === defaultProjectId
                 return `${project.id}: ${project.name} (${project.cwd}, model=${project.model}, sandbox=${project.sandboxPolicy}, approval=${project.approvalPolicy})${
-                  isDefault ? " (default)" : ""
-                }`;
+                  isDefault ? ' (default)' : ''
+                }`
               })
-              .join("\n");
-            emitLine(sendOutput, message);
-            return message;
+              .join('\n')
+            emitLine(sendOutput, message)
+            return message
           },
           create: (
             name: string,
@@ -739,7 +872,7 @@ export function createAppJsGlobals({
             model: string,
             sandboxPolicy: string,
             approvalPolicy: string,
-            personality: string,
+            personality: string
           ) => {
             const created = codexProjectManager.create(
               name,
@@ -747,282 +880,286 @@ export function createAppJsGlobals({
               model,
               sandboxPolicy,
               approvalPolicy,
-              personality,
-            );
-            const message = `Codex project ${created.name} created (${created.id})`;
-            emitLine(sendOutput, message);
-            return message;
+              personality
+            )
+            const message = `Codex project ${created.name} created (${created.id})`
+            emitLine(sendOutput, message)
+            return message
           },
           update: (id: string, patch: Partial<CodexProject>) => {
-            const updated = codexProjectManager.update(id, patch);
-            const message = `Codex project ${updated.name} updated (${updated.id})`;
-            emitLine(sendOutput, message);
-            return message;
+            const updated = codexProjectManager.update(id, patch)
+            const message = `Codex project ${updated.name} updated (${updated.id})`
+            emitLine(sendOutput, message)
+            return message
           },
           delete: (id: string) => {
-            codexProjectManager.delete(id);
-            const message = `Codex project ${id} deleted`;
-            emitLine(sendOutput, message);
-            return message;
+            codexProjectManager.delete(id)
+            const message = `Codex project ${id} deleted`
+            emitLine(sendOutput, message)
+            return message
           },
           getDefault: () => {
-            const project = codexProjectManager.getDefault();
-            const message = `Default codex project: ${project.name} (${project.id}, cwd=${project.cwd}, model=${project.model})`;
-            emitLine(sendOutput, message);
-            return message;
+            const project = codexProjectManager.getDefault()
+            const message = `Default codex project: ${project.name} (${project.id}, cwd=${project.cwd}, model=${project.model})`
+            emitLine(sendOutput, message)
+            return message
           },
           setDefault: (id: string) => {
-            codexProjectManager.setDefault(id);
-            const message = `Default codex project set to ${id}`;
-            emitLine(sendOutput, message);
-            return message;
+            codexProjectManager.setDefault(id)
+            const message = `Default codex project set to ${id}`
+            emitLine(sendOutput, message)
+            return message
           },
         },
       },
       responsesDirect: {
         get: () => responsesDirect.getSnapshot(),
         setAuthMethod: (authMethod: string) => {
-          return responsesDirect.setAuthMethod(authMethod);
+          return responsesDirect.setAuthMethod(authMethod)
         },
         setOpenAIOrganization: (openaiOrganization: string) => {
-          return responsesDirect.setOpenAIOrganization(openaiOrganization);
+          return responsesDirect.setOpenAIOrganization(openaiOrganization)
         },
         setOpenAIProject: (openaiProject: string) => {
-          return responsesDirect.setOpenAIProject(openaiProject);
+          return responsesDirect.setOpenAIProject(openaiProject)
         },
         setVectorStores: (vectorStores: string[] | string) => {
-          return responsesDirect.setVectorStores(parseVectorStores(vectorStores));
+          return responsesDirect.setVectorStores(
+            parseVectorStores(vectorStores)
+          )
         },
         setAPIKey: (apiKey: string) => {
-          return responsesDirect.setAPIKey(apiKey);
+          return responsesDirect.setAPIKey(apiKey)
         },
         clearAPIKey: () => {
-          return responsesDirect.clearAPIKey();
+          return responsesDirect.clearAPIKey()
         },
       },
     },
     help: () => {
       const message = [
-        "Available namespaces:",
-        "  runme           - Notebook helpers (run all, clear outputs)",
-        "  explorer        - Manage workspace folders and notebooks",
-        "  runmeRunners    - Configure runner endpoints",
-        "  jupyter         - Manage Jupyter servers and kernels",
-        "  agent           - Configure assistant/API agent endpoint",
-        "  files           - Import local files and access their bytes",
-        "  drive           - List/create/copy/update Google Drive notebook files",
-        "  oidc            - OIDC/OAuth configuration and auth status",
-        "  googleClientManager - Google OAuth client settings",
-        "  app             - App-level configuration helpers",
-        "  credentials     - Shorthand for google/oidc/openai credential managers",
-        "",
-        "Type <namespace>.help() for detailed commands, e.g. explorer.help()",
-      ].join("\n");
-      emitLine(sendOutput, message);
-      return message;
+        'Available namespaces:',
+        '  runme           - Notebook helpers (run all, clear outputs)',
+        '  opfs            - Origin-private browser file storage helpers',
+        '  net             - Browser network helpers',
+        '  explorer        - Manage workspace folders and notebooks',
+        '  runmeRunners    - Configure runner endpoints',
+        '  jupyter         - Manage Jupyter servers and kernels',
+        '  agent           - Configure assistant/API agent endpoint',
+        '  files           - Import local files and access their bytes',
+        '  drive           - List/create/copy/update Google Drive notebook files',
+        '  oidc            - OIDC/OAuth configuration and auth status',
+        '  googleClientManager - Google OAuth client settings',
+        '  app             - App-level configuration helpers',
+        '  credentials     - Shorthand for google/oidc/openai credential managers',
+        '',
+        'Type <namespace>.help() for detailed commands, e.g. explorer.help()',
+      ].join('\n')
+      emitLine(sendOutput, message)
+      return message
     },
     explorer: {
       addFolder: (path?: string) => {
         if (path) {
-          return "explorer.addFolder() does not accept a path when using the File System Access API.";
+          return 'explorer.addFolder() does not accept a path when using the File System Access API.'
         }
-        return openWorkspaceAndAdd();
+        return openWorkspaceAndAdd()
       },
       mountDrive: (driveUrl: string) => {
         if (!driveUrl) {
-          return "Usage: explorer.mountDrive(driveUrl)";
+          return 'Usage: explorer.mountDrive(driveUrl)'
         }
-        addWorkspaceItem(driveUrl);
-        return `Mounted Drive link: ${driveUrl}`;
+        addWorkspaceItem(driveUrl)
+        return `Mounted Drive link: ${driveUrl}`
       },
       openPicker: () => openWorkspaceAndAdd(),
       importMarkdown: () => {
-        void importMarkdownAndOpen();
-        return "Opening markdown file picker...";
+        void importMarkdownAndOpen()
+        return 'Opening markdown file picker...'
       },
       removeFolder: (uri: string) => {
         if (!uri) {
-          return "Usage: explorer.removeFolder(uri)";
+          return 'Usage: explorer.removeFolder(uri)'
         }
-        removeWorkspaceItem(uri);
-        return `Removed: ${uri}`;
+        removeWorkspaceItem(uri)
+        return `Removed: ${uri}`
       },
       listFolders: () => {
-        const items = getWorkspaceItems();
+        const items = getWorkspaceItems()
         if (items.length === 0) {
-          return "No folders in workspace.";
+          return 'No folders in workspace.'
         }
-        return items.join("\n");
+        return items.join('\n')
       },
       help: () => {
         return [
-          "explorer.addFolder()           - Open the folder picker and mount a local folder",
-          "explorer.mountDrive(driveUrl)   - Mount a Google Drive link",
-          "explorer.openPicker()           - Alias for explorer.addFolder()",
-          "explorer.importMarkdown()       - Import a local Markdown file as a notebook",
-          "explorer.removeFolder(uri)      - Remove a folder from workspace",
-          "explorer.listFolders()          - List all workspace folders",
-          "explorer.help()                 - Show this help",
-        ].join("\n");
+          'explorer.addFolder()           - Open the folder picker and mount a local folder',
+          'explorer.mountDrive(driveUrl)   - Mount a Google Drive link',
+          'explorer.openPicker()           - Alias for explorer.addFolder()',
+          'explorer.importMarkdown()       - Import a local Markdown file as a notebook',
+          'explorer.removeFolder(uri)      - Remove a folder from workspace',
+          'explorer.listFolders()          - List all workspace folders',
+          'explorer.help()                 - Show this help',
+        ].join('\n')
       },
     },
     files: {
       pickMarkdown: async () => {
-        const picked = await pickMarkdownSource();
+        const picked = await pickMarkdownSource()
         if (!picked) {
-          emitLine(sendOutput, "Markdown pick cancelled.");
-          return null;
+          emitLine(sendOutput, 'Markdown pick cancelled.')
+          return null
         }
-        emitLine(sendOutput, `Picked ${picked.name} -> ${picked.sourceUri}`);
-        return picked;
+        emitLine(sendOutput, `Picked ${picked.name} -> ${picked.sourceUri}`)
+        return picked
       },
       importMarkdown: async (sourceUri: string, targetFolderUri?: string) => {
         if (!sourceUri) {
           throw new Error(
-            "Usage: files.importMarkdown(sourceUri, targetFolderUri?)",
-          );
+            'Usage: files.importMarkdown(sourceUri, targetFolderUri?)'
+          )
         }
-        const selection = getPickedMarkdownSelection(sourceUri);
-        const store = resolveStore();
+        const selection = getPickedMarkdownSelection(sourceUri)
+        const store = resolveStore()
         if (!store) {
-          throw new Error("Notebook store is not initialized yet.");
+          throw new Error('Notebook store is not initialized yet.')
         }
-        const notebook = await deserializeMarkdownToNotebook(selection);
-        const fileName = toImportedNotebookName(selection.name);
-        const parentUri = targetFolderUri || LOCAL_FOLDER_URI;
-        const created = await store.create(parentUri, fileName);
-        await store.save(created.uri, notebook);
+        const notebook = await deserializeMarkdownToNotebook(selection)
+        const fileName = toImportedNotebookName(selection.name)
+        const parentUri = targetFolderUri || LOCAL_FOLDER_URI
+        const created = await store.create(parentUri, fileName)
+        await store.save(created.uri, notebook)
         if (!getWorkspaceItems().includes(parentUri)) {
-          addWorkspaceItem(parentUri);
+          addWorkspaceItem(parentUri)
         }
         if (!getWorkspaceItems().includes(LOCAL_FOLDER_URI)) {
-          addWorkspaceItem(LOCAL_FOLDER_URI);
+          addWorkspaceItem(LOCAL_FOLDER_URI)
         }
-        registerImportedMarkdownForUri(created.uri, selection);
-        emitLine(sendOutput, `Imported ${selection.name} -> ${created.uri}`);
+        registerImportedMarkdownForUri(created.uri, selection)
+        emitLine(sendOutput, `Imported ${selection.name} -> ${created.uri}`)
         return {
           localUri: created.uri,
           sourceUri,
           name: selection.name,
           notebookName: fileName,
           size: selection.bytes.byteLength,
-        };
+        }
       },
       getBytes: (localUri: string) => {
         if (!localUri) {
-          throw new Error("Usage: files.getBytes(localUri)");
+          throw new Error('Usage: files.getBytes(localUri)')
         }
-        return getImportedFileBytes(localUri);
+        return getImportedFileBytes(localUri)
       },
       getName: (localUri: string) => {
         if (!localUri) {
-          throw new Error("Usage: files.getName(localUri)");
+          throw new Error('Usage: files.getName(localUri)')
         }
-        return getImportedFileName(localUri);
+        return getImportedFileName(localUri)
       },
       help: () => {
         return [
-          "files.pickMarkdown()           - Open local picker and return sourceUri",
-          "files.importMarkdown(sourceUri, targetFolderUri?) - Import picked markdown into local notebooks",
-          "files.getBytes(localUri)       - Return imported Markdown Uint8Array bytes for a local notebook URI",
-          "files.getName(localUri)        - Return original filename for imported file URI",
-          "files.help()                   - Show this help",
-        ].join("\n");
+          'files.pickMarkdown()           - Open local picker and return sourceUri',
+          'files.importMarkdown(sourceUri, targetFolderUri?) - Import picked markdown into local notebooks',
+          'files.getBytes(localUri)       - Return imported Markdown Uint8Array bytes for a local notebook URI',
+          'files.getName(localUri)        - Return original filename for imported file URI',
+          'files.help()                   - Show this help',
+        ].join('\n')
       },
     },
     drive: {
       list: async (folder: string) => {
-        const items = await listDriveFolderItems(folder);
-        emitLine(sendOutput, `Listed ${items.length} Drive item(s)`);
-        return items;
+        const items = await listDriveFolderItems(folder)
+        emitLine(sendOutput, `Listed ${items.length} Drive item(s)`)
+        return items
       },
       create: async (folder: string, name: string) => {
-        const id = await createDriveFile(folder, name);
-        emitLine(sendOutput, `Created Drive file ${id}`);
-        return id;
+        const id = await createDriveFile(folder, name)
+        emitLine(sendOutput, `Created Drive file ${id}`)
+        return id
       },
       update: async (idOrUri: string, bytes: Uint8Array) => {
-        const id = await updateDriveFileBytes(idOrUri, bytes);
-        emitLine(sendOutput, `Updated Drive file ${id}`);
-        return id;
+        const id = await updateDriveFileBytes(idOrUri, bytes)
+        emitLine(sendOutput, `Updated Drive file ${id}`)
+        return id
       },
       saveAsCurrentNotebook: async (folder: string, name: string) => {
         if (!folder?.trim() || !name?.trim()) {
           throw new Error(
-            "Usage: drive.saveAsCurrentNotebook(folderIdOrUri, fileName)",
-          );
+            'Usage: drive.saveAsCurrentNotebook(folderIdOrUri, fileName)'
+          )
         }
-        const notebook = runme.getCurrentNotebook();
+        const notebook = runme.getCurrentNotebook()
         if (!notebook) {
-          throw new Error("No active notebook handle available.");
+          throw new Error('No active notebook handle available.')
         }
         const result = await saveNotebookAsDriveCopy(
           notebook.getNotebook(),
           folder,
-          name,
-        );
+          name
+        )
         emitLine(
           sendOutput,
-          `Saved notebook as ${result.fileName} (${result.fileId}) and switched to ${result.localUri}`,
-        );
-        return result;
+          `Saved notebook as ${result.fileName} (${result.fileId}) and switched to ${result.localUri}`
+        )
+        return result
       },
       copyNotebook: async (
         sourceIdOrUri: string,
         targetFolder: string,
-        targetName?: string,
+        targetName?: string
       ) => {
         const result = await copyDriveNotebookFile(
           sourceIdOrUri,
           targetFolder,
-          targetName,
-        );
+          targetName
+        )
         emitLine(
           sendOutput,
-          `Copied notebook ${result.sourceUri} -> ${result.targetUri}`,
-        );
-        return result;
+          `Copied notebook ${result.sourceUri} -> ${result.targetUri}`
+        )
+        return result
       },
       listPendingSync: async () => {
-        const localStore = resolveLocalMirrorStore();
-        const pending = await localStore.listDriveBackedFilesNeedingSync();
+        const localStore = resolveLocalMirrorStore()
+        const pending = await localStore.listDriveBackedFilesNeedingSync()
         if (pending.length === 0) {
-          emitLine(sendOutput, "No Drive-backed notebooks pending sync.");
-          return pending;
+          emitLine(sendOutput, 'No Drive-backed notebooks pending sync.')
+          return pending
         }
         emitLine(
           sendOutput,
-          `Drive-backed notebooks pending sync (${pending.length}):`,
-        );
-        pending.forEach((uri) => emitLine(sendOutput, `- ${uri}`));
-        return pending;
+          `Drive-backed notebooks pending sync (${pending.length}):`
+        )
+        pending.forEach((uri) => emitLine(sendOutput, `- ${uri}`))
+        return pending
       },
       requeuePendingSync: async () => {
-        const localStore = resolveLocalMirrorStore();
-        const enqueued = await localStore.enqueueDriveBackedFilesNeedingSync();
+        const localStore = resolveLocalMirrorStore()
+        const enqueued = await localStore.enqueueDriveBackedFilesNeedingSync()
         if (enqueued.length === 0) {
-          emitLine(sendOutput, "No Drive-backed notebooks required requeue.");
-          return enqueued;
+          emitLine(sendOutput, 'No Drive-backed notebooks required requeue.')
+          return enqueued
         }
         emitLine(
           sendOutput,
-          `Requeued Drive-backed notebooks for sync (${enqueued.length}):`,
-        );
-        enqueued.forEach((uri) => emitLine(sendOutput, `- ${uri}`));
-        return enqueued;
+          `Requeued Drive-backed notebooks for sync (${enqueued.length}):`
+        )
+        enqueued.forEach((uri) => emitLine(sendOutput, `- ${uri}`))
+        return enqueued
       },
       help: () => {
         return [
-          "drive.list(folder)            - List Drive items in a folder",
-          "drive.create(folder, name)     - Create a Drive file in folder; returns file id",
-          "drive.update(id, bytes)        - Write UTF-8 bytes to a Drive file id/URI",
-          "drive.saveAsCurrentNotebook(folder, fileName) - Save current notebook to Drive and switch current doc",
-          "drive.copyNotebook(source, targetFolder, fileName?) - Copy a notebook file to another Drive folder",
-          "drive.listPendingSync()        - List Drive-backed local notebooks that currently need sync",
-          "drive.requeuePendingSync()     - Requeue all Drive-backed local notebooks that need sync",
-          "drive.help()                   - Show this help",
-        ].join("\n");
+          'drive.list(folder)            - List Drive items in a folder',
+          'drive.create(folder, name)     - Create a Drive file in folder; returns file id',
+          'drive.update(id, bytes)        - Write UTF-8 bytes to a Drive file id/URI',
+          'drive.saveAsCurrentNotebook(folder, fileName) - Save current notebook to Drive and switch current doc',
+          'drive.copyNotebook(source, targetFolder, fileName?) - Copy a notebook file to another Drive folder',
+          'drive.listPendingSync()        - List Drive-backed local notebooks that currently need sync',
+          'drive.requeuePendingSync()     - Requeue all Drive-backed local notebooks that need sync',
+          'drive.help()                   - Show this help',
+        ].join('\n')
       },
     },
-  };
+  }
 }

--- a/app/src/lib/runtime/appKernelLowLevelApis.ts
+++ b/app/src/lib/runtime/appKernelLowLevelApis.ts
@@ -58,6 +58,19 @@ function isNotFoundError(error: unknown): boolean {
         (error as { name?: unknown }).name === 'NotFoundError'
 }
 
+function isTypeMismatchError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === 'TypeMismatchError'
+    : typeof error === 'object' &&
+        error !== null &&
+        'name' in error &&
+        (error as { name?: unknown }).name === 'TypeMismatchError'
+}
+
+function isMissingHandleError(error: unknown): boolean {
+  return isNotFoundError(error) || isTypeMismatchError(error)
+}
+
 async function getNativeOpfsRoot(): Promise<FileSystemDirectoryHandle> {
   const storage = navigator.storage
   if (!storage || typeof storage.getDirectory !== 'function') {
@@ -90,7 +103,7 @@ async function tryGetDirectoryHandle(
   try {
     return await getDirectoryHandle(root, segments)
   } catch (error) {
-    if (isNotFoundError(error)) {
+    if (isMissingHandleError(error)) {
       return null
     }
     throw error
@@ -113,7 +126,7 @@ async function tryGetFileHandle(
   try {
     return await parent.getFileHandle(segments.at(-1) ?? '')
   } catch (error) {
-    if (isNotFoundError(error)) {
+    if (isMissingHandleError(error)) {
       return null
     }
     throw error

--- a/app/src/lib/runtime/appKernelLowLevelApis.ts
+++ b/app/src/lib/runtime/appKernelLowLevelApis.ts
@@ -1,0 +1,341 @@
+export type AppKernelOpfsApi = {
+  exists(path: string): Promise<boolean>
+  readText(path: string): Promise<string>
+  writeText(path: string, text: string): Promise<void>
+  readBytes(path: string): Promise<Uint8Array>
+  writeBytes(path: string, bytes: Uint8Array): Promise<void>
+  list(
+    path: string
+  ): Promise<Array<{ name: string; kind: 'file' | 'directory' }>>
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>
+  stat(
+    path: string
+  ): Promise<{ kind: 'file' | 'directory'; size?: number; mtime?: string }>
+  remove(path: string, options?: { recursive?: boolean }): Promise<void>
+}
+
+export type AppKernelNetworkApi = {
+  get(
+    url: string,
+    options?: {
+      headers?: Record<string, string>
+      responseType?: 'text' | 'bytes' | 'json'
+    }
+  ): Promise<{
+    ok: boolean
+    status: number
+    headers: Record<string, string>
+    text?: string
+    bytes?: Uint8Array
+    json?: unknown
+  }>
+}
+
+function normalizePath(path: string): string[] {
+  const value = String(path ?? '').trim()
+  if (value === '' || value === '/') {
+    return []
+  }
+
+  const segments = value
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error(`Invalid OPFS path: ${path}`)
+  }
+
+  return segments
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === 'NotFoundError'
+    : typeof error === 'object' &&
+        error !== null &&
+        'name' in error &&
+        (error as { name?: unknown }).name === 'NotFoundError'
+}
+
+async function getNativeOpfsRoot(): Promise<FileSystemDirectoryHandle> {
+  const storage = navigator.storage
+  if (!storage || typeof storage.getDirectory !== 'function') {
+    throw new Error('OPFS is not available in this browser.')
+  }
+  return storage.getDirectory()
+}
+
+async function getDirectoryHandle(
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+  options?: { create?: boolean }
+): Promise<FileSystemDirectoryHandle> {
+  let current = root
+  for (const segment of segments) {
+    if (typeof current.getDirectoryHandle !== 'function') {
+      throw new Error('OPFS directory access is not available.')
+    }
+    current = await current.getDirectoryHandle(segment, {
+      create: options?.create === true,
+    })
+  }
+  return current
+}
+
+async function tryGetDirectoryHandle(
+  root: FileSystemDirectoryHandle,
+  segments: string[]
+): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    return await getDirectoryHandle(root, segments)
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+async function tryGetFileHandle(
+  root: FileSystemDirectoryHandle,
+  segments: string[]
+): Promise<FileSystemFileHandle | null> {
+  if (segments.length === 0) {
+    return null
+  }
+
+  const parent = await tryGetDirectoryHandle(root, segments.slice(0, -1))
+  if (!parent || typeof parent.getFileHandle !== 'function') {
+    return null
+  }
+
+  try {
+    return await parent.getFileHandle(segments.at(-1) ?? '')
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+async function getOrCreateParentDirectory(
+  root: FileSystemDirectoryHandle,
+  segments: string[]
+): Promise<FileSystemDirectoryHandle> {
+  return getDirectoryHandle(root, segments.slice(0, -1), { create: true })
+}
+
+function headersToObject(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    result[key] = value
+  })
+  return result
+}
+
+export function createAppKernelOpfsApi(options?: {
+  getRootDirectory?: () => Promise<FileSystemDirectoryHandle>
+}): AppKernelOpfsApi {
+  const getRootDirectory = options?.getRootDirectory ?? getNativeOpfsRoot
+
+  return {
+    async exists(path) {
+      const segments = normalizePath(path)
+      if (segments.length === 0) {
+        return true
+      }
+
+      const root = await getRootDirectory()
+      if (await tryGetDirectoryHandle(root, segments)) {
+        return true
+      }
+      return (await tryGetFileHandle(root, segments)) !== null
+    },
+
+    async readText(path) {
+      const segments = normalizePath(path)
+      const root = await getRootDirectory()
+      const handle = await tryGetFileHandle(root, segments)
+      if (!handle || typeof handle.getFile !== 'function') {
+        throw new Error(`OPFS file not found: ${path}`)
+      }
+      const file = await handle.getFile()
+      return file.text()
+    },
+
+    async writeText(path, text) {
+      const segments = normalizePath(path)
+      if (segments.length === 0) {
+        throw new Error('Cannot write to the OPFS root.')
+      }
+      const root = await getRootDirectory()
+      const parent = await getOrCreateParentDirectory(root, segments)
+      if (typeof parent.getFileHandle !== 'function') {
+        throw new Error('OPFS file access is not available.')
+      }
+      const handle = await parent.getFileHandle(segments.at(-1) ?? '', {
+        create: true,
+      })
+      if (typeof handle.createWritable !== 'function') {
+        throw new Error('OPFS writable file access is not available.')
+      }
+      const writable = await handle.createWritable()
+      await writable.write(text)
+      await writable.close()
+    },
+
+    async readBytes(path) {
+      const segments = normalizePath(path)
+      const root = await getRootDirectory()
+      const handle = await tryGetFileHandle(root, segments)
+      if (!handle || typeof handle.getFile !== 'function') {
+        throw new Error(`OPFS file not found: ${path}`)
+      }
+      const file = await handle.getFile()
+      return new Uint8Array(await file.arrayBuffer())
+    },
+
+    async writeBytes(path, bytes) {
+      const segments = normalizePath(path)
+      if (segments.length === 0) {
+        throw new Error('Cannot write to the OPFS root.')
+      }
+      const root = await getRootDirectory()
+      const parent = await getOrCreateParentDirectory(root, segments)
+      if (typeof parent.getFileHandle !== 'function') {
+        throw new Error('OPFS file access is not available.')
+      }
+      const handle = await parent.getFileHandle(segments.at(-1) ?? '', {
+        create: true,
+      })
+      if (typeof handle.createWritable !== 'function') {
+        throw new Error('OPFS writable file access is not available.')
+      }
+      const writable = await handle.createWritable()
+      await writable.write(bytes)
+      await writable.close()
+    },
+
+    async list(path) {
+      const segments = normalizePath(path)
+      const root = await getRootDirectory()
+      const directory = await getDirectoryHandle(root, segments)
+      if (typeof directory.entries !== 'function') {
+        throw new Error('OPFS directory iteration is not available.')
+      }
+
+      const items: Array<{ name: string; kind: 'file' | 'directory' }> = []
+      for await (const [name, handle] of directory.entries()) {
+        const kind = (handle as { kind?: 'file' | 'directory' }).kind ?? 'file'
+        items.push({ name, kind })
+      }
+      items.sort((left, right) => left.name.localeCompare(right.name))
+      return items
+    },
+
+    async mkdir(path, options) {
+      const segments = normalizePath(path)
+      if (segments.length === 0) {
+        return
+      }
+
+      const root = await getRootDirectory()
+      if (options?.recursive === true) {
+        await getDirectoryHandle(root, segments, { create: true })
+        return
+      }
+
+      const parent = await getDirectoryHandle(root, segments.slice(0, -1))
+      if (typeof parent.getDirectoryHandle !== 'function') {
+        throw new Error('OPFS directory access is not available.')
+      }
+      await parent.getDirectoryHandle(segments.at(-1) ?? '', { create: true })
+    },
+
+    async stat(path) {
+      const segments = normalizePath(path)
+      const root = await getRootDirectory()
+      if (segments.length === 0) {
+        return { kind: 'directory' }
+      }
+
+      const fileHandle = await tryGetFileHandle(root, segments)
+      if (fileHandle && typeof fileHandle.getFile === 'function') {
+        const file = await fileHandle.getFile()
+        return {
+          kind: 'file',
+          size: file.size,
+          mtime: new Date(file.lastModified).toISOString(),
+        }
+      }
+
+      const directoryHandle = await tryGetDirectoryHandle(root, segments)
+      if (directoryHandle) {
+        return { kind: 'directory' }
+      }
+
+      throw new Error(`OPFS path not found: ${path}`)
+    },
+
+    async remove(path, options) {
+      const segments = normalizePath(path)
+      if (segments.length === 0) {
+        throw new Error('Cannot remove the OPFS root.')
+      }
+
+      const root = await getRootDirectory()
+      const parent = await getDirectoryHandle(root, segments.slice(0, -1))
+      if (typeof parent.removeEntry !== 'function') {
+        throw new Error('OPFS removeEntry is not available.')
+      }
+      await parent.removeEntry(segments.at(-1) ?? '', {
+        recursive: options?.recursive === true,
+      })
+    },
+  }
+}
+
+export function createAppKernelNetworkApi(options?: {
+  fetchImpl?: typeof fetch
+}): AppKernelNetworkApi {
+  const fetchImpl = options?.fetchImpl ?? fetch
+
+  return {
+    async get(url, requestOptions) {
+      const response = await fetchImpl(url, {
+        method: 'GET',
+        headers: requestOptions?.headers,
+      })
+      const headers = headersToObject(response.headers)
+      const result: {
+        ok: boolean
+        status: number
+        headers: Record<string, string>
+        text?: string
+        bytes?: Uint8Array
+        json?: unknown
+      } = {
+        ok: response.ok,
+        status: response.status,
+        headers,
+      }
+
+      switch (requestOptions?.responseType ?? 'text') {
+        case 'bytes':
+          result.bytes = new Uint8Array(await response.arrayBuffer())
+          break
+        case 'json':
+          result.json = await response.json()
+          break
+        case 'text':
+        default:
+          result.text = await response.text()
+          break
+      }
+
+      return result
+    },
+  }
+}

--- a/app/src/lib/runtime/codeModeExecutor.test.ts
+++ b/app/src/lib/runtime/codeModeExecutor.test.ts
@@ -128,6 +128,9 @@ describe('codeModeExecutor', () => {
           path === '/' ? '' : (path.split('/').filter(Boolean).at(-1) ?? ''),
         async getDirectoryHandle(name: string, options?: { create?: boolean }) {
           const childPath = normalizePath(`${path}/${name}`)
+          if (files.has(childPath)) {
+            throw new DOMException('wrong kind', 'TypeMismatchError')
+          }
           if (!directories.has(childPath)) {
             if (!options?.create) {
               throw new DOMException('missing', 'NotFoundError')
@@ -138,6 +141,9 @@ describe('codeModeExecutor', () => {
         },
         async getFileHandle(name: string, options?: { create?: boolean }) {
           const childPath = normalizePath(`${path}/${name}`)
+          if (directories.has(childPath)) {
+            throw new DOMException('wrong kind', 'TypeMismatchError')
+          }
           if (!files.has(childPath)) {
             if (!options?.create) {
               throw new DOMException('missing', 'NotFoundError')
@@ -282,6 +288,7 @@ describe('codeModeExecutor', () => {
         "console.log(await opfs.exists('/code/runmedev/web.txt'));",
         "console.log(await opfs.readText('/code/runmedev/web.txt'));",
         "console.log(JSON.stringify(await opfs.list('/code/runmedev')));",
+        "console.log(JSON.stringify(await opfs.stat('/code/runmedev')));",
         "const response = await net.get('https://example.test/docs');",
         'console.log(response.status);',
         'console.log(response.text);',
@@ -291,6 +298,7 @@ describe('codeModeExecutor', () => {
     expect(result.output).toContain('true')
     expect(result.output).toContain('hello')
     expect(result.output).toContain('"name":"web.txt"')
+    expect(result.output).toContain('"kind":"directory"')
     expect(result.output).toContain('200')
     expect(result.output).toContain('network-response')
   })

--- a/app/src/lib/runtime/codeModeExecutor.test.ts
+++ b/app/src/lib/runtime/codeModeExecutor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { create } from '@bufbuild/protobuf'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { parser_pb } from '../../runme/client'
 import { appLogger } from '../logging/runtime'
@@ -23,6 +23,10 @@ const createNotebook = () => {
 }
 
 describe('codeModeExecutor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('merges stdout and stderr into one ordered output string', async () => {
     const infoSpy = vi.spyOn(appLogger, 'info')
     const notebook = createNotebook()
@@ -95,5 +99,199 @@ describe('codeModeExecutor', () => {
       expect(String(error)).toMatch(/timed out/)
       expect(getCodeModeErrorOutput(error)).toContain('started')
     }
+  })
+
+  it('exposes opfs and net helpers in browser mode', async () => {
+    const files = new Map<string, Uint8Array>()
+    const directories = new Set<string>(['/'])
+
+    const normalizePath = (path: string): string => {
+      const segments = String(path ?? '')
+        .split('/')
+        .filter((segment) => segment.length > 0)
+      return segments.length === 0 ? '/' : `/${segments.join('/')}`
+    }
+
+    const parentPath = (path: string): string => {
+      const normalized = normalizePath(path)
+      if (normalized === '/') {
+        return '/'
+      }
+      const segments = normalized.split('/').filter(Boolean)
+      return segments.length <= 1 ? '/' : `/${segments.slice(0, -1).join('/')}`
+    }
+
+    const makeDirectoryHandle = (path: string): FileSystemDirectoryHandle =>
+      ({
+        kind: 'directory',
+        name:
+          path === '/' ? '' : (path.split('/').filter(Boolean).at(-1) ?? ''),
+        async getDirectoryHandle(name: string, options?: { create?: boolean }) {
+          const childPath = normalizePath(`${path}/${name}`)
+          if (!directories.has(childPath)) {
+            if (!options?.create) {
+              throw new DOMException('missing', 'NotFoundError')
+            }
+            directories.add(childPath)
+          }
+          return makeDirectoryHandle(childPath)
+        },
+        async getFileHandle(name: string, options?: { create?: boolean }) {
+          const childPath = normalizePath(`${path}/${name}`)
+          if (!files.has(childPath)) {
+            if (!options?.create) {
+              throw new DOMException('missing', 'NotFoundError')
+            }
+            directories.add(path)
+            files.set(childPath, new Uint8Array())
+          }
+          return makeFileHandle(childPath)
+        },
+        async *entries() {
+          const seen = new Set<string>()
+          const prefix = path === '/' ? '/' : `${path}/`
+          for (const directory of directories) {
+            if (directory === path || !directory.startsWith(prefix)) {
+              continue
+            }
+            const remainder = directory.slice(prefix.length)
+            if (!remainder || remainder.includes('/')) {
+              continue
+            }
+            if (seen.has(remainder)) {
+              continue
+            }
+            seen.add(remainder)
+            yield [remainder, makeDirectoryHandle(directory)] as const
+          }
+          for (const [filePath] of files) {
+            if (!filePath.startsWith(prefix)) {
+              continue
+            }
+            const remainder = filePath.slice(prefix.length)
+            if (!remainder || remainder.includes('/')) {
+              continue
+            }
+            if (seen.has(remainder)) {
+              continue
+            }
+            seen.add(remainder)
+            yield [remainder, makeFileHandle(filePath)] as const
+          }
+        },
+        async removeEntry(name: string, options?: { recursive?: boolean }) {
+          const childPath = normalizePath(`${path}/${name}`)
+          if (files.delete(childPath)) {
+            return
+          }
+          if (!directories.has(childPath)) {
+            throw new DOMException('missing', 'NotFoundError')
+          }
+          const hasChildren =
+            [...directories].some(
+              (directory) =>
+                directory !== childPath && directory.startsWith(`${childPath}/`)
+            ) ||
+            [...files.keys()].some((filePath) =>
+              filePath.startsWith(`${childPath}/`)
+            )
+          if (hasChildren && options?.recursive !== true) {
+            throw new DOMException('not empty', 'InvalidModificationError')
+          }
+          for (const directory of [...directories]) {
+            if (
+              directory === childPath ||
+              directory.startsWith(`${childPath}/`)
+            ) {
+              directories.delete(directory)
+            }
+          }
+          for (const filePath of [...files.keys()]) {
+            if (
+              filePath === childPath ||
+              filePath.startsWith(`${childPath}/`)
+            ) {
+              files.delete(filePath)
+            }
+          }
+        },
+      }) as FileSystemDirectoryHandle
+
+    const makeFileHandle = (path: string): FileSystemFileHandle =>
+      ({
+        kind: 'file',
+        name: path.split('/').filter(Boolean).at(-1) ?? '',
+        async getFile() {
+          const bytes = files.get(path)
+          if (!bytes) {
+            throw new DOMException('missing', 'NotFoundError')
+          }
+          const blob = new Blob([bytes])
+          return {
+            size: bytes.byteLength,
+            lastModified: 0,
+            text: async () => new TextDecoder().decode(bytes),
+            arrayBuffer: async () => blob.arrayBuffer(),
+          } as File
+        },
+        async createWritable() {
+          return {
+            write: async (data: string | Uint8Array | Blob | ArrayBuffer) => {
+              let next: Uint8Array
+              if (typeof data === 'string') {
+                next = new TextEncoder().encode(data)
+              } else if (data instanceof Uint8Array) {
+                next = data
+              } else if (data instanceof ArrayBuffer) {
+                next = new Uint8Array(data)
+              } else {
+                next = new Uint8Array(await data.arrayBuffer())
+              }
+              directories.add(parentPath(path))
+              files.set(path, next)
+            },
+            close: async () => {},
+          }
+        },
+      }) as FileSystemFileHandle
+
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: {
+        getDirectory: vi.fn(async () => makeDirectoryHandle('/')),
+      },
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('network-response', { status: 200 }))
+    )
+
+    const notebook = createNotebook()
+    const executor = createCodeModeExecutor({
+      mode: 'browser',
+      resolveNotebook: () => notebook,
+      listNotebooks: () => [notebook],
+    })
+
+    const result = await executor.execute({
+      source: 'codex',
+      code: [
+        "await opfs.mkdir('/code/runmedev', { recursive: true });",
+        "await opfs.writeText('/code/runmedev/web.txt', 'hello');",
+        "console.log(await opfs.exists('/code/runmedev/web.txt'));",
+        "console.log(await opfs.readText('/code/runmedev/web.txt'));",
+        "console.log(JSON.stringify(await opfs.list('/code/runmedev')));",
+        "const response = await net.get('https://example.test/docs');",
+        'console.log(response.status);',
+        'console.log(response.text);',
+      ].join('\n'),
+    })
+
+    expect(result.output).toContain('true')
+    expect(result.output).toContain('hello')
+    expect(result.output).toContain('"name":"web.txt"')
+    expect(result.output).toContain('200')
+    expect(result.output).toContain('network-response')
   })
 })

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -1,15 +1,16 @@
 import { appLogger } from '../logging/runtime'
 import { createAppJsGlobals } from './appJsGlobals'
-import { JSKernel } from './jsKernel'
 import {
-  type NotebookDataLike,
-  createRunmeConsoleApi,
-} from './runmeConsole'
+  createAppKernelNetworkApi,
+  createAppKernelOpfsApi,
+} from './appKernelLowLevelApis'
+import { JSKernel } from './jsKernel'
 import {
   type NotebooksApiBridgeServer,
   createHostNotebooksApi,
   createNotebooksApiBridgeServer,
 } from './notebooksApiBridge'
+import { type NotebookDataLike, createRunmeConsoleApi } from './runmeConsole'
 import { SandboxJSKernel } from './sandboxJsKernel'
 
 export type CodeModeSource = 'chatkit' | 'codex'
@@ -95,6 +96,8 @@ export function createCodeModeExecutor(options: {
       const runmeApi = createRunmeConsoleApi({
         resolveNotebook,
       })
+      const opfsApi = createAppKernelOpfsApi()
+      const networkApi = createAppKernelNetworkApi()
       const notebooksApiBridgeServer = createNotebooksApiBridgeServer({
         notebooksApi: createHostNotebooksApi({
           resolveNotebook,
@@ -131,6 +134,8 @@ export function createCodeModeExecutor(options: {
         sendOutput: appendOutput,
         resolveNotebook,
         listNotebooks,
+        opfsApi,
+        networkApi,
       })
 
       const abortController = new AbortController()
@@ -147,6 +152,8 @@ export function createCodeModeExecutor(options: {
                     method,
                     args,
                     runmeApi,
+                    opfsApi,
+                    networkApi,
                     notebooksApiBridgeServer,
                   }),
               },
@@ -215,11 +222,15 @@ async function handleSandboxAppKernelBridgeCall({
   method,
   args,
   runmeApi,
+  opfsApi,
+  networkApi,
   notebooksApiBridgeServer,
 }: {
   method: string
   args: unknown[]
   runmeApi: ReturnType<typeof createRunmeConsoleApi>
+  opfsApi: ReturnType<typeof createAppKernelOpfsApi>
+  networkApi: ReturnType<typeof createAppKernelNetworkApi>
   notebooksApiBridgeServer: NotebooksApiBridgeServer
 }): Promise<unknown> {
   const target = args[0]
@@ -234,6 +245,50 @@ async function handleSandboxAppKernelBridgeCall({
       return runmeApi.rerun(target)
     case 'runme.help':
       return runmeApi.help()
+    case 'opfs.exists':
+      return opfsApi.exists(String(args[0] ?? ''))
+    case 'opfs.readText':
+      return opfsApi.readText(String(args[0] ?? ''))
+    case 'opfs.writeText':
+      return opfsApi.writeText(String(args[0] ?? ''), String(args[1] ?? ''))
+    case 'opfs.readBytes':
+      return opfsApi.readBytes(String(args[0] ?? ''))
+    case 'opfs.writeBytes': {
+      const bytesArg = args[1]
+      const bytes =
+        bytesArg instanceof Uint8Array
+          ? bytesArg
+          : Array.isArray(bytesArg)
+            ? new Uint8Array(bytesArg)
+            : new Uint8Array()
+      return opfsApi.writeBytes(String(args[0] ?? ''), bytes)
+    }
+    case 'opfs.list':
+      return opfsApi.list(String(args[0] ?? ''))
+    case 'opfs.mkdir':
+      return opfsApi.mkdir(
+        String(args[0] ?? ''),
+        args[1] as {
+          recursive?: boolean
+        }
+      )
+    case 'opfs.stat':
+      return opfsApi.stat(String(args[0] ?? ''))
+    case 'opfs.remove':
+      return opfsApi.remove(
+        String(args[0] ?? ''),
+        args[1] as {
+          recursive?: boolean
+        }
+      )
+    case 'net.get':
+      return networkApi.get(
+        String(args[0] ?? ''),
+        (args[1] as {
+          headers?: Record<string, string>
+          responseType?: 'text' | 'bytes' | 'json'
+        }) ?? undefined
+      )
     case 'runme.getCurrentNotebook': {
       const notebook = runmeApi.getCurrentNotebook()
       if (!notebook) {

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -11,7 +11,10 @@ import {
   createNotebooksApiBridgeServer,
 } from './notebooksApiBridge'
 import { type NotebookDataLike, createRunmeConsoleApi } from './runmeConsole'
-import { SandboxJSKernel } from './sandboxJsKernel'
+import {
+  CODE_MODE_SANDBOX_ALLOWED_METHODS,
+  SandboxJSKernel,
+} from './sandboxJsKernel'
 
 export type CodeModeSource = 'chatkit' | 'codex'
 export type CodeModeRunnerMode = 'browser' | 'sandbox'
@@ -146,6 +149,7 @@ export function createCodeModeExecutor(options: {
                 onStdout: appendOutput,
                 onStderr: appendOutput,
               },
+              allowedMethods: CODE_MODE_SANDBOX_ALLOWED_METHODS,
               bridge: {
                 call: (method, args) =>
                   handleSandboxAppKernelBridgeCall({

--- a/app/src/lib/runtime/codexWasmHarnessLoader.ts
+++ b/app/src/lib/runtime/codexWasmHarnessLoader.ts
@@ -2,6 +2,8 @@ import { resolveAppUrl } from '../appBase'
 
 export type BrowserCodexInstance = {
   set_api_key(apiKey: string): void
+  setSessionOptions(options: BrowserSessionOptions): void
+  clearSessionOptions(): void
   set_code_executor(executor: (input: string) => string | Promise<string>): void
   clear_code_executor(): void
   submit_turn(
@@ -13,6 +15,17 @@ export type BrowserCodexInstance = {
 export type BrowserCodexConstructor = new (
   apiKey: string
 ) => BrowserCodexInstance
+
+export type BrowserInstructionOverrides = {
+  base?: string
+  developer?: string
+  user?: string
+}
+
+export type BrowserSessionOptions = {
+  cwd?: string
+  instructions?: BrowserInstructionOverrides
+}
 
 export type CodexWasmGeneratedModule = {
   default: (moduleOrPath?: string | URL | Request) => Promise<unknown>
@@ -26,9 +39,7 @@ export function getCodexWasmAssetUrls(): { moduleUrl: string; wasmUrl: URL } {
     moduleUrl: resolveAppUrl(
       'generated/codex-wasm/codex_wasm_harness.js'
     ).toString(),
-    wasmUrl: resolveAppUrl(
-      'generated/codex-wasm/codex_wasm_harness_bg.wasm'
-    ),
+    wasmUrl: resolveAppUrl('generated/codex-wasm/codex_wasm_harness_bg.wasm'),
   }
 }
 

--- a/app/src/lib/runtime/codexWasmSession.test.ts
+++ b/app/src/lib/runtime/codexWasmSession.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __resetResponsesDirectConfigManagerForTests } from './responsesDirectConfigManager'
+
+const submitTurnMock =
+  vi.fn<
+    (prompt: string, onEvent: (event: unknown) => void) => Promise<unknown>
+  >()
+const setApiKeyMock = vi.fn<(apiKey: string) => void>()
+const setSessionOptionsMock = vi.fn<(options: unknown) => void>()
+const setCodeExecutorMock =
+  vi.fn<(executor: (input: string) => Promise<string>) => void>()
+
+vi.mock('./codexWasmHarnessLoader', () => ({
+  loadCodexWasmModule: async () => ({
+    BrowserCodex: class MockBrowserCodex {
+      constructor(_apiKey: string) {}
+
+      set_api_key(apiKey: string) {
+        setApiKeyMock(apiKey)
+      }
+
+      setSessionOptions(options: unknown) {
+        setSessionOptionsMock(options)
+      }
+
+      clearSessionOptions() {}
+
+      set_code_executor(executor: (input: string) => Promise<string>) {
+        setCodeExecutorMock(executor)
+      }
+
+      clear_code_executor() {}
+
+      async submit_turn(
+        prompt: string,
+        onEvent: (event: unknown) => void
+      ): Promise<unknown> {
+        return submitTurnMock(prompt, onEvent)
+      }
+    },
+  }),
+}))
+
+describe('codexWasmSession', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    localStorage.removeItem('runme/responses-direct-config')
+    __resetResponsesDirectConfigManagerForTests()
+    const { responsesDirectConfigManager } = await import(
+      './responsesDirectConfigManager'
+    )
+    responsesDirectConfigManager.setAuthMethod('api_key')
+    responsesDirectConfigManager.setAPIKey('sk-test')
+  })
+
+  it('configures session instructions and forwards the raw user prompt', async () => {
+    submitTurnMock.mockResolvedValueOnce('submission-1')
+
+    const { createCodexWasmSession } = await import('./codexWasmSession')
+    const session = createCodexWasmSession({
+      codeModeExecutor: {
+        execute: vi.fn(async () => ({ output: '' })),
+      },
+    })
+
+    const submissionId = await session.submitTurn({
+      prompt: 'How do I configure a runner in Runme?',
+      onEvent: vi.fn(),
+    })
+
+    expect(submissionId).toBe('submission-1')
+    expect(setApiKeyMock).toHaveBeenCalledWith('sk-test')
+    expect(setSessionOptionsMock).toHaveBeenCalledTimes(1)
+    expect(setSessionOptionsMock).toHaveBeenCalledWith({
+      cwd: '/workspace',
+      instructions: {
+        developer: expect.stringContaining(
+          'Executed JavaScript runs inside the Runme AppKernel runtime.'
+        ),
+      },
+    })
+    expect(setCodeExecutorMock).toHaveBeenCalledTimes(1)
+    expect(submitTurnMock).toHaveBeenCalledWith(
+      'How do I configure a runner in Runme?',
+      expect.any(Function)
+    )
+  })
+})

--- a/app/src/lib/runtime/codexWasmSession.ts
+++ b/app/src/lib/runtime/codexWasmSession.ts
@@ -3,10 +3,11 @@ import {
   getCodeModeErrorOutput,
 } from './codeModeExecutor'
 import {
-  loadCodexWasmModule,
   type BrowserCodexInstance,
+  loadCodexWasmModule,
 } from './codexWasmHarnessLoader'
 import { responsesDirectConfigManager } from './responsesDirectConfigManager'
+import { buildRunmeCodexWasmSessionOptions } from './runmeChatkitPrompts'
 
 export type CodexWasmSessionEvent = Record<string, unknown>
 
@@ -15,19 +16,6 @@ export type CodexWasmSession = {
     prompt: string
     onEvent: (event: CodexWasmSessionEvent) => void
   }): Promise<string>
-}
-
-const RUNME_CODE_MODE_PROMPT_PREFIX = [
-  'You are operating inside the Runme app ChatKit panel in a browser.',
-  'When you need to inspect or modify notebooks, use Codex code mode.',
-  'Executed JavaScript runs in the Runme browser sandbox.',
-  'The runtime inside executed code exposes helpers named runme, notebooks, and help.',
-  'Always await helper calls before reading or logging their results.',
-  'Use concise JavaScript snippets and report concrete notebook-visible results.',
-].join('\n')
-
-function buildPrompt(prompt: string): string {
-  return `${RUNME_CODE_MODE_PROMPT_PREFIX}\n\nUser request:\n${prompt}`
 }
 
 function normalizeString(value: unknown): string {
@@ -56,6 +44,7 @@ export function createCodexWasmSession(options: {
 
     const browserCodex = await browserCodexPromise
     browserCodex.set_api_key(apiKey)
+    browserCodex.setSessionOptions(buildRunmeCodexWasmSessionOptions())
     browserCodex.set_code_executor(async (input: string) => {
       let request: {
         source?: unknown
@@ -108,7 +97,7 @@ export function createCodexWasmSession(options: {
     async submitTurn(args) {
       const browserCodex = await getBrowserCodex()
       const submissionId = await browserCodex.submit_turn(
-        buildPrompt(args.prompt),
+        normalizeString(args.prompt),
         (event: unknown) => {
           if (event && typeof event === 'object' && !Array.isArray(event)) {
             args.onEvent(event as CodexWasmSessionEvent)

--- a/app/src/lib/runtime/responsesDirectChatkitFetch.ts
+++ b/app/src/lib/runtime/responsesDirectChatkitFetch.ts
@@ -2,6 +2,7 @@ import { getAccessToken } from '../../token'
 import { appLogger } from '../logging/runtime'
 import type { ChatKitThreadDetail } from './chatkitProtocol'
 import { responsesDirectConfigManager } from './responsesDirectConfigManager'
+import { RUNME_RESPONSES_DIRECT_INSTRUCTIONS } from './runmeChatkitPrompts'
 
 type JsonRecord = Record<string, unknown>
 
@@ -23,28 +24,6 @@ type StoredThread = {
 const DEFAULT_OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
 const DEFAULT_MODEL = 'gpt-5.2'
 const EXECUTE_CODE_TOOL_NAME = 'ExecuteCode'
-const RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL =
-  'https://drive.google.com/drive/folders/1Qdg_VA4ZBlOKojJqW2CqSVuJ2p2I4yS5'
-const CODE_MODE_INSTRUCTIONS = [
-  'You are embedded in the Runme app ChatKit panel. When the user asks "What is Runme?" or asks about "Runme", assume they mean this app unless they say otherwise.',
-  'For high-level Runme questions, give a concise product overview, list key features (open notebooks from local files/Google Drive, execute notebook cells, share notebooks with collaborators), and explain core concepts such as notebooks, runners, and agent harnesses. Mention that Runme public docs are available in this Google Drive folder and users can add that folder in Explorer to browse docs in-app: ' +
-    RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL +
-    '. Ask whether they want you to check if the docs folder is mounted and help mount it if needed.',
-  'You are operating a Runme notebook through a single tool: ExecuteCode.',
-  'ExecuteCode runs JavaScript in sandboxed AppKernel and exposes helpers: runme, notebooks, and help.',
-  'Sandbox ExecuteCode does not expose explorer/drive helpers directly. If the user asks you to mount a Google Drive docs folder (or another Explorer-only operation), do not claim you completed the mount from sandbox. Instead, use ExecuteCode to append a browser JavaScript cell to the current notebook via notebooks.get() + notebooks.update(), then call notebooks.get({ handle: result.handle }) to verify the new cell exists, report the new cell refId, and tell the user to click Run on that cell manually. Example cell source: console.log(explorer.mountDrive("' +
-    RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL +
-    '")); console.log(explorer.listFolders()); Set the inserted cell languageId to "javascript" and include metadata { "runme.dev/runnerName": "appkernel-js" } so it runs in browser AppKernel.',
-  'Always await helper calls before reading or logging their results: await runme.getCurrentNotebook(), await runme.help(), await notebooks.help(...), await notebooks.list(...), await notebooks.get(...), await notebooks.update(...), await notebooks.execute(...). If console.log(...) prints {} for one of these helpers, you probably forgot await.',
-  'When you need notebook API details, inspect the runtime contract with await help(), await notebooks.help(), or await notebooks.help("update" | "get" | "execute").',
-  'notebooks.get(target?) returns { summary, handle, notebook }. If target is omitted, it returns the notebook currently selected in the UI. Read cell arrays from doc.notebook.cells, not doc.cells. notebooks.list(query?) returns NotebookSummary[]. notebooks.update({ target, expectedRevision?, operations }) and notebooks.execute({ target, refIds }) require an explicit target.',
-  'For notebook edits, first call const doc = await notebooks.get(); const cells = doc.notebook.cells ?? []; then call await notebooks.update({ target: { handle: doc.handle }, expectedRevision: doc.handle.revision, operations: [...] }). Re-read with await notebooks.get({ handle: result.handle }) after mutations when you need to report the final notebook state.',
-  'Supported notebooks.update operations are op="insert" with at={ index | beforeRefId | afterRefId } and cells=[{ kind, languageId?, value?, metadata? }], op="update" with refId and patch={ value?, languageId?, metadata?, outputs? }, and op="remove" with refIds=[...]. To append a cell, use at: { index: -1 }. To prepend, use at: { index: 0 }.',
-  'Notebook execution and cell outputs are binary payloads in cell.outputs[*].items[*].data. Decode stdout/stderr with new TextDecoder().decode(item.data) and filter by mime "application/vnd.code.notebook.stdout" or "application/vnd.code.notebook.stderr". Do not expect a direct item.text field.',
-  'Do not use JSON Patch style mutations such as { op: "add", path: "/cells/-", value: ... }. Do not construct raw protobuf cells with $typeName, numeric kind values, or numeric role values. Let notebooks.update create/normalize cells from the SDK-shaped insert/update payload.',
-  'Use notebooks.list(...) to enumerate open notebooks, notebooks.get(target?) to inspect notebook contents, notebooks.update({ target, ... }) to modify notebook cells, and notebooks.execute({ target, refIds }) only when execution is explicitly requested.',
-  'Use console.log for concise progress/output and prefer small, deterministic code snippets.',
-].join('\n')
 
 function buildCodeModeToolDefinition(): JsonRecord {
   return {
@@ -364,7 +343,7 @@ function buildOpenAIResponsesRequestForInput(options: {
   const payload: JsonRecord = {
     model: options.model || DEFAULT_MODEL,
     stream: true,
-    instructions: CODE_MODE_INSTRUCTIONS,
+    instructions: RUNME_RESPONSES_DIRECT_INSTRUCTIONS,
     input: [
       {
         role: 'user',
@@ -398,7 +377,7 @@ function buildOpenAIResponsesRequestForToolOutput(options: {
   const payload: JsonRecord = {
     model: options.model || DEFAULT_MODEL,
     stream: true,
-    instructions: CODE_MODE_INSTRUCTIONS,
+    instructions: RUNME_RESPONSES_DIRECT_INSTRUCTIONS,
     input: [
       {
         type: 'function_call_output',

--- a/app/src/lib/runtime/runmeChatkitPrompts.ts
+++ b/app/src/lib/runtime/runmeChatkitPrompts.ts
@@ -3,14 +3,26 @@ import type { BrowserSessionOptions } from './codexWasmHarnessLoader'
 export const RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL =
   'https://drive.google.com/drive/folders/1Qdg_VA4ZBlOKojJqW2CqSVuJ2p2I4yS5'
 
-export const RUNME_RESPONSES_DIRECT_INSTRUCTIONS = [
+const RUNME_SHARED_APP_INSTRUCTIONS = [
   'You are embedded in the Runme app ChatKit panel. When the user asks "What is Runme?" or asks about "Runme", assume they mean this app unless they say otherwise.',
   'For high-level Runme questions, give a concise product overview, list key features (open notebooks from local files/Google Drive, execute notebook cells, share notebooks with collaborators), and explain core concepts such as notebooks, runners, and agent harnesses. Mention that Runme public docs are available in this Google Drive folder and users can add that folder in Explorer to browse docs in-app: ' +
     RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL +
     '. Ask whether they want you to check if the docs folder is mounted and help mount it if needed.',
-  'You are operating a Runme notebook through a single tool: ExecuteCode.',
-  'ExecuteCode runs JavaScript in sandboxed AppKernel and exposes helpers: runme, notebooks, and help.',
-  'Sandbox ExecuteCode does not expose explorer/drive helpers directly. If the user asks you to mount a Google Drive docs folder (or another Explorer-only operation), do not claim you completed the mount from sandbox. Instead, use ExecuteCode to append a browser JavaScript cell to the current notebook via notebooks.get() + notebooks.update(), then call notebooks.get({ handle: result.handle }) to verify the new cell exists, report the new cell refId, and tell the user to click Run on that cell manually. Example cell source: console.log(explorer.mountDrive("' +
+]
+
+const RUNME_SHARED_APPKERNEL_INSTRUCTIONS = [
+  'Executed JavaScript runs inside the Runme AppKernel runtime.',
+  'Inside AppKernel, the runtime exposes helpers named runme, opfs, net, notebooks, and help.',
+  'Use opfs as local browser storage and net.get(...) for HTTP GET requests.',
+  'Use OPFS as a local repo cache under /code/${ORG}/${REPO}.',
+  'For Runme source questions, prefer caching the public runmedev/web repository under /code/runmedev/web.',
+  'If /code/runmedev/web is missing or stale, fetch the GitHub tree manifest from https://api.github.com/repos/runmedev/web/ and fetch file contents from https://raw.githubusercontent.com/runmedev/web/.',
+  'Persist fetched files in OPFS and search them lexically with JavaScript before answering.',
+  'For now, assume HTTP GET requests and OPFS operations are available without approval.',
+]
+
+const RUNME_SHARED_NOTEBOOK_INSTRUCTIONS = [
+  'If the user asks you to mount a Google Drive docs folder (or another Explorer-only operation), do not claim you completed the mount from sandbox. Instead, append a browser JavaScript cell to the current notebook via notebooks.get() + notebooks.update(), then call notebooks.get({ handle: result.handle }) to verify the new cell exists, report the new cell refId, and tell the user to click Run on that cell manually. Example cell source: console.log(explorer.mountDrive("' +
     RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL +
     '")); console.log(explorer.listFolders()); Set the inserted cell languageId to "javascript" and include metadata { "runme.dev/runnerName": "appkernel-js" } so it runs in browser AppKernel.',
   'Always await helper calls before reading or logging their results: await runme.getCurrentNotebook(), await runme.help(), await notebooks.help(...), await notebooks.list(...), await notebooks.get(...), await notebooks.update(...), await notebooks.execute(...). If console.log(...) prints {} for one of these helpers, you probably forgot await.',
@@ -21,25 +33,40 @@ export const RUNME_RESPONSES_DIRECT_INSTRUCTIONS = [
   'Notebook execution and cell outputs are binary payloads in cell.outputs[*].items[*].data. Decode stdout/stderr with new TextDecoder().decode(item.data) and filter by mime "application/vnd.code.notebook.stdout" or "application/vnd.code.notebook.stderr". Do not expect a direct item.text field.',
   'Do not use JSON Patch style mutations such as { op: "add", path: "/cells/-", value: ... }. Do not construct raw protobuf cells with $typeName, numeric kind values, or numeric role values. Let notebooks.update create/normalize cells from the SDK-shaped insert/update payload.',
   'Use notebooks.list(...) to enumerate open notebooks, notebooks.get(target?) to inspect notebook contents, notebooks.update({ target, ... }) to modify notebook cells, and notebooks.execute({ target, refIds }) only when execution is explicitly requested.',
+]
+
+const RUNME_SHARED_EXECUTION_INSTRUCTIONS = [
+  'Preserve source path and revision metadata when you report findings.',
   'Use console.log for concise progress/output and prefer small, deterministic code snippets.',
+]
+
+export const RUNME_SHARED_RUNTIME_INSTRUCTIONS = [
+  ...RUNME_SHARED_APP_INSTRUCTIONS,
+  ...RUNME_SHARED_APPKERNEL_INSTRUCTIONS,
+  ...RUNME_SHARED_NOTEBOOK_INSTRUCTIONS,
+  ...RUNME_SHARED_EXECUTION_INSTRUCTIONS,
+].join('\n')
+
+const RUNME_RESPONSES_DIRECT_OVERLAY = [
+  'You are operating a Runme notebook through a single tool: ExecuteCode.',
+  'ExecuteCode runs JavaScript in the same Runme AppKernel runtime described above.',
+]
+
+export const RUNME_RESPONSES_DIRECT_INSTRUCTIONS = [
+  ...RUNME_RESPONSES_DIRECT_OVERLAY,
+  RUNME_SHARED_RUNTIME_INSTRUCTIONS,
 ].join('\n')
 
 export const RUNME_CODEX_WASM_CWD = '/workspace'
 
-export const RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS = [
-  'You are operating inside the Runme app ChatKit panel in a browser.',
+const RUNME_CODEX_WASM_OVERLAY = [
   'When you need to inspect or modify notebooks, use Codex code mode.',
-  'Executed JavaScript runs inside the Runme AppKernel runtime.',
-  'Inside AppKernel, the runtime exposes helpers named runme, opfs, net, notebooks, and help.',
-  'Use opfs as local browser storage and net.get(...) for HTTP GET requests.',
-  'Use OPFS as a local repo cache under /code/${ORG}/${REPO}.',
-  'For Runme source questions, prefer caching the public runmedev/web repository under /code/runmedev/web.',
-  'If /code/runmedev/web is missing or stale, fetch the GitHub tree manifest from https://api.github.com/repos/runmedev/web/ and fetch file contents from https://raw.githubusercontent.com/runmedev/web/.',
-  'Persist fetched files in OPFS and search them lexically with JavaScript before answering.',
-  'For now, assume HTTP GET requests and OPFS operations are available without approval.',
-  'Always await helper calls before reading or logging their results.',
-  'Preserve source path and revision metadata when you report findings.',
-  'Use concise JavaScript snippets and report concrete notebook-visible results.',
+  'Codex code mode executes JavaScript in the same Runme AppKernel runtime described above.',
+]
+
+export const RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS = [
+  ...RUNME_CODEX_WASM_OVERLAY,
+  RUNME_SHARED_RUNTIME_INSTRUCTIONS,
 ].join('\n')
 
 export function buildRunmeCodexWasmSessionOptions(): BrowserSessionOptions {

--- a/app/src/lib/runtime/runmeChatkitPrompts.ts
+++ b/app/src/lib/runtime/runmeChatkitPrompts.ts
@@ -1,0 +1,52 @@
+import type { BrowserSessionOptions } from './codexWasmHarnessLoader'
+
+export const RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL =
+  'https://drive.google.com/drive/folders/1Qdg_VA4ZBlOKojJqW2CqSVuJ2p2I4yS5'
+
+export const RUNME_RESPONSES_DIRECT_INSTRUCTIONS = [
+  'You are embedded in the Runme app ChatKit panel. When the user asks "What is Runme?" or asks about "Runme", assume they mean this app unless they say otherwise.',
+  'For high-level Runme questions, give a concise product overview, list key features (open notebooks from local files/Google Drive, execute notebook cells, share notebooks with collaborators), and explain core concepts such as notebooks, runners, and agent harnesses. Mention that Runme public docs are available in this Google Drive folder and users can add that folder in Explorer to browse docs in-app: ' +
+    RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL +
+    '. Ask whether they want you to check if the docs folder is mounted and help mount it if needed.',
+  'You are operating a Runme notebook through a single tool: ExecuteCode.',
+  'ExecuteCode runs JavaScript in sandboxed AppKernel and exposes helpers: runme, notebooks, and help.',
+  'Sandbox ExecuteCode does not expose explorer/drive helpers directly. If the user asks you to mount a Google Drive docs folder (or another Explorer-only operation), do not claim you completed the mount from sandbox. Instead, use ExecuteCode to append a browser JavaScript cell to the current notebook via notebooks.get() + notebooks.update(), then call notebooks.get({ handle: result.handle }) to verify the new cell exists, report the new cell refId, and tell the user to click Run on that cell manually. Example cell source: console.log(explorer.mountDrive("' +
+    RUNME_PUBLIC_DOCS_DRIVE_FOLDER_URL +
+    '")); console.log(explorer.listFolders()); Set the inserted cell languageId to "javascript" and include metadata { "runme.dev/runnerName": "appkernel-js" } so it runs in browser AppKernel.',
+  'Always await helper calls before reading or logging their results: await runme.getCurrentNotebook(), await runme.help(), await notebooks.help(...), await notebooks.list(...), await notebooks.get(...), await notebooks.update(...), await notebooks.execute(...). If console.log(...) prints {} for one of these helpers, you probably forgot await.',
+  'When you need notebook API details, inspect the runtime contract with await help(), await notebooks.help(), or await notebooks.help("update" | "get" | "execute").',
+  'notebooks.get(target?) returns { summary, handle, notebook }. If target is omitted, it returns the notebook currently selected in the UI. Read cell arrays from doc.notebook.cells, not doc.cells. notebooks.list(query?) returns NotebookSummary[]. notebooks.update({ target, expectedRevision?, operations }) and notebooks.execute({ target, refIds }) require an explicit target.',
+  'For notebook edits, first call const doc = await notebooks.get(); const cells = doc.notebook.cells ?? []; then call await notebooks.update({ target: { handle: doc.handle }, expectedRevision: doc.handle.revision, operations: [...] }). Re-read with await notebooks.get({ handle: result.handle }) after mutations when you need to report the final notebook state.',
+  'Supported notebooks.update operations are op="insert" with at={ index | beforeRefId | afterRefId } and cells=[{ kind, languageId?, value?, metadata? }], op="update" with refId and patch={ value?, languageId?, metadata?, outputs? }, and op="remove" with refIds=[...]. To append a cell, use at: { index: -1 }. To prepend, use at: { index: 0 }.',
+  'Notebook execution and cell outputs are binary payloads in cell.outputs[*].items[*].data. Decode stdout/stderr with new TextDecoder().decode(item.data) and filter by mime "application/vnd.code.notebook.stdout" or "application/vnd.code.notebook.stderr". Do not expect a direct item.text field.',
+  'Do not use JSON Patch style mutations such as { op: "add", path: "/cells/-", value: ... }. Do not construct raw protobuf cells with $typeName, numeric kind values, or numeric role values. Let notebooks.update create/normalize cells from the SDK-shaped insert/update payload.',
+  'Use notebooks.list(...) to enumerate open notebooks, notebooks.get(target?) to inspect notebook contents, notebooks.update({ target, ... }) to modify notebook cells, and notebooks.execute({ target, refIds }) only when execution is explicitly requested.',
+  'Use console.log for concise progress/output and prefer small, deterministic code snippets.',
+].join('\n')
+
+export const RUNME_CODEX_WASM_CWD = '/workspace'
+
+export const RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS = [
+  'You are operating inside the Runme app ChatKit panel in a browser.',
+  'When you need to inspect or modify notebooks, use Codex code mode.',
+  'Executed JavaScript runs inside the Runme AppKernel runtime.',
+  'Inside AppKernel, the runtime exposes helpers named runme, opfs, net, notebooks, and help.',
+  'Use opfs as local browser storage and net.get(...) for HTTP GET requests.',
+  'Use OPFS as a local repo cache under /code/${ORG}/${REPO}.',
+  'For Runme source questions, prefer caching the public runmedev/web repository under /code/runmedev/web.',
+  'If /code/runmedev/web is missing or stale, fetch the GitHub tree manifest from https://api.github.com/repos/runmedev/web/ and fetch file contents from https://raw.githubusercontent.com/runmedev/web/.',
+  'Persist fetched files in OPFS and search them lexically with JavaScript before answering.',
+  'For now, assume HTTP GET requests and OPFS operations are available without approval.',
+  'Always await helper calls before reading or logging their results.',
+  'Preserve source path and revision metadata when you report findings.',
+  'Use concise JavaScript snippets and report concrete notebook-visible results.',
+].join('\n')
+
+export function buildRunmeCodexWasmSessionOptions(): BrowserSessionOptions {
+  return {
+    cwd: RUNME_CODEX_WASM_CWD,
+    instructions: {
+      developer: RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS,
+    },
+  }
+}

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest'
 
-import { SandboxJSKernel } from './sandboxJsKernel'
+import {
+  CODE_MODE_SANDBOX_ALLOWED_METHODS,
+  SandboxJSKernel,
+} from './sandboxJsKernel'
 
 type Scenario = 'success' | 'disallowed' | 'hang' | 'lowLevel'
 
@@ -90,7 +93,7 @@ class MockSandboxPort {
     }
 
     if (type === 'host-error') {
-      if (this.scenario === 'disallowed') {
+      if (this.scenario === 'disallowed' || this.scenario === 'lowLevel') {
         this.emit({ type: 'stderr', data: String(message.error ?? '') + '\n' })
         this.emit({ type: 'exit', exitCode: 1 })
       }
@@ -234,7 +237,34 @@ describe('SandboxJSKernel', () => {
     expect(disposeSession).toHaveBeenCalledTimes(1)
   })
 
-  it('allows low-level opfs and net bridge methods by default', async () => {
+  it('rejects low-level opfs and net bridge methods by default', async () => {
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async () => null)
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('lowLevel'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run("console.log('noop');")
+
+    expect(bridgeCall).not.toHaveBeenCalled()
+    expect(stderr).toContain('Sandbox method not allowed: opfs.readText')
+    expect(exitCode).toBe(1)
+  })
+
+  it('allows low-level opfs and net bridge methods in code mode', async () => {
     let stdout = ''
     let stderr = ''
     let exitCode = -1
@@ -252,6 +282,7 @@ describe('SandboxJSKernel', () => {
       new MockSandboxPort('lowLevel'),
       {
         bridge: { call: bridgeCall },
+        allowedMethods: CODE_MODE_SANDBOX_ALLOWED_METHODS,
         hooks: {
           onStdout: (data) => {
             stdout += data

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -1,66 +1,98 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
-import { SandboxJSKernel } from "./sandboxJsKernel";
+import { describe, expect, it, vi } from 'vitest'
 
-type Scenario = "success" | "disallowed" | "hang";
+import { SandboxJSKernel } from './sandboxJsKernel'
+
+type Scenario = 'success' | 'disallowed' | 'hang' | 'lowLevel'
 
 class MockSandboxPort {
-  onmessage: ((event: MessageEvent<any>) => void) | null = null;
-  readonly sentFromHost: Array<Record<string, unknown>> = [];
-  private readonly hostResults = new Map<number, unknown>();
+  onmessage: ((event: MessageEvent<any>) => void) | null = null
+  readonly sentFromHost: Array<Record<string, unknown>> = []
+  private readonly hostResults = new Map<number, unknown>()
 
   constructor(private readonly scenario: Scenario) {}
 
   postMessage(message: Record<string, unknown>) {
-    this.sentFromHost.push(message);
-    const type = String(message.type ?? "");
+    this.sentFromHost.push(message)
+    const type = String(message.type ?? '')
 
-    if (type === "run") {
-      if (this.scenario === "success") {
+    if (type === 'run') {
+      if (this.scenario === 'success') {
         this.emit({
-          type: "host-call",
+          type: 'host-call',
           callId: 1,
-          method: "runme.getCurrentNotebook",
+          method: 'runme.getCurrentNotebook',
           args: [],
-        });
+        })
         this.emit({
-          type: "host-call",
+          type: 'host-call',
           callId: 2,
-          method: "runme.clear",
+          method: 'runme.clear',
           args: [undefined],
-        });
-      } else if (this.scenario === "hang") {
-        this.emit({ type: "stdout", data: "started\n" });
+        })
+      } else if (this.scenario === 'lowLevel') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'opfs.readText',
+          args: ['/code/runmedev/web.txt'],
+        })
+        this.emit({
+          type: 'host-call',
+          callId: 2,
+          method: 'net.get',
+          args: ['https://example.test/docs'],
+        })
+      } else if (this.scenario === 'hang') {
+        this.emit({ type: 'stdout', data: 'started\n' })
       } else {
         this.emit({
-          type: "host-call",
+          type: 'host-call',
           callId: 1,
-          method: "runme.clear",
+          method: 'runme.clear',
           args: [undefined],
-        });
+        })
       }
-      return;
+      return
     }
 
-    if (type === "host-result") {
-      const callId = Number(message.callId ?? 0);
-      this.hostResults.set(callId, message.result);
-      if (this.scenario === "success" && this.hostResults.has(1) && this.hostResults.has(2)) {
-        const notebookInfo = this.hostResults.get(1) as
-          | { name?: string; cellCount?: number }
-          | undefined;
-        this.emit({ type: "stdout", data: `${notebookInfo?.name ?? ""}\n` });
-        this.emit({ type: "stdout", data: `${notebookInfo?.cellCount ?? ""}\n` });
-        this.emit({ type: "stdout", data: `${String(this.hostResults.get(2) ?? "")}\n` });
-        this.emit({ type: "exit", exitCode: 0 });
+    if (type === 'host-result') {
+      const callId = Number(message.callId ?? 0)
+      this.hostResults.set(callId, message.result)
+      if (this.hostResults.has(1) && this.hostResults.has(2)) {
+        if (this.scenario === 'success') {
+          const notebookInfo = this.hostResults.get(1) as
+            | { name?: string; cellCount?: number }
+            | undefined
+          this.emit({ type: 'stdout', data: `${notebookInfo?.name ?? ''}\n` })
+          this.emit({
+            type: 'stdout',
+            data: `${notebookInfo?.cellCount ?? ''}\n`,
+          })
+          this.emit({
+            type: 'stdout',
+            data: `${String(this.hostResults.get(2) ?? '')}\n`,
+          })
+          this.emit({ type: 'exit', exitCode: 0 })
+        } else if (this.scenario === 'lowLevel') {
+          this.emit({
+            type: 'stdout',
+            data: `${String(this.hostResults.get(1) ?? '')}\n`,
+          })
+          this.emit({
+            type: 'stdout',
+            data: `${JSON.stringify(this.hostResults.get(2) ?? null)}\n`,
+          })
+          this.emit({ type: 'exit', exitCode: 0 })
+        }
       }
-      return;
+      return
     }
 
-    if (type === "host-error") {
-      if (this.scenario === "disallowed") {
-        this.emit({ type: "stderr", data: String(message.error ?? "") + "\n" });
-        this.emit({ type: "exit", exitCode: 1 });
+    if (type === 'host-error') {
+      if (this.scenario === 'disallowed') {
+        this.emit({ type: 'stderr', data: String(message.error ?? '') + '\n' })
+        this.emit({ type: 'exit', exitCode: 1 })
       }
     }
   }
@@ -71,7 +103,7 @@ class MockSandboxPort {
   removeEventListener() {}
 
   private emit(data: unknown) {
-    this.onmessage?.({ data } as MessageEvent);
+    this.onmessage?.({ data } as MessageEvent)
   }
 }
 
@@ -79,9 +111,9 @@ class TestableSandboxJSKernel extends SandboxJSKernel {
   constructor(
     private readonly port: MockSandboxPort,
     options: ConstructorParameters<typeof SandboxJSKernel>[0],
-    private readonly disposeSession = () => {},
+    private readonly disposeSession = () => {}
   ) {
-    super(options);
+    super(options)
   }
 
   protected override async createSession(): Promise<any> {
@@ -89,109 +121,162 @@ class TestableSandboxJSKernel extends SandboxJSKernel {
       iframe: {} as HTMLIFrameElement,
       port: this.port as unknown as MessagePort,
       dispose: this.disposeSession,
-    };
+    }
   }
 }
 
-describe("SandboxJSKernel", () => {
-  it("runs javascript and resolves runme host calls through the bridge", async () => {
-    let stdout = "";
-    let stderr = "";
-    let exitCode = -1;
+describe('SandboxJSKernel', () => {
+  it('runs javascript and resolves runme host calls through the bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
     const bridgeCall = vi.fn(async (method: string) => {
-      if (method === "runme.getCurrentNotebook") {
-        return { name: "sandbox-test", cellCount: 4 };
+      if (method === 'runme.getCurrentNotebook') {
+        return { name: 'sandbox-test', cellCount: 4 }
       }
-      if (method === "runme.clear") {
-        return "cleared";
+      if (method === 'runme.clear') {
+        return 'cleared'
       }
-      return "";
-    });
+      return ''
+    })
 
-    const kernel = new TestableSandboxJSKernel(new MockSandboxPort("success"), {
+    const kernel = new TestableSandboxJSKernel(new MockSandboxPort('success'), {
       bridge: { call: bridgeCall },
       hooks: {
         onStdout: (data) => {
-          stdout += data;
+          stdout += data
         },
         onStderr: (data) => {
-          stderr += data;
+          stderr += data
         },
         onExit: (code) => {
-          exitCode = code;
+          exitCode = code
         },
       },
-    });
+    })
 
-    await kernel.run("console.log('noop');");
+    await kernel.run("console.log('noop');")
 
-    expect(bridgeCall).toHaveBeenCalledWith("runme.getCurrentNotebook", []);
-    expect(bridgeCall).toHaveBeenCalledWith("runme.clear", [undefined]);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("sandbox-test");
-    expect(stdout).toContain("4");
-    expect(stdout).toContain("cleared");
-    expect(exitCode).toBe(0);
-  });
+    expect(bridgeCall).toHaveBeenCalledWith('runme.getCurrentNotebook', [])
+    expect(bridgeCall).toHaveBeenCalledWith('runme.clear', [undefined])
+    expect(stderr).toBe('')
+    expect(stdout).toContain('sandbox-test')
+    expect(stdout).toContain('4')
+    expect(stdout).toContain('cleared')
+    expect(exitCode).toBe(0)
+  })
 
-  it("rejects host calls that are outside the allowlist", async () => {
-    let stderr = "";
-    let exitCode = -1;
+  it('rejects host calls that are outside the allowlist', async () => {
+    let stderr = ''
+    let exitCode = -1
 
-    const kernel = new TestableSandboxJSKernel(new MockSandboxPort("disallowed"), {
-      bridge: {
-        call: vi.fn(async () => "ignored"),
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('disallowed'),
+      {
+        bridge: {
+          call: vi.fn(async () => 'ignored'),
+        },
+        allowedMethods: ['runme.help'],
+        hooks: {
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run('await runme.clear();')
+
+    expect(stderr).toContain('Sandbox method not allowed: runme.clear')
+    expect(exitCode).toBe(1)
+  })
+
+  it('disposes the sandbox session when aborted', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const disposeSession = vi.fn()
+    const abortController = new AbortController()
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('hang'),
+      {
+        bridge: {
+          call: vi.fn(async () => 'ignored'),
+        },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
       },
-      allowedMethods: ["runme.help"],
-      hooks: {
-        onStderr: (data) => {
-          stderr += data;
-        },
-        onExit: (code) => {
-          exitCode = code;
-        },
-      },
-    });
+      disposeSession
+    )
 
-    await kernel.run("await runme.clear();");
-
-    expect(stderr).toContain("Sandbox method not allowed: runme.clear");
-    expect(exitCode).toBe(1);
-  });
-
-  it("disposes the sandbox session when aborted", async () => {
-    let stdout = "";
-    let stderr = "";
-    let exitCode = -1;
-    const disposeSession = vi.fn();
-    const abortController = new AbortController();
-    const kernel = new TestableSandboxJSKernel(new MockSandboxPort("hang"), {
-      bridge: {
-        call: vi.fn(async () => "ignored"),
-      },
-      hooks: {
-        onStdout: (data) => {
-          stdout += data;
-        },
-        onStderr: (data) => {
-          stderr += data;
-        },
-        onExit: (code) => {
-          exitCode = code;
-        },
-      },
-    }, disposeSession);
-
-    const run = kernel.run("await new Promise(() => {});", {
+    const run = kernel.run('await new Promise(() => {});', {
       signal: abortController.signal,
-    });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    abortController.abort();
-    await run;
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    abortController.abort()
+    await run
 
-    expect(stdout).toContain("started");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(1);
-    expect(disposeSession).toHaveBeenCalledTimes(1);
-  });
-});
+    expect(stdout).toContain('started')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(1)
+    expect(disposeSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows low-level opfs and net bridge methods by default', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'opfs.readText') {
+        return 'cached-doc'
+      }
+      if (method === 'net.get') {
+        return { ok: true, status: 200, text: 'remote-doc' }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('lowLevel'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run("console.log('noop');")
+
+    expect(bridgeCall).toHaveBeenCalledWith('opfs.readText', [
+      '/code/runmedev/web.txt',
+    ])
+    expect(bridgeCall).toHaveBeenCalledWith('net.get', [
+      'https://example.test/docs',
+    ])
+    expect(stdout).toContain('cached-doc')
+    expect(stdout).toContain('"status":200')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+})

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -32,7 +32,101 @@ const SANDBOX_INIT_MESSAGE = 'runme-appkernel-sandbox-init'
 const LOAD_TIMEOUT_MS = 3_000
 const READY_TIMEOUT_MS = 3_000
 
-const SANDBOX_SRC_DOC = `<!doctype html>
+const DEFAULT_SANDBOX_ALLOWED_METHODS = [
+  'runme.clear',
+  'runme.clearOutputs',
+  'runme.runAll',
+  'runme.rerun',
+  'runme.getCurrentNotebook',
+  'runme.help',
+  ...SANDBOX_NOTEBOOKS_API_METHODS,
+]
+
+const LOW_LEVEL_SANDBOX_ALLOWED_METHODS = [
+  'opfs.exists',
+  'opfs.readText',
+  'opfs.writeText',
+  'opfs.readBytes',
+  'opfs.writeBytes',
+  'opfs.list',
+  'opfs.mkdir',
+  'opfs.stat',
+  'opfs.remove',
+  'net.get',
+]
+
+export const CODE_MODE_SANDBOX_ALLOWED_METHODS = [
+  ...DEFAULT_SANDBOX_ALLOWED_METHODS,
+  ...LOW_LEVEL_SANDBOX_ALLOWED_METHODS,
+]
+
+function buildSandboxSrcDoc(options: {
+  enableOpfs: boolean
+  enableNet: boolean
+}): string {
+  const opfsHelper = options.enableOpfs
+    ? `
+        const opfs = {
+          exists: (path) => hostCall("opfs.exists", [path]),
+          readText: (path) => hostCall("opfs.readText", [path]),
+          writeText: (path, text) => hostCall("opfs.writeText", [path, text]),
+          readBytes: (path) => hostCall("opfs.readBytes", [path]),
+          writeBytes: (path, bytes) => hostCall("opfs.writeBytes", [path, bytes]),
+          list: (path) => hostCall("opfs.list", [path]),
+          mkdir: (path, options) => hostCall("opfs.mkdir", [path, options]),
+          stat: (path) => hostCall("opfs.stat", [path]),
+          remove: (path, options) => hostCall("opfs.remove", [path, options]),
+          help: () => {
+            consoleProxy.log("opfs.exists(path)");
+            consoleProxy.log("opfs.readText(path)");
+            consoleProxy.log("opfs.writeText(path, text)");
+            consoleProxy.log("opfs.readBytes(path)");
+            consoleProxy.log("opfs.writeBytes(path, bytes)");
+            consoleProxy.log("opfs.list(path)");
+            consoleProxy.log("opfs.mkdir(path, { recursive? })");
+            consoleProxy.log("opfs.stat(path)");
+            consoleProxy.log("opfs.remove(path, { recursive? })");
+            consoleProxy.log("opfs.help()");
+          },
+        };
+      `
+    : 'const opfs = undefined;'
+
+  const netHelper = options.enableNet
+    ? `
+        const net = {
+          get: (url, options) => hostCall("net.get", [url, options]),
+          help: () => {
+            consoleProxy.log("net.get(url, { headers?, responseType? })");
+            consoleProxy.log("net.help()");
+          },
+        };
+      `
+    : 'const net = undefined;'
+
+  const opfsHelpLines = options.enableOpfs
+    ? `
+          consoleProxy.log("- opfs.exists(path)");
+          consoleProxy.log("- opfs.readText(path)");
+          consoleProxy.log("- opfs.writeText(path, text)");
+          consoleProxy.log("- opfs.readBytes(path)");
+          consoleProxy.log("- opfs.writeBytes(path, bytes)");
+          consoleProxy.log("- opfs.list(path)");
+          consoleProxy.log("- opfs.mkdir(path, { recursive? })");
+          consoleProxy.log("- opfs.stat(path)");
+          consoleProxy.log("- opfs.remove(path, { recursive? })");
+          consoleProxy.log("- opfs.help()");
+      `
+    : ''
+
+  const netHelpLines = options.enableNet
+    ? `
+          consoleProxy.log("- net.get(url, { headers?, responseType? })");
+          consoleProxy.log("- net.help()");
+      `
+    : ''
+
+  return `<!doctype html>
 <html>
   <head><meta charset="utf-8" /></head>
   <body>
@@ -94,37 +188,9 @@ const SANDBOX_SRC_DOC = `<!doctype html>
           help: () => hostCall("runme.help", []),
         };
 
-        const opfs = {
-          exists: (path) => hostCall("opfs.exists", [path]),
-          readText: (path) => hostCall("opfs.readText", [path]),
-          writeText: (path, text) => hostCall("opfs.writeText", [path, text]),
-          readBytes: (path) => hostCall("opfs.readBytes", [path]),
-          writeBytes: (path, bytes) => hostCall("opfs.writeBytes", [path, bytes]),
-          list: (path) => hostCall("opfs.list", [path]),
-          mkdir: (path, options) => hostCall("opfs.mkdir", [path, options]),
-          stat: (path) => hostCall("opfs.stat", [path]),
-          remove: (path, options) => hostCall("opfs.remove", [path, options]),
-          help: () => {
-            consoleProxy.log("opfs.exists(path)");
-            consoleProxy.log("opfs.readText(path)");
-            consoleProxy.log("opfs.writeText(path, text)");
-            consoleProxy.log("opfs.readBytes(path)");
-            consoleProxy.log("opfs.writeBytes(path, bytes)");
-            consoleProxy.log("opfs.list(path)");
-            consoleProxy.log("opfs.mkdir(path, { recursive? })");
-            consoleProxy.log("opfs.stat(path)");
-            consoleProxy.log("opfs.remove(path, { recursive? })");
-            consoleProxy.log("opfs.help()");
-          },
-        };
+        ${opfsHelper}
 
-        const net = {
-          get: (url, options) => hostCall("net.get", [url, options]),
-          help: () => {
-            consoleProxy.log("net.get(url, { headers?, responseType? })");
-            consoleProxy.log("net.help()");
-          },
-        };
+        ${netHelper}
 
         const createSandboxNotebooksApiClient = (callHost) => ({
           help: (topic) => callHost("notebooks.help", [topic]),
@@ -145,18 +211,8 @@ const SANDBOX_SRC_DOC = `<!doctype html>
           consoleProxy.log("- runme.rerun([target])");
           consoleProxy.log("- runme.getCurrentNotebook()");
           consoleProxy.log("- runme.help()");
-          consoleProxy.log("- opfs.exists(path)");
-          consoleProxy.log("- opfs.readText(path)");
-          consoleProxy.log("- opfs.writeText(path, text)");
-          consoleProxy.log("- opfs.readBytes(path)");
-          consoleProxy.log("- opfs.writeBytes(path, bytes)");
-          consoleProxy.log("- opfs.list(path)");
-          consoleProxy.log("- opfs.mkdir(path, { recursive? })");
-          consoleProxy.log("- opfs.stat(path)");
-          consoleProxy.log("- opfs.remove(path, { recursive? })");
-          consoleProxy.log("- opfs.help()");
-          consoleProxy.log("- net.get(url, { headers?, responseType? })");
-          consoleProxy.log("- net.help()");
+          ${opfsHelpLines}
+          ${netHelpLines}
           consoleProxy.log("- notebooks.help([topic])");
           consoleProxy.log("- notebooks.list([query])");
           consoleProxy.log("- notebooks.get([target]) # omitted target = current UI notebook");
@@ -229,6 +285,7 @@ const SANDBOX_SRC_DOC = `<!doctype html>
     </script>
   </body>
 </html>`
+}
 
 /**
  * SandboxJSKernel executes JavaScript in a sandboxed iframe and only exposes a
@@ -245,25 +302,7 @@ export class SandboxJSKernel {
   constructor({
     bridge,
     hooks = {},
-    allowedMethods = [
-      'runme.clear',
-      'runme.clearOutputs',
-      'runme.runAll',
-      'runme.rerun',
-      'runme.getCurrentNotebook',
-      'runme.help',
-      'opfs.exists',
-      'opfs.readText',
-      'opfs.writeText',
-      'opfs.readBytes',
-      'opfs.writeBytes',
-      'opfs.list',
-      'opfs.mkdir',
-      'opfs.stat',
-      'opfs.remove',
-      'net.get',
-      ...SANDBOX_NOTEBOOKS_API_METHODS,
-    ],
+    allowedMethods = DEFAULT_SANDBOX_ALLOWED_METHODS,
   }: {
     bridge: SandboxBridge
     hooks?: KernelHooks
@@ -424,7 +463,12 @@ export class SandboxJSKernel {
     iframe.setAttribute('sandbox', 'allow-scripts')
     iframe.setAttribute('aria-hidden', 'true')
     iframe.style.display = 'none'
-    iframe.srcdoc = SANDBOX_SRC_DOC
+    iframe.srcdoc = buildSandboxSrcDoc({
+      enableOpfs: LOW_LEVEL_SANDBOX_ALLOWED_METHODS.some((method) =>
+        this.allowedMethods.has(method)
+      ),
+      enableNet: this.allowedMethods.has('net.get'),
+    })
 
     await new Promise<void>((resolve, reject) => {
       const timeoutId = setTimeout(() => {

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -1,36 +1,36 @@
-import { appLogger } from "../logging/runtime";
-import { SANDBOX_NOTEBOOKS_API_METHODS } from "./notebooksApiBridge";
+import { appLogger } from '../logging/runtime'
+import { SANDBOX_NOTEBOOKS_API_METHODS } from './notebooksApiBridge'
 
 type KernelHooks = {
-  onStdout?: (data: string) => void;
-  onStderr?: (data: string) => void;
-  onExit?: (exitCode: number) => void;
-};
+  onStdout?: (data: string) => void
+  onStderr?: (data: string) => void
+  onExit?: (exitCode: number) => void
+}
 
 type RunOptions = {
-  signal?: AbortSignal | null;
-};
+  signal?: AbortSignal | null
+}
 
 type SandboxBridge = {
-  call: (method: string, args: unknown[]) => Promise<unknown> | unknown;
-};
+  call: (method: string, args: unknown[]) => Promise<unknown> | unknown
+}
 
 type SandboxMessage =
-  | { type: "ready" }
-  | { type: "stdout"; data?: string }
-  | { type: "stderr"; data?: string }
-  | { type: "exit"; exitCode?: number }
-  | { type: "host-call"; callId?: number; method?: string; args?: unknown[] };
+  | { type: 'ready' }
+  | { type: 'stdout'; data?: string }
+  | { type: 'stderr'; data?: string }
+  | { type: 'exit'; exitCode?: number }
+  | { type: 'host-call'; callId?: number; method?: string; args?: unknown[] }
 
 type SandboxSession = {
-  iframe: HTMLIFrameElement;
-  port: MessagePort;
-  dispose: () => void;
-};
+  iframe: HTMLIFrameElement
+  port: MessagePort
+  dispose: () => void
+}
 
-const SANDBOX_INIT_MESSAGE = "runme-appkernel-sandbox-init";
-const LOAD_TIMEOUT_MS = 3_000;
-const READY_TIMEOUT_MS = 3_000;
+const SANDBOX_INIT_MESSAGE = 'runme-appkernel-sandbox-init'
+const LOAD_TIMEOUT_MS = 3_000
+const READY_TIMEOUT_MS = 3_000
 
 const SANDBOX_SRC_DOC = `<!doctype html>
 <html>
@@ -94,6 +94,38 @@ const SANDBOX_SRC_DOC = `<!doctype html>
           help: () => hostCall("runme.help", []),
         };
 
+        const opfs = {
+          exists: (path) => hostCall("opfs.exists", [path]),
+          readText: (path) => hostCall("opfs.readText", [path]),
+          writeText: (path, text) => hostCall("opfs.writeText", [path, text]),
+          readBytes: (path) => hostCall("opfs.readBytes", [path]),
+          writeBytes: (path, bytes) => hostCall("opfs.writeBytes", [path, bytes]),
+          list: (path) => hostCall("opfs.list", [path]),
+          mkdir: (path, options) => hostCall("opfs.mkdir", [path, options]),
+          stat: (path) => hostCall("opfs.stat", [path]),
+          remove: (path, options) => hostCall("opfs.remove", [path, options]),
+          help: () => {
+            consoleProxy.log("opfs.exists(path)");
+            consoleProxy.log("opfs.readText(path)");
+            consoleProxy.log("opfs.writeText(path, text)");
+            consoleProxy.log("opfs.readBytes(path)");
+            consoleProxy.log("opfs.writeBytes(path, bytes)");
+            consoleProxy.log("opfs.list(path)");
+            consoleProxy.log("opfs.mkdir(path, { recursive? })");
+            consoleProxy.log("opfs.stat(path)");
+            consoleProxy.log("opfs.remove(path, { recursive? })");
+            consoleProxy.log("opfs.help()");
+          },
+        };
+
+        const net = {
+          get: (url, options) => hostCall("net.get", [url, options]),
+          help: () => {
+            consoleProxy.log("net.get(url, { headers?, responseType? })");
+            consoleProxy.log("net.help()");
+          },
+        };
+
         const createSandboxNotebooksApiClient = (callHost) => ({
           help: (topic) => callHost("notebooks.help", [topic]),
           list: (query) => callHost("notebooks.list", [query]),
@@ -113,6 +145,18 @@ const SANDBOX_SRC_DOC = `<!doctype html>
           consoleProxy.log("- runme.rerun([target])");
           consoleProxy.log("- runme.getCurrentNotebook()");
           consoleProxy.log("- runme.help()");
+          consoleProxy.log("- opfs.exists(path)");
+          consoleProxy.log("- opfs.readText(path)");
+          consoleProxy.log("- opfs.writeText(path, text)");
+          consoleProxy.log("- opfs.readBytes(path)");
+          consoleProxy.log("- opfs.writeBytes(path, bytes)");
+          consoleProxy.log("- opfs.list(path)");
+          consoleProxy.log("- opfs.mkdir(path, { recursive? })");
+          consoleProxy.log("- opfs.stat(path)");
+          consoleProxy.log("- opfs.remove(path, { recursive? })");
+          consoleProxy.log("- opfs.help()");
+          consoleProxy.log("- net.get(url, { headers?, responseType? })");
+          consoleProxy.log("- net.help()");
           consoleProxy.log("- notebooks.help([topic])");
           consoleProxy.log("- notebooks.list([query])");
           consoleProxy.log("- notebooks.get([target]) # omitted target = current UI notebook");
@@ -127,11 +171,13 @@ const SANDBOX_SRC_DOC = `<!doctype html>
             const runner = new Function(
               "console",
               "runme",
+              "opfs",
+              "net",
               "notebooks",
               "help",
               '"use strict"; return (async () => {\\n' + code + '\\n})();',
             );
-            await runner(consoleProxy, runme, notebooks, help);
+            await runner(consoleProxy, runme, opfs, net, notebooks, help);
           } catch (error) {
             exitCode = 1;
             post({ type: "stderr", data: String(error) + "\\n" });
@@ -182,7 +228,7 @@ const SANDBOX_SRC_DOC = `<!doctype html>
       })();
     </script>
   </body>
-</html>`;
+</html>`
 
 /**
  * SandboxJSKernel executes JavaScript in a sandboxed iframe and only exposes a
@@ -190,242 +236,252 @@ const SANDBOX_SRC_DOC = `<!doctype html>
  * window realm directly.
  */
 export class SandboxJSKernel {
-  private readonly hooks: Required<KernelHooks>;
-  private readonly bridge: SandboxBridge;
-  private readonly allowedMethods: Set<string>;
-  private runCounter = 0;
-  private activeRunId: number | null = null;
+  private readonly hooks: Required<KernelHooks>
+  private readonly bridge: SandboxBridge
+  private readonly allowedMethods: Set<string>
+  private runCounter = 0
+  private activeRunId: number | null = null
 
   constructor({
     bridge,
     hooks = {},
     allowedMethods = [
-      "runme.clear",
-      "runme.clearOutputs",
-      "runme.runAll",
-      "runme.rerun",
-      "runme.getCurrentNotebook",
-      "runme.help",
+      'runme.clear',
+      'runme.clearOutputs',
+      'runme.runAll',
+      'runme.rerun',
+      'runme.getCurrentNotebook',
+      'runme.help',
+      'opfs.exists',
+      'opfs.readText',
+      'opfs.writeText',
+      'opfs.readBytes',
+      'opfs.writeBytes',
+      'opfs.list',
+      'opfs.mkdir',
+      'opfs.stat',
+      'opfs.remove',
+      'net.get',
       ...SANDBOX_NOTEBOOKS_API_METHODS,
     ],
   }: {
-    bridge: SandboxBridge;
-    hooks?: KernelHooks;
-    allowedMethods?: string[];
+    bridge: SandboxBridge
+    hooks?: KernelHooks
+    allowedMethods?: string[]
   }) {
-    this.bridge = bridge;
-    this.allowedMethods = new Set(allowedMethods);
+    this.bridge = bridge
+    this.allowedMethods = new Set(allowedMethods)
     this.hooks = {
       onStdout: hooks.onStdout ?? (() => {}),
       onStderr: hooks.onStderr ?? (() => {}),
       onExit: hooks.onExit ?? (() => {}),
-    };
+    }
   }
 
   async run(code: string, options: RunOptions = {}): Promise<void> {
-    const runId = ++this.runCounter;
-    this.activeRunId = runId;
-    let exitCode = 0;
-    let session: SandboxSession | null = null;
-    let disposed = false;
+    const runId = ++this.runCounter
+    this.activeRunId = runId
+    let exitCode = 0
+    let session: SandboxSession | null = null
+    let disposed = false
 
     const disposeSession = () => {
       if (disposed || !session) {
-        return;
+        return
       }
-      disposed = true;
-      session.dispose();
-    };
+      disposed = true
+      session.dispose()
+    }
 
     const stdout = (data: string) => {
       if (this.activeRunId !== runId) {
-        return;
+        return
       }
-      this.hooks.onStdout(data);
-    };
+      this.hooks.onStdout(data)
+    }
     const stderr = (data: string) => {
       if (this.activeRunId !== runId) {
-        return;
+        return
       }
-      this.hooks.onStderr(data);
-    };
+      this.hooks.onStderr(data)
+    }
 
     try {
       if (options.signal?.aborted) {
-        throw new Error("Sandbox JS execution cancelled.");
+        throw new Error('Sandbox JS execution cancelled.')
       }
-      session = await this.createSession();
+      session = await this.createSession()
       if (options.signal?.aborted) {
-        throw new Error("Sandbox JS execution cancelled.");
+        throw new Error('Sandbox JS execution cancelled.')
       }
-      const activeSession = session;
+      const activeSession = session
       await new Promise<void>((resolve, reject) => {
         const abortRun = () => {
-          exitCode = 1;
+          exitCode = 1
           if (this.activeRunId === runId) {
-            this.activeRunId = null;
+            this.activeRunId = null
           }
-          disposeSession();
-          reject(new Error("Sandbox JS execution cancelled."));
-        };
-        options.signal?.addEventListener("abort", abortRun, { once: true });
-        activeSession.port.onmessage = (event: MessageEvent<SandboxMessage>) => {
-          const payload = event.data;
-          if (!payload || typeof payload !== "object") {
-            return;
+          disposeSession()
+          reject(new Error('Sandbox JS execution cancelled.'))
+        }
+        options.signal?.addEventListener('abort', abortRun, { once: true })
+        activeSession.port.onmessage = (
+          event: MessageEvent<SandboxMessage>
+        ) => {
+          const payload = event.data
+          if (!payload || typeof payload !== 'object') {
+            return
           }
           switch (payload.type) {
-            case "stdout":
-              stdout(String(payload.data ?? ""));
-              break;
-            case "stderr":
-              stderr(String(payload.data ?? ""));
-              break;
-            case "host-call":
-              void this.handleHostCall(activeSession.port, payload, runId);
-              break;
-            case "exit":
-              exitCode = Number(payload.exitCode ?? 1);
-              options.signal?.removeEventListener("abort", abortRun);
-              resolve();
-              break;
+            case 'stdout':
+              stdout(String(payload.data ?? ''))
+              break
+            case 'stderr':
+              stderr(String(payload.data ?? ''))
+              break
+            case 'host-call':
+              void this.handleHostCall(activeSession.port, payload, runId)
+              break
+            case 'exit':
+              exitCode = Number(payload.exitCode ?? 1)
+              options.signal?.removeEventListener('abort', abortRun)
+              resolve()
+              break
             default:
-              break;
+              break
           }
-        };
-        activeSession.port.postMessage({ type: "run", code });
-      });
-      disposeSession();
+        }
+        activeSession.port.postMessage({ type: 'run', code })
+      })
+      disposeSession()
     } catch (error) {
-      exitCode = 1;
-      appLogger.error("SandboxJSKernel execution failed", {
+      exitCode = 1
+      appLogger.error('SandboxJSKernel execution failed', {
         attrs: {
-          scope: "appkernel.sandbox",
+          scope: 'appkernel.sandbox',
           error: String(error),
           runId,
           codeLength: code.length,
         },
-      });
-      stderr(`${String(error)}\n`);
+      })
+      stderr(`${String(error)}\n`)
     } finally {
       if (this.activeRunId === runId) {
-        this.activeRunId = null;
+        this.activeRunId = null
       }
-      disposeSession();
-      this.hooks.onExit(exitCode);
+      disposeSession()
+      this.hooks.onExit(exitCode)
     }
   }
 
   private async handleHostCall(
     port: MessagePort,
-    payload: Extract<SandboxMessage, { type: "host-call" }>,
-    runId: number,
+    payload: Extract<SandboxMessage, { type: 'host-call' }>,
+    runId: number
   ): Promise<void> {
-    const callId = Number(payload.callId ?? 0);
-    const method = String(payload.method ?? "");
-    const args = Array.isArray(payload.args) ? payload.args : [];
+    const callId = Number(payload.callId ?? 0)
+    const method = String(payload.method ?? '')
+    const args = Array.isArray(payload.args) ? payload.args : []
 
     if (!callId) {
-      return;
+      return
     }
     if (this.activeRunId !== runId) {
       port.postMessage({
-        type: "host-error",
+        type: 'host-error',
         callId,
-        error: "Sandbox call ignored because the run is no longer active.",
-      });
-      return;
+        error: 'Sandbox call ignored because the run is no longer active.',
+      })
+      return
     }
     if (!this.allowedMethods.has(method)) {
       port.postMessage({
-        type: "host-error",
+        type: 'host-error',
         callId,
         error: `Sandbox method not allowed: ${method}`,
-      });
-      return;
+      })
+      return
     }
 
     try {
-      const result = await this.bridge.call(method, args);
-      port.postMessage({ type: "host-result", callId, result });
+      const result = await this.bridge.call(method, args)
+      port.postMessage({ type: 'host-result', callId, result })
     } catch (error) {
       port.postMessage({
-        type: "host-error",
+        type: 'host-error',
         callId,
         error: String(error),
-      });
+      })
     }
   }
 
   protected async createSession(): Promise<SandboxSession> {
     if (!document?.body) {
-      throw new Error("SandboxJSKernel requires document.body.");
+      throw new Error('SandboxJSKernel requires document.body.')
     }
 
-    const iframe = document.createElement("iframe");
-    iframe.setAttribute("sandbox", "allow-scripts");
-    iframe.setAttribute("aria-hidden", "true");
-    iframe.style.display = "none";
-    iframe.srcdoc = SANDBOX_SRC_DOC;
+    const iframe = document.createElement('iframe')
+    iframe.setAttribute('sandbox', 'allow-scripts')
+    iframe.setAttribute('aria-hidden', 'true')
+    iframe.style.display = 'none'
+    iframe.srcdoc = SANDBOX_SRC_DOC
 
     await new Promise<void>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        reject(new Error("Timed out waiting for sandbox iframe to load."));
-      }, LOAD_TIMEOUT_MS);
+        reject(new Error('Timed out waiting for sandbox iframe to load.'))
+      }, LOAD_TIMEOUT_MS)
       iframe.onload = () => {
-        clearTimeout(timeoutId);
-        resolve();
-      };
+        clearTimeout(timeoutId)
+        resolve()
+      }
       iframe.onerror = () => {
-        clearTimeout(timeoutId);
-        reject(new Error("Failed to load sandbox iframe."));
-      };
-      document.body.appendChild(iframe);
-    });
+        clearTimeout(timeoutId)
+        reject(new Error('Failed to load sandbox iframe.'))
+      }
+      document.body.appendChild(iframe)
+    })
 
     if (!iframe.contentWindow) {
-      iframe.remove();
-      throw new Error("Sandbox iframe content window is unavailable.");
+      iframe.remove()
+      throw new Error('Sandbox iframe content window is unavailable.')
     }
 
-    const channel = new MessageChannel();
-    const hostPort = channel.port1;
-    hostPort.start();
+    const channel = new MessageChannel()
+    const hostPort = channel.port1
+    hostPort.start()
 
     await new Promise<void>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        reject(new Error("Timed out waiting for sandbox iframe readiness."));
-      }, READY_TIMEOUT_MS);
+        reject(new Error('Timed out waiting for sandbox iframe readiness.'))
+      }, READY_TIMEOUT_MS)
 
       const onReady = (event: MessageEvent<SandboxMessage>) => {
-        const payload = event.data;
-        if (!payload || payload.type !== "ready") {
-          return;
+        const payload = event.data
+        if (!payload || payload.type !== 'ready') {
+          return
         }
-        clearTimeout(timeoutId);
-        hostPort.removeEventListener("message", onReady as EventListener);
-        resolve();
-      };
-      hostPort.addEventListener("message", onReady as EventListener);
-      iframe.contentWindow.postMessage(
-        { type: SANDBOX_INIT_MESSAGE },
-        "*",
-        [channel.port2],
-      );
-    });
+        clearTimeout(timeoutId)
+        hostPort.removeEventListener('message', onReady as EventListener)
+        resolve()
+      }
+      hostPort.addEventListener('message', onReady as EventListener)
+      iframe.contentWindow.postMessage({ type: SANDBOX_INIT_MESSAGE }, '*', [
+        channel.port2,
+      ])
+    })
 
     return {
       iframe,
       port: hostPort,
       dispose: () => {
-        hostPort.onmessage = null;
+        hostPort.onmessage = null
         try {
-          hostPort.close();
+          hostPort.close()
         } catch {
           // no-op
         }
-        iframe.remove();
+        iframe.remove()
       },
-    };
+    }
   }
 }

--- a/docs-dev/design/20260415_agentic_search.md
+++ b/docs-dev/design/20260415_agentic_search.md
@@ -1,0 +1,618 @@
+# 20260415 Agentic Search
+
+## Status
+
+Draft proposal.
+
+## Summary
+
+Add low-level browser capabilities to the `codex-wasm` harness so the agent
+can answer questions about Runme by fetching public Runme sources from GitHub,
+caching them locally, and searching those cached files with a workflow that
+feels closer to `ripgrep` (`rg`) than to semantic retrieval.
+
+The v0 platform should provide:
+
+- policy-governed `fetch` for remote reads,
+- policy-governed OPFS primitives for local persistence,
+- enough browser runtime context for the agent to write JavaScript that fetches
+  manifests, downloads files, persists them, and searches them,
+- a path for the agent to retain reusable snippets and patterns via memory.
+
+The key design choice is to separate:
+
+1. low-level sandbox capabilities,
+2. policy over those capabilities,
+3. optional higher-level SDKs that may emerge later.
+
+This document now recommends shipping the low-level capability substrate first
+and deferring bespoke search SDK design until we see what patterns the agent
+actually converges on.
+
+## Problem
+
+Today the browser-local agent harness can execute code in sandboxed AppKernel,
+but it does not have a strong way to answer "How does Runme work?" or "Where is
+X implemented?" by consulting the Runme docs and codebase.
+
+For `codex-wasm`, we want something closer to Codex searching a local checkout:
+
+1. find candidate files quickly,
+2. show path + snippet + line context,
+3. open the best file for deeper inspection,
+4. avoid repeatedly downloading the same corpus.
+
+The browser environment changes a few constraints:
+
+- the corpus is remote and must be fetched,
+- the cache must live in browser storage,
+- we should not assume shell access or the `ripgrep` (`rg`) binary,
+- the agent still needs concrete instructions about which sources exist and how
+  to query them.
+
+## Goals
+
+- Let `codex-wasm` answer Runme product and implementation questions using
+  Runme docs and source.
+- Support at least the public `runmedev/web` repository in v0.
+- Expose low-level browser capabilities that let sandboxed agent-authored code
+  fetch, persist, and search corpus data without human approval inside policy.
+- Cache fetched text locally in the browser.
+- Return or derive stable source URIs, file paths, and snippets.
+- Make policy the primary control point for safety.
+- Make the storage and search design compatible with future private or
+  user-mounted corpora.
+- Leave room for higher-level SDKs once real agent usage shows which
+  abstractions are worth standardizing.
+
+## Non-Goals
+
+- No mutation of remote GitHub content.
+- No semantic/vector retrieval system in v0.
+- No unrestricted network or filesystem access outside policy.
+- No attempt to mirror every Git object or preserve a full local git checkout.
+- No general web crawler in v0.
+- No requirement to design a bespoke host-provided search SDK before the agent
+  can search.
+
+## Initial Corpus Scope
+
+For v0, the initial unattended corpus should be the public `runmedev/web`
+repository at `main`.
+
+This is not meant to introduce a new host-owned source abstraction. It is
+simply the initial policy/config choice for what the sandboxed agent is allowed
+to fetch and cache without approval.
+
+Recommended scope:
+
+- GitHub tree manifests under `https://api.github.com/repos/runmedev/web/`
+- raw file content under `https://raw.githubusercontent.com/runmedev/web/main/`
+
+with an allowlist roughly like:
+
+- `docs/**`
+- `docs-dev/**`
+- `app/src/**`
+- `packages/**`
+- top-level text files such as `README*`, `AGENTS.md`, `package.json`,
+  `pnpm-lock.yaml`
+
+and excludes for:
+
+- `node_modules/**`
+- generated protobuf output where not useful for product questions
+- binary assets, large media, and build output
+
+This keeps the first corpus aligned with the questions we expect users to ask
+about Runme while avoiding low-value files, without requiring a broader
+source-root abstraction in v0.
+
+## Minimum Low-Level Capability
+
+The transport primitive can be plain HTTP `GET`, but raw blob `GET` alone is
+not enough to recurse a repository.
+
+There are two cases:
+
+1. `GET` against a known file URL such as
+   `raw.githubusercontent.com/.../path/to/file.md` is sufficient to fetch one
+   blob.
+2. To crawl a repo, the runtime also needs a `GET`-addressable manifest or tree
+   endpoint that lists paths under a revision.
+
+So the correct answer is:
+
+- `GET` is sufficient as a transport primitive,
+- but only if the runtime can call endpoints that return directory/tree
+  metadata,
+- and only if the host already knows how to turn those results into file fetch
+  URLs.
+
+For GitHub public repos, the runtime should use:
+
+- a tree/contents manifest endpoint to enumerate files at a ref,
+- raw file fetch URLs to fetch file contents.
+
+The model should not be asked to discover GitHub URL conventions or recurse an
+HTML directory listing on its own.
+
+### GitHub tree enumeration details
+
+For v0, the preferred enumeration endpoint is the GitHub Git Trees API:
+
+```text
+GET https://api.github.com/repos/{owner}/{repo}/git/trees/{ref}?recursive=1
+```
+
+Example:
+
+```text
+GET https://api.github.com/repos/runmedev/web/git/trees/main?recursive=1
+```
+
+Important behavior:
+
+- with `recursive=1`, the response includes descendants under the requested
+  tree,
+- entries with `type: "blob"` are files,
+- entries with `type: "tree"` are directories,
+- for `blob` entries, `path` is already the canonical repo-relative file path.
+
+Example `blob` entry:
+
+```json
+{
+  "path": "docs/design/20260331_remove_chatkit_responses_runme_converter.md",
+  "mode": "100644",
+  "type": "blob",
+  "sha": "...",
+  "url": "https://api.github.com/repos/runmedev/web/git/blobs/..."
+}
+```
+
+In this case, the canonical repo-relative file path is simply:
+
+```text
+docs/design/20260331_remove_chatkit_responses_runme_converter.md
+```
+
+The runtime should persist that `path` value directly in search metadata.
+
+If the runtime uses a non-recursive tree response instead, then each `tree`
+entry represents a directory. In that mode, full file paths must be built by
+recursing into child tree URLs and joining parent `path` values with descendant
+paths. We should avoid that extra complexity in v0 unless the recursive tree
+response is truncated.
+
+For content fetches, prefer raw GitHub URLs built from the repo, ref, and
+repo-relative `path`:
+
+```text
+https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}
+```
+
+Example:
+
+```text
+https://raw.githubusercontent.com/runmedev/web/main/docs/design/20260331_remove_chatkit_responses_runme_converter.md
+```
+
+The `url` field in the tree response is a Git object API URL, not the
+canonical file path and not the preferred file-content URL for this design.
+
+## Capability Layers
+
+This design should separate three layers.
+
+### 1) Sandbox primitives
+
+These are the low-level capabilities available to sandboxed AI-generated
+JavaScript without human approval, subject to policy.
+
+Recommended v0 primitives:
+
+- `fetch` for remote reads
+- OPFS file and directory operations
+- structured `postMessage` bridges that implement those primitives inside the
+  existing sandbox kernel
+
+Representative OPFS-oriented API shape:
+
+```ts
+type OpfsApi = {
+  readText(path: string): Promise<string>;
+  writeText(path: string, text: string): Promise<void>;
+  readBytes(path: string): Promise<Uint8Array>;
+  writeBytes(path: string, bytes: Uint8Array): Promise<void>;
+  list(path: string): Promise<Array<{ name: string; kind: "file" | "directory" }>>;
+  mkdir(path: string): Promise<void>;
+  stat(path: string): Promise<{ kind: "file" | "directory"; size?: number; mtime?: string }>;
+  remove(path: string, options?: { recursive?: boolean }): Promise<void>;
+};
+
+type FetchApi = {
+  fetch(input: string, init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string | Uint8Array;
+  }): Promise<{
+    ok: boolean;
+    status: number;
+    headers: Record<string, string>;
+    text?: string;
+    bytes?: Uint8Array;
+  }>;
+};
+```
+
+These are intentionally low-level. They are enough for the agent to:
+
+1. fetch a GitHub tree manifest,
+2. iterate over entries,
+3. fetch individual files,
+4. persist them in OPFS,
+5. build its own lexical scan or local index in JavaScript.
+
+### 2) Policy
+
+Policy is the primary safety boundary.
+
+For this design, policy should answer:
+
+- which HTTP methods are allowed without approval,
+- which URI prefixes/domains are allowed,
+- what response size, timeout, and content-type limits apply,
+- which OPFS paths are writable,
+- which operations require approval.
+
+Example v0 policy posture:
+
+- allow `GET` to:
+  - `https://api.github.com/repos/runmedev/web/`
+  - `https://raw.githubusercontent.com/runmedev/web/`
+- deny or require approval for `POST`, `PUT`, `PATCH`, `DELETE`
+- allow OPFS reads/writes under a harness-owned prefix such as
+  `/agent-cache/runmedev-web/`
+- enforce maximum response size and per-file size limits
+
+This is the right place to control exfiltration risk. The question is not
+whether the agent has raw primitives; the question is what those primitives are
+allowed to touch without approval.
+
+### 3) Higher-level SDKs
+
+Higher-level helpers may still be useful, but they are a separate decision.
+
+Examples:
+
+- a GitHub tree walker,
+- a blob cache helper,
+- a line-index builder,
+- a lexical search helper,
+- a refresh/checkpoint helper.
+
+This document does not recommend requiring those SDKs in v0. The initial
+expectation should be that the agent writes JavaScript using the low-level
+primitives above, and that reusable patterns can later be standardized once we
+observe what the agent actually needs.
+
+## Recommended GitHub Retrieval Flow
+
+Rather than expose a bespoke host search service immediately, v0 should assume
+the agent writes JavaScript that performs the following flow:
+
+1. fetch the GitHub recursive tree manifest for the target ref,
+2. filter entries to `type === "blob"` and allowed paths,
+3. derive raw content URLs from `{owner, repo, ref, path}`,
+4. fetch file contents,
+5. write normalized blobs into OPFS,
+6. scan cached blobs lexically or build a local index over them.
+
+That keeps the platform substrate small while still supporting rich retrieval
+behaviors.
+
+## Browser Storage Design
+
+Use a hybrid layout:
+
+- IndexedDB via Dexie for metadata, manifests, and optional index tables.
+- OPFS for raw normalized blob bodies, derived artifacts, and agent-authored
+  cache state.
+
+This fits the existing repo shape:
+
+- the web app already uses Dexie-backed stores such as
+  `runme-local-notebooks` and `runme-fs-workspaces`,
+- the app already has `ensurePersistentStorage()` for requesting persistent
+  browser storage,
+- OPFS gives better behavior for larger file-like blobs than storing every body
+  directly inside IndexedDB rows.
+
+For this design, OPFS is not hidden from the agent behind a host-owned search
+service. OPFS is part of the substrate the sandboxed agent uses to persist its
+own cache and derived files.
+
+### Proposed Local Schema
+
+```ts
+type SearchBlobRecord = {
+  uri: string;           // e.g. github://runmedev/web/main/app/src/...
+  rootId: string;
+  path: string;
+  revision: string;
+  sha?: string;
+  sizeBytes: number;
+  fetchedAt: string;
+  contentType: string;
+  bodyKey: string;       // OPFS path or content-addressed key
+  lineIndexKey?: string; // optional derived line-offset table
+};
+
+type SearchRootStateRecord = {
+  id: string;
+  title: string;
+  kind: string;
+  revision?: string;
+  syncedAt?: string;
+  lastSyncError?: string;
+};
+```
+
+Recommended layout:
+
+- Dexie table `searchRoots`
+- Dexie table `searchBlobs`
+- OPFS directory `search-blobs/`
+- OPFS directory `search-derived/`
+- OPFS directory `search-memories/` or similar scratch area for reusable
+  agent-authored helper code if we decide to persist snippets locally
+
+If OPFS is unavailable, fall back to storing small bodies in IndexedDB so the
+feature still works, just less efficiently.
+
+### OPFS API surface
+
+At the browser level, OPFS is reached through:
+
+- `navigator.storage.getDirectory()`
+
+which returns a `FileSystemDirectoryHandle` for the origin-private root. The
+underlying platform APIs include:
+
+- `getDirectoryHandle(...)`
+- `getFileHandle(...)`
+- `entries()`, `keys()`, `values()`
+- `removeEntry(...)`
+- `FileSystemFileHandle.getFile()`
+- `FileSystemFileHandle.createWritable()`
+- `FileSystemFileHandle.createSyncAccessHandle()` in dedicated workers
+
+The sandbox kernel does not need to expose those browser objects directly. It
+can expose a simpler RPC-style OPFS API over `postMessage` that maps onto them.
+
+## Search Strategy
+
+### V0: Ripgrep-Style Scan Over Cached Blobs
+
+Do not make a full-text index a prerequisite for v0.
+
+For the first corpus size, agent-authored JavaScript running in the browser can
+scan cached text blobs fast enough if we keep the corpus narrow and text-only.
+This is closer to the `ripgrep` mental model the user already has:
+
+- query a cached corpus,
+- return file/line/snippet matches,
+- open the file if needed.
+
+Implementation outline:
+
+1. fetch and maintain normalized text blobs,
+2. maintain per-file line offsets or compute them on demand,
+3. execute substring or regex search in a worker-friendly loop,
+4. collect top matches,
+5. rank by:
+   - exact path/name hits first,
+   - then exact text matches,
+   - then shorter path distance and fresher files.
+
+This avoids premature complexity and gives us a direct baseline for latency.
+
+### V1: Optional Incremental Local Index
+
+If warm-cache search latency is not good enough, add an incremental inverted
+index over the same blob corpus.
+
+Recommended first index shape:
+
+- tokenize normalized text into lowercase terms,
+- store `(term -> [uri, positions])` postings in IndexedDB,
+- optionally add a trigram index for substring queries.
+
+We should not start with embeddings or vector search. The dominant query style
+for code/docs lookup is still lexical:
+
+- API names,
+- config keys,
+- file names,
+- URLs,
+- feature labels,
+- exact phrases from errors or UI text.
+
+## Sync and Freshness Model
+
+The runtime should support revision-aware caches per root, but v0 should assume
+the first cache manager is agent-authored JavaScript running on top of the
+low-level primitives.
+
+Recommended policy:
+
+1. on first use, sync the root manifest,
+2. fetch blobs lazily as the agent searches/opens,
+3. opportunistically prefetch high-value files under `docs/`, `docs-dev/`, and
+   `README*`,
+4. on later turns, compare the root revision and only refetch changed files.
+
+For GitHub-backed roots, the cache key should include:
+
+- repo identity,
+- ref or resolved commit SHA,
+- path,
+- blob SHA when available.
+
+Agent-authored search code should preserve freshness metadata so the agent can
+say whether it searched cached data from a specific sync time or revision.
+
+## Query UX for the Agent
+
+The derived search results should look like a code search tool, not like
+document retrieval.
+
+Example result:
+
+```json
+{
+  "matches": [
+    {
+      "uri": "github://runmedev/web/main/app/src/lib/runtime/codexWasmSession.ts",
+      "rootId": "github://runmedev/web?ref=main",
+      "path": "app/src/lib/runtime/codexWasmSession.ts",
+      "line": 16,
+      "snippet": "const RUNME_CODE_MODE_PROMPT_PREFIX = ["
+    }
+  ]
+}
+```
+
+This is the important behavioral point: the model should search by terms that
+look like how engineers search locally, even if the initial implementation is a
+library the agent writes for itself rather than a built-in host tool.
+
+Examples:
+
+- search for `"codex wasm prompt"` under cached `app/src/**`
+- search for `"ExecuteCode"` under cached `app/src/**`
+- search for `"Runme public docs"` under cached `docs/**`
+
+## Codex WASM Harness Integration
+
+For this design, the important integration point is not a native search tool.
+It is the low-level capability bridge exposed to sandboxed JavaScript in the
+`codex-wasm` harness.
+
+Rationale:
+
+- safety is controlled by policy over the bridge,
+- the agent can evolve its own retrieval code rather than waiting for bespoke
+  host SDKs,
+- the same substrate can later support more than GitHub search,
+- AppKernel code mode remains the place where agent-authored JS runs.
+
+Recommended layering:
+
+1. `codex-wasm` exposes low-level `fetch` + OPFS capabilities into sandboxed
+   code mode.
+2. Policy enforcement happens at the kernel/bridge boundary.
+3. Agent-authored JS performs crawl/cache/search work.
+4. Later host SDKs remain optional and can be added once justified by usage.
+
+## System and User Instruction Shape
+
+The harness should tell Codex three things clearly:
+
+1. what low-level capabilities exist,
+2. what policy boundaries apply,
+3. what known corpora or URL patterns are expected.
+
+Recommended system prompt addition:
+
+```text
+You are operating inside the Runme app ChatKit panel in a browser.
+Sandboxed JavaScript can make policy-approved fetch requests and can persist
+files in origin-private browser storage. Use those capabilities to fetch Runme
+source manifests and files, cache them locally, and search them lexically when
+the user asks how Runme works, where a feature is implemented, or what a Runme
+document says.
+
+Allowed sources for unattended reads include:
+- https://api.github.com/repos/runmedev/web/
+- https://raw.githubusercontent.com/runmedev/web/
+
+Persist reusable cache state under the approved OPFS prefix. Preserve revision
+and path metadata so you can explain freshness and provenance in your answer.
+```
+
+If we add more allowed corpora later, include them explicitly in the prompt and
+policy configuration rather than expecting the model to infer them.
+
+The user-facing prompt does not need to teach OPFS internals, but the system
+prompt should make the runtime capability model explicit.
+
+## V0 Recommendation
+
+For the first version, do the following:
+
+1. Expose policy-governed `fetch` primitives to sandboxed JS.
+2. Expose policy-governed OPFS primitives to sandboxed JS.
+3. Add policy for unattended `GET` access to the relevant GitHub endpoints for
+   `runmedev/web`.
+4. Request persistent browser storage when available.
+5. Seed the system prompt with the approved URL prefixes and cache/freshness
+   expectations.
+6. Expect the agent to write JS that fetches the GitHub tree manifest, downloads
+   files, writes them to OPFS, and searches them lexically.
+7. Invest early in browser/Codex memory so the agent can retain and reuse those
+   snippets rather than rediscovering them every session.
+
+This is enough to answer "what is Runme?", "where is codex-wasm implemented?",
+"what do the design docs say about Drive agentic search?", and similar
+questions without introducing a full search engine or bespoke retrieval SDK
+first.
+
+## Why This Is Better Than Starting With an Index
+
+The strongest argument for this design is that it gives us the right capability
+surface early:
+
+- explicit safety and policy boundaries,
+- a reusable browser substrate for fetch + persistence,
+- room for the agent to evolve retrieval code,
+- prompt instructions aligned with the actual runtime.
+
+If we start by designing an index or a host-owned search SDK before we have
+those pieces, we risk solving the wrong problem. `ripgrep` is effective because
+lexical search over files is a strong workflow; the browser equivalent should
+first make that workflow possible.
+
+## Open Questions
+
+- Should v0 policy allow only `runmedev/web`, or should it include another
+  public Runme repo?
+- Do we want background warmup for high-value files on app load, or only after
+  the first Runme-related question?
+- Should the initial agent-authored search library support regex in v0, or
+  should it start with substring plus path filtering only?
+- Is revision checking done on every turn, or only when the user explicitly
+  asks for refresh/current data?
+- What memory mechanism should Codex/browser use to preserve reusable
+  crawl/cache/search snippets across sessions?
+- At what point should agent-evolved patterns graduate into first-class SDKs or
+  tools owned by the host runtime?
+
+## Implementation Sketch
+
+1. Add sandbox-kernel RPCs for policy-governed `fetch`.
+2. Add sandbox-kernel RPCs for policy-governed OPFS operations.
+3. Add policy configuration for allowed GitHub URL prefixes, methods, and size
+   limits.
+4. Add Dexie metadata tables for manifests and cached blobs.
+5. Add an OPFS-backed cache layout for fetched blob bodies and derived files.
+6. Extend the `codex-wasm` prompt prefix with the capability/policy guidance.
+7. Build or enable a memory path for Codex/browser to retain reusable
+   crawl/cache/search snippets.
+
+## References
+
+- [20260403 Drive Agentic Search](/Users/jlewi/code/runmecodex/web/docs-dev/design/20260403_drive_agentic_search.md)
+- [20260414 Codex WASM Harness](/Users/jlewi/code/runmecodex/web/docs-dev/design/20260414_codex_wasm.md)
+- [20260331 Code Mode](/Users/jlewi/code/runmecodex/web/docs-dev/design/20260331_code_mode.md)

--- a/docs-dev/design/20260415_agentic_search.md
+++ b/docs-dev/design/20260415_agentic_search.md
@@ -13,8 +13,8 @@ feels closer to `ripgrep` (`rg`) than to semantic retrieval.
 
 The v0 platform should provide:
 
-- policy-governed `fetch` for remote reads,
-- policy-governed OPFS primitives for local persistence,
+- `GET`-oriented network reads for remote fetches,
+- OPFS primitives for local persistence,
 - enough browser runtime context for the agent to write JavaScript that fetches
   manifests, downloads files, persists them, and searches them,
 - a path for the agent to retain reusable snippets and patterns via memory.
@@ -50,13 +50,90 @@ The browser environment changes a few constraints:
 - the agent still needs concrete instructions about which sources exist and how
   to query them.
 
+## Background
+
+### What native Codex already does
+
+In the native Codex codebase, project-level instructions are pulled from
+`AGENTS.md` files and appended to the user instructions. The implementation is
+in [`project_doc.rs`](/Users/jlewi/code/codex/codex-rs/core/src/project_doc.rs).
+It walks from repo root to cwd, reads `AGENTS.md`, and injects that text into
+the prompt.
+
+Native Codex also exposes general-purpose tools such as shell/command tools and
+optionally `js_repl`. The `js_repl` instructions explicitly tell the model to
+use `codex.tool(...)` to call normal tools, including shell tools, from inside
+JavaScript.
+
+That means native Codex usually gets filesystem context in one of three ways:
+
+- prompt context from `AGENTS.md`,
+- shell-style inspection of the local checkout with tools like `rg`, `find`,
+  `sed`, and `cat`,
+- JavaScript that calls those tools through `codex.tool(...)` when `js_repl` is
+  enabled.
+
+There is a `codex-file-search` crate in the Codex repo, but it is currently
+used for fuzzy file search in the TUI and app-server UI flows. It is not the
+primary model-facing filesystem retrieval mechanism that the browser harness can
+simply inherit.
+
+### What the current WASM harness actually does
+
+The current browser harness in
+[`codex-rs/wasm-harness/src/browser.rs`](/Users/jlewi/code/codex/codex-rs/wasm-harness/src/browser.rs)
+starts a real `CodexThread` and injects one browser-side code executor. The
+browser-facing API is:
+
+- `new BrowserCodex(apiKey)`
+- `set_api_key(...)`
+- `set_code_executor(...)`
+- `submit_turn(prompt, on_event)`
+
+Important current limitations:
+
+- the WASM build does not automatically read project docs; the wasm variant in
+  [`project_doc_wasm.rs`](/Users/jlewi/code/codex/codex-rs/core/src/project_doc_wasm.rs)
+  returns `None`,
+- the exec-server filesystem implementation on wasm is unsupported,
+- nested code-mode tools are disabled on wasm because
+  `build_enabled_tools(...)` returns an empty list under `#[cfg(target_arch =
+  "wasm32")]`.
+
+So the browser harness does not currently inherit desktop Codex's filesystem
+or shell-oriented retrieval surface. We have to provide that browser runtime
+context ourselves.
+
+### What output Code Mode returns to the model
+
+In the WASM harness, the JS executor returns JSON of the form:
+
+```json
+{
+  "output": "...",
+  "stored_values": {},
+  "error_text": null
+}
+```
+
+`BrowserCodeModeRuntime` turns `output` into a
+`FunctionCallOutputContentItem::InputText`, and Codex prepends a status header
+such as `Script completed` and wall time before sending the tool result back to
+the model.
+
+In the current Runme integration, that `output` string comes from
+[`codeModeExecutor.ts`](/Users/jlewi/code/runmecodex/web/app/src/lib/runtime/codeModeExecutor.ts),
+which captures stdout and stderr from the sandbox JS kernel and returns one
+merged output string. In practice, that means code-mode output is effectively
+"whatever the code printed to stdout/stderr", plus the Codex status wrapper.
+
 ## Goals
 
 - Let `codex-wasm` answer Runme product and implementation questions using
   Runme docs and source.
 - Support at least the public `runmedev/web` repository in v0.
 - Expose low-level browser capabilities that let sandboxed agent-authored code
-  fetch, persist, and search corpus data without human approval inside policy.
+  fetch, persist, and search corpus data without human approval in v0.
 - Cache fetched text locally in the browser.
 - Return or derive stable source URIs, file paths, and snippets.
 - Make policy the primary control point for safety.
@@ -75,21 +152,75 @@ The browser environment changes a few constraints:
 - No requirement to design a bespoke host-provided search SDK before the agent
   can search.
 
-## Initial Corpus Scope
+## Proposal
+
+### Overview
+
+For v0, we should assume the agent answers Runme questions by writing
+JavaScript in AppKernel against low-level browser APIs, not by calling a
+host-owned search SDK.
+
+The intended flow for a question such as "How do you configure a runner in
+Runme?" is:
+
+1. The harness prompt tells the agent that public Runme source lives in
+   `runmedev/web` and that cached repos should be laid out in OPFS under
+   `/code/${ORG}/${REPO}`.
+2. The agent writes JS that checks whether `/code/runmedev/web` already exists
+   in OPFS.
+3. If the repo is missing or stale, the agent uses policy-approved network reads
+   to fetch the GitHub tree manifest for `runmedev/web@main`, iterates the
+   returned `blob` entries, fetches relevant files, and writes them into
+   `/code/runmedev/web/...`.
+4. The agent writes JS that recursively walks files under that cached tree,
+   applies lexical matching with JavaScript regexes or substring checks, and
+   finds relevant sections in docs and source.
+5. The agent prints or otherwise returns the matched snippets and paths through
+   code-mode output.
+6. Codex then uses those snippets as immediate working context to answer the
+   user's question.
+
+For the runner example, the agent should search terms such as:
+
+- `runner`
+- `runnerName`
+- `runme.dev/runnerName`
+- `configure runner`
+- `AppKernel`
+
+and inspect the matching docs/source before answering.
+
+The explicit v0 posture is:
+
+- expose low-level OPFS and network primitives,
+- let the agent author the crawl/cache/search code it needs,
+- defer higher-level SDK functions until later.
+
+We should be explicit about why we are deferring higher-level SDKs: the desired
+end state is that the AI learns the patterns it needs, retains reusable code via
+memories or snippets, and only later graduates the most stable patterns into
+host-owned abstractions.
+
+### Initial Corpus and OPFS Layout
 
 For v0, the initial unattended corpus should be the public `runmedev/web`
 repository at `main`.
 
-This is not meant to introduce a new host-owned source abstraction. It is
-simply the initial policy/config choice for what the sandboxed agent is allowed
-to fetch and cache without approval.
+We should assume the agent caches repos in OPFS under a layout like:
 
-Recommended scope:
+```text
+/code/runmedev/web/
+```
 
-- GitHub tree manifests under `https://api.github.com/repos/runmedev/web/`
-- raw file content under `https://raw.githubusercontent.com/runmedev/web/main/`
+That directory should contain a repo-like mirror of fetched files, for example:
 
-with an allowlist roughly like:
+```text
+/code/runmedev/web/docs/...
+/code/runmedev/web/docs-dev/...
+/code/runmedev/web/app/src/...
+```
+
+Recommended include scope:
 
 - `docs/**`
 - `docs-dev/**`
@@ -98,48 +229,109 @@ with an allowlist roughly like:
 - top-level text files such as `README*`, `AGENTS.md`, `package.json`,
   `pnpm-lock.yaml`
 
-and excludes for:
+Recommended excludes:
 
 - `node_modules/**`
 - generated protobuf output where not useful for product questions
 - binary assets, large media, and build output
 
-This keeps the first corpus aligned with the questions we expect users to ask
-about Runme while avoiding low-value files, without requiring a broader
-source-root abstraction in v0.
+This keeps the first corpus aligned with likely user questions while keeping
+search and sync cost bounded.
 
-## Minimum Low-Level Capability
+### Low-Level APIs in AppKernel
+
+The low-level AppKernel/browser substrate for this design should be:
+
+1. a subset of OPFS
+2. a network read API, either raw `fetch` or a thin `GET`-oriented wrapper
+
+Representative API shape:
+
+```ts
+type OpfsApi = {
+  exists(path: string): Promise<boolean>;
+  readText(path: string): Promise<string>;
+  writeText(path: string, text: string): Promise<void>;
+  readBytes(path: string): Promise<Uint8Array>;
+  writeBytes(path: string, bytes: Uint8Array): Promise<void>;
+  list(path: string): Promise<Array<{ name: string; kind: "file" | "directory" }>>;
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  stat(path: string): Promise<{ kind: "file" | "directory"; size?: number; mtime?: string }>;
+  remove(path: string, options?: { recursive?: boolean }): Promise<void>;
+};
+
+type NetworkApi = {
+  get(url: string, options?: {
+    headers?: Record<string, string>;
+    responseType?: "text" | "bytes" | "json";
+  }): Promise<{
+    ok: boolean;
+    status: number;
+    headers: Record<string, string>;
+    text?: string;
+    bytes?: Uint8Array;
+    json?: unknown;
+  }>;
+};
+```
+
+This `OpfsApi` is intentionally **not** the native browser OPFS API. Native
+OPFS is handle-based:
+
+- `navigator.storage.getDirectory()`
+- `FileSystemDirectoryHandle.getDirectoryHandle(...)`
+- `FileSystemDirectoryHandle.getFileHandle(...)`
+- `FileSystemFileHandle.getFile()`
+- `FileSystemFileHandle.createWritable()`
+
+It does not provide direct path-based helpers such as `exists(path)`,
+`readText(path)`, or `mkdir(path, { recursive: true })`. Those are convenience
+operations we would implement on top of the native handle API.
+
+If raw `fetch` is easier to wire than a thin `get(...)` wrapper, raw `fetch` is
+acceptable. The more important point is that the API is policy-governed and
+available inside AppKernel code mode.
+
+For v0, these APIs should be enough. We do not need a hand-crafted cache/search
+SDK before the agent can operate.
+
+We should implement this path-based API in both:
+
+- the Sandbox Kernel
+- the browser-mode kernel
+
+so that the same AppKernel JavaScript can run in either mode without branching
+on the storage implementation.
+
+### Policy
+
+For v0, we should keep policy simple:
+
+- all OPFS operations are assumed safe for the AI agent
+- all HTTP `GET` requests are assumed safe
+
+That is enough to support the initial crawl/cache/search workflow without
+introducing a more complicated policy system up front.
+
+In the future, we can define and enforce a richer policy mechanism covering
+things such as:
+
+- allowed HTTP methods
+- allowed URI prefixes/domains
+- response size, timeout, and content-type limits
+- writable OPFS namespaces
+- operations that require approval
+
+For now, this proposal assumes the low-level substrate is broadly available and
+that stricter enforcement is a follow-on design.
+
+### GitHub Fetch Flow
 
 The transport primitive can be plain HTTP `GET`, but raw blob `GET` alone is
-not enough to recurse a repository.
+not enough to recurse a repository. To crawl a repo, the agent also needs a
+tree or manifest endpoint that it can fetch over `GET`.
 
-There are two cases:
-
-1. `GET` against a known file URL such as
-   `raw.githubusercontent.com/.../path/to/file.md` is sufficient to fetch one
-   blob.
-2. To crawl a repo, the runtime also needs a `GET`-addressable manifest or tree
-   endpoint that lists paths under a revision.
-
-So the correct answer is:
-
-- `GET` is sufficient as a transport primitive,
-- but only if the runtime can call endpoints that return directory/tree
-  metadata,
-- and only if the host already knows how to turn those results into file fetch
-  URLs.
-
-For GitHub public repos, the runtime should use:
-
-- a tree/contents manifest endpoint to enumerate files at a ref,
-- raw file fetch URLs to fetch file contents.
-
-The model should not be asked to discover GitHub URL conventions or recurse an
-HTML directory listing on its own.
-
-### GitHub tree enumeration details
-
-For v0, the preferred enumeration endpoint is the GitHub Git Trees API:
+For GitHub public repos, the preferred enumeration endpoint is:
 
 ```text
 GET https://api.github.com/repos/{owner}/{repo}/git/trees/{ref}?recursive=1
@@ -153,8 +345,6 @@ GET https://api.github.com/repos/runmedev/web/git/trees/main?recursive=1
 
 Important behavior:
 
-- with `recursive=1`, the response includes descendants under the requested
-  tree,
 - entries with `type: "blob"` are files,
 - entries with `type: "tree"` are directories,
 - for `blob` entries, `path` is already the canonical repo-relative file path.
@@ -171,22 +361,19 @@ Example `blob` entry:
 }
 ```
 
-In this case, the canonical repo-relative file path is simply:
+In this case, the canonical repo-relative file path is:
 
 ```text
 docs/design/20260331_remove_chatkit_responses_runme_converter.md
 ```
 
-The runtime should persist that `path` value directly in search metadata.
+The agent should use that `path` when writing the file into OPFS:
 
-If the runtime uses a non-recursive tree response instead, then each `tree`
-entry represents a directory. In that mode, full file paths must be built by
-recursing into child tree URLs and joining parent `path` values with descendant
-paths. We should avoid that extra complexity in v0 unless the recursive tree
-response is truncated.
+```text
+/code/runmedev/web/docs/design/20260331_remove_chatkit_responses_runme_converter.md
+```
 
-For content fetches, prefer raw GitHub URLs built from the repo, ref, and
-repo-relative `path`:
+For content fetches, prefer raw GitHub URLs built from repo, ref, and path:
 
 ```text
 https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}
@@ -198,418 +385,179 @@ Example:
 https://raw.githubusercontent.com/runmedev/web/main/docs/design/20260331_remove_chatkit_responses_runme_converter.md
 ```
 
-The `url` field in the tree response is a Git object API URL, not the
-canonical file path and not the preferred file-content URL for this design.
+The `url` field in the tree response is a Git object API URL, not the preferred
+file-content URL for this design.
 
-## Capability Layers
+### Ripgrep-Style Search Workflow
 
-This design should separate three layers.
+The intended search behavior is lexical and file-oriented, closer to `ripgrep`
+than to vector retrieval.
 
-### 1) Sandbox primitives
+In practice, the agent should:
 
-These are the low-level capabilities available to sandboxed AI-generated
-JavaScript without human approval, subject to policy.
+1. recursively walk files under `/code/runmedev/web/`,
+2. filter by path patterns if useful,
+3. read file contents,
+4. apply JavaScript lexical matching using `RegExp`, substring matching, or
+   other JS/TS libraries when needed,
+5. collect file path + snippet + line context,
+6. use that material as context for the final answer.
 
-Recommended v0 primitives:
+This is fundamentally a search over individual files. It is not a requirement
+that v0 build a formal full-text index first.
 
-- `fetch` for remote reads
-- OPFS file and directory operations
-- structured `postMessage` bridges that implement those primitives inside the
-  existing sandbox kernel
+For the expected corpus size, simple recursive scanning over cached files is a
+reasonable starting point. If latency later becomes a problem, we can add an
+incremental index over the same OPFS-backed corpus.
 
-Representative OPFS-oriented API shape:
+### Browser Storage Design
 
-```ts
-type OpfsApi = {
-  readText(path: string): Promise<string>;
-  writeText(path: string, text: string): Promise<void>;
-  readBytes(path: string): Promise<Uint8Array>;
-  writeBytes(path: string, bytes: Uint8Array): Promise<void>;
-  list(path: string): Promise<Array<{ name: string; kind: "file" | "directory" }>>;
-  mkdir(path: string): Promise<void>;
-  stat(path: string): Promise<{ kind: "file" | "directory"; size?: number; mtime?: string }>;
-  remove(path: string, options?: { recursive?: boolean }): Promise<void>;
-};
+OPFS should hold the agent-managed repo mirror and derived artifacts. IndexedDB
+via Dexie can still be useful for metadata, manifests, and future indexes, but
+the primary mental model for v0 should be "the agent is writing a repo mirror
+under `/code/...` in OPFS".
 
-type FetchApi = {
-  fetch(input: string, init?: {
-    method?: string;
-    headers?: Record<string, string>;
-    body?: string | Uint8Array;
-  }): Promise<{
-    ok: boolean;
-    status: number;
-    headers: Record<string, string>;
-    text?: string;
-    bytes?: Uint8Array;
-  }>;
-};
+Suggested layout:
+
+```text
+/code/runmedev/web/...
+/derived/runmedev/web/...
+/memories/...
 ```
-
-These are intentionally low-level. They are enough for the agent to:
-
-1. fetch a GitHub tree manifest,
-2. iterate over entries,
-3. fetch individual files,
-4. persist them in OPFS,
-5. build its own lexical scan or local index in JavaScript.
-
-### 2) Policy
-
-Policy is the primary safety boundary.
-
-For this design, policy should answer:
-
-- which HTTP methods are allowed without approval,
-- which URI prefixes/domains are allowed,
-- what response size, timeout, and content-type limits apply,
-- which OPFS paths are writable,
-- which operations require approval.
-
-Example v0 policy posture:
-
-- allow `GET` to:
-  - `https://api.github.com/repos/runmedev/web/`
-  - `https://raw.githubusercontent.com/runmedev/web/`
-- deny or require approval for `POST`, `PUT`, `PATCH`, `DELETE`
-- allow OPFS reads/writes under a harness-owned prefix such as
-  `/agent-cache/runmedev-web/`
-- enforce maximum response size and per-file size limits
-
-This is the right place to control exfiltration risk. The question is not
-whether the agent has raw primitives; the question is what those primitives are
-allowed to touch without approval.
-
-### 3) Higher-level SDKs
-
-Higher-level helpers may still be useful, but they are a separate decision.
-
-Examples:
-
-- a GitHub tree walker,
-- a blob cache helper,
-- a line-index builder,
-- a lexical search helper,
-- a refresh/checkpoint helper.
-
-This document does not recommend requiring those SDKs in v0. The initial
-expectation should be that the agent writes JavaScript using the low-level
-primitives above, and that reusable patterns can later be standardized once we
-observe what the agent actually needs.
-
-## Recommended GitHub Retrieval Flow
-
-Rather than expose a bespoke host search service immediately, v0 should assume
-the agent writes JavaScript that performs the following flow:
-
-1. fetch the GitHub recursive tree manifest for the target ref,
-2. filter entries to `type === "blob"` and allowed paths,
-3. derive raw content URLs from `{owner, repo, ref, path}`,
-4. fetch file contents,
-5. write normalized blobs into OPFS,
-6. scan cached blobs lexically or build a local index over them.
-
-That keeps the platform substrate small while still supporting rich retrieval
-behaviors.
-
-## Browser Storage Design
-
-Use a hybrid layout:
-
-- IndexedDB via Dexie for metadata, manifests, and optional index tables.
-- OPFS for raw normalized blob bodies, derived artifacts, and agent-authored
-  cache state.
-
-This fits the existing repo shape:
-
-- the web app already uses Dexie-backed stores such as
-  `runme-local-notebooks` and `runme-fs-workspaces`,
-- the app already has `ensurePersistentStorage()` for requesting persistent
-  browser storage,
-- OPFS gives better behavior for larger file-like blobs than storing every body
-  directly inside IndexedDB rows.
-
-For this design, OPFS is not hidden from the agent behind a host-owned search
-service. OPFS is part of the substrate the sandboxed agent uses to persist its
-own cache and derived files.
-
-### Proposed Local Schema
-
-```ts
-type SearchBlobRecord = {
-  uri: string;           // e.g. github://runmedev/web/main/app/src/...
-  rootId: string;
-  path: string;
-  revision: string;
-  sha?: string;
-  sizeBytes: number;
-  fetchedAt: string;
-  contentType: string;
-  bodyKey: string;       // OPFS path or content-addressed key
-  lineIndexKey?: string; // optional derived line-offset table
-};
-
-type SearchRootStateRecord = {
-  id: string;
-  title: string;
-  kind: string;
-  revision?: string;
-  syncedAt?: string;
-  lastSyncError?: string;
-};
-```
-
-Recommended layout:
-
-- Dexie table `searchRoots`
-- Dexie table `searchBlobs`
-- OPFS directory `search-blobs/`
-- OPFS directory `search-derived/`
-- OPFS directory `search-memories/` or similar scratch area for reusable
-  agent-authored helper code if we decide to persist snippets locally
-
-If OPFS is unavailable, fall back to storing small bodies in IndexedDB so the
-feature still works, just less efficiently.
-
-### OPFS API surface
 
 At the browser level, OPFS is reached through:
 
 - `navigator.storage.getDirectory()`
 
 which returns a `FileSystemDirectoryHandle` for the origin-private root. The
-underlying platform APIs include:
-
-- `getDirectoryHandle(...)`
-- `getFileHandle(...)`
-- `entries()`, `keys()`, `values()`
-- `removeEntry(...)`
-- `FileSystemFileHandle.getFile()`
-- `FileSystemFileHandle.createWritable()`
-- `FileSystemFileHandle.createSyncAccessHandle()` in dedicated workers
+underlying platform APIs include `getDirectoryHandle(...)`,
+`getFileHandle(...)`, directory iteration, `removeEntry(...)`,
+`createWritable()`, and `createSyncAccessHandle()` in dedicated workers.
 
 The sandbox kernel does not need to expose those browser objects directly. It
 can expose a simpler RPC-style OPFS API over `postMessage` that maps onto them.
 
-## Search Strategy
+We should use the same path-based wrapper contract in both sandbox and
+browser-mode kernels. That way agent-authored code can say
+`await opfs.readText("/code/runmedev/web/README.md")` regardless of whether the
+current AppKernel execution is running in the sandbox iframe or the direct
+browser JS kernel.
 
-### V0: Ripgrep-Style Scan Over Cached Blobs
+### Requirements for the Codex WASM Harness
 
-Do not make a full-text index a prerequisite for v0.
+To make this proposal work, the `codex-wasm` harness needs to provide more than
+just a generic code executor.
 
-For the first corpus size, agent-authored JavaScript running in the browser can
-scan cached text blobs fast enough if we keep the corpus narrow and text-only.
-This is closer to the `ripgrep` mental model the user already has:
+Required v0 capabilities:
 
-- query a cached corpus,
-- return file/line/snippet matches,
-- open the file if needed.
+1. System prompt injection  
+   The browser harness must provide explicit system/developer instructions
+   describing:
+   - that code runs inside AppKernel,
+   - that OPFS and network APIs are available,
+   - the approved OPFS path layout,
+   - the approved GitHub URL prefixes,
+   - the expectation that the agent should fetch/cache/search source itself.
 
-Implementation outline:
+   This is necessary because the wasm build currently does not read project docs
+   from `AGENTS.md` on its own.
 
-1. fetch and maintain normalized text blobs,
-2. maintain per-file line offsets or compute them on demand,
-3. execute substring or regex search in a worker-friendly loop,
-4. collect top matches,
-5. rank by:
-   - exact path/name hits first,
-   - then exact text matches,
-   - then shorter path distance and fresher files.
+2. Low-level bridge APIs in code mode  
+   AppKernel code mode must expose the OPFS/network primitives described above.
 
-This avoids premature complexity and gives us a direct baseline for latency.
+3. Stable code-mode output semantics  
+   The agent needs predictable tool output. Today the browser executor returns
+   one merged `output` string, and Codex wraps that in a status header. That is
+   workable for v0, but the harness should preserve that behavior explicitly so
+   agent-authored retrieval code can rely on printed snippets showing up in tool
+   output.
 
-### V1: Optional Incremental Local Index
+4. Sufficient code payload/runtime limits  
+   The harness needs enough code size, output size, and timeout budget for
+   crawl/search tasks. The current defaults in Runme are oriented toward short
+   snippets and may need adjustment as soon as the agent starts walking repos.
 
-If warm-cache search latency is not good enough, add an incremental inverted
-index over the same blob corpus.
+5. Reusable per-turn or cross-turn state  
+   The current WASM bridge already supports `stored_values` in the code-mode
+   runtime contract. We should preserve or extend that path so the agent can
+   retain helper functions and small bits of state across executions.
 
-Recommended first index shape:
+6. Memory integration  
+   If the product direction is "let the AI evolve the SDK it needs", then the
+   harness needs a memory mechanism that lets the agent retain successful
+   crawl/cache/search code snippets and reuse them later.
 
-- tokenize normalized text into lowercase terms,
-- store `(term -> [uri, positions])` postings in IndexedDB,
-- optionally add a trigram index for substring queries.
+### System Prompt Shape
 
-We should not start with embeddings or vector search. The dominant query style
-for code/docs lookup is still lexical:
-
-- API names,
-- config keys,
-- file names,
-- URLs,
-- feature labels,
-- exact phrases from errors or UI text.
-
-## Sync and Freshness Model
-
-The runtime should support revision-aware caches per root, but v0 should assume
-the first cache manager is agent-authored JavaScript running on top of the
-low-level primitives.
-
-Recommended policy:
-
-1. on first use, sync the root manifest,
-2. fetch blobs lazily as the agent searches/opens,
-3. opportunistically prefetch high-value files under `docs/`, `docs-dev/`, and
-   `README*`,
-4. on later turns, compare the root revision and only refetch changed files.
-
-For GitHub-backed roots, the cache key should include:
-
-- repo identity,
-- ref or resolved commit SHA,
-- path,
-- blob SHA when available.
-
-Agent-authored search code should preserve freshness metadata so the agent can
-say whether it searched cached data from a specific sync time or revision.
-
-## Query UX for the Agent
-
-The derived search results should look like a code search tool, not like
-document retrieval.
-
-Example result:
-
-```json
-{
-  "matches": [
-    {
-      "uri": "github://runmedev/web/main/app/src/lib/runtime/codexWasmSession.ts",
-      "rootId": "github://runmedev/web?ref=main",
-      "path": "app/src/lib/runtime/codexWasmSession.ts",
-      "line": 16,
-      "snippet": "const RUNME_CODE_MODE_PROMPT_PREFIX = ["
-    }
-  ]
-}
-```
-
-This is the important behavioral point: the model should search by terms that
-look like how engineers search locally, even if the initial implementation is a
-library the agent writes for itself rather than a built-in host tool.
-
-Examples:
-
-- search for `"codex wasm prompt"` under cached `app/src/**`
-- search for `"ExecuteCode"` under cached `app/src/**`
-- search for `"Runme public docs"` under cached `docs/**`
-
-## Codex WASM Harness Integration
-
-For this design, the important integration point is not a native search tool.
-It is the low-level capability bridge exposed to sandboxed JavaScript in the
-`codex-wasm` harness.
-
-Rationale:
-
-- safety is controlled by policy over the bridge,
-- the agent can evolve its own retrieval code rather than waiting for bespoke
-  host SDKs,
-- the same substrate can later support more than GitHub search,
-- AppKernel code mode remains the place where agent-authored JS runs.
-
-Recommended layering:
-
-1. `codex-wasm` exposes low-level `fetch` + OPFS capabilities into sandboxed
-   code mode.
-2. Policy enforcement happens at the kernel/bridge boundary.
-3. Agent-authored JS performs crawl/cache/search work.
-4. Later host SDKs remain optional and can be added once justified by usage.
-
-## System and User Instruction Shape
-
-The harness should tell Codex three things clearly:
+The harness prompt should tell Codex three things clearly:
 
 1. what low-level capabilities exist,
 2. what policy boundaries apply,
-3. what known corpora or URL patterns are expected.
+3. what repo layout and retrieval workflow are expected.
 
 Recommended system prompt addition:
 
 ```text
 You are operating inside the Runme app ChatKit panel in a browser.
-Sandboxed JavaScript can make policy-approved fetch requests and can persist
-files in origin-private browser storage. Use those capabilities to fetch Runme
-source manifests and files, cache them locally, and search them lexically when
-the user asks how Runme works, where a feature is implemented, or what a Runme
-document says.
+Executed JavaScript runs in AppKernel. Inside AppKernel you have access to
+policy-approved browser storage and network APIs.
 
-Allowed sources for unattended reads include:
-- https://api.github.com/repos/runmedev/web/
-- https://raw.githubusercontent.com/runmedev/web/
+Use OPFS as a local repo cache under /code/${ORG}/${REPO}. For Runme source
+questions, prefer caching runmedev/web under /code/runmedev/web.
 
-Persist reusable cache state under the approved OPFS prefix. Preserve revision
-and path metadata so you can explain freshness and provenance in your answer.
+If /code/runmedev/web is missing or stale, fetch the GitHub tree manifest from
+https://api.github.com/repos/runmedev/web/ and fetch file contents from
+https://raw.githubusercontent.com/runmedev/web/. Persist fetched files in OPFS,
+then search them lexically with JavaScript before answering.
+
+For now, assume HTTP GET and OPFS operations are available without approval.
+Preserve path and revision metadata when you report findings.
 ```
 
-If we add more allowed corpora later, include them explicitly in the prompt and
-policy configuration rather than expecting the model to infer them.
+### Why We Are Deferring Higher-Level SDKs
 
-The user-facing prompt does not need to teach OPFS internals, but the system
-prompt should make the runtime capability model explicit.
+We should be explicit that v0 is intentionally not defining a bespoke search
+SDK.
 
-## V0 Recommendation
+The reason is not that higher-level SDKs are always bad. The reason is that the
+desired product behavior is:
 
-For the first version, do the following:
+- expose minimal primitives first,
+- let the agent discover which retrieval patterns actually matter,
+- preserve those patterns via memory/snippets,
+- standardize only the patterns that prove stable and broadly useful.
 
-1. Expose policy-governed `fetch` primitives to sandboxed JS.
-2. Expose policy-governed OPFS primitives to sandboxed JS.
-3. Add policy for unattended `GET` access to the relevant GitHub endpoints for
-   `runmedev/web`.
-4. Request persistent browser storage when available.
-5. Seed the system prompt with the approved URL prefixes and cache/freshness
-   expectations.
-6. Expect the agent to write JS that fetches the GitHub tree manifest, downloads
-   files, writes them to OPFS, and searches them lexically.
-7. Invest early in browser/Codex memory so the agent can retain and reuse those
-   snippets rather than rediscovering them every session.
+That is a better fit for the "agentic search" goal than freezing a host-owned
+API surface too early.
 
-This is enough to answer "what is Runme?", "where is codex-wasm implemented?",
-"what do the design docs say about Drive agentic search?", and similar
-questions without introducing a full search engine or bespoke retrieval SDK
-first.
+### V0 Implementation Sketch
 
-## Why This Is Better Than Starting With an Index
-
-The strongest argument for this design is that it gives us the right capability
-surface early:
-
-- explicit safety and policy boundaries,
-- a reusable browser substrate for fetch + persistence,
-- room for the agent to evolve retrieval code,
-- prompt instructions aligned with the actual runtime.
-
-If we start by designing an index or a host-owned search SDK before we have
-those pieces, we risk solving the wrong problem. `ripgrep` is effective because
-lexical search over files is a strong workflow; the browser equivalent should
-first make that workflow possible.
+1. Add sandbox-kernel RPCs for policy-governed OPFS operations.
+2. Add sandbox-kernel RPCs for policy-governed network reads (`fetch` or
+   `get`).
+3. Request persistent browser storage when available.
+4. Update the `codex-wasm` prompt prefix so it describes:
+   - AppKernel runtime,
+   - OPFS path layout,
+   - the availability of OPFS operations and HTTP `GET`,
+   - the expected fetch/cache/search workflow.
+5. Ensure AppKernel code mode has enough timeout/output budget for crawl/search
+   snippets.
+6. Add or plan a memory path so the agent can retain successful crawl/cache/search
+   snippets across sessions.
 
 ## Open Questions
 
-- Should v0 policy allow only `runmedev/web`, or should it include another
-  public Runme repo?
-- Do we want background warmup for high-value files on app load, or only after
-  the first Runme-related question?
-- Should the initial agent-authored search library support regex in v0, or
-  should it start with substring plus path filtering only?
-- Is revision checking done on every turn, or only when the user explicitly
-  asks for refresh/current data?
+- Should the network API be raw `fetch`, or do we want a slightly narrower
+  `get(...)` helper?
+- Do we want to reserve a second OPFS namespace for derived artifacts such as
+  line indexes or cached match results?
+- How much output budget is needed before crawl/search snippets become usable in
+  practice?
 - What memory mechanism should Codex/browser use to preserve reusable
   crawl/cache/search snippets across sessions?
 - At what point should agent-evolved patterns graduate into first-class SDKs or
   tools owned by the host runtime?
-
-## Implementation Sketch
-
-1. Add sandbox-kernel RPCs for policy-governed `fetch`.
-2. Add sandbox-kernel RPCs for policy-governed OPFS operations.
-3. Add policy configuration for allowed GitHub URL prefixes, methods, and size
-   limits.
-4. Add Dexie metadata tables for manifests and cached blobs.
-5. Add an OPFS-backed cache layout for fetched blob bodies and derived files.
-6. Extend the `codex-wasm` prompt prefix with the capability/policy guidance.
-7. Build or enable a memory path for Codex/browser to retain reusable
-   crawl/cache/search snippets.
 
 ## References
 


### PR DESCRIPTION
## Summary
- add the agentic search design note for Runme docs/codebase retrieval in the browser
- expose low-level AppKernel OPFS and HTTP GET helpers for both browser and sandbox code mode
- move Runme runtime guidance into shared prompt sections for responses-direct and codex-wasm

## Testing
- pnpm --dir app exec vitest run src/lib/runtime/codeModeExecutor.test.ts src/lib/runtime/sandboxJsKernel.test.ts src/lib/runtime/codexWasmSession.test.ts src/lib/runtime/codexWasmChatkitFetch.test.ts