### PR TITLE
Open Google Drive auth in a new tab by default

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -21,10 +21,10 @@ In order to be able to access Google Drive.
 Follow the [Google docs](https://support.google.com/cloud/answer/15549257?sjid=2630967979572079554-NC) for creating
 an OAuth credential with the following settings
 
-* Application Type: Web Application
-* Authorized redirect URIs:
-   - http://localhost:5173
-   - http://localhost:5174
+- Application Type: Web Application
+- Authorized redirect URIs:
+  - http://localhost:5173
+  - http://localhost:5174
 
 If you plan on hosting the app at your own domain you'll need to add the redirect URI at which your app gets served
 
@@ -48,9 +48,9 @@ Refresh the webapp for the settings to take effect.
 You need to signon into the app in order to authenticate to the different services the app talks to (e.g. kernels and the AI backend).
 You do this with OIDC. You'll need an OIDC provider such as
 
-* Google
-* Microsoft Entra
-* GitHub
+- Google
+- Microsoft Entra
+- GitHub
 
 ### Using Google
 
@@ -109,9 +109,9 @@ cp ${REPODIR}$/app/config.dev.yaml \
 
 Make the relevant changes to your config
 
-* Set the path to your OpenAI API Key
-* Change your email in the IAM rules
-* Add the Google OAuth Client ID
+- Set the path to your OpenAI API Key
+- Change your email in the IAM rules
+- Add the Google OAuth Client ID
 
 ```sh
 go run ./ agent --config=${HOME}/.runme-agent/config.dev.yaml serve
@@ -119,37 +119,36 @@ go run ./ agent --config=${HOME}/.runme-agent/config.dev.yaml serve
 
 # Configure the server to serve app configuration
 
-* You can configure the app with one command by hosting the application configuration at a URL
-* For example you can put a YAML files into the assets directory (e.g. `${HOME}/.runme-agent/assets/configs/app-configs.yaml`) to
+- You can configure the app with one command by hosting the application configuration at a URL
+- For example you can put a YAML files into the assets directory (e.g. `${HOME}/.runme-agent/assets/configs/app-configs.yaml`) to
   host the OIDC and Google Drive configuration that the App should use. For example.
 
   ```yaml
   # app-configs.yaml is a file that will be served by the server as a static asset.
-    # It will be used by the frontend to configure itself.
-    # The agent mints OAuth tokens for the user to login to the assistant and the runners
-    oidc:
-        # OIDC callback handling should happen in the browser.
-        clientExchange: true    
-        google:
-            # Runtime config applies Google defaults automatically when this block is present.
-            clientID: "44661292282-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com"
+  # It will be used by the frontend to configure itself.
+  # The agent mints OAuth tokens for the user to login to the assistant and the runners
+  oidc:
+    # OIDC callback handling should happen in the browser.
+    clientExchange: true
+    google:
+      # Runtime config applies Google defaults automatically when this block is present.
+      clientID: '44661292282-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com'
 
-    googleDrive:
-        clientID: "44661292282-bqhl39ugf2kn7r8vv4f6766jt0a7tom9.apps.googleusercontent.com"
-        clientSecret: ""
-        # Optional: implicit (token) or pkce (authorization code)
-        authFlow: "implicit"
-        # Optional: popup or redirect
-        authUxMode: "redirect"
+  googleDrive:
+    clientID: '44661292282-bqhl39ugf2kn7r8vv4f6766jt0a7tom9.apps.googleusercontent.com'
+    clientSecret: ''
+    # Optional: implicit (token) or pkce (authorization code)
+    authFlow: 'implicit'
+    # Optional: popup, redirect, or new_tab
+    authUxMode: 'new_tab'
 
-    chatkit:
-        domainKey: "<chatkit-domain-key>"
+  chatkit:
+    domainKey: '<chatkit-domain-key>'
   ```
 
   If you need to override the discovery URL, redirect URL, or scopes explicitly, add an `oidc.generic` block alongside `oidc.google`.
 
-
-* Then in the web in the console you can do.
+- Then in the web in the console you can do.
 
   ```
   app.setConfig(app.getDefaultConfigUrl())
@@ -165,7 +164,7 @@ In the app console.
 app.runners.update("localhost","ws://localhost:9977/ws")
 ```
 
-* Change the port to whatever port your runme agent is serving on
+- Change the port to whatever port your runme agent is serving on
 
 ## Deployment
 
@@ -181,12 +180,12 @@ This repo includes a GitHub Actions workflow at `.github/workflows/publish-app-a
 
 The artifact is published as:
 
-* `ghcr.io/runmedev/app-assets:sha-<commit-sha>`
-* `ghcr.io/runmedev/app-assets:latest` (for `main`)
+- `ghcr.io/runmedev/app-assets:sha-<commit-sha>`
+- `ghcr.io/runmedev/app-assets:latest` (for `main`)
 
 It uses a custom artifact type:
 
-* `application/vnd.runmeweb.assets.v1`
+- `application/vnd.runmeweb.assets.v1`
 
 ### Pull and extract the static assets
 

--- a/app/assets/configs/app-configs.yaml
+++ b/app/assets/configs/app-configs.yaml
@@ -2,33 +2,33 @@
 # It will be used by the frontend to configure itself.
 # This is the configuration for local development.
 agent:
-    endpoint: "http://localhost:5191"
-    defaultRunnerEndpoint: "ws://localhost:5191/ws"
-    openai:
-        # Supported values: OAuth, APIKey
-        authMethod: "OAuth"
-        # Required when authMethod is OAuth.
-        # Replace with your OpenAI organization and project values.
-        organization: "org-not-set"
-        project: "proj-not-set"
-        # Optional file-search vector stores for direct Responses mode.
-        vectorStores: []
+  endpoint: 'http://localhost:5191'
+  defaultRunnerEndpoint: 'ws://localhost:5191/ws'
+  openai:
+    # Supported values: OAuth, APIKey
+    authMethod: 'OAuth'
+    # Required when authMethod is OAuth.
+    # Replace with your OpenAI organization and project values.
+    organization: 'org-not-set'
+    project: 'proj-not-set'
+    # Optional file-search vector stores for direct Responses mode.
+    vectorStores: []
 
 oidc:
-    # OIDC callback handling should happen in the browser.
-    clientExchange: true
+  # OIDC callback handling should happen in the browser.
+  clientExchange: true
 
-    # Use google as the OIDC provider
-    google:
-        clientID: "554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com"
-        clientSecret: "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"
+  # Use google as the OIDC provider
+  google:
+    clientID: '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com'
+    clientSecret: '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'
 
 googleDrive:
-    clientID: "554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com"
-    # Supported values for authFlow: implicit (token), pkce (authorization code).
-    authFlow: "implicit"
-    # Supported values for authUxMode: popup, redirect.
-    authUxMode: "redirect"
+  clientID: '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com'
+  # Supported values for authFlow: implicit (token), pkce (authorization code).
+  authFlow: 'implicit'
+  # Supported values for authUxMode: popup, redirect, new_tab.
+  authUxMode: 'new_tab'
 
 chatkit:
-    domainKey: "domain_pk_69a4995c6a28819687dae60b7fff88150c50b644747c389a"
+  domainKey: 'domain_pk_69a4995c6a28819687dae60b7fff88150c50b644747c389a'

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -1,71 +1,114 @@
 // @vitest-environment jsdom
-import { useEffect } from "react";
-import { render, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { googleClientManager } from "../lib/googleClientManager";
-import { GoogleAuthProvider, useGoogleAuth } from "./GoogleAuthContext";
+import { useEffect } from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { googleClientManager } from '../lib/googleClientManager'
+import { GoogleAuthProvider, useGoogleAuth } from './GoogleAuthContext'
 
-const PKCE_STATE_KEY = "runme/google-auth/pkce-state";
-const PKCE_CODE_VERIFIER_KEY = "runme/google-auth/pkce-code-verifier";
-const PKCE_RETURN_TO_KEY = "runme/google-auth/pkce-return-to";
-const IMPLICIT_PROMPT_MODE_KEY = "runme/google-auth/implicit-prompt-mode";
+const PKCE_STATE_KEY = 'runme/google-auth/pkce-state'
+const PKCE_CODE_VERIFIER_KEY = 'runme/google-auth/pkce-code-verifier'
+const PKCE_RETURN_TO_KEY = 'runme/google-auth/pkce-return-to'
+const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
+const STORAGE_KEY = 'runme/google-auth/token'
 
 function CaptureAuth(props: {
-  onReady: (auth: ReturnType<typeof useGoogleAuth>) => void;
+  onReady: (auth: ReturnType<typeof useGoogleAuth>) => void
 }) {
-  const { onReady } = props;
-  const auth = useGoogleAuth();
+  const { onReady } = props
+  const auth = useGoogleAuth()
   useEffect(() => {
-    onReady(auth);
-  }, [auth, onReady]);
-  return null;
+    onReady(auth)
+  }, [auth, onReady])
+  return null
 }
 
 async function renderWithGoogleAuthProvider() {
-  let captured: ReturnType<typeof useGoogleAuth> | null = null;
+  let captured: ReturnType<typeof useGoogleAuth> | null = null
   render(
     <GoogleAuthProvider>
       <CaptureAuth
         onReady={(auth) => {
-          captured = auth;
+          captured = auth
         }}
       />
-    </GoogleAuthProvider>,
-  );
+    </GoogleAuthProvider>
+  )
   await waitFor(() => {
-    expect(captured).not.toBeNull();
-  });
-  return captured!;
+    expect(captured).not.toBeNull()
+  })
+  return captured!
 }
 
-describe("GoogleAuthProvider implicit redirect flow", () => {
+describe('GoogleAuthProvider implicit redirect flow', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-    window.localStorage.clear();
-    window.sessionStorage.clear();
-    window.history.replaceState(null, "", "/");
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    window.history.replaceState(null, '', '/')
     googleClientManager.setOAuthClient({
-      clientId: "test-client.apps.googleusercontent.com",
-      authFlow: "implicit",
-      authUxMode: "popup",
-    });
-  });
+      clientId: 'test-client.apps.googleusercontent.com',
+      authFlow: 'implicit',
+      authUxMode: 'popup',
+    })
+  })
 
-  it("starts implicit redirect flow when authFlow=implicit and authUxMode=redirect", async () => {
+  it('starts implicit redirect flow when authFlow=implicit and authUxMode=redirect', async () => {
     googleClientManager.setOAuthClient({
-      authFlow: "implicit",
-      authUxMode: "redirect",
-    });
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const auth = await renderWithGoogleAuthProvider();
+      authFlow: 'implicit',
+      authUxMode: 'redirect',
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const auth = await renderWithGoogleAuthProvider()
 
-    await expect(auth.ensureAccessToken()).rejects.toThrow();
+    await expect(auth.ensureAccessToken()).rejects.toThrow()
 
-    expect(window.localStorage.getItem(PKCE_STATE_KEY)).toBeTruthy();
-    expect(window.localStorage.getItem(PKCE_RETURN_TO_KEY)).toBe("/");
-    expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe("none");
+    expect(window.localStorage.getItem(PKCE_STATE_KEY)).toBeTruthy()
+    expect(window.localStorage.getItem(PKCE_RETURN_TO_KEY)).toBe('/')
+    expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe('none')
     // Implicit redirect should not mint a PKCE verifier.
-    expect(window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)).toBeNull();
-  });
+    expect(window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)).toBeNull()
+  })
 
-});
+  it('starts implicit auth in a new tab when authUxMode=new_tab', async () => {
+    googleClientManager.setOAuthClient({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(window as unknown as Window)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await expect(auth.ensureAccessToken()).rejects.toThrow()
+
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    expect(openSpy.mock.calls[0]?.[1]).toBe('_blank')
+    expect(window.localStorage.getItem(PKCE_STATE_KEY)).toBeTruthy()
+    expect(window.localStorage.getItem(PKCE_RETURN_TO_KEY)).toBe('/')
+    expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe('none')
+    expect(window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)).toBeNull()
+  })
+
+  it('syncs stored tokens from another tab via the storage event', async () => {
+    const auth = await renderWithGoogleAuthProvider()
+    const tokenInfo = {
+      token: 'test-access-token',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    }
+    await act(async () => {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tokenInfo))
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: STORAGE_KEY,
+          newValue: JSON.stringify(tokenInfo),
+          storageArea: window.localStorage,
+        })
+      )
+    })
+
+    await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
+      'test-access-token'
+    )
+  })
+})

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -9,6 +9,7 @@ const PKCE_STATE_KEY = 'runme/google-auth/pkce-state'
 const PKCE_CODE_VERIFIER_KEY = 'runme/google-auth/pkce-code-verifier'
 const PKCE_RETURN_TO_KEY = 'runme/google-auth/pkce-return-to'
 const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
+const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
 const STORAGE_KEY = 'runme/google-auth/token'
 
 function CaptureAuth(props: {
@@ -88,6 +89,29 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(window.localStorage.getItem(PKCE_RETURN_TO_KEY)).toBe('/')
     expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe('none')
     expect(window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)).toBeNull()
+  })
+
+  it('does not relaunch new-tab auth while a handoff is already in progress', async () => {
+    googleClientManager.setOAuthClient({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(window as unknown as Window)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await expect(auth.ensureAccessToken()).rejects.toThrow()
+    const initialState = window.localStorage.getItem(PKCE_STATE_KEY)
+
+    await expect(auth.ensureAccessToken()).rejects.toThrow()
+
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(PKCE_STATE_KEY)).toBe(initialState)
+    expect(window.localStorage.getItem(PKCE_RETURN_TO_KEY)).toBe('/')
+    expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe('none')
+    expect(window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)).toBe('new_tab')
   })
 
   it('syncs stored tokens from another tab via the storage event', async () => {

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -266,6 +266,18 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     []
   )
 
+  const hasRedirectAuthHandoffInProgress = useCallback(() => {
+    try {
+      const state = window.localStorage.getItem(PKCE_STATE_KEY)
+      const handoffMode = window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)
+      return Boolean(
+        state && (handoffMode === 'redirect' || handoffMode === 'new_tab')
+      )
+    } catch {
+      return false
+    }
+  }, [])
+
   const readImplicitRedirectTokenFromHash = useCallback(() => {
     const hash = window.location.hash.startsWith('#')
       ? window.location.hash.slice(1)
@@ -799,6 +811,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
 
         const oauthClient = googleClientManager.getOAuthClient()
+        if (hasRedirectAuthHandoffInProgress()) {
+          throw new Error(
+            'Redirecting to Google OAuth for Drive authorization.'
+          )
+        }
         if (oauthClient.authFlow === 'pkce') {
           await startPkceRedirect(
             oauthClient.authUxMode === 'redirect' ? 'redirect' : 'new_tab'
@@ -865,6 +882,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     },
     [
       ensureTokenClient,
+      hasRedirectAuthHandoffInProgress,
       refreshAccessToken,
       setAccessToken,
       startImplicitRedirect,

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -7,101 +7,108 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
-import pkceChallenge from "pkce-challenge";
-import { googleClientManager } from "../lib/googleClientManager";
+} from 'react'
+import pkceChallenge from 'pkce-challenge'
+import { googleClientManager } from '../lib/googleClientManager'
 import {
   APP_ROUTE_PATHS,
   getAppPath,
   getGoogleDriveOAuthCallbackUrl,
-} from "../lib/appBase";
-import { appLogger } from "../lib/logging/runtime";
+} from '../lib/appBase'
+import type { GoogleDriveAuthUxMode } from '../lib/googleClientManager'
+import { appLogger } from '../lib/logging/runtime'
 
 // N.B. I couldn't make sharing work with the more restrictive "https://www.googleapis.com/auth/drive.file"
 // scope. In particular, I couldn't quite figure out how to share a link with a user and then have that
 // user go through the Drive Picker flow to associate that file with the app. So for now we use the broader
 // drive scope to give the app access to all of the user's files.
 export const DRIVE_SCOPES = [
-  "https://www.googleapis.com/auth/drive",  
-  "https://www.googleapis.com/auth/drive.install",
-];
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/drive.install',
+]
 
-const STORAGE_KEY = "runme/google-auth/token";
-const LEGACY_STORAGE_KEY = "aisre/google-auth/token";
-const PKCE_STATE_KEY = "runme/google-auth/pkce-state";
-const PKCE_CODE_VERIFIER_KEY = "runme/google-auth/pkce-code-verifier";
-const PKCE_RETURN_TO_KEY = "runme/google-auth/pkce-return-to";
-const PKCE_ERROR_KEY = "runme/google-auth/pkce-error";
-const IMPLICIT_PROMPT_MODE_KEY = "runme/google-auth/implicit-prompt-mode";
+const STORAGE_KEY = 'runme/google-auth/token'
+const LEGACY_STORAGE_KEY = 'aisre/google-auth/token'
+const PKCE_STATE_KEY = 'runme/google-auth/pkce-state'
+const PKCE_CODE_VERIFIER_KEY = 'runme/google-auth/pkce-code-verifier'
+const PKCE_RETURN_TO_KEY = 'runme/google-auth/pkce-return-to'
+const PKCE_ERROR_KEY = 'runme/google-auth/pkce-error'
+const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
+const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
 
 interface AccessTokenInfo {
-  token: string;
-  expiresAt: number;
-  refreshToken?: string;
+  token: string
+  expiresAt: number
+  refreshToken?: string
 }
 
 interface EnsureAccessTokenOptions {
-  interactive?: boolean;
+  interactive?: boolean
 }
 
 interface GoogleAuthContextType {
-  ensureAccessToken: (options?: EnsureAccessTokenOptions) => Promise<string>;
-  setAccessToken: (token: string, expiresIn?: number) => void;
-  isDriveSyncing: boolean;
+  ensureAccessToken: (options?: EnsureAccessTokenOptions) => Promise<string>
+  setAccessToken: (token: string, expiresIn?: number) => void
+  isDriveSyncing: boolean
 }
 
+type GoogleRedirectUxMode = Extract<
+  GoogleDriveAuthUxMode,
+  'redirect' | 'new_tab'
+>
+
 type PendingHandlers = {
-  resolve: (token: string) => void;
-  reject: (error: unknown) => void;
-};
+  resolve: (token: string) => void
+  reject: (error: unknown) => void
+}
 
 interface TokenClient {
-  callback: (response: AccessTokenResponse) => void;
-  requestAccessToken: (options?: { prompt?: string }) => void;
+  callback: (response: AccessTokenResponse) => void
+  requestAccessToken: (options?: { prompt?: string }) => void
 }
 
 interface AccessTokenResponse {
-  access_token?: string;
-  expires_in?: number;
-  refresh_token?: string;
-  scope?: string;
-  token_type?: string;
-  error?: string;
-  error_description?: string;
+  access_token?: string
+  expires_in?: number
+  refresh_token?: string
+  scope?: string
+  token_type?: string
+  error?: string
+  error_description?: string
 }
 
 interface GoogleOAuth {
   initTokenClient: (options: {
-    client_id: string;
-    scope: string;
-    callback: (response: AccessTokenResponse) => void;
-  }) => TokenClient;
+    client_id: string
+    scope: string
+    callback: (response: AccessTokenResponse) => void
+  }) => TokenClient
 }
 
 declare global {
   interface Window {
     google?: {
       accounts?: {
-        oauth2?: GoogleOAuth;
-      };
-    };
+        oauth2?: GoogleOAuth
+      }
+    }
   }
 }
 
 const GoogleAuthContext = createContext<GoogleAuthContextType | undefined>(
-  undefined,
-);
+  undefined
+)
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function useGoogleAuth() {
-  const ctx = useContext(GoogleAuthContext);
+  const ctx = useContext(GoogleAuthContext)
   if (!ctx) {
-    throw new Error("useGoogleAuth must be used within a GoogleAuthProvider");
+    throw new Error('useGoogleAuth must be used within a GoogleAuthProvider')
   }
-  return ctx;
+  return ctx
 }
 
-const REFRESH_MARGIN_MS = 60_000;
+const REFRESH_MARGIN_MS = 60_000
 
 // GoogleAuthProvider owns all OAuth state for the app. It exposes a small
 // surface (ensureAccessToken / setAccessToken) through context so the rest of
@@ -111,39 +118,39 @@ function loadStoredToken(): AccessTokenInfo | null {
   try {
     const raw =
       window.localStorage.getItem(STORAGE_KEY) ??
-      window.localStorage.getItem(LEGACY_STORAGE_KEY);
+      window.localStorage.getItem(LEGACY_STORAGE_KEY)
     if (!raw) {
-      return null;
+      return null
     }
-    const parsed = JSON.parse(raw) as Partial<AccessTokenInfo> | null;
-    if (!parsed?.token || typeof parsed.token !== "string") {
-      window.localStorage.removeItem(STORAGE_KEY);
-      window.localStorage.removeItem(LEGACY_STORAGE_KEY);
-      return null;
+    const parsed = JSON.parse(raw) as Partial<AccessTokenInfo> | null
+    if (!parsed?.token || typeof parsed.token !== 'string') {
+      window.localStorage.removeItem(STORAGE_KEY)
+      window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+      return null
     }
-    if (typeof parsed.expiresAt !== "number") {
-      window.localStorage.removeItem(STORAGE_KEY);
-      window.localStorage.removeItem(LEGACY_STORAGE_KEY);
-      return null;
+    if (typeof parsed.expiresAt !== 'number') {
+      window.localStorage.removeItem(STORAGE_KEY)
+      window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+      return null
     }
     const refreshToken =
-      typeof parsed.refreshToken === "string" && parsed.refreshToken.trim()
+      typeof parsed.refreshToken === 'string' && parsed.refreshToken.trim()
         ? parsed.refreshToken.trim()
-        : undefined;
+        : undefined
 
     if (parsed.expiresAt <= Date.now() + REFRESH_MARGIN_MS && !refreshToken) {
-      window.localStorage.removeItem(STORAGE_KEY);
-      window.localStorage.removeItem(LEGACY_STORAGE_KEY);
-      return null;
+      window.localStorage.removeItem(STORAGE_KEY)
+      window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+      return null
     }
     return {
       token: parsed.token,
       expiresAt: parsed.expiresAt,
       refreshToken,
-    };
+    }
   } catch (error) {
-    console.error("Failed to read Google auth token from storage", error);
-    return null;
+    console.error('Failed to read Google auth token from storage', error)
+    return null
   }
 }
 
@@ -154,22 +161,22 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
   // trips. When the token changes, React will re-render this provider and
   // consequently re-run any hooks that depend on tokenInfo.
   const [tokenInfo, setTokenInfo] = useState<AccessTokenInfo | null>(
-    loadStoredToken,
-  );
-  const [nowMs, setNowMs] = useState(() => Date.now());
+    loadStoredToken
+  )
+  const [nowMs, setNowMs] = useState(() => Date.now())
 
   // The remaining mutable pieces do not participate in rendering, so they are
   // stored in refs instead of state. This keeps React from re-rendering whenever
   // these values change and also gives us stable references across function
   // calls.
-  const tokenInfoRef = useRef<AccessTokenInfo | null>(null);
-  const tokenClientRef = useRef<TokenClient | null>(null);
-  const oauthClientIdRef = useRef<string | null>(null);
-  const handlersRef = useRef<PendingHandlers | null>(null);
-  const pendingPromiseRef = useRef<Promise<string> | null>(null);
-  const scriptPromiseRef = useRef<Promise<void> | null>(null);
-  const callbackPromiseRef = useRef<Promise<void> | null>(null);
-  const callbackErrorRef = useRef<unknown>(null);
+  const tokenInfoRef = useRef<AccessTokenInfo | null>(null)
+  const tokenClientRef = useRef<TokenClient | null>(null)
+  const oauthClientIdRef = useRef<string | null>(null)
+  const handlersRef = useRef<PendingHandlers | null>(null)
+  const pendingPromiseRef = useRef<Promise<string> | null>(null)
+  const scriptPromiseRef = useRef<Promise<void> | null>(null)
+  const callbackPromiseRef = useRef<Promise<void> | null>(null)
+  const callbackErrorRef = useRef<unknown>(null)
 
   // useCallback memoises the function instance so consumers receive a stable
   // reference between renders. That is important because the callback is passed
@@ -180,76 +187,110 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     (
       token: string,
       expiresIn = 3600,
-      options?: { refreshToken?: string | null },
+      options?: { refreshToken?: string | null }
     ) => {
       if (!token) {
-        setTokenInfo(null);
-        tokenInfoRef.current = null;
+        setTokenInfo(null)
+        tokenInfoRef.current = null
         try {
-          window.localStorage.removeItem(STORAGE_KEY);
-          window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+          window.localStorage.removeItem(STORAGE_KEY)
+          window.localStorage.removeItem(LEGACY_STORAGE_KEY)
         } catch (error) {
-          console.error("Failed to clear Google auth token", error);
+          console.error('Failed to clear Google auth token', error)
         }
-        return;
+        return
       }
 
       const refreshToken =
         options?.refreshToken === undefined
           ? tokenInfoRef.current?.refreshToken
-          : options.refreshToken || undefined;
-      const expiresAt = Date.now() + (expiresIn * 1000 - REFRESH_MARGIN_MS);
+          : options.refreshToken || undefined
+      const expiresAt = Date.now() + (expiresIn * 1000 - REFRESH_MARGIN_MS)
       const info: AccessTokenInfo = {
         token,
         expiresAt,
         ...(refreshToken ? { refreshToken } : {}),
-      };
-      setTokenInfo(info);
-      tokenInfoRef.current = info;
+      }
+      setTokenInfo(info)
+      tokenInfoRef.current = info
       try {
-        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(info));
-        window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(info))
+        window.localStorage.removeItem(LEGACY_STORAGE_KEY)
       } catch (error) {
-        console.error("Failed to persist Google auth token", error);
+        console.error('Failed to persist Google auth token', error)
       }
     },
-    [],
-  );
+    []
+  )
 
-  const clearPkceState = useCallback(() => {
-    try {
-      window.localStorage.removeItem(PKCE_STATE_KEY);
-      window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY);
-      window.localStorage.removeItem(PKCE_RETURN_TO_KEY);
-      window.localStorage.removeItem(IMPLICIT_PROMPT_MODE_KEY);
-      window.sessionStorage.removeItem(PKCE_ERROR_KEY);
-    } catch (error) {
-      console.error("Failed to clear Google PKCE state", error);
-    }
-  }, []);
+  const clearPkceState = useCallback(
+    (options?: { preserveHandoffMode?: boolean }) => {
+      try {
+        window.localStorage.removeItem(PKCE_STATE_KEY)
+        window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY)
+        window.localStorage.removeItem(PKCE_RETURN_TO_KEY)
+        window.localStorage.removeItem(IMPLICIT_PROMPT_MODE_KEY)
+        if (!options?.preserveHandoffMode) {
+          window.localStorage.removeItem(AUTH_HANDOFF_MODE_KEY)
+        }
+        window.sessionStorage.removeItem(PKCE_ERROR_KEY)
+      } catch (error) {
+        console.error('Failed to clear Google PKCE state', error)
+      }
+    },
+    []
+  )
+
+  const openAuthUrl = useCallback(
+    (authUrl: URL, mode: GoogleRedirectUxMode) => {
+      window.localStorage.setItem(AUTH_HANDOFF_MODE_KEY, mode)
+      if (mode === 'new_tab') {
+        const authWindow = window.open(authUrl.toString(), '_blank')
+        if (authWindow) {
+          authWindow.focus?.()
+          return
+        }
+        appLogger.warn(
+          'Failed to open Google OAuth in a new tab; falling back to redirect',
+          {
+            attrs: {
+              scope: 'storage.drive.auth',
+              code: 'DRIVE_AUTH_NEW_TAB_OPEN_FAILED',
+            },
+          }
+        )
+        window.localStorage.setItem(AUTH_HANDOFF_MODE_KEY, 'redirect')
+      }
+      window.location.assign(authUrl.toString())
+    },
+    []
+  )
 
   const readImplicitRedirectTokenFromHash = useCallback(() => {
-    const hash = window.location.hash.startsWith("#")
+    const hash = window.location.hash.startsWith('#')
       ? window.location.hash.slice(1)
-      : window.location.hash;
+      : window.location.hash
     if (!hash) {
-      return null;
+      return null
     }
-    const params = new URLSearchParams(hash);
+    const params = new URLSearchParams(hash)
     return {
-      accessToken: params.get("access_token"),
-      expiresInRaw: params.get("expires_in"),
-      state: params.get("state"),
-      error: params.get("error"),
-      errorDescription: params.get("error_description"),
-    };
-  }, []);
+      accessToken: params.get('access_token'),
+      expiresInRaw: params.get('expires_in'),
+      state: params.get('state'),
+      error: params.get('error'),
+      errorDescription: params.get('error_description'),
+    }
+  }, [])
 
   const exchangeAuthorizationCode = useCallback(
-    async (code: string, codeVerifier: string): Promise<AccessTokenResponse> => {
-      const { clientId, clientSecret } = googleClientManager.getOAuthClient();
+    async (
+      code: string,
+      codeVerifier: string
+    ): Promise<AccessTokenResponse> => {
+      const { clientId, clientSecret } = googleClientManager.getOAuthClient()
       if (!clientId?.trim()) {
-        throw new Error("Google OAuth client is not configured.");
+        throw new Error('Google OAuth client is not configured.')
       }
 
       const body = new URLSearchParams({
@@ -257,522 +298,579 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         code,
         code_verifier: codeVerifier,
         redirect_uri: getGoogleDriveOAuthCallbackUrl(),
-        grant_type: "authorization_code",
-      });
+        grant_type: 'authorization_code',
+      })
       if (clientSecret?.trim()) {
-        body.set("client_secret", clientSecret.trim());
+        body.set('client_secret', clientSecret.trim())
       }
 
-      const response = await fetch("https://oauth2.googleapis.com/token", {
-        method: "POST",
+      const response = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
         body,
-      });
+      })
 
-      let token: AccessTokenResponse | null = null;
+      let token: AccessTokenResponse | null = null
       try {
-        token = (await response.json()) as AccessTokenResponse;
+        token = (await response.json()) as AccessTokenResponse
       } catch {
-        token = null;
+        token = null
       }
 
       if (!response.ok) {
         throw new Error(
           token?.error_description ??
             token?.error ??
-            `Google OAuth token exchange failed (${response.status})`,
-        );
+            `Google OAuth token exchange failed (${response.status})`
+        )
       }
 
-      return token ?? {};
+      return token ?? {}
     },
-    [],
-  );
+    []
+  )
 
   const handleRedirectCallbackIfPresent = useCallback(async () => {
-    const callbackPath = new URL(getGoogleDriveOAuthCallbackUrl()).pathname;
+    const callbackPath = new URL(getGoogleDriveOAuthCallbackUrl()).pathname
     if (window.location.pathname !== callbackPath) {
-      return;
+      return
     }
 
-    const params = new URLSearchParams(window.location.search);
-    const implicitToken = readImplicitRedirectTokenFromHash();
-    const oauthError = params.get("error") ?? implicitToken?.error;
+    const params = new URLSearchParams(window.location.search)
+    const implicitToken = readImplicitRedirectTokenFromHash()
+    const oauthError = params.get('error') ?? implicitToken?.error
     if (oauthError) {
       const attemptedPromptMode = window.localStorage.getItem(
-        IMPLICIT_PROMPT_MODE_KEY,
-      );
+        IMPLICIT_PROMPT_MODE_KEY
+      )
       const shouldRetryWithConsent =
-        attemptedPromptMode === "none" &&
-        (oauthError === "interaction_required" ||
-          oauthError === "login_required" ||
-          oauthError === "consent_required");
+        attemptedPromptMode === 'none' &&
+        (oauthError === 'interaction_required' ||
+          oauthError === 'login_required' ||
+          oauthError === 'consent_required')
       if (shouldRetryWithConsent) {
-        clearPkceState();
-        const { clientId } = googleClientManager.getOAuthClient();
+        clearPkceState({ preserveHandoffMode: true })
+        const { clientId } = googleClientManager.getOAuthClient()
         if (!clientId?.trim()) {
-          throw new Error("Google OAuth client is not configured.");
+          throw new Error('Google OAuth client is not configured.')
         }
         const state = globalThis.crypto?.randomUUID
           ? globalThis.crypto.randomUUID()
-          : `${Date.now()}-${Math.random()}`;
-        const returnTo = getAppPath(APP_ROUTE_PATHS.home);
+          : `${Date.now()}-${Math.random()}`
+        const returnTo = getAppPath(APP_ROUTE_PATHS.home)
 
-        window.localStorage.setItem(PKCE_STATE_KEY, state);
-        window.localStorage.setItem(PKCE_RETURN_TO_KEY, returnTo);
-        window.localStorage.setItem(IMPLICIT_PROMPT_MODE_KEY, "consent");
-        window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY);
+        window.localStorage.setItem(PKCE_STATE_KEY, state)
+        window.localStorage.setItem(PKCE_RETURN_TO_KEY, returnTo)
+        window.localStorage.setItem(IMPLICIT_PROMPT_MODE_KEY, 'consent')
+        window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY)
 
-        const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-        authUrl.searchParams.set("client_id", clientId);
-        authUrl.searchParams.set("redirect_uri", getGoogleDriveOAuthCallbackUrl());
-        authUrl.searchParams.set("response_type", "token");
-        authUrl.searchParams.set("scope", DRIVE_SCOPES.join(" "));
-        authUrl.searchParams.set("state", state);
-        authUrl.searchParams.set("include_granted_scopes", "true");
-        authUrl.searchParams.set("prompt", "consent");
-        window.location.assign(authUrl.toString());
-        return;
+        const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+        authUrl.searchParams.set('client_id', clientId)
+        authUrl.searchParams.set(
+          'redirect_uri',
+          getGoogleDriveOAuthCallbackUrl()
+        )
+        authUrl.searchParams.set('response_type', 'token')
+        authUrl.searchParams.set('scope', DRIVE_SCOPES.join(' '))
+        authUrl.searchParams.set('state', state)
+        authUrl.searchParams.set('include_granted_scopes', 'true')
+        authUrl.searchParams.set('prompt', 'consent')
+        window.location.assign(authUrl.toString())
+        return
       }
       const message =
-        params.get("error_description") ??
+        params.get('error_description') ??
         implicitToken?.errorDescription ??
-        `Google OAuth failed: ${oauthError}`;
-      clearPkceState();
-      throw new Error(message);
+        `Google OAuth failed: ${oauthError}`
+      clearPkceState()
+      throw new Error(message)
     }
 
-    const code = params.get("code");
-    const state = params.get("state") ?? implicitToken?.state;
-    const accessToken = implicitToken?.accessToken;
+    const code = params.get('code')
+    const state = params.get('state') ?? implicitToken?.state
+    const accessToken = implicitToken?.accessToken
     if (!code && !state && !accessToken) {
-      return;
+      return
     }
 
-    const storedState = window.localStorage.getItem(PKCE_STATE_KEY);
-    const codeVerifier = window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY);
+    const storedState = window.localStorage.getItem(PKCE_STATE_KEY)
+    const codeVerifier = window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)
     const returnTo =
       window.localStorage.getItem(PKCE_RETURN_TO_KEY) ??
-      getAppPath(APP_ROUTE_PATHS.home);
+      getAppPath(APP_ROUTE_PATHS.home)
 
     if (!state || !storedState) {
-      clearPkceState();
-      throw new Error("Google OAuth callback is missing required state.");
+      clearPkceState()
+      throw new Error('Google OAuth callback is missing required state.')
     }
     if (state !== storedState) {
-      clearPkceState();
-      throw new Error("Google OAuth callback state mismatch.");
+      clearPkceState()
+      throw new Error('Google OAuth callback state mismatch.')
     }
 
     if (accessToken) {
-      const expiresIn = Number.parseInt(implicitToken?.expiresInRaw ?? "", 10);
-      const resolvedExpiresIn = Number.isFinite(expiresIn) && expiresIn > 0
-        ? expiresIn
-        : 3600;
-      setAccessToken(accessToken, resolvedExpiresIn, { refreshToken: null });
-      clearPkceState();
-      window.location.replace(returnTo);
-      return;
+      const expiresIn = Number.parseInt(implicitToken?.expiresInRaw ?? '', 10)
+      const resolvedExpiresIn =
+        Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600
+      const handoffMode = window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)
+      setAccessToken(accessToken, resolvedExpiresIn, { refreshToken: null })
+      clearPkceState()
+      if (handoffMode === 'new_tab') {
+        window.close()
+      }
+      window.location.replace(returnTo)
+      return
     }
 
     if (!code || !codeVerifier) {
-      clearPkceState();
-      throw new Error("Google OAuth callback is missing required PKCE state.");
+      clearPkceState()
+      throw new Error('Google OAuth callback is missing required PKCE state.')
     }
 
-    const tokenResponse = await exchangeAuthorizationCode(code, codeVerifier);
+    const tokenResponse = await exchangeAuthorizationCode(code, codeVerifier)
     if (tokenResponse.error || !tokenResponse.access_token) {
-      clearPkceState();
+      clearPkceState()
       throw new Error(
         tokenResponse.error_description ??
           tokenResponse.error ??
-          "Failed to obtain access token",
-      );
+          'Failed to obtain access token'
+      )
     }
 
-    setAccessToken(tokenResponse.access_token, tokenResponse.expires_in ?? 3600, {
-      refreshToken: tokenResponse.refresh_token,
-    });
-    clearPkceState();
-    window.location.replace(returnTo);
+    setAccessToken(
+      tokenResponse.access_token,
+      tokenResponse.expires_in ?? 3600,
+      {
+        refreshToken: tokenResponse.refresh_token,
+      }
+    )
+    const handoffMode = window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)
+    clearPkceState()
+    if (handoffMode === 'new_tab') {
+      window.close()
+    }
+    window.location.replace(returnTo)
   }, [
     clearPkceState,
     exchangeAuthorizationCode,
     readImplicitRedirectTokenFromHash,
     setAccessToken,
-  ]);
+  ])
 
-  const startPkceRedirect = useCallback(async () => {
-    const { clientId } = googleClientManager.getOAuthClient();
-    if (!clientId?.trim()) {
-      throw new Error("Google OAuth client is not configured.");
-    }
+  const startPkceRedirect = useCallback(
+    async (mode: GoogleRedirectUxMode) => {
+      const { clientId } = googleClientManager.getOAuthClient()
+      if (!clientId?.trim()) {
+        throw new Error('Google OAuth client is not configured.')
+      }
 
-    const { code_verifier: codeVerifier, code_challenge: codeChallenge } =
-      await pkceChallenge();
-    const state = globalThis.crypto?.randomUUID
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now()}-${Math.random()}`;
-    const returnTo = getAppPath(APP_ROUTE_PATHS.home);
+      const { code_verifier: codeVerifier, code_challenge: codeChallenge } =
+        await pkceChallenge()
+      const state = globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`
+      const returnTo = getAppPath(APP_ROUTE_PATHS.home)
 
-    window.localStorage.setItem(PKCE_CODE_VERIFIER_KEY, codeVerifier);
-    window.localStorage.setItem(PKCE_STATE_KEY, state);
-    window.localStorage.setItem(PKCE_RETURN_TO_KEY, returnTo);
+      window.localStorage.setItem(PKCE_CODE_VERIFIER_KEY, codeVerifier)
+      window.localStorage.setItem(PKCE_STATE_KEY, state)
+      window.localStorage.setItem(PKCE_RETURN_TO_KEY, returnTo)
 
-    const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-    authUrl.searchParams.set("client_id", clientId);
-    authUrl.searchParams.set("redirect_uri", getGoogleDriveOAuthCallbackUrl());
-    authUrl.searchParams.set("response_type", "code");
-    authUrl.searchParams.set("scope", DRIVE_SCOPES.join(" "));
-    authUrl.searchParams.set("state", state);
-    authUrl.searchParams.set("code_challenge", codeChallenge);
-    authUrl.searchParams.set("code_challenge_method", "S256");
-    authUrl.searchParams.set("include_granted_scopes", "true");
-    authUrl.searchParams.set("access_type", "offline");
+      const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+      authUrl.searchParams.set('client_id', clientId)
+      authUrl.searchParams.set('redirect_uri', getGoogleDriveOAuthCallbackUrl())
+      authUrl.searchParams.set('response_type', 'code')
+      authUrl.searchParams.set('scope', DRIVE_SCOPES.join(' '))
+      authUrl.searchParams.set('state', state)
+      authUrl.searchParams.set('code_challenge', codeChallenge)
+      authUrl.searchParams.set('code_challenge_method', 'S256')
+      authUrl.searchParams.set('include_granted_scopes', 'true')
+      authUrl.searchParams.set('access_type', 'offline')
 
-    // Force consent only until we obtain a refresh token.
-    if (!tokenInfoRef.current?.refreshToken) {
-      authUrl.searchParams.set("prompt", "consent");
-    }
+      // Force consent only until we obtain a refresh token.
+      if (!tokenInfoRef.current?.refreshToken) {
+        authUrl.searchParams.set('prompt', 'consent')
+      }
 
-    window.location.assign(authUrl.toString());
-  }, []);
+      openAuthUrl(authUrl, mode)
+    },
+    [openAuthUrl]
+  )
 
   const startImplicitRedirect = useCallback(
-    (promptMode: "none" | "consent" = "none") => {
-    const { clientId } = googleClientManager.getOAuthClient();
-    if (!clientId?.trim()) {
-      throw new Error("Google OAuth client is not configured.");
-    }
+    (
+      promptMode: 'none' | 'consent' = 'none',
+      mode: GoogleRedirectUxMode = 'new_tab'
+    ) => {
+      const { clientId } = googleClientManager.getOAuthClient()
+      if (!clientId?.trim()) {
+        throw new Error('Google OAuth client is not configured.')
+      }
 
-    const state = globalThis.crypto?.randomUUID
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now()}-${Math.random()}`;
-    const returnTo = getAppPath(APP_ROUTE_PATHS.home);
+      const state = globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`
+      const returnTo = getAppPath(APP_ROUTE_PATHS.home)
 
-    window.localStorage.setItem(PKCE_STATE_KEY, state);
-    window.localStorage.setItem(PKCE_RETURN_TO_KEY, returnTo);
-    window.localStorage.setItem(IMPLICIT_PROMPT_MODE_KEY, promptMode);
-    window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY);
+      window.localStorage.setItem(PKCE_STATE_KEY, state)
+      window.localStorage.setItem(PKCE_RETURN_TO_KEY, returnTo)
+      window.localStorage.setItem(IMPLICIT_PROMPT_MODE_KEY, promptMode)
+      window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY)
 
-    const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-    authUrl.searchParams.set("client_id", clientId);
-    authUrl.searchParams.set("redirect_uri", getGoogleDriveOAuthCallbackUrl());
-    authUrl.searchParams.set("response_type", "token");
-    authUrl.searchParams.set("scope", DRIVE_SCOPES.join(" "));
-    authUrl.searchParams.set("state", state);
-    authUrl.searchParams.set("include_granted_scopes", "true");
-    authUrl.searchParams.set("prompt", promptMode);
+      const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+      authUrl.searchParams.set('client_id', clientId)
+      authUrl.searchParams.set('redirect_uri', getGoogleDriveOAuthCallbackUrl())
+      authUrl.searchParams.set('response_type', 'token')
+      authUrl.searchParams.set('scope', DRIVE_SCOPES.join(' '))
+      authUrl.searchParams.set('state', state)
+      authUrl.searchParams.set('include_granted_scopes', 'true')
+      authUrl.searchParams.set('prompt', promptMode)
 
-    window.location.assign(authUrl.toString());
+      openAuthUrl(authUrl, mode)
     },
-    [],
-  );
+    [openAuthUrl]
+  )
 
   const refreshAccessToken = useCallback(async (): Promise<string | null> => {
-    const refreshToken = tokenInfoRef.current?.refreshToken?.trim();
+    const refreshToken = tokenInfoRef.current?.refreshToken?.trim()
     if (!refreshToken) {
-      return null;
+      return null
     }
 
-    const { clientId, clientSecret } = googleClientManager.getOAuthClient();
+    const { clientId, clientSecret } = googleClientManager.getOAuthClient()
     if (!clientId?.trim()) {
-      throw new Error("Google OAuth client is not configured.");
+      throw new Error('Google OAuth client is not configured.')
     }
 
     const body = new URLSearchParams({
       client_id: clientId,
-      grant_type: "refresh_token",
+      grant_type: 'refresh_token',
       refresh_token: refreshToken,
-    });
+    })
     if (clientSecret?.trim()) {
-      body.set("client_secret", clientSecret.trim());
+      body.set('client_secret', clientSecret.trim())
     }
 
-    const response = await fetch("https://oauth2.googleapis.com/token", {
-      method: "POST",
+    const response = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
       body,
-    });
+    })
 
-    let token: AccessTokenResponse | null = null;
+    let token: AccessTokenResponse | null = null
     try {
-      token = (await response.json()) as AccessTokenResponse;
+      token = (await response.json()) as AccessTokenResponse
     } catch {
-      token = null;
+      token = null
     }
 
     if (!response.ok || token?.error || !token?.access_token) {
-      if (token?.error === "invalid_grant") {
-        setAccessToken("");
+      if (token?.error === 'invalid_grant') {
+        setAccessToken('')
       }
       throw new Error(
         token?.error_description ??
           token?.error ??
-          `Google OAuth refresh failed (${response.status})`,
-      );
+          `Google OAuth refresh failed (${response.status})`
+      )
     }
 
     setAccessToken(token.access_token, token.expires_in ?? 3600, {
       refreshToken: token.refresh_token ?? refreshToken,
-    });
-    return token.access_token;
-  }, [setAccessToken]);
+    })
+    return token.access_token
+  }, [setAccessToken])
 
   useEffect(() => {
-    tokenInfoRef.current = tokenInfo;
-  }, [tokenInfo]);
+    tokenInfoRef.current = tokenInfo
+  }, [tokenInfo])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
-      setNowMs(Date.now());
-    }, 30_000);
+      setNowMs(Date.now())
+    }, 30_000)
     return () => {
-      window.clearInterval(intervalId);
-    };
-  }, []);
+      window.clearInterval(intervalId)
+    }
+  }, [])
 
-  const isDriveSyncing = Boolean(tokenInfo?.token && tokenInfo.expiresAt > nowMs);
+  const isDriveSyncing = Boolean(
+    tokenInfo?.token && tokenInfo.expiresAt > nowMs
+  )
 
   useEffect(() => {
-    callbackErrorRef.current = null;
+    const handleStorage = (event: StorageEvent) => {
+      if (
+        event.storageArea !== window.localStorage ||
+        (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY)
+      ) {
+        return
+      }
+      const nextTokenInfo = loadStoredToken()
+      tokenInfoRef.current = nextTokenInfo
+      setTokenInfo(nextTokenInfo)
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+
+  useEffect(() => {
+    callbackErrorRef.current = null
     const pending = handleRedirectCallbackIfPresent().catch((error) => {
-      callbackErrorRef.current = error;
+      callbackErrorRef.current = error
       try {
-        window.sessionStorage.setItem(PKCE_ERROR_KEY, String(error));
+        window.sessionStorage.setItem(PKCE_ERROR_KEY, String(error))
       } catch {
         // Ignore session storage failures.
       }
-      appLogger.error("Failed to handle Google Drive OAuth callback", {
+      appLogger.error('Failed to handle Google Drive OAuth callback', {
         attrs: {
-          scope: "storage.drive.auth",
-          code: "DRIVE_AUTH_CALLBACK_FAILED",
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_CALLBACK_FAILED',
           error: String(error),
         },
-      });
-      const callbackPath = new URL(getGoogleDriveOAuthCallbackUrl()).pathname;
+      })
+      const callbackPath = new URL(getGoogleDriveOAuthCallbackUrl()).pathname
       if (window.location.pathname === callbackPath) {
-        window.location.replace(getAppPath(APP_ROUTE_PATHS.home));
+        window.location.replace(getAppPath(APP_ROUTE_PATHS.home))
       }
-    });
+    })
     callbackPromiseRef.current = pending.finally(() => {
-      callbackPromiseRef.current = null;
-    });
-  }, [handleRedirectCallbackIfPresent]);
+      callbackPromiseRef.current = null
+    })
+  }, [handleRedirectCallbackIfPresent])
 
   // Loads the Google Identity Services script exactly once. We memoise the
   // function so callers share the same pending promise, and we stash the promise
   // itself in scriptPromiseRef so multiple callers can await the same work.
   const ensureScriptLoaded = useCallback(() => {
     if (window.google?.accounts?.oauth2?.initTokenClient) {
-      return Promise.resolve();
+      return Promise.resolve()
     }
 
     if (!scriptPromiseRef.current) {
       scriptPromiseRef.current = new Promise<void>((resolve, reject) => {
         const existingScript = document.querySelector<HTMLScriptElement>(
-          'script[src="https://accounts.google.com/gsi/client"]',
-        );
+          'script[src="https://accounts.google.com/gsi/client"]'
+        )
 
         if (existingScript) {
-          existingScript.addEventListener("load", () => resolve(), {
+          existingScript.addEventListener('load', () => resolve(), {
             once: true,
-          });
-          existingScript.addEventListener("error", reject, { once: true });
-          return;
+          })
+          existingScript.addEventListener('error', reject, { once: true })
+          return
         }
 
-        const script = document.createElement("script");
-        script.src = "https://accounts.google.com/gsi/client";
-        script.async = true;
-        script.defer = true;
-        script.onload = () => resolve();
-        script.onerror = reject;
-        document.head.appendChild(script);
+        const script = document.createElement('script')
+        script.src = 'https://accounts.google.com/gsi/client'
+        script.async = true
+        script.defer = true
+        script.onload = () => resolve()
+        script.onerror = reject
+        document.head.appendChild(script)
       }).finally(() => {
-        scriptPromiseRef.current = null;
-      });
+        scriptPromiseRef.current = null
+      })
     }
 
-    return scriptPromiseRef.current;
-  }, []);
+    return scriptPromiseRef.current
+  }, [])
 
   // Lazily create the OAuth token client. We only initialise the client when a
   // consumer actually asks for a token. The client instance is cached in a ref
   // so subsequent callers reuse the same object.
   const ensureTokenClient = useCallback(async () => {
-    const { clientId } = googleClientManager.getOAuthClient();
+    const { clientId } = googleClientManager.getOAuthClient()
     if (!clientId?.trim()) {
-      throw new Error("Google OAuth client is not configured.");
+      throw new Error('Google OAuth client is not configured.')
     }
     if (tokenClientRef.current && oauthClientIdRef.current === clientId) {
-      return tokenClientRef.current;
+      return tokenClientRef.current
     }
-    tokenClientRef.current = null;
-    oauthClientIdRef.current = clientId;
+    tokenClientRef.current = null
+    oauthClientIdRef.current = clientId
 
-    await ensureScriptLoaded();
+    await ensureScriptLoaded()
 
-    const oauth = window.google?.accounts?.oauth2;
+    const oauth = window.google?.accounts?.oauth2
     if (!oauth?.initTokenClient) {
-      throw new Error("Google OAuth client is not available.");
+      throw new Error('Google OAuth client is not available.')
     }
 
     const client = oauth.initTokenClient({
       client_id: clientId,
-      scope: DRIVE_SCOPES.join(" "),
+      scope: DRIVE_SCOPES.join(' '),
       callback: (response: AccessTokenResponse) => {
         if (!handlersRef.current) {
-          return;
+          return
         }
-        const { resolve, reject } = handlersRef.current;
-        handlersRef.current = null;
+        const { resolve, reject } = handlersRef.current
+        handlersRef.current = null
         if (response.error || !response.access_token) {
-          reject(response.error ?? new Error("Failed to obtain access token"));
-          return;
+          reject(response.error ?? new Error('Failed to obtain access token'))
+          return
         }
-        setAccessToken(response.access_token, response.expires_in ?? 3600);
-        resolve(response.access_token);
+        setAccessToken(response.access_token, response.expires_in ?? 3600)
+        resolve(response.access_token)
       },
-    });
+    })
 
-    tokenClientRef.current = client;
-    return client;
-  }, [ensureScriptLoaded, setAccessToken]);
+    tokenClientRef.current = client
+    return client
+  }, [ensureScriptLoaded, setAccessToken])
 
   // Public entry point: fetch (or reuse) an access token. The callback contains
   // all of the state orchestration so Callers can simply `await`.
-  const ensureAccessToken = useCallback((options?: EnsureAccessTokenOptions) => {
-    const interactive = options?.interactive ?? true;
-    const currentInfo = tokenInfoRef.current;
-    if (
-      currentInfo?.token &&
-      currentInfo.expiresAt > Date.now() + REFRESH_MARGIN_MS
-    ) {
-      return Promise.resolve(currentInfo.token);
-    }
-
-    if (pendingPromiseRef.current) {
-      return pendingPromiseRef.current;
-    }
-
-    pendingPromiseRef.current = (async () => {
-      if (callbackPromiseRef.current) {
-        await callbackPromiseRef.current;
-      }
-      let callbackErrorFromStorage: string | null = null;
-      try {
-        callbackErrorFromStorage = window.sessionStorage.getItem(PKCE_ERROR_KEY);
-        if (callbackErrorFromStorage) {
-          window.sessionStorage.removeItem(PKCE_ERROR_KEY);
-        }
-      } catch {
-        callbackErrorFromStorage = null;
-      }
-      if (callbackErrorFromStorage) {
-        throw new Error(callbackErrorFromStorage);
-      }
-      if (callbackErrorRef.current) {
-        const callbackError = callbackErrorRef.current;
-        callbackErrorRef.current = null;
-        throw callbackError;
-      }
-
-      const refreshedInfo = tokenInfoRef.current;
+  const ensureAccessToken = useCallback(
+    (options?: EnsureAccessTokenOptions) => {
+      const interactive = options?.interactive ?? true
+      const currentInfo = tokenInfoRef.current
       if (
-        refreshedInfo?.token &&
-        refreshedInfo.expiresAt > Date.now() + REFRESH_MARGIN_MS
+        currentInfo?.token &&
+        currentInfo.expiresAt > Date.now() + REFRESH_MARGIN_MS
       ) {
-        return refreshedInfo.token;
+        return Promise.resolve(currentInfo.token)
       }
 
-      try {
-        const refreshedToken = await refreshAccessToken();
-        if (refreshedToken) {
-          return refreshedToken;
+      if (pendingPromiseRef.current) {
+        return pendingPromiseRef.current
+      }
+
+      pendingPromiseRef.current = (async () => {
+        if (callbackPromiseRef.current) {
+          await callbackPromiseRef.current
         }
-      } catch (error) {
-        appLogger.error("Failed to refresh Google access token", {
-          attrs: {
-            scope: "storage.drive.auth",
-            code: "DRIVE_AUTH_TOKEN_REFRESH_FAILED",
-            error: String(error),
-          },
-        });
-        if (!interactive) {
-          throw new Error(
-            `Google Drive authorization is required: ${String(error)}`,
-          );
-        }
-      }
-
-      if (!interactive) {
-        throw new Error("Google Drive authorization is required.");
-      }
-
-      const oauthClient = googleClientManager.getOAuthClient();
-      if (oauthClient.authFlow === "pkce") {
-        await startPkceRedirect();
-        throw new Error("Redirecting to Google OAuth for Drive authorization.");
-      }
-      if (oauthClient.authUxMode === "redirect") {
-        startImplicitRedirect();
-        throw new Error("Redirecting to Google OAuth for Drive authorization.");
-      }
-
-      const client = await ensureTokenClient();
-      return await new Promise<string>((resolve, reject) => {
-        handlersRef.current = { resolve, reject };
-        client.callback = (response: AccessTokenResponse) => {
-          if (!handlersRef.current) {
-            return;
-          }
-          const { resolve: pendingResolve, reject: pendingReject } =
-            handlersRef.current;
-          handlersRef.current = null;
-
-          if (response.error || !response.access_token) {
-            pendingReject(
-              response.error ?? new Error("Failed to obtain access token"),
-            );
-            return;
-          }
-          setAccessToken(response.access_token, response.expires_in ?? 3600);
-          pendingResolve(response.access_token);
-        };
+        let callbackErrorFromStorage: string | null = null
         try {
-          console.log("Requesting access token from Google OAuth");
-          client.requestAccessToken({
-            prompt: currentInfo?.token ? "" : "consent",
-          });
+          callbackErrorFromStorage =
+            window.sessionStorage.getItem(PKCE_ERROR_KEY)
+          if (callbackErrorFromStorage) {
+            window.sessionStorage.removeItem(PKCE_ERROR_KEY)
+          }
+        } catch {
+          callbackErrorFromStorage = null
+        }
+        if (callbackErrorFromStorage) {
+          throw new Error(callbackErrorFromStorage)
+        }
+        if (callbackErrorRef.current) {
+          const callbackError = callbackErrorRef.current
+          callbackErrorRef.current = null
+          throw callbackError
+        }
+
+        const refreshedInfo = tokenInfoRef.current
+        if (
+          refreshedInfo?.token &&
+          refreshedInfo.expiresAt > Date.now() + REFRESH_MARGIN_MS
+        ) {
+          return refreshedInfo.token
+        }
+
+        try {
+          const refreshedToken = await refreshAccessToken()
+          if (refreshedToken) {
+            return refreshedToken
+          }
         } catch (error) {
-          handlersRef.current = null;
-          appLogger.error("Failed to request Google access token", {
+          appLogger.error('Failed to refresh Google access token', {
             attrs: {
-              scope: "storage.drive.auth",
-              code: "DRIVE_AUTH_TOKEN_REQUEST_FAILED",
+              scope: 'storage.drive.auth',
+              code: 'DRIVE_AUTH_TOKEN_REFRESH_FAILED',
               error: String(error),
             },
-          });
-          reject(error);
+          })
+          if (!interactive) {
+            throw new Error(
+              `Google Drive authorization is required: ${String(error)}`
+            )
+          }
         }
-      });
-    })().finally(() => {
-      pendingPromiseRef.current = null;
-    });
 
-    return pendingPromiseRef.current;
-  }, [
-    ensureTokenClient,
-    refreshAccessToken,
-    setAccessToken,
-    startImplicitRedirect,
-    startPkceRedirect,
-  ]);
+        if (!interactive) {
+          throw new Error('Google Drive authorization is required.')
+        }
+
+        const oauthClient = googleClientManager.getOAuthClient()
+        if (oauthClient.authFlow === 'pkce') {
+          await startPkceRedirect(
+            oauthClient.authUxMode === 'redirect' ? 'redirect' : 'new_tab'
+          )
+          throw new Error(
+            'Redirecting to Google OAuth for Drive authorization.'
+          )
+        }
+        if (oauthClient.authUxMode === 'redirect') {
+          startImplicitRedirect('none', 'redirect')
+          throw new Error(
+            'Redirecting to Google OAuth for Drive authorization.'
+          )
+        }
+        if (oauthClient.authUxMode === 'new_tab') {
+          startImplicitRedirect('none', 'new_tab')
+          throw new Error(
+            'Redirecting to Google OAuth for Drive authorization.'
+          )
+        }
+
+        const client = await ensureTokenClient()
+        return await new Promise<string>((resolve, reject) => {
+          handlersRef.current = { resolve, reject }
+          client.callback = (response: AccessTokenResponse) => {
+            if (!handlersRef.current) {
+              return
+            }
+            const { resolve: pendingResolve, reject: pendingReject } =
+              handlersRef.current
+            handlersRef.current = null
+
+            if (response.error || !response.access_token) {
+              pendingReject(
+                response.error ?? new Error('Failed to obtain access token')
+              )
+              return
+            }
+            setAccessToken(response.access_token, response.expires_in ?? 3600)
+            pendingResolve(response.access_token)
+          }
+          try {
+            console.log('Requesting access token from Google OAuth')
+            client.requestAccessToken({
+              prompt: currentInfo?.token ? '' : 'consent',
+            })
+          } catch (error) {
+            handlersRef.current = null
+            appLogger.error('Failed to request Google access token', {
+              attrs: {
+                scope: 'storage.drive.auth',
+                code: 'DRIVE_AUTH_TOKEN_REQUEST_FAILED',
+                error: String(error),
+              },
+            })
+            reject(error)
+          }
+        })
+      })().finally(() => {
+        pendingPromiseRef.current = null
+      })
+
+      return pendingPromiseRef.current
+    },
+    [
+      ensureTokenClient,
+      refreshAccessToken,
+      setAccessToken,
+      startImplicitRedirect,
+      startPkceRedirect,
+    ]
+  )
 
   // useMemo caches the context value so React hands the same object reference to
   // consumers unless one of the dependencies changes. This prevents needless
@@ -783,12 +881,12 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       isDriveSyncing,
       setAccessToken,
     }),
-    [ensureAccessToken, isDriveSyncing, setAccessToken],
-  );
+    [ensureAccessToken, isDriveSyncing, setAccessToken]
+  )
 
   return (
     <GoogleAuthContext.Provider value={value}>
       {children}
     </GoogleAuthContext.Provider>
-  );
+  )
 }

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -1,361 +1,386 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 async function loadModules() {
-  vi.resetModules();
-  const appConfig = await import("./appConfig");
-  const oidcConfig = await import("../auth/oidcConfig");
+  vi.resetModules()
+  const appConfig = await import('./appConfig')
+  const oidcConfig = await import('../auth/oidcConfig')
   return {
     ...appConfig,
     ...oidcConfig,
-  };
+  }
 }
 
-describe("appConfig OIDC Google shorthand", () => {
+describe('appConfig OIDC Google shorthand', () => {
   beforeEach(() => {
-    window.localStorage.clear();
-    window.history.replaceState(null, "", "/index.html");
-  });
+    window.localStorage.clear()
+    window.history.replaceState(null, '', '/index.html')
+  })
 
-  it("applies Google defaults when oidc.google is configured", async () => {
-    const { applyAppConfig } = await loadModules();
+  it('applies Google defaults when oidc.google is configured', async () => {
+    const { applyAppConfig } = await loadModules()
 
     const result = applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         oidc: {
           google: {
-            clientID: "client-id.apps.googleusercontent.com",
+            clientID: 'client-id.apps.googleusercontent.com',
           },
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
-    expect(result.warnings).toEqual([]);
+    expect(result.warnings).toEqual([])
     expect(result.oidc).toMatchObject({
       discoveryUrl:
-        "https://accounts.google.com/.well-known/openid-configuration",
-      clientId: "client-id.apps.googleusercontent.com",
-      scope: "openid https://www.googleapis.com/auth/userinfo.email",
+        'https://accounts.google.com/.well-known/openid-configuration',
+      clientId: 'client-id.apps.googleusercontent.com',
+      scope: 'openid https://www.googleapis.com/auth/userinfo.email',
       extraAuthParams: {
-        access_type: "offline",
-        prompt: "consent",
+        access_type: 'offline',
+        prompt: 'consent',
       },
-    });
+    })
     expect(result.oidc?.redirectUri).toMatch(
-      /^http:\/\/localhost(:\d+)?\/oidc\/callback$/,
-    );
-  });
+      /^http:\/\/localhost(:\d+)?\/oidc\/callback$/
+    )
+  })
 
-  it("allows setGoogleDefaults before the client ID is set", async () => {
-    const { oidcConfigManager } = await loadModules();
+  it('allows setGoogleDefaults before the client ID is set', async () => {
+    const { oidcConfigManager } = await loadModules()
 
-    expect(() => oidcConfigManager.setGoogleDefaults()).not.toThrow();
+    expect(() => oidcConfigManager.setGoogleDefaults()).not.toThrow()
 
     const config = oidcConfigManager.setClientId(
-      "client-id.apps.googleusercontent.com",
-    );
+      'client-id.apps.googleusercontent.com'
+    )
 
     expect(config.discoveryUrl).toBe(
-      "https://accounts.google.com/.well-known/openid-configuration",
-    );
+      'https://accounts.google.com/.well-known/openid-configuration'
+    )
     expect(config.scope).toBe(
-      "openid https://www.googleapis.com/auth/userinfo.email",
-    );
-    expect(config.clientId).toBe("client-id.apps.googleusercontent.com");
+      'openid https://www.googleapis.com/auth/userinfo.email'
+    )
+    expect(config.clientId).toBe('client-id.apps.googleusercontent.com')
     expect(config.extraAuthParams).toEqual({
-      access_type: "offline",
-      prompt: "consent",
-    });
-  });
+      access_type: 'offline',
+      prompt: 'consent',
+    })
+  })
 
-  it("stores the ChatKit domain key from app config in local storage", async () => {
-    const { applyAppConfig, getConfiguredChatKitDomainKey } = await loadModules();
+  it('stores the ChatKit domain key from app config in local storage', async () => {
+    const { applyAppConfig, getConfiguredChatKitDomainKey } =
+      await loadModules()
 
     const result = applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         chatkit: {
-          domainKey: "domain_pk_configured",
+          domainKey: 'domain_pk_configured',
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
-    expect(result.warnings).toEqual([]);
-    expect(result.chatkitDomainKey).toBe("domain_pk_configured");
-    expect(getConfiguredChatKitDomainKey()).toBe("domain_pk_configured");
+    expect(result.warnings).toEqual([])
+    expect(result.chatkitDomainKey).toBe('domain_pk_configured')
+    expect(getConfiguredChatKitDomainKey()).toBe('domain_pk_configured')
 
     const stored = JSON.parse(
-      window.localStorage.getItem("cloudAssistantSettings") ?? "{}",
-    );
+      window.localStorage.getItem('cloudAssistantSettings') ?? '{}'
+    )
     expect(stored.chatkit).toEqual({
-      domainKey: "domain_pk_configured",
-    });
-  });
+      domainKey: 'domain_pk_configured',
+    })
+  })
 
-  it("falls back to the existing ChatKit localhost default when no config is stored", async () => {
-    const { getConfiguredChatKitDomainKey } = await loadModules();
+  it('falls back to the existing ChatKit localhost default when no config is stored', async () => {
+    const { getConfiguredChatKitDomainKey } = await loadModules()
 
-    expect(getConfiguredChatKitDomainKey()).toBe("domain_pk_localhost_dev");
-  });
+    expect(getConfiguredChatKitDomainKey()).toBe('domain_pk_localhost_dev')
+  })
 
-  it("applies direct Responses OpenAI config from agent.openai", async () => {
-    const { applyAppConfig } = await loadModules();
+  it('applies direct Responses OpenAI config from agent.openai', async () => {
+    const { applyAppConfig } = await loadModules()
 
     const result = applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
           openai: {
-            authMethod: "OAuth",
-            organization: "org-test",
-            project: "proj-test",
-            vectorStores: ["vs_1", "vs_2"],
+            authMethod: 'OAuth',
+            organization: 'org-test',
+            project: 'proj-test',
+            vectorStores: ['vs_1', 'vs_2'],
           },
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
-    expect(result.warnings).toEqual([]);
+    expect(result.warnings).toEqual([])
     expect(result.responsesDirect).toEqual({
-      authMethod: "oauth",
-      openaiOrganization: "org-test",
-      openaiProject: "proj-test",
-      vectorStores: ["vs_1", "vs_2"],
+      authMethod: 'oauth',
+      openaiOrganization: 'org-test',
+      openaiProject: 'proj-test',
+      vectorStores: ['vs_1', 'vs_2'],
       apiKeySet: false,
-    });
-  });
+    })
+  })
 
-  it("supports go-style top-level OpenAI and cloudAssistant vectorStores", async () => {
-    const { applyAppConfig } = await loadModules();
+  it('supports go-style top-level OpenAI and cloudAssistant vectorStores', async () => {
+    const { applyAppConfig } = await loadModules()
 
     const result = applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         openai: {
-          authMethod: "OAuth",
-          organization: "org-top-level",
-          project: "proj-top-level",
+          authMethod: 'OAuth',
+          organization: 'org-top-level',
+          project: 'proj-top-level',
         },
         cloudAssistant: {
-          vectorStores: ["vs_top"],
+          vectorStores: ['vs_top'],
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
-    expect(result.warnings).toEqual([]);
+    expect(result.warnings).toEqual([])
     expect(result.responsesDirect).toEqual({
-      authMethod: "oauth",
-      openaiOrganization: "org-top-level",
-      openaiProject: "proj-top-level",
-      vectorStores: ["vs_top"],
+      authMethod: 'oauth',
+      openaiOrganization: 'org-top-level',
+      openaiProject: 'proj-top-level',
+      vectorStores: ['vs_top'],
       apiKeySet: false,
-    });
-  });
+    })
+  })
 
-  it("warns when direct Responses is configured for API key auth without a key", async () => {
-    const { applyAppConfig } = await loadModules();
+  it('warns when direct Responses is configured for API key auth without a key', async () => {
+    const { applyAppConfig } = await loadModules()
 
     const result = applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
           openai: {
-            authMethod: "APIKey",
+            authMethod: 'APIKey',
           },
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
-    expect(result.responsesDirect?.authMethod).toBe("api_key");
+    expect(result.responsesDirect?.authMethod).toBe('api_key')
     expect(result.warnings).toContain(
-      "Direct Responses API key auth selected; set API key via app.responsesDirect.setAPIKey(...)",
-    );
-  });
+      'Direct Responses API key auth selected; set API key via app.responsesDirect.setAPIKey(...)'
+    )
+  })
 
-  it("preserves the runtime Google Drive base URL when config omits it", async () => {
-    const { applyAppConfig } = await loadModules();
+  it('preserves the runtime Google Drive base URL when config omits it', async () => {
+    const { applyAppConfig } = await loadModules()
     const { setGoogleDriveBaseUrl, getGoogleDriveBaseUrl } = await import(
-      "./googleDriveRuntime"
-    );
+      './googleDriveRuntime'
+    )
 
-    setGoogleDriveBaseUrl("http://127.0.0.1:9090");
-
-    applyAppConfig(
-      {
-        agent: {
-          endpoint: "http://localhost:9977",
-        },
-        googleDrive: {
-          clientID: "client-id.apps.googleusercontent.com",
-        },
-      },
-      "http://localhost/configs/app-configs.yaml",
-    );
-
-    expect(getGoogleDriveBaseUrl()).toBe("http://127.0.0.1:9090");
-  });
-
-  it("applies Google Drive PKCE auth flow when configured", async () => {
-    const { applyAppConfig } = await loadModules();
-    const { googleClientManager } = await import("./googleClientManager");
+    setGoogleDriveBaseUrl('http://127.0.0.1:9090')
 
     applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         googleDrive: {
-          clientID: "client-id.apps.googleusercontent.com",
-          authFlow: "pkce",
+          clientID: 'client-id.apps.googleusercontent.com',
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
+
+    expect(getGoogleDriveBaseUrl()).toBe('http://127.0.0.1:9090')
+  })
+
+  it('applies Google Drive PKCE auth flow when configured', async () => {
+    const { applyAppConfig } = await loadModules()
+    const { googleClientManager } = await import('./googleClientManager')
+
+    applyAppConfig(
+      {
+        agent: {
+          endpoint: 'http://localhost:9977',
+        },
+        googleDrive: {
+          clientID: 'client-id.apps.googleusercontent.com',
+          authFlow: 'pkce',
+        },
+      },
+      'http://localhost/configs/app-configs.yaml'
+    )
 
     expect(googleClientManager.getOAuthClient()).toMatchObject({
-      clientId: "client-id.apps.googleusercontent.com",
-      authFlow: "pkce",
-      authUxMode: "redirect",
-    });
+      clientId: 'client-id.apps.googleusercontent.com',
+      authFlow: 'pkce',
+      authUxMode: 'new_tab',
+    })
     expect(googleClientManager.getDrivePickerConfig().clientId).toBe(
-      "client-id.apps.googleusercontent.com",
-    );
-  });
+      'client-id.apps.googleusercontent.com'
+    )
+  })
 
-  it("applies Google Drive implicit redirect auth mode when configured", async () => {
-    const { applyAppConfig } = await loadModules();
-    const { googleClientManager } = await import("./googleClientManager");
+  it('applies Google Drive implicit redirect auth mode when configured', async () => {
+    const { applyAppConfig } = await loadModules()
+    const { googleClientManager } = await import('./googleClientManager')
 
     applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         googleDrive: {
-          clientID: "client-id.apps.googleusercontent.com",
-          authFlow: "implicit",
-          authUxMode: "redirect",
+          clientID: 'client-id.apps.googleusercontent.com',
+          authFlow: 'implicit',
+          authUxMode: 'redirect',
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
     expect(googleClientManager.getOAuthClient()).toMatchObject({
-      clientId: "client-id.apps.googleusercontent.com",
-      authFlow: "implicit",
-      authUxMode: "redirect",
-    });
-  });
+      clientId: 'client-id.apps.googleusercontent.com',
+      authFlow: 'implicit',
+      authUxMode: 'redirect',
+    })
+  })
 
-  it("preserves local Google Drive config when local precedence is requested", async () => {
-    const { applyAppConfig } = await loadModules();
-    const { googleClientManager } = await import("./googleClientManager");
+  it('defaults Google Drive auth UX mode to new_tab when not configured', async () => {
+    const { applyAppConfig } = await loadModules()
+    const { googleClientManager } = await import('./googleClientManager')
+
+    applyAppConfig(
+      {
+        agent: {
+          endpoint: 'http://localhost:9977',
+        },
+        googleDrive: {
+          clientID: 'client-id.apps.googleusercontent.com',
+          authFlow: 'implicit',
+        },
+      },
+      'http://localhost/configs/app-configs.yaml'
+    )
+
+    expect(googleClientManager.getOAuthClient()).toMatchObject({
+      clientId: 'client-id.apps.googleusercontent.com',
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+  })
+
+  it('preserves local Google Drive config when local precedence is requested', async () => {
+    const { applyAppConfig } = await loadModules()
+    const { googleClientManager } = await import('./googleClientManager')
 
     googleClientManager.setOAuthClient({
-      clientId: "local-client.apps.googleusercontent.com",
-      authFlow: "pkce",
-      authUxMode: "redirect",
-    });
+      clientId: 'local-client.apps.googleusercontent.com',
+      authFlow: 'pkce',
+      authUxMode: 'redirect',
+    })
 
     applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         googleDrive: {
-          clientID: "config-client.apps.googleusercontent.com",
-          authFlow: "implicit",
+          clientID: 'config-client.apps.googleusercontent.com',
+          authFlow: 'implicit',
         },
       },
-      "http://localhost/configs/app-configs.yaml",
+      'http://localhost/configs/app-configs.yaml',
       {
         preserveLocalConfiguration: true,
-      },
-    );
+      }
+    )
 
     expect(googleClientManager.getOAuthClient()).toMatchObject({
-      clientId: "local-client.apps.googleusercontent.com",
-      authFlow: "pkce",
-      authUxMode: "redirect",
-    });
-  });
+      clientId: 'local-client.apps.googleusercontent.com',
+      authFlow: 'pkce',
+      authUxMode: 'redirect',
+    })
+  })
 
-  it("uses joined googleDrive clientMaterial as clientSecret when provided", async () => {
-    const { applyAppConfig } = await loadModules();
-    const { googleClientManager } = await import("./googleClientManager");
+  it('uses joined googleDrive clientMaterial as clientSecret when provided', async () => {
+    const { applyAppConfig } = await loadModules()
+    const { googleClientManager } = await import('./googleClientManager')
 
     applyAppConfig(
       {
         agent: {
-          endpoint: "http://localhost:9977",
+          endpoint: 'http://localhost:9977',
         },
         googleDrive: {
-          clientID: "client-id.apps.googleusercontent.com",
-          clientSecret: "ignored-client-secret",
-          clientMaterial: ["GOCSPX-3N-", "FPEy4XWoKz", "cVwSyt3yDz_Xwzo"],
+          clientID: 'client-id.apps.googleusercontent.com',
+          clientSecret: 'ignored-client-secret',
+          clientMaterial: ['GOCSPX-3N-', 'FPEy4XWoKz', 'cVwSyt3yDz_Xwzo'],
         },
       },
-      "http://localhost/configs/app-configs.yaml",
-    );
+      'http://localhost/configs/app-configs.yaml'
+    )
 
     expect(googleClientManager.getOAuthClient()).toMatchObject({
-      clientId: "client-id.apps.googleusercontent.com",
-      clientSecret: "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",
-    });
-  });
+      clientId: 'client-id.apps.googleusercontent.com',
+      clientSecret: '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',
+    })
+  })
 
-  it("toggles app-config local precedence on load", async () => {
+  it('toggles app-config local precedence on load', async () => {
     const {
       disableAppConfigOverridesOnLoad,
       enableAppConfigOverridesOnLoad,
       isLocalConfigPreferredOnLoad,
       setLocalConfigPreferredOnLoad,
-    } = await loadModules();
+    } = await loadModules()
 
-    expect(isLocalConfigPreferredOnLoad()).toBe(false);
+    expect(isLocalConfigPreferredOnLoad()).toBe(false)
 
-    expect(disableAppConfigOverridesOnLoad()).toBe(true);
-    expect(isLocalConfigPreferredOnLoad()).toBe(true);
+    expect(disableAppConfigOverridesOnLoad()).toBe(true)
+    expect(isLocalConfigPreferredOnLoad()).toBe(true)
 
-    expect(setLocalConfigPreferredOnLoad(false)).toBe(false);
-    expect(isLocalConfigPreferredOnLoad()).toBe(false);
+    expect(setLocalConfigPreferredOnLoad(false)).toBe(false)
+    expect(isLocalConfigPreferredOnLoad()).toBe(false)
 
-    expect(enableAppConfigOverridesOnLoad()).toBe(false);
-    expect(isLocalConfigPreferredOnLoad()).toBe(false);
-  });
+    expect(enableAppConfigOverridesOnLoad()).toBe(false)
+    expect(isLocalConfigPreferredOnLoad()).toBe(false)
+  })
 
-  it("applies inline YAML via setAppConfigFromYaml", async () => {
-    const { setAppConfigFromYaml } = await loadModules();
+  it('applies inline YAML via setAppConfigFromYaml', async () => {
+    const { setAppConfigFromYaml } = await loadModules()
 
     const result = setAppConfigFromYaml(
       [
-        "agent:",
-        "  endpoint: http://localhost:9977",
-        "  openai:",
-        "    authMethod: OAuth",
-        "    organization: org-inline",
-        "    project: proj-inline",
-      ].join("\n"),
-      "inline://test-config.yaml",
-    );
+        'agent:',
+        '  endpoint: http://localhost:9977',
+        '  openai:',
+        '    authMethod: OAuth',
+        '    organization: org-inline',
+        '    project: proj-inline',
+      ].join('\n'),
+      'inline://test-config.yaml'
+    )
 
-    expect(result.url).toBe("inline://test-config.yaml");
-    expect(result.agentEndpoint).toBe("http://localhost:9977");
+    expect(result.url).toBe('inline://test-config.yaml')
+    expect(result.agentEndpoint).toBe('http://localhost:9977')
     expect(result.responsesDirect).toMatchObject({
-      authMethod: "oauth",
-      openaiOrganization: "org-inline",
-      openaiProject: "proj-inline",
-    });
-  });
-});
+      authMethod: 'oauth',
+      openaiOrganization: 'org-inline',
+      openaiProject: 'proj-inline',
+    })
+  })
+})

--- a/app/src/lib/appConfig.ts
+++ b/app/src/lib/appConfig.ts
@@ -1,278 +1,291 @@
-import YAML from "yaml";
+import YAML from 'yaml'
 
-import type { OidcConfig } from "../auth/oidcConfig";
-import { OIDC_STORAGE_KEY, oidcConfigManager } from "../auth/oidcConfig";
-import { getOidcCallbackUrl, resolveAppUrl } from "./appBase";
+import type { OidcConfig } from '../auth/oidcConfig'
+import { OIDC_STORAGE_KEY, oidcConfigManager } from '../auth/oidcConfig'
+import { agentEndpointManager } from './agentEndpointManager'
+import { getOidcCallbackUrl, resolveAppUrl } from './appBase'
 import type {
   GoogleDriveAuthFlow,
   GoogleDriveAuthUxMode,
   GoogleOAuthClientConfig,
-} from "./googleClientManager";
+} from './googleClientManager'
 import {
   GOOGLE_CLIENT_STORAGE_KEY,
   googleClientManager,
-} from "./googleClientManager";
-import { agentEndpointManager } from "./agentEndpointManager";
-import { appLogger } from "./logging/runtime";
-import { getGoogleDriveBaseUrl, setGoogleDriveBaseUrl } from "./googleDriveRuntime";
-import { responsesDirectConfigManager } from "./runtime/responsesDirectConfigManager";
+} from './googleClientManager'
+import {
+  getGoogleDriveBaseUrl,
+  setGoogleDriveBaseUrl,
+} from './googleDriveRuntime'
+import { appLogger } from './logging/runtime'
+import { responsesDirectConfigManager } from './runtime/responsesDirectConfigManager'
 
 type StoredRunner = {
-  name: string;
-  endpoint: string;
-  reconnect: boolean;
-};
+  name: string
+  endpoint: string
+  reconnect: boolean
+}
 
-export const SETTINGS_STORAGE_KEY = "cloudAssistantSettings";
-const RUNNERS_STORAGE_KEY = "runme/runners";
-const LEGACY_RUNNERS_STORAGE_KEY = "aisre/runners";
-const DEFAULT_RUNNER_NAME_STORAGE_KEY = "runme/defaultRunner";
-const LEGACY_DEFAULT_RUNNER_NAME_STORAGE_KEY = "aisre/defaultRunner";
-const DEFAULT_RUNNER_NAME = "default";
-export const APP_CONFIG_PATH_DEFAULT = "configs/app-configs.yaml";
-export const APP_CONFIG_PREFER_LOCAL_STORAGE_KEY = "runme/app-config/prefer-local";
+export const SETTINGS_STORAGE_KEY = 'cloudAssistantSettings'
+const RUNNERS_STORAGE_KEY = 'runme/runners'
+const LEGACY_RUNNERS_STORAGE_KEY = 'aisre/runners'
+const DEFAULT_RUNNER_NAME_STORAGE_KEY = 'runme/defaultRunner'
+const LEGACY_DEFAULT_RUNNER_NAME_STORAGE_KEY = 'aisre/defaultRunner'
+const DEFAULT_RUNNER_NAME = 'default'
+export const APP_CONFIG_PATH_DEFAULT = 'configs/app-configs.yaml'
+export const APP_CONFIG_PREFER_LOCAL_STORAGE_KEY =
+  'runme/app-config/prefer-local'
 
 export type AppConfigApplyOptions = {
-  preserveLocalConfiguration?: boolean;
-};
+  preserveLocalConfiguration?: boolean
+}
 
 export interface OidcGenericRuntimeConfig {
-  clientId: string;
-  clientSecret: string;
-  discoveryUrl: string;
-  issuer: string;
-  redirectUrl: string;
-  scopes: string[];
+  clientId: string
+  clientSecret: string
+  discoveryUrl: string
+  issuer: string
+  redirectUrl: string
+  scopes: string[]
 }
 
 export interface OidcGoogleRuntimeConfig {
-  clientId: string;
-  clientSecret: string;
+  clientId: string
+  clientSecret: string
 }
 
 export interface OidcRuntimeConfig {
-  clientExchange: boolean;
-  generic: OidcGenericRuntimeConfig;
-  google: OidcGoogleRuntimeConfig;
+  clientExchange: boolean
+  generic: OidcGenericRuntimeConfig
+  google: OidcGoogleRuntimeConfig
 }
 
 export interface GoogleDriveRuntimeConfig {
-  clientId: string;
-  clientSecret: string;
-  baseUrl: string;
-  authFlow: GoogleDriveAuthFlow;
-  authUxMode: GoogleDriveAuthUxMode;
+  clientId: string
+  clientSecret: string
+  baseUrl: string
+  authFlow: GoogleDriveAuthFlow
+  authUxMode: GoogleDriveAuthUxMode
 }
 
 export interface ChatkitRuntimeConfig {
-  domainKey: string;
+  domainKey: string
 }
 
 export interface AgentRuntimeConfig {
-  endpoint: string;
-  defaultRunnerEndpoint: string;
-  openai: AgentOpenAIRuntimeConfig;
+  endpoint: string
+  defaultRunnerEndpoint: string
+  openai: AgentOpenAIRuntimeConfig
 }
 
 export interface AgentOpenAIRuntimeConfig {
-  authMethod: string;
-  organization: string;
-  project: string;
-  vectorStores: string[];
+  authMethod: string
+  organization: string
+  project: string
+  vectorStores: string[]
 }
 
 export interface RuntimeAppConfig {
-  agent: AgentRuntimeConfig;
-  oidc: OidcRuntimeConfig;
-  googleDrive: GoogleDriveRuntimeConfig;
-  chatkit: ChatkitRuntimeConfig;
+  agent: AgentRuntimeConfig
+  oidc: OidcRuntimeConfig
+  googleDrive: GoogleDriveRuntimeConfig
+  chatkit: ChatkitRuntimeConfig
 }
 
 export type AppliedAppConfig = {
-  url: string;
-  oidc?: OidcConfig;
-  googleOAuth?: GoogleOAuthClientConfig;
-  agentEndpoint?: string;
-  defaultRunnerEndpoint?: string;
-  chatkitDomainKey?: string;
+  url: string
+  oidc?: OidcConfig
+  googleOAuth?: GoogleOAuthClientConfig
+  agentEndpoint?: string
+  defaultRunnerEndpoint?: string
+  chatkitDomainKey?: string
   responsesDirect?: {
-    authMethod: string;
-    openaiOrganization: string;
-    openaiProject: string;
-    vectorStores: string[];
-    apiKeySet: boolean;
-  };
-  warnings: string[];
-};
+    authMethod: string
+    openaiOrganization: string
+    openaiProject: string
+    vectorStores: string[]
+    apiKeySet: boolean
+  }
+  warnings: string[]
+}
 
 function normalizeString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
+  if (typeof value !== 'string') {
+    return undefined
   }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
   }
-  return value as Record<string, unknown>;
+  return value as Record<string, unknown>
 }
 
 function asNonEmptyString(value: unknown): string {
-  if (typeof value !== "string") {
-    return "";
+  if (typeof value !== 'string') {
+    return ''
   }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : "";
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : ''
 }
 
 function asBoolean(value: unknown): boolean {
-  return typeof value === "boolean" ? value : false;
+  return typeof value === 'boolean' ? value : false
 }
 
-function asGoogleDriveAuthFlow(value: unknown): GoogleDriveAuthFlow | undefined {
-  if (typeof value !== "string") {
-    return undefined;
+function asGoogleDriveAuthFlow(
+  value: unknown
+): GoogleDriveAuthFlow | undefined {
+  if (typeof value !== 'string') {
+    return undefined
   }
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "implicit" || normalized === "pkce") {
-    return normalized;
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'implicit' || normalized === 'pkce') {
+    return normalized
   }
-  return undefined;
+  return undefined
 }
 
 function asGoogleDriveAuthUxMode(
-  value: unknown,
+  value: unknown
 ): GoogleDriveAuthUxMode | undefined {
-  if (typeof value !== "string") {
-    return undefined;
+  if (typeof value !== 'string') {
+    return undefined
   }
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "popup" || normalized === "redirect") {
-    return normalized;
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'popup' || normalized === 'redirect') {
+    return normalized
   }
-  return undefined;
+  if (
+    normalized === 'new_tab' ||
+    normalized === 'new-tab' ||
+    normalized === 'tab'
+  ) {
+    return 'new_tab'
+  }
+  return undefined
 }
 
 function asStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
-    return [];
+    return []
   }
   const values = value
     .map((item) => asNonEmptyString(item))
-    .filter((item): item is string => Boolean(item));
-  return values;
+    .filter((item): item is string => Boolean(item))
+  return values
 }
 
 function readSettingsFromStorage(storage: Storage): Record<string, unknown> {
-  const settingsRaw = storage.getItem(SETTINGS_STORAGE_KEY);
+  const settingsRaw = storage.getItem(SETTINGS_STORAGE_KEY)
   if (!settingsRaw) {
-    return {};
+    return {}
   }
   try {
-    return JSON.parse(settingsRaw) as Record<string, unknown>;
+    return JSON.parse(settingsRaw) as Record<string, unknown>
   } catch (error) {
-    appLogger.warn("Failed to parse cloudAssistantSettings; resetting.", {
+    appLogger.warn('Failed to parse cloudAssistantSettings; resetting.', {
       attrs: {
-        scope: "config.app",
-        code: "APP_CONFIG_SETTINGS_PARSE_FAILED",
+        scope: 'config.app',
+        code: 'APP_CONFIG_SETTINGS_PARSE_FAILED',
         error: String(error),
       },
-    });
-    return {};
+    })
+    return {}
   }
 }
 
 function writeSettingsToStorage(
   storage: Storage,
-  settings: Record<string, unknown>,
+  settings: Record<string, unknown>
 ): void {
-  storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
 }
 
 export function resolveDefaultRunnerEndpointFallback(): string {
-  if (typeof window === "undefined") {
-    return "";
+  if (typeof window === 'undefined') {
+    return ''
   }
-  const protocol = window.location.protocol === "http:" ? "ws:" : "wss:";
-  return `${protocol}//${window.location.host}/ws`;
+  const protocol = window.location.protocol === 'http:' ? 'ws:' : 'wss:'
+  return `${protocol}//${window.location.host}/ws`
 }
 
 function readStoredRunnerEndpoint(storage: Storage): string | undefined {
   const raw =
     storage.getItem(RUNNERS_STORAGE_KEY) ??
-    storage.getItem(LEGACY_RUNNERS_STORAGE_KEY);
+    storage.getItem(LEGACY_RUNNERS_STORAGE_KEY)
   if (!raw) {
-    return undefined;
+    return undefined
   }
 
   try {
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) {
-      return undefined;
+      return undefined
     }
 
     const defaultRunnerName = normalizeString(
       storage.getItem(DEFAULT_RUNNER_NAME_STORAGE_KEY) ??
-        storage.getItem(LEGACY_DEFAULT_RUNNER_NAME_STORAGE_KEY),
-    );
+        storage.getItem(LEGACY_DEFAULT_RUNNER_NAME_STORAGE_KEY)
+    )
 
     const normalized = parsed
       .map((item) => {
-        const runner = asRecord(item);
+        const runner = asRecord(item)
         if (!runner) {
-          return null;
+          return null
         }
-        const name = normalizeString(runner.name);
-        const endpoint = normalizeString(runner.endpoint);
+        const name = normalizeString(runner.name)
+        const endpoint = normalizeString(runner.endpoint)
         if (!name || !endpoint) {
-          return null;
+          return null
         }
-        return { name, endpoint };
+        return { name, endpoint }
       })
       .filter((item): item is { name: string; endpoint: string } =>
-        Boolean(item),
-      );
+        Boolean(item)
+      )
 
     if (normalized.length === 0) {
-      return undefined;
+      return undefined
     }
 
     if (defaultRunnerName) {
       const defaultRunner = normalized.find(
-        (runner) => runner.name === defaultRunnerName,
-      );
+        (runner) => runner.name === defaultRunnerName
+      )
       if (defaultRunner) {
-        return defaultRunner.endpoint;
+        return defaultRunner.endpoint
       }
     }
 
-    return normalized[0].endpoint;
+    return normalized[0].endpoint
   } catch (error) {
-    appLogger.warn("Failed to parse runners storage", {
+    appLogger.warn('Failed to parse runners storage', {
       attrs: {
-        scope: "config.app",
-        code: "APP_CONFIG_RUNNERS_PARSE_FAILED",
+        scope: 'config.app',
+        code: 'APP_CONFIG_RUNNERS_PARSE_FAILED',
         error: String(error),
       },
-    });
-    return undefined;
+    })
+    return undefined
   }
 }
 
 function hasConfiguredRunners(storage: Storage): boolean {
   if (readStoredRunnerEndpoint(storage)) {
-    return true;
+    return true
   }
-  const settings = readSettingsFromStorage(storage);
-  const settingsWebApp = asRecord(settings.webApp);
-  return Boolean(normalizeString(settingsWebApp?.runner));
+  const settings = readSettingsFromStorage(storage)
+  const settingsWebApp = asRecord(settings.webApp)
+  return Boolean(normalizeString(settingsWebApp?.runner))
 }
 
 function seedDefaultRunner(storage: Storage, endpoint: string): void {
@@ -280,108 +293,105 @@ function seedDefaultRunner(storage: Storage, endpoint: string): void {
     name: DEFAULT_RUNNER_NAME,
     endpoint,
     reconnect: true,
-  };
+  }
 
-  storage.setItem(RUNNERS_STORAGE_KEY, JSON.stringify([runner]));
-  storage.removeItem(LEGACY_RUNNERS_STORAGE_KEY);
-  storage.setItem(DEFAULT_RUNNER_NAME_STORAGE_KEY, runner.name);
-  storage.removeItem(LEGACY_DEFAULT_RUNNER_NAME_STORAGE_KEY);
+  storage.setItem(RUNNERS_STORAGE_KEY, JSON.stringify([runner]))
+  storage.removeItem(LEGACY_RUNNERS_STORAGE_KEY)
+  storage.setItem(DEFAULT_RUNNER_NAME_STORAGE_KEY, runner.name)
+  storage.removeItem(LEGACY_DEFAULT_RUNNER_NAME_STORAGE_KEY)
 }
 
 export function getConfiguredAgentEndpoint(): string {
-  return agentEndpointManager.get();
+  return agentEndpointManager.get()
 }
 
 export function getConfiguredDefaultRunnerEndpoint(): string {
-  if (typeof window === "undefined" || !window.localStorage) {
-    return resolveDefaultRunnerEndpointFallback();
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return resolveDefaultRunnerEndpointFallback()
   }
 
-  const storage = window.localStorage;
-  const storedRunnerEndpoint = readStoredRunnerEndpoint(storage);
+  const storage = window.localStorage
+  const storedRunnerEndpoint = readStoredRunnerEndpoint(storage)
   if (storedRunnerEndpoint) {
-    return storedRunnerEndpoint;
+    return storedRunnerEndpoint
   }
 
-  const settings = readSettingsFromStorage(storage);
-  const settingsWebApp = asRecord(settings.webApp);
+  const settings = readSettingsFromStorage(storage)
+  const settingsWebApp = asRecord(settings.webApp)
   return (
     normalizeString(settingsWebApp?.runner) ??
     resolveDefaultRunnerEndpointFallback()
-  );
+  )
 }
 
 export function resolveDefaultChatKitDomainKeyFallback(): string {
-  const envValue = normalizeString(import.meta.env.VITE_CHATKIT_DOMAIN_KEY);
+  const envValue = normalizeString(import.meta.env.VITE_CHATKIT_DOMAIN_KEY)
   if (envValue) {
-    return envValue;
+    return envValue
   }
   if (
-    typeof window !== "undefined" &&
-    window.location.hostname === "localhost"
+    typeof window !== 'undefined' &&
+    window.location.hostname === 'localhost'
   ) {
-    return "domain_pk_localhost_dev";
+    return 'domain_pk_localhost_dev'
   }
-  return "domain_pk_68f8054e7da081908cc1972e9167ec270895bf04413e753b";
+  return 'domain_pk_68f8054e7da081908cc1972e9167ec270895bf04413e753b'
 }
 
 function readStoredChatKitDomainKey(storage: Storage): string | undefined {
-  const settings = readSettingsFromStorage(storage);
-  const settingsChatkit = asRecord(settings.chatkit);
-  return normalizeString(settingsChatkit?.domainKey);
+  const settings = readSettingsFromStorage(storage)
+  const settingsChatkit = asRecord(settings.chatkit)
+  return normalizeString(settingsChatkit?.domainKey)
 }
 
 export function getConfiguredChatKitDomainKey(): string {
-  if (typeof window === "undefined" || !window.localStorage) {
-    return resolveDefaultChatKitDomainKeyFallback();
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return resolveDefaultChatKitDomainKeyFallback()
   }
 
   return (
     readStoredChatKitDomainKey(window.localStorage) ??
     resolveDefaultChatKitDomainKeyFallback()
-  );
+  )
 }
 
-function pickString(
-  source: Record<string, unknown>,
-  keys: string[],
-): string {
+function pickString(source: Record<string, unknown>, keys: string[]): string {
   for (const key of keys) {
-    const value = asNonEmptyString(source[key]);
+    const value = asNonEmptyString(source[key])
     if (value) {
-      return value;
+      return value
     }
   }
-  return "";
+  return ''
 }
 
 function createDefaultOidcGenericRuntimeConfig(): OidcGenericRuntimeConfig {
   return {
-    clientId: "",
-    clientSecret: "",
-    discoveryUrl: "",
-    issuer: "",
-    redirectUrl: "",
+    clientId: '',
+    clientSecret: '',
+    discoveryUrl: '',
+    issuer: '',
+    redirectUrl: '',
     scopes: [],
-  };
+  }
 }
 
 function createDefaultOidcGoogleRuntimeConfig(): OidcGoogleRuntimeConfig {
   return {
-    clientId: "",
-    clientSecret: "",
-  };
+    clientId: '',
+    clientSecret: '',
+  }
 }
 
 function createDefaultRuntimeAppConfig(): RuntimeAppConfig {
   return {
     agent: {
-      endpoint: "",
-      defaultRunnerEndpoint: "",
+      endpoint: '',
+      defaultRunnerEndpoint: '',
       openai: {
-        authMethod: "",
-        organization: "",
-        project: "",
+        authMethod: '',
+        organization: '',
+        project: '',
         vectorStores: [],
       },
     },
@@ -391,16 +401,16 @@ function createDefaultRuntimeAppConfig(): RuntimeAppConfig {
       google: createDefaultOidcGoogleRuntimeConfig(),
     },
     googleDrive: {
-      clientId: "",
-      clientSecret: "",
-      baseUrl: "",
-      authFlow: "implicit",
-      authUxMode: "popup",
+      clientId: '',
+      clientSecret: '',
+      baseUrl: '',
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
     },
     chatkit: {
-      domainKey: "",
+      domainKey: '',
     },
-  };
+  }
 }
 
 /**
@@ -409,236 +419,243 @@ function createDefaultRuntimeAppConfig(): RuntimeAppConfig {
  */
 export class RuntimeAppConfigSchema {
   static fromUnknown(value: unknown): RuntimeAppConfig {
-    const parsed = createDefaultRuntimeAppConfig();
-    const root = asRecord(value);
+    const parsed = createDefaultRuntimeAppConfig()
+    const root = asRecord(value)
     if (!root) {
-      return parsed;
+      return parsed
     }
 
-    const agent = asRecord(root.agent);
-    const oidc = asRecord(root.oidc);
-    const oidcGeneric = asRecord(oidc?.generic);
-    const oidcGoogle = asRecord(oidc?.google);
-    const drive = asRecord(root.googleDrive);
-    const chatkit = asRecord(root.chatkit);
-    const topLevelOpenAI = asRecord(root.openai);
-    const cloudAssistant = asRecord(root.cloudAssistant);
-    const agentOpenAI = asRecord(agent?.openai);
+    const agent = asRecord(root.agent)
+    const oidc = asRecord(root.oidc)
+    const oidcGeneric = asRecord(oidc?.generic)
+    const oidcGoogle = asRecord(oidc?.google)
+    const drive = asRecord(root.googleDrive)
+    const chatkit = asRecord(root.chatkit)
+    const topLevelOpenAI = asRecord(root.openai)
+    const cloudAssistant = asRecord(root.cloudAssistant)
+    const agentOpenAI = asRecord(agent?.openai)
 
     parsed.agent = {
       endpoint:
-        pickString(agent ?? {}, ["endpoint", "agentEndpoint"]) ||
+        pickString(agent ?? {}, ['endpoint', 'agentEndpoint']) ||
         asNonEmptyString(root.agentEndpoint),
       defaultRunnerEndpoint:
-        pickString(agent ?? {}, ["defaultRunnerEndpoint", "runnerEndpoint"]) ||
+        pickString(agent ?? {}, ['defaultRunnerEndpoint', 'runnerEndpoint']) ||
         asNonEmptyString(root.defaultRunnerEndpoint),
       openai: {
         authMethod:
-          pickString(agentOpenAI ?? {}, ["authMethod", "auth_method", "method"]) ||
-          pickString(topLevelOpenAI ?? {}, ["authMethod", "auth_method", "method"]),
+          pickString(agentOpenAI ?? {}, [
+            'authMethod',
+            'auth_method',
+            'method',
+          ]) ||
+          pickString(topLevelOpenAI ?? {}, [
+            'authMethod',
+            'auth_method',
+            'method',
+          ]),
         organization:
-          pickString(agentOpenAI ?? {}, ["organization"]) ||
-          pickString(topLevelOpenAI ?? {}, ["organization"]),
+          pickString(agentOpenAI ?? {}, ['organization']) ||
+          pickString(topLevelOpenAI ?? {}, ['organization']),
         project:
-          pickString(agentOpenAI ?? {}, ["project"]) ||
-          pickString(topLevelOpenAI ?? {}, ["project"]),
+          pickString(agentOpenAI ?? {}, ['project']) ||
+          pickString(topLevelOpenAI ?? {}, ['project']),
         vectorStores: (() => {
-          const explicit = asStringArray(agentOpenAI?.vectorStores);
+          const explicit = asStringArray(agentOpenAI?.vectorStores)
           if (explicit.length > 0) {
-            return explicit;
+            return explicit
           }
-          return asStringArray(cloudAssistant?.vectorStores);
+          return asStringArray(cloudAssistant?.vectorStores)
         })(),
       },
-    };
+    }
 
     if (oidc) {
-      parsed.oidc.clientExchange = asBoolean(oidc.clientExchange);
+      parsed.oidc.clientExchange = asBoolean(oidc.clientExchange)
     }
     if (oidcGeneric) {
       parsed.oidc.generic = {
-        clientId: pickString(oidcGeneric, ["clientId", "clientID"]),
+        clientId: pickString(oidcGeneric, ['clientId', 'clientID']),
         clientSecret: pickString(oidcGeneric, [
-          "clientSecret",
-          "client_secret",
+          'clientSecret',
+          'client_secret',
         ]),
-        discoveryUrl: pickString(oidcGeneric, ["discoveryUrl", "discoveryURL"]),
-        issuer: pickString(oidcGeneric, ["issuer"]),
-        redirectUrl: pickString(oidcGeneric, ["redirectUrl", "redirectURL"]),
+        discoveryUrl: pickString(oidcGeneric, ['discoveryUrl', 'discoveryURL']),
+        issuer: pickString(oidcGeneric, ['issuer']),
+        redirectUrl: pickString(oidcGeneric, ['redirectUrl', 'redirectURL']),
         scopes: asStringArray(oidcGeneric.scopes),
-      };
+      }
     }
     if (oidcGoogle) {
       parsed.oidc.google = {
-        clientId: pickString(oidcGoogle, ["clientId", "clientID"]),
-        clientSecret: pickString(oidcGoogle, ["clientSecret", "client_secret"]),
-      };
+        clientId: pickString(oidcGoogle, ['clientId', 'clientID']),
+        clientSecret: pickString(oidcGoogle, ['clientSecret', 'client_secret']),
+      }
     }
 
     if (drive) {
       const hasClientMaterial =
-        Object.prototype.hasOwnProperty.call(drive, "clientMaterial") ||
-        Object.prototype.hasOwnProperty.call(drive, "client_material");
+        Object.prototype.hasOwnProperty.call(drive, 'clientMaterial') ||
+        Object.prototype.hasOwnProperty.call(drive, 'client_material')
       const clientMaterial = asStringArray(
-        drive.clientMaterial ?? drive.client_material,
-      ).join("");
+        drive.clientMaterial ?? drive.client_material
+      ).join('')
       const authFlow =
         asGoogleDriveAuthFlow(
-          drive.authFlow ?? drive.auth_flow ?? drive.oauthFlow ?? drive.flow,
-        ) ?? "implicit";
+          drive.authFlow ?? drive.auth_flow ?? drive.oauthFlow ?? drive.flow
+        ) ?? 'implicit'
       const authUxMode =
         asGoogleDriveAuthUxMode(
           drive.authUxMode ??
             drive.auth_ux_mode ??
             drive.oauthUxMode ??
-            drive.uxMode,
-        ) ?? (authFlow === "pkce" ? "redirect" : "popup");
+            drive.uxMode
+        ) ?? 'new_tab'
       parsed.googleDrive = {
-        clientId: pickString(drive, ["clientId", "clientID"]),
+        clientId: pickString(drive, ['clientId', 'clientID']),
         clientSecret: hasClientMaterial
           ? clientMaterial
-          : pickString(drive, ["clientSecret", "client_secret"]),
+          : pickString(drive, ['clientSecret', 'client_secret']),
         baseUrl: asNonEmptyString(drive.baseUrl),
         authFlow,
         authUxMode,
-      };
+      }
     }
 
     if (chatkit) {
       parsed.chatkit = {
-        domainKey: pickString(chatkit, ["domainKey", "domain_key"]),
-      };
+        domainKey: pickString(chatkit, ['domainKey', 'domain_key']),
+      }
     }
 
-    return parsed;
+    return parsed
   }
 }
 
 export function getDefaultAppConfigUrl(): string {
-  if (typeof window === "undefined") {
-    return APP_CONFIG_PATH_DEFAULT;
+  if (typeof window === 'undefined') {
+    return APP_CONFIG_PATH_DEFAULT
   }
-  return resolveAppUrl(APP_CONFIG_PATH_DEFAULT).toString();
+  return resolveAppUrl(APP_CONFIG_PATH_DEFAULT).toString()
 }
 
 export function applyAppConfig(
   rawConfig: unknown,
   url: string,
-  options?: AppConfigApplyOptions,
+  options?: AppConfigApplyOptions
 ): AppliedAppConfig {
   if (!isRecord(rawConfig)) {
-    throw new Error("App config is empty or invalid");
+    throw new Error('App config is empty or invalid')
   }
   const preserveLocalConfiguration = Boolean(
-    options?.preserveLocalConfiguration,
-  );
+    options?.preserveLocalConfiguration
+  )
   const localStorageRef =
-    typeof window !== "undefined" && window.localStorage
+    typeof window !== 'undefined' && window.localStorage
       ? window.localStorage
-      : null;
-  const hasLocalOidcConfig = Boolean(
-    localStorageRef?.getItem(OIDC_STORAGE_KEY),
-  );
+      : null
+  const hasLocalOidcConfig = Boolean(localStorageRef?.getItem(OIDC_STORAGE_KEY))
   const hasLocalDriveConfig = Boolean(
-    localStorageRef?.getItem(GOOGLE_CLIENT_STORAGE_KEY),
-  );
-  const hasLocalDriveRuntimeBaseUrl = Boolean(getGoogleDriveBaseUrl());
+    localStorageRef?.getItem(GOOGLE_CLIENT_STORAGE_KEY)
+  )
+  const hasLocalDriveRuntimeBaseUrl = Boolean(getGoogleDriveBaseUrl())
 
-  const parsed = RuntimeAppConfigSchema.fromUnknown(rawConfig);
-  const hasOidcBlock = isRecord(rawConfig.oidc);
-  const rawOidc = asRecord(rawConfig.oidc);
-  const hasOidcGoogleBlock = isRecord(rawOidc?.google);
-  const hasGoogleDriveBlock = isRecord(rawConfig.googleDrive);
-  const hasChatkitBlock = isRecord(rawConfig.chatkit);
-  const rawAgent = asRecord(rawConfig.agent);
-  const hasAgentOpenAIBlock = isRecord(asRecord(rawAgent?.openai));
-  const hasTopLevelOpenAIBlock = isRecord(rawConfig.openai);
-  const hasCloudAssistantBlock = isRecord(rawConfig.cloudAssistant);
+  const parsed = RuntimeAppConfigSchema.fromUnknown(rawConfig)
+  const hasOidcBlock = isRecord(rawConfig.oidc)
+  const rawOidc = asRecord(rawConfig.oidc)
+  const hasOidcGoogleBlock = isRecord(rawOidc?.google)
+  const hasGoogleDriveBlock = isRecord(rawConfig.googleDrive)
+  const hasChatkitBlock = isRecord(rawConfig.chatkit)
+  const rawAgent = asRecord(rawConfig.agent)
+  const hasAgentOpenAIBlock = isRecord(asRecord(rawAgent?.openai))
+  const hasTopLevelOpenAIBlock = isRecord(rawConfig.openai)
+  const hasCloudAssistantBlock = isRecord(rawConfig.cloudAssistant)
   const hasResponsesDirectConfigBlock =
-    hasAgentOpenAIBlock || hasTopLevelOpenAIBlock || hasCloudAssistantBlock;
-  const warnings: string[] = [];
-  let oidc: OidcConfig | undefined;
-  let googleOAuth: GoogleOAuthClientConfig | undefined;
-  let agentEndpoint: string | undefined;
-  let defaultRunnerEndpoint: string | undefined;
-  let chatkitDomainKey: string | undefined;
+    hasAgentOpenAIBlock || hasTopLevelOpenAIBlock || hasCloudAssistantBlock
+  const warnings: string[] = []
+  let oidc: OidcConfig | undefined
+  let googleOAuth: GoogleOAuthClientConfig | undefined
+  let agentEndpoint: string | undefined
+  let defaultRunnerEndpoint: string | undefined
+  let chatkitDomainKey: string | undefined
   let responsesDirect:
     | {
-        authMethod: string;
-        openaiOrganization: string;
-        openaiProject: string;
-        vectorStores: string[];
-        apiKeySet: boolean;
+        authMethod: string
+        openaiOrganization: string
+        openaiProject: string
+        vectorStores: string[]
+        apiKeySet: boolean
       }
-    | undefined;
+    | undefined
 
-  const oidcConfig: Partial<OidcConfig> = {};
-  const genericOidcConfig = parsed.oidc.generic;
-  const googleOidcConfig = parsed.oidc.google;
-  const googleOidcClientId = normalizeString(googleOidcConfig.clientId);
-  const googleOidcClientSecret = normalizeString(googleOidcConfig.clientSecret);
+  const oidcConfig: Partial<OidcConfig> = {}
+  const genericOidcConfig = parsed.oidc.generic
+  const googleOidcConfig = parsed.oidc.google
+  const googleOidcClientId = normalizeString(googleOidcConfig.clientId)
+  const googleOidcClientSecret = normalizeString(googleOidcConfig.clientSecret)
   const oidcScope =
     genericOidcConfig.scopes.length > 0
-      ? genericOidcConfig.scopes.join(" ")
-      : undefined;
-  const discoveryUrl = normalizeString(genericOidcConfig.discoveryUrl);
+      ? genericOidcConfig.scopes.join(' ')
+      : undefined
+  const discoveryUrl = normalizeString(genericOidcConfig.discoveryUrl)
   const clientId =
-    googleOidcClientId ?? normalizeString(genericOidcConfig.clientId);
+    googleOidcClientId ?? normalizeString(genericOidcConfig.clientId)
   const clientSecret =
-    googleOidcClientSecret ?? normalizeString(genericOidcConfig.clientSecret);
-  const redirectUri = normalizeString(genericOidcConfig.redirectUrl);
-  const configuredChatkitDomainKey = normalizeString(parsed.chatkit.domainKey);
-  const skipOidcFromConfig =
-    preserveLocalConfiguration && hasLocalOidcConfig;
+    googleOidcClientSecret ?? normalizeString(genericOidcConfig.clientSecret)
+  const redirectUri = normalizeString(genericOidcConfig.redirectUrl)
+  const configuredChatkitDomainKey = normalizeString(parsed.chatkit.domainKey)
+  const skipOidcFromConfig = preserveLocalConfiguration && hasLocalOidcConfig
   if (skipOidcFromConfig) {
     try {
-      oidc = oidcConfigManager.getConfig();
+      oidc = oidcConfigManager.getConfig()
     } catch {
-      oidc = undefined;
+      oidc = undefined
     }
   } else {
     if (hasOidcGoogleBlock) {
-      oidcConfigManager.setGoogleDefaults();
+      oidcConfigManager.setGoogleDefaults()
     }
     if (discoveryUrl) {
-      oidcConfig.discoveryUrl = discoveryUrl;
+      oidcConfig.discoveryUrl = discoveryUrl
     }
     if (clientId) {
-      oidcConfig.clientId = clientId;
+      oidcConfig.clientId = clientId
     }
     if (clientSecret) {
-      oidcConfig.clientSecret = clientSecret;
+      oidcConfig.clientSecret = clientSecret
     }
     if (redirectUri) {
-      oidcConfig.redirectUri = redirectUri;
+      oidcConfig.redirectUri = redirectUri
     }
     if (oidcScope) {
-      oidcConfig.scope = oidcScope;
+      oidcConfig.scope = oidcScope
     }
     if (Object.keys(oidcConfig).length > 0) {
-      if (!oidcConfig.redirectUri && typeof window !== "undefined") {
-        oidcConfig.redirectUri = getOidcCallbackUrl();
+      if (!oidcConfig.redirectUri && typeof window !== 'undefined') {
+        oidcConfig.redirectUri = getOidcCallbackUrl()
       }
       try {
-        oidc = oidcConfigManager.setConfig(oidcConfig);
+        oidc = oidcConfigManager.setConfig(oidcConfig)
       } catch (error) {
-        warnings.push(`OIDC config not applied: ${String(error)}`);
+        warnings.push(`OIDC config not applied: ${String(error)}`)
       }
     } else if (hasOidcGoogleBlock) {
-      warnings.push("OIDC Google config missing clientID/clientId");
+      warnings.push('OIDC Google config missing clientID/clientId')
     } else if (hasOidcBlock) {
-      warnings.push("OIDC config present but no applicable generic values found");
+      warnings.push(
+        'OIDC config present but no applicable generic values found'
+      )
     }
   }
 
-  const googleClientId = normalizeString(parsed.googleDrive.clientId);
-  const googleClientSecret = normalizeString(parsed.googleDrive.clientSecret);
-  const googleAuthFlow = parsed.googleDrive.authFlow;
-  const googleAuthUxMode = parsed.googleDrive.authUxMode;
+  const googleClientId = normalizeString(parsed.googleDrive.clientId)
+  const googleClientSecret = normalizeString(parsed.googleDrive.clientSecret)
+  const googleAuthFlow = parsed.googleDrive.authFlow
+  const googleAuthUxMode = parsed.googleDrive.authUxMode
   const skipGoogleDriveFromConfig =
-    preserveLocalConfiguration && hasLocalDriveConfig;
+    preserveLocalConfiguration && hasLocalDriveConfig
   if (skipGoogleDriveFromConfig) {
-    googleOAuth = googleClientManager.getOAuthClient();
+    googleOAuth = googleClientManager.getOAuthClient()
   } else {
     if (googleClientId) {
       try {
@@ -647,81 +664,86 @@ export function applyAppConfig(
           clientSecret: googleClientSecret,
           authFlow: googleAuthFlow,
           authUxMode: googleAuthUxMode,
-        });
+        })
       } catch (error) {
-        warnings.push(`Google OAuth config not applied: ${String(error)}`);
+        warnings.push(`Google OAuth config not applied: ${String(error)}`)
       }
     } else if (hasGoogleDriveBlock) {
-      warnings.push("Google Drive config missing clientID/clientId");
+      warnings.push('Google Drive config missing clientID/clientId')
     }
   }
   if (
     parsed.googleDrive.baseUrl &&
     !(preserveLocalConfiguration && hasLocalDriveRuntimeBaseUrl)
   ) {
-    setGoogleDriveBaseUrl(parsed.googleDrive.baseUrl);
+    setGoogleDriveBaseUrl(parsed.googleDrive.baseUrl)
   }
 
   if (localStorageRef) {
-    const settings = readSettingsFromStorage(localStorageRef);
-    const settingsWebApp = asRecord(settings.webApp);
-    const settingsChatkit = asRecord(settings.chatkit);
-    const configAgentEndpoint = normalizeString(parsed.agent.endpoint);
-    const hadAgentOverride = agentEndpointManager.hasOverride();
-    agentEndpointManager.setDefaultEndpoint(configAgentEndpoint);
+    const settings = readSettingsFromStorage(localStorageRef)
+    const settingsWebApp = asRecord(settings.webApp)
+    const settingsChatkit = asRecord(settings.chatkit)
+    const configAgentEndpoint = normalizeString(parsed.agent.endpoint)
+    const hadAgentOverride = agentEndpointManager.hasOverride()
+    agentEndpointManager.setDefaultEndpoint(configAgentEndpoint)
     if (!configAgentEndpoint && !hadAgentOverride) {
       warnings.push(
-        "App config missing agent.endpoint; defaulting to window.location.origin",
-      );
+        'App config missing agent.endpoint; defaulting to window.location.origin'
+      )
     }
-    agentEndpoint = agentEndpointManager.get();
+    agentEndpoint = agentEndpointManager.get()
 
     const configRunnerEndpoint = normalizeString(
-      parsed.agent.defaultRunnerEndpoint,
-    );
-    const hasStoredRunnerEndpoint = hasConfiguredRunners(localStorageRef);
+      parsed.agent.defaultRunnerEndpoint
+    )
+    const hasStoredRunnerEndpoint = hasConfiguredRunners(localStorageRef)
 
     if (!hasStoredRunnerEndpoint && configRunnerEndpoint) {
-      defaultRunnerEndpoint = configRunnerEndpoint;
-      seedDefaultRunner(localStorageRef, configRunnerEndpoint);
+      defaultRunnerEndpoint = configRunnerEndpoint
+      seedDefaultRunner(localStorageRef, configRunnerEndpoint)
 
       const webApp = {
         ...(settingsWebApp ?? {}),
         runner: configRunnerEndpoint,
-      };
-      settings.webApp = webApp;
-      writeSettingsToStorage(localStorageRef, settings);
+      }
+      settings.webApp = webApp
+      writeSettingsToStorage(localStorageRef, settings)
     } else if (hasStoredRunnerEndpoint) {
-      defaultRunnerEndpoint = readStoredRunnerEndpoint(localStorageRef);
+      defaultRunnerEndpoint = readStoredRunnerEndpoint(localStorageRef)
     }
 
-    const storedChatkitDomainKey = readStoredChatKitDomainKey(localStorageRef);
+    const storedChatkitDomainKey = readStoredChatKitDomainKey(localStorageRef)
     if (!storedChatkitDomainKey && configuredChatkitDomainKey) {
-      chatkitDomainKey = configuredChatkitDomainKey;
+      chatkitDomainKey = configuredChatkitDomainKey
       settings.chatkit = {
         ...(settingsChatkit ?? {}),
         domainKey: configuredChatkitDomainKey,
-      };
-      writeSettingsToStorage(localStorageRef, settings);
+      }
+      writeSettingsToStorage(localStorageRef, settings)
     } else {
-      chatkitDomainKey = storedChatkitDomainKey;
+      chatkitDomainKey = storedChatkitDomainKey
     }
   }
 
   if (!chatkitDomainKey) {
-    chatkitDomainKey = configuredChatkitDomainKey;
+    chatkitDomainKey = configuredChatkitDomainKey
   }
   if (hasChatkitBlock && !configuredChatkitDomainKey) {
-    warnings.push("ChatKit config missing domainKey");
+    warnings.push('ChatKit config missing domainKey')
   }
 
-  const configuredOpenAIAuthMethod = normalizeString(parsed.agent.openai.authMethod);
-  const configuredOpenAIOrganization = normalizeString(parsed.agent.openai.organization);
-  const configuredOpenAIProject = normalizeString(parsed.agent.openai.project);
-  const configuredVectorStores = parsed.agent.openai.vectorStores;
+  const configuredOpenAIAuthMethod = normalizeString(
+    parsed.agent.openai.authMethod
+  )
+  const configuredOpenAIOrganization = normalizeString(
+    parsed.agent.openai.organization
+  )
+  const configuredOpenAIProject = normalizeString(parsed.agent.openai.project)
+  const configuredVectorStores = parsed.agent.openai.vectorStores
 
   const shouldApplyResponsesDirectDefaults =
-    hasResponsesDirectConfigBlock || responsesDirectConfigManager.hasInitializedConfig();
+    hasResponsesDirectConfigBlock ||
+    responsesDirectConfigManager.hasInitializedConfig()
   const responsesDirectSnapshot = shouldApplyResponsesDirectDefaults
     ? responsesDirectConfigManager.applyDefaults({
         authMethod: configuredOpenAIAuthMethod,
@@ -729,29 +751,31 @@ export function applyAppConfig(
         openaiProject: configuredOpenAIProject,
         vectorStores: configuredVectorStores,
       })
-    : responsesDirectConfigManager.getSnapshot();
+    : responsesDirectConfigManager.getSnapshot()
   responsesDirect = {
     authMethod: responsesDirectSnapshot.authMethod,
     openaiOrganization: responsesDirectSnapshot.openaiOrganization,
     openaiProject: responsesDirectSnapshot.openaiProject,
     vectorStores: responsesDirectSnapshot.vectorStores,
     apiKeySet: responsesDirectSnapshot.apiKey.length > 0,
-  };
+  }
 
   if (hasResponsesDirectConfigBlock) {
-    if (responsesDirectSnapshot.authMethod === "oauth") {
+    if (responsesDirectSnapshot.authMethod === 'oauth') {
       if (!responsesDirectSnapshot.openaiOrganization) {
         warnings.push(
-          "Direct Responses OAuth requires openai organization (agent.openai.organization)",
-        );
+          'Direct Responses OAuth requires openai organization (agent.openai.organization)'
+        )
       }
       if (!responsesDirectSnapshot.openaiProject) {
-        warnings.push("Direct Responses OAuth requires openai project (agent.openai.project)");
+        warnings.push(
+          'Direct Responses OAuth requires openai project (agent.openai.project)'
+        )
       }
     } else if (!responsesDirectSnapshot.apiKey) {
       warnings.push(
-        "Direct Responses API key auth selected; set API key via app.responsesDirect.setAPIKey(...)",
-      );
+        'Direct Responses API key auth selected; set API key via app.responsesDirect.setAPIKey(...)'
+      )
     }
   }
 
@@ -764,101 +788,101 @@ export function applyAppConfig(
     chatkitDomainKey,
     responsesDirect,
     warnings,
-  };
+  }
 }
 
 export async function setAppConfig(
   url?: string,
-  options?: AppConfigApplyOptions,
+  options?: AppConfigApplyOptions
 ): Promise<AppliedAppConfig> {
-  const resolvedUrl = normalizeString(url) ?? getDefaultAppConfigUrl();
-  const response = await fetch(resolvedUrl, { cache: "no-store" });
+  const resolvedUrl = normalizeString(url) ?? getDefaultAppConfigUrl()
+  const response = await fetch(resolvedUrl, { cache: 'no-store' })
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch app config (${response.status} ${response.statusText})`,
-    );
+      `Failed to fetch app config (${response.status} ${response.statusText})`
+    )
   }
-  const text = await response.text();
-  return setAppConfigFromYaml(text, resolvedUrl, options);
+  const text = await response.text()
+  return setAppConfigFromYaml(text, resolvedUrl, options)
 }
 
 export function setAppConfigFromYaml(
   yamlText: string,
-  source = "inline://app-config.yaml",
-  options?: AppConfigApplyOptions,
+  source = 'inline://app-config.yaml',
+  options?: AppConfigApplyOptions
 ): AppliedAppConfig {
-  const normalizedYaml = typeof yamlText === "string" ? yamlText : "";
+  const normalizedYaml = typeof yamlText === 'string' ? yamlText : ''
   if (!normalizedYaml.trim()) {
-    throw new Error("App config YAML is empty");
+    throw new Error('App config YAML is empty')
   }
-  const parsed = YAML.parse(normalizedYaml) as unknown;
-  return applyAppConfig(parsed, source, options);
+  const parsed = YAML.parse(normalizedYaml) as unknown
+  return applyAppConfig(parsed, source, options)
 }
 
 export function isLocalConfigPreferredOnLoad(): boolean {
-  if (typeof window === "undefined" || !window.localStorage) {
-    return false;
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return false
   }
   return (
     normalizeString(
-      window.localStorage.getItem(APP_CONFIG_PREFER_LOCAL_STORAGE_KEY),
-    ) === "true"
-  );
+      window.localStorage.getItem(APP_CONFIG_PREFER_LOCAL_STORAGE_KEY)
+    ) === 'true'
+  )
 }
 
 export function setLocalConfigPreferredOnLoad(preferLocal: boolean): boolean {
-  if (typeof window === "undefined" || !window.localStorage) {
-    return preferLocal;
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return preferLocal
   }
   window.localStorage.setItem(
     APP_CONFIG_PREFER_LOCAL_STORAGE_KEY,
-    preferLocal ? "true" : "false",
-  );
-  return preferLocal;
+    preferLocal ? 'true' : 'false'
+  )
+  return preferLocal
 }
 
 export function disableAppConfigOverridesOnLoad(): boolean {
-  return setLocalConfigPreferredOnLoad(true);
+  return setLocalConfigPreferredOnLoad(true)
 }
 
 export function enableAppConfigOverridesOnLoad(): boolean {
-  return setLocalConfigPreferredOnLoad(false);
+  return setLocalConfigPreferredOnLoad(false)
 }
 
 export async function maybeSetAppConfig(): Promise<AppliedAppConfig | null> {
-  if (typeof window === "undefined" || !window.localStorage) {
-    return null;
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null
   }
-  const preserveLocalConfiguration = isLocalConfigPreferredOnLoad();
-  appLogger.info("Attempting app config preload", {
+  const preserveLocalConfiguration = isLocalConfigPreferredOnLoad()
+  appLogger.info('Attempting app config preload', {
     attrs: {
-      scope: "config.app",
-      code: "APP_CONFIG_PRELOAD_ATTEMPT",
+      scope: 'config.app',
+      code: 'APP_CONFIG_PRELOAD_ATTEMPT',
       preserveLocalConfiguration,
     },
-  });
+  })
 
   try {
     const applied = await setAppConfig(undefined, {
       preserveLocalConfiguration,
-    });
-    appLogger.info("App config loaded.", {
+    })
+    appLogger.info('App config loaded.', {
       attrs: {
-        scope: "config.app",
-        code: "APP_CONFIG_LOADED",
+        scope: 'config.app',
+        code: 'APP_CONFIG_LOADED',
         url: applied.url,
         warningCount: applied.warnings.length,
       },
-    });
-    return applied;
+    })
+    return applied
   } catch (error) {
-    appLogger.warn("Skipping app config preload", {
+    appLogger.warn('Skipping app config preload', {
       attrs: {
-        scope: "config.app",
-        code: "APP_CONFIG_PRELOAD_FAILED",
+        scope: 'config.app',
+        code: 'APP_CONFIG_PRELOAD_FAILED',
         error: String(error),
       },
-    });
-    return null;
+    })
+    return null
   }
 }

--- a/app/src/lib/googleClientManager.test.ts
+++ b/app/src/lib/googleClientManager.test.ts
@@ -1,69 +1,85 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   GOOGLE_CLIENT_STORAGE_KEY,
   GoogleClientManager,
-} from "./googleClientManager";
+} from './googleClientManager'
 
 function createManager(): GoogleClientManager {
-  (
+  ;(
     GoogleClientManager as unknown as {
-      singleton: GoogleClientManager | null;
+      singleton: GoogleClientManager | null
     }
-  ).singleton = null;
-  return GoogleClientManager.instance();
+  ).singleton = null
+  return GoogleClientManager.instance()
 }
 
-describe("GoogleClientManager", () => {
+describe('GoogleClientManager', () => {
   beforeEach(() => {
-    window.localStorage.clear();
-    (
+    window.localStorage.clear()
+    ;(
       GoogleClientManager as unknown as {
-        singleton: GoogleClientManager | null;
+        singleton: GoogleClientManager | null
       }
-    ).singleton = null;
-  });
+    ).singleton = null
+  })
 
-  it("reuses the OAuth client ID for Drive Picker config", () => {
-    const manager = createManager();
+  it('reuses the OAuth client ID for Drive Picker config', () => {
+    const manager = createManager()
 
     manager.setOAuthClient({
-      clientId: "554943104515-example.apps.googleusercontent.com",
-      clientSecret: "secret",
-    });
-
-    expect(manager.getDrivePickerConfig()).toEqual({
-      clientId: "554943104515-example.apps.googleusercontent.com",
-      developerKey: "",
-      appId: "554943104515",
-    });
-  });
-
-  it("persists picker-only config while keeping the client ID in OAuth config", () => {
-    const manager = createManager();
-
-    manager.setDrivePickerConfig({
-      clientId: "554943104515-example.apps.googleusercontent.com",
-      developerKey: "developer-key",
-      appId: "custom-app-id",
-    });
+      clientId: '554943104515-example.apps.googleusercontent.com',
+      clientSecret: 'secret',
+    })
 
     expect(manager.getOAuthClient()).toEqual({
-      clientId: "554943104515-example.apps.googleusercontent.com",
-    });
+      clientId: '554943104515-example.apps.googleusercontent.com',
+      clientSecret: 'secret',
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
     expect(manager.getDrivePickerConfig()).toEqual({
-      clientId: "554943104515-example.apps.googleusercontent.com",
-      developerKey: "developer-key",
-      appId: "custom-app-id",
-    });
+      clientId: '554943104515-example.apps.googleusercontent.com',
+      developerKey: '',
+      appId: 'notavalidappid',
+    })
+  })
+
+  it('updates picker-only config without changing the OAuth client config', () => {
+    const manager = createManager()
+
+    manager.setDrivePickerConfig({
+      clientId: '554943104515-example.apps.googleusercontent.com',
+      developerKey: 'developer-key',
+      appId: 'custom-app-id',
+    })
+
+    expect(manager.getOAuthClient()).toEqual({
+      clientId: '',
+      clientSecret: undefined,
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    expect(manager.getDrivePickerConfig()).toEqual({
+      clientId: '554943104515-example.apps.googleusercontent.com',
+      developerKey: 'developer-key',
+      appId: 'custom-app-id',
+    })
 
     const stored = JSON.parse(
-      window.localStorage.getItem(GOOGLE_CLIENT_STORAGE_KEY) ?? "{}",
-    ) as Record<string, string>;
-    expect(stored).toMatchObject({
-      oauthClientId: "554943104515-example.apps.googleusercontent.com",
-      drivePickerDeveloperKey: "developer-key",
-      drivePickerAppId: "custom-app-id",
-    });
-  });
-});
+      window.localStorage.getItem(GOOGLE_CLIENT_STORAGE_KEY) ?? '{}'
+    ) as Record<string, string | undefined>
+    expect(stored).toEqual({})
+  })
+
+  it('defaults new Drive auth sessions to opening in a new tab', () => {
+    const manager = createManager()
+
+    expect(manager.getOAuthClient()).toEqual({
+      clientId: '',
+      clientSecret: undefined,
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+  })
+})

--- a/app/src/lib/googleClientManager.ts
+++ b/app/src/lib/googleClientManager.ts
@@ -1,67 +1,67 @@
 export type GoogleOAuthClientConfig = {
-  clientId: string;
-  clientSecret?: string;
-  authFlow: GoogleDriveAuthFlow;
-  authUxMode: GoogleDriveAuthUxMode;
-};
+  clientId: string
+  clientSecret?: string
+  authFlow: GoogleDriveAuthFlow
+  authUxMode: GoogleDriveAuthUxMode
+}
 
 export type GoogleDrivePickerConfig = {
-  clientId: string;
-  developerKey: string;
-  appId: string;
-};
+  clientId: string
+  developerKey: string
+  appId: string
+}
 
-export const GOOGLE_CLIENT_STORAGE_KEY = "googleClientConfig";
-const STORAGE_KEY = GOOGLE_CLIENT_STORAGE_KEY;
+export const GOOGLE_CLIENT_STORAGE_KEY = 'googleClientConfig'
+const STORAGE_KEY = GOOGLE_CLIENT_STORAGE_KEY
 
-export type GoogleDriveAuthFlow = "implicit" | "pkce";
-export type GoogleDriveAuthUxMode = "popup" | "redirect";
+export type GoogleDriveAuthFlow = 'implicit' | 'pkce'
+export type GoogleDriveAuthUxMode = 'popup' | 'redirect' | 'new_tab'
 
-const DEFAULT_AUTH_FLOW: GoogleDriveAuthFlow = "implicit";
+const DEFAULT_AUTH_FLOW: GoogleDriveAuthFlow = 'implicit'
 const DEFAULT_AUTH_UX_MODE_FOR_FLOW: Record<
   GoogleDriveAuthFlow,
   GoogleDriveAuthUxMode
 > = {
-  implicit: "popup",
-  pkce: "redirect",
-};
+  implicit: 'new_tab',
+  pkce: 'new_tab',
+}
 
 function isGoogleDriveAuthFlow(value: unknown): value is GoogleDriveAuthFlow {
-  return value === "implicit" || value === "pkce";
+  return value === 'implicit' || value === 'pkce'
 }
 
 function isGoogleDriveAuthUxMode(
-  value: unknown,
+  value: unknown
 ): value is GoogleDriveAuthUxMode {
-  return value === "popup" || value === "redirect";
+  return value === 'popup' || value === 'redirect' || value === 'new_tab'
 }
 
 function resolveDefaultUxModeForFlow(
-  flow: GoogleDriveAuthFlow,
+  flow: GoogleDriveAuthFlow
 ): GoogleDriveAuthUxMode {
-  return DEFAULT_AUTH_UX_MODE_FOR_FLOW[flow];
+  return DEFAULT_AUTH_UX_MODE_FOR_FLOW[flow]
 }
 
 type GoogleClientConfig = {
-  oauth: GoogleOAuthClientConfig;
-  drivePicker: GoogleDrivePickerConfig;
-};
+  oauth: GoogleOAuthClientConfig
+  drivePicker: GoogleDrivePickerConfig
+}
 
 export class GoogleClientManager {
-  private static singleton: GoogleClientManager | null = null;
-  private config: GoogleClientConfig;
+  private static singleton: GoogleClientManager | null = null
+  private config: GoogleClientConfig
 
   private constructor() {
-    const defaultClientId = "";
-    const storedClientId = this.readOAuthClientIdFromStorage();
-    const storedClientSecret = this.readOAuthClientSecretFromStorage();
-    const storedAuthFlow = this.readOAuthAuthFlowFromStorage();
-    const storedAuthUxMode = this.readOAuthAuthUxModeFromStorage();
-    const resolvedClientId = storedClientId ?? defaultClientId;
-    const resolvedClientSecret = storedClientSecret ?? undefined;
-    const resolvedAuthFlow = storedAuthFlow ?? DEFAULT_AUTH_FLOW;
+    const defaultClientId = ''
+    const storedClientId = this.readOAuthClientIdFromStorage()
+    const storedClientSecret = this.readOAuthClientSecretFromStorage()
+    const storedAuthFlow = this.readOAuthAuthFlowFromStorage()
+    const storedAuthUxMode = this.readOAuthAuthUxModeFromStorage()
+    const resolvedClientId = storedClientId ?? defaultClientId
+    const resolvedClientSecret = storedClientSecret ?? undefined
+    const resolvedAuthFlow = storedAuthFlow ?? DEFAULT_AUTH_FLOW
     const resolvedAuthUxMode =
-      storedAuthUxMode ?? resolveDefaultUxModeForFlow(resolvedAuthFlow);
+      storedAuthUxMode ?? resolveDefaultUxModeForFlow(resolvedAuthFlow)
     this.config = {
       oauth: {
         clientId: resolvedClientId,
@@ -71,133 +71,135 @@ export class GoogleClientManager {
       },
       drivePicker: {
         clientId: resolvedClientId,
-        developerKey: "",
+        developerKey: '',
         // TODO(jlewi): Do we still need this
-        appId: "notavalidappid",
+        appId: 'notavalidappid',
       },
-    };
+    }
   }
 
   static instance(): GoogleClientManager {
     if (!this.singleton) {
-      this.singleton = new GoogleClientManager();
+      this.singleton = new GoogleClientManager()
     }
-    return this.singleton;
+    return this.singleton
   }
 
   getOAuthClient(): GoogleOAuthClientConfig {
-    return this.config.oauth;
+    return this.config.oauth
   }
 
   setClientId(clientId: string): GoogleOAuthClientConfig {
-    return this.setOAuthClient({ clientId });
+    return this.setOAuthClient({ clientId })
   }
 
-  setOAuthClient(config: Partial<GoogleOAuthClientConfig>): GoogleOAuthClientConfig {
-    const requestedAuthFlow = config.authFlow;
+  setOAuthClient(
+    config: Partial<GoogleOAuthClientConfig>
+  ): GoogleOAuthClientConfig {
+    const requestedAuthFlow = config.authFlow
     if (requestedAuthFlow && !isGoogleDriveAuthFlow(requestedAuthFlow)) {
       throw new Error(
-        `Unsupported Google Drive auth flow: ${String(requestedAuthFlow)}`,
-      );
+        `Unsupported Google Drive auth flow: ${String(requestedAuthFlow)}`
+      )
     }
-    const requestedAuthUxMode = config.authUxMode;
+    const requestedAuthUxMode = config.authUxMode
     if (requestedAuthUxMode && !isGoogleDriveAuthUxMode(requestedAuthUxMode)) {
       throw new Error(
-        `Unsupported Google Drive auth UX mode: ${String(requestedAuthUxMode)}`,
-      );
+        `Unsupported Google Drive auth UX mode: ${String(requestedAuthUxMode)}`
+      )
     }
-    const nextAuthFlow = requestedAuthFlow ?? this.config.oauth.authFlow;
+    const nextAuthFlow = requestedAuthFlow ?? this.config.oauth.authFlow
     const nextAuthUxMode =
       requestedAuthUxMode ??
       (requestedAuthFlow
         ? resolveDefaultUxModeForFlow(nextAuthFlow)
-        : this.config.oauth.authUxMode);
+        : this.config.oauth.authUxMode)
 
     this.config.oauth = {
       ...this.config.oauth,
       ...config,
       authFlow: nextAuthFlow,
       authUxMode: nextAuthUxMode,
-    };
+    }
     if (config.clientId !== undefined) {
       this.config.drivePicker = {
         ...this.config.drivePicker,
         clientId: config.clientId,
-      };
+      }
     }
-    this.persistOAuthClient(this.config.oauth);
-    return this.config.oauth;
+    this.persistOAuthClient(this.config.oauth)
+    return this.config.oauth
   }
 
   setClientSecret(clientSecret: string): GoogleOAuthClientConfig {
-    return this.setOAuthClient({ clientSecret });
+    return this.setOAuthClient({ clientSecret })
   }
 
   setAuthFlow(authFlow: GoogleDriveAuthFlow): GoogleOAuthClientConfig {
-    return this.setOAuthClient({ authFlow });
+    return this.setOAuthClient({ authFlow })
   }
 
   setAuthUxMode(authUxMode: GoogleDriveAuthUxMode): GoogleOAuthClientConfig {
-    return this.setOAuthClient({ authUxMode });
+    return this.setOAuthClient({ authUxMode })
   }
 
   setOAuthClientFromJson(raw: string): GoogleOAuthClientConfig {
-    let parsed:
-      | {
-          client_id?: string;
-          clientId?: string;
-          client_secret?: string;
-          auth_flow?: string;
-          authFlow?: string;
-          oauthFlow?: string;
-          flow?: string;
-          auth_ux_mode?: string;
-          authUxMode?: string;
-          oauthUxMode?: string;
-          uxMode?: string;
-        }
-      | null = null;
+    let parsed: {
+      client_id?: string
+      clientId?: string
+      client_secret?: string
+      auth_flow?: string
+      authFlow?: string
+      oauthFlow?: string
+      flow?: string
+      auth_ux_mode?: string
+      authUxMode?: string
+      oauthUxMode?: string
+      uxMode?: string
+    } | null = null
     try {
       parsed = JSON.parse(raw) as {
-        client_id?: string;
-        clientId?: string;
-        client_secret?: string;
-        auth_flow?: string;
-        authFlow?: string;
-        oauthFlow?: string;
-        flow?: string;
-        auth_ux_mode?: string;
-        authUxMode?: string;
-        oauthUxMode?: string;
-        uxMode?: string;
-      };
+        client_id?: string
+        clientId?: string
+        client_secret?: string
+        auth_flow?: string
+        authFlow?: string
+        oauthFlow?: string
+        flow?: string
+        auth_ux_mode?: string
+        authUxMode?: string
+        oauthUxMode?: string
+        uxMode?: string
+      }
     } catch {
-      throw new Error("Invalid JSON: unable to parse OAuth client config");
+      throw new Error('Invalid JSON: unable to parse OAuth client config')
     }
 
-    const clientId = (parsed?.client_id ?? parsed?.clientId ?? "").trim();
+    const clientId = (parsed?.client_id ?? parsed?.clientId ?? '').trim()
     if (!clientId) {
-      throw new Error("OAuth client config is missing client_id");
+      throw new Error('OAuth client config is missing client_id')
     }
-    const clientSecret = parsed?.client_secret?.trim() ?? "";
+    const clientSecret = parsed?.client_secret?.trim() ?? ''
     const rawAuthFlow =
-      parsed?.auth_flow ?? parsed?.authFlow ?? parsed?.oauthFlow ?? parsed?.flow;
+      parsed?.auth_flow ?? parsed?.authFlow ?? parsed?.oauthFlow ?? parsed?.flow
     const rawAuthUxMode =
       parsed?.auth_ux_mode ??
       parsed?.authUxMode ??
       parsed?.oauthUxMode ??
-      parsed?.uxMode;
+      parsed?.uxMode
     if (
       rawAuthFlow !== undefined &&
       !isGoogleDriveAuthFlow(rawAuthFlow?.trim())
     ) {
-      throw new Error(`Unsupported auth_flow value: ${String(rawAuthFlow)}`);
+      throw new Error(`Unsupported auth_flow value: ${String(rawAuthFlow)}`)
     }
     if (
       rawAuthUxMode !== undefined &&
       !isGoogleDriveAuthUxMode(rawAuthUxMode?.trim())
     ) {
-      throw new Error(`Unsupported auth_ux_mode value: ${String(rawAuthUxMode)}`);
+      throw new Error(
+        `Unsupported auth_ux_mode value: ${String(rawAuthUxMode)}`
+      )
     }
 
     return this.setOAuthClient({
@@ -205,100 +207,100 @@ export class GoogleClientManager {
       clientSecret: clientSecret.length > 0 ? clientSecret : undefined,
       authFlow: rawAuthFlow?.trim() as GoogleDriveAuthFlow | undefined,
       authUxMode: rawAuthUxMode?.trim() as GoogleDriveAuthUxMode | undefined,
-    });
+    })
   }
 
   getDrivePickerConfig(): GoogleDrivePickerConfig {
-    return this.config.drivePicker;
+    return this.config.drivePicker
   }
 
   setDrivePickerConfig(
-    config: Partial<GoogleDrivePickerConfig>,
+    config: Partial<GoogleDrivePickerConfig>
   ): GoogleDrivePickerConfig {
     this.config.drivePicker = {
       ...this.config.drivePicker,
       ...config,
-    };
-    return this.config.drivePicker;
+    }
+    return this.config.drivePicker
   }
 
   private readOAuthClientIdFromStorage(): string | null {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null
     }
     try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
+      const raw = window.localStorage.getItem(STORAGE_KEY)
       if (!raw) {
-        return null;
+        return null
       }
-      const parsed = JSON.parse(raw) as { oauthClientId?: string } | null;
-      const clientId = parsed?.oauthClientId?.trim();
-      return clientId && clientId.length > 0 ? clientId : null;
+      const parsed = JSON.parse(raw) as { oauthClientId?: string } | null
+      const clientId = parsed?.oauthClientId?.trim()
+      return clientId && clientId.length > 0 ? clientId : null
     } catch (error) {
-      console.warn("Failed to read Google OAuth client config", error);
-      return null;
+      console.warn('Failed to read Google OAuth client config', error)
+      return null
     }
   }
 
   private readOAuthClientSecretFromStorage(): string | null {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null
     }
     try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
+      const raw = window.localStorage.getItem(STORAGE_KEY)
       if (!raw) {
-        return null;
+        return null
       }
-      const parsed = JSON.parse(raw) as { oauthClientSecret?: string } | null;
-      const clientSecret = parsed?.oauthClientSecret?.trim();
-      return clientSecret && clientSecret.length > 0 ? clientSecret : null;
+      const parsed = JSON.parse(raw) as { oauthClientSecret?: string } | null
+      const clientSecret = parsed?.oauthClientSecret?.trim()
+      return clientSecret && clientSecret.length > 0 ? clientSecret : null
     } catch (error) {
-      console.warn("Failed to read Google OAuth client config", error);
-      return null;
+      console.warn('Failed to read Google OAuth client config', error)
+      return null
     }
   }
 
   private readOAuthAuthFlowFromStorage(): GoogleDriveAuthFlow | null {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null
     }
     try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
+      const raw = window.localStorage.getItem(STORAGE_KEY)
       if (!raw) {
-        return null;
+        return null
       }
-      const parsed = JSON.parse(raw) as { oauthAuthFlow?: string } | null;
-      const authFlow = parsed?.oauthAuthFlow?.trim();
-      return authFlow && isGoogleDriveAuthFlow(authFlow) ? authFlow : null;
+      const parsed = JSON.parse(raw) as { oauthAuthFlow?: string } | null
+      const authFlow = parsed?.oauthAuthFlow?.trim()
+      return authFlow && isGoogleDriveAuthFlow(authFlow) ? authFlow : null
     } catch (error) {
-      console.warn("Failed to read Google OAuth auth flow", error);
-      return null;
+      console.warn('Failed to read Google OAuth auth flow', error)
+      return null
     }
   }
 
   private readOAuthAuthUxModeFromStorage(): GoogleDriveAuthUxMode | null {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null
     }
     try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
+      const raw = window.localStorage.getItem(STORAGE_KEY)
       if (!raw) {
-        return null;
+        return null
       }
-      const parsed = JSON.parse(raw) as { oauthAuthUxMode?: string } | null;
-      const authUxMode = parsed?.oauthAuthUxMode?.trim();
+      const parsed = JSON.parse(raw) as { oauthAuthUxMode?: string } | null
+      const authUxMode = parsed?.oauthAuthUxMode?.trim()
       return authUxMode && isGoogleDriveAuthUxMode(authUxMode)
         ? authUxMode
-        : null;
+        : null
     } catch (error) {
-      console.warn("Failed to read Google OAuth auth UX mode", error);
-      return null;
+      console.warn('Failed to read Google OAuth auth UX mode', error)
+      return null
     }
   }
 
   private persistOAuthClient(config: GoogleOAuthClientConfig): void {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return;
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return
     }
     try {
       window.localStorage.setItem(
@@ -308,12 +310,12 @@ export class GoogleClientManager {
           oauthClientSecret: config.clientSecret,
           oauthAuthFlow: config.authFlow,
           oauthAuthUxMode: config.authUxMode,
-        }),
-      );
+        })
+      )
     } catch (error) {
-      console.warn("Failed to persist Google OAuth client config", error);
+      console.warn('Failed to persist Google OAuth client config', error)
     }
   }
 }
 
-export const googleClientManager = GoogleClientManager.instance();
+export const googleClientManager = GoogleClientManager.instance()

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -737,7 +737,7 @@ export function createAppJsGlobals({
         clientId?: string
         clientSecret?: string
         authFlow?: 'implicit' | 'pkce'
-        authUxMode?: 'popup' | 'redirect'
+        authUxMode?: 'popup' | 'redirect' | 'new_tab'
       }) => googleClientManager.setOAuthClient(config),
       setClientId: (clientId: string) =>
         googleClientManager.setOAuthClient({ clientId }),
@@ -745,7 +745,7 @@ export function createAppJsGlobals({
         googleClientManager.setClientSecret(clientSecret),
       setAuthFlow: (authFlow: 'implicit' | 'pkce') =>
         googleClientManager.setAuthFlow(authFlow),
-      setAuthUxMode: (authUxMode: 'popup' | 'redirect') =>
+      setAuthUxMode: (authUxMode: 'popup' | 'redirect' | 'new_tab') =>
         googleClientManager.setAuthUxMode(authUxMode),
       setFromJson: (raw: string) =>
         googleClientManager.setOAuthClientFromJson(raw),

--- a/docs-dev/architecture/configuration.md
+++ b/docs-dev/architecture/configuration.md
@@ -72,6 +72,55 @@ chatkit:
 
 When `oidc.google` is present, runtime config loading applies the same Google OIDC defaults as `oidc.setGoogleDefaults()` and then sets the configured client ID. Use `oidc.generic` when you need to override the discovery URL, redirect URL, or scopes explicitly.
 
+## Google Drive auth configuration
+
+`googleDrive` runtime config controls Drive auth independently from the app's main OIDC login.
+
+Supported fields:
+
+- `clientID`: Google OAuth client ID used for Drive authorization.
+- `clientSecret`: optional client secret; mainly relevant for code-exchange flows.
+- `baseUrl`: optional Drive API base URL override for fake/test servers.
+- `authFlow`: either `implicit` or `pkce`.
+- `authUxMode`: either `popup`, `redirect`, or `new_tab`.
+
+Example:
+
+```yaml
+googleDrive:
+  clientID: "<google-drive-client-id>"
+  clientSecret: ""
+  authFlow: "implicit"
+  authUxMode: "new_tab"
+```
+
+Behavior:
+
+- `authFlow: implicit`
+  - requests a browser access token directly from Google.
+  - works with `popup`, `redirect`, or `new_tab`.
+- `authFlow: pkce`
+  - uses authorization code + PKCE.
+  - works with `redirect` or `new_tab`.
+
+UX modes:
+
+- `popup`
+  - keeps the current tab in place and uses the Google popup/token client path.
+  - only applies to implicit auth.
+- `redirect`
+  - navigates the current tab to Google and returns through the Drive callback route.
+- `new_tab`
+  - opens the Drive auth flow in a separate tab and leaves the original tab in place.
+  - this is the default mode for new Drive auth configuration.
+  - after callback completion, the original tab picks up the updated token from browser storage.
+
+Recommended choices:
+
+- Default to `implicit` + `new_tab` for the least disruptive browser flow.
+- Use `pkce` + `new_tab` if you want PKCE but still want to avoid taking over the current tab.
+- Use `redirect` only when current-tab navigation is explicitly preferred.
+
 ## Vite Dev Server Support
 
 Yes, this works with Vite.

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -29,6 +29,39 @@ Benefits:
 - copy a notebook into another Drive folder,
 - inspect or requeue pending sync.
 
+## Controlling Drive auth behavior
+
+Drive auth is configured separately from the app's main OIDC login.
+
+Runtime config under `googleDrive` controls both:
+
+- which OAuth flow is used,
+- and how the browser hands the user off to Google.
+
+Example:
+
+```yaml
+googleDrive:
+  clientID: "<google-drive-client-id>"
+  clientSecret: ""
+  authFlow: "implicit"
+  authUxMode: "new_tab"
+```
+
+Meaning:
+
+- `authFlow: "implicit"` asks Google for an access token directly in the browser.
+- `authFlow: "pkce"` uses the authorization-code flow and exchanges the code after the callback.
+- `authUxMode: "popup"` uses the Google Identity Services popup flow.
+- `authUxMode: "redirect"` redirects the current tab to Google and back.
+- `authUxMode: "new_tab"` opens the Drive auth flow in a separate tab and is the default.
+
+Recommended defaults:
+
+- Use `implicit` + `new_tab` for the least disruptive browser UX.
+- Use `pkce` + `new_tab` when you want authorization-code flow semantics but still want to avoid taking over the current tab.
+- Use `redirect` only when you explicitly want the current tab to navigate through the OAuth flow.
+
 ## Useful App Console commands
 
 ```js


### PR DESCRIPTION
## Summary
- add a new_tab Google Drive auth UX mode and make it the default for Drive auth handoffs
- open Drive OAuth in a separate tab, preserve the callback handoff mode, and sync token changes back to the original tab
- update config, docs, and tests for the new default behavior

## Testing
- runme run build test
- ./node_modules/.bin/vitest run src/contexts/GoogleAuthContext.test.tsx src/lib/appConfig.test.ts src/lib/googleClientManager.test.ts

Closes #148