### PR TITLE
Build codex wasm assets in test CI

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -17,6 +17,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CODEX_REPO: openai/codex
+  CODEX_REF: dev/jlewi/wasm
+  CODEX_WASM_PKG_DIR: ${{ github.workspace }}/codex-src/codex-rs/wasm-harness/examples/pkg
+
 jobs:
   run-app-tests:
     runs-on: ubuntu-latest
@@ -96,6 +101,11 @@ jobs:
         with:
           go-version: "1.23.x"
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -117,12 +127,34 @@ jobs:
           corepack enable
           pnpm --version
 
+      - name: Install wasm-bindgen CLI
+        shell: bash
+        run: cargo install wasm-bindgen-cli --version 0.2.108
+
+      - name: Checkout Codex WASM source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CODEX_REPO }}
+          ref: ${{ env.CODEX_REF }}
+          path: codex-src
+          fetch-depth: 1
+
       - name: Install dependencies
         shell: bash
         run: |
           set -euo pipefail
           pnpm config set @buf:registry https://buf.build/gen/npm/v1
           pnpm install --frozen-lockfile
+
+      - name: Build and sync Codex WASM assets
+        shell: bash
+        working-directory: ${{ github.workspace }}/codex-src
+        env:
+          CODEX_WASM_PKG_DIR: ${{ env.CODEX_WASM_PKG_DIR }}
+        run: |
+          set -euo pipefail
+          ./codex-rs/wasm-harness/scripts/build-browser-demo.sh
+          pnpm -C "${GITHUB_WORKSPACE}/app" run sync:codex-wasm
 
       - name: Build app dependencies
         shell: bash

--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   run-app-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       GCP_PROJECT_ID: runme-lewi-dev
       GCP_PROJECT_NUMBER: "690012737568"

--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -153,6 +153,8 @@ jobs:
           CODEX_WASM_PKG_DIR: ${{ env.CODEX_WASM_PKG_DIR }}
         run: |
           set -euo pipefail
+          TOOLCHAIN="$(cd codex-rs && rustup show active-toolchain | awk '{print $1}')"
+          rustup target add --toolchain "${TOOLCHAIN}" wasm32-unknown-unknown
           ./codex-rs/wasm-harness/scripts/build-browser-demo.sh
           pnpm -C "${GITHUB_WORKSPACE}/app" run sync:codex-wasm
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,6 +71,8 @@ jobs:
           CODEX_WASM_PKG_DIR: ${{ env.CODEX_WASM_PKG_DIR }}
         run: |
           set -euo pipefail
+          TOOLCHAIN="$(cd codex-rs && rustup show active-toolchain | awk '{print $1}')"
+          rustup target add --toolchain "${TOOLCHAIN}" wasm32-unknown-unknown
           ./codex-rs/wasm-harness/scripts/build-browser-demo.sh
           pnpm -C "${GITHUB_WORKSPACE}/app" run sync:codex-wasm
       - name: 📦 Bundle

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,9 @@ concurrency:
 env:
   DO_NOT_TRACK: 1
   SHELL: /bin/bash
+  CODEX_REPO: openai/codex
+  CODEX_REF: dev/jlewi/wasm
+  CODEX_WASM_PKG_DIR: ${{ github.workspace }}/codex-src/codex-rs/wasm-harness/examples/pkg
 
 jobs:
   test:
@@ -28,8 +31,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
+      - name: Install wasm-bindgen CLI
+        shell: bash
+        run: cargo install wasm-bindgen-cli --version 0.2.108
+      - name: Checkout Codex WASM source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CODEX_REPO }}
+          ref: ${{ env.CODEX_REF }}
+          path: codex-src
+          fetch-depth: 1
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -47,6 +64,15 @@ jobs:
           workflows: |
             configure
             setup
+      - name: Build and sync Codex WASM assets
+        shell: bash
+        working-directory: ${{ github.workspace }}/codex-src
+        env:
+          CODEX_WASM_PKG_DIR: ${{ env.CODEX_WASM_PKG_DIR }}
+        run: |
+          set -euo pipefail
+          ./codex-rs/wasm-harness/scripts/build-browser-demo.sh
+          pnpm -C "${GITHUB_WORKSPACE}/app" run sync:codex-wasm
       - name: 📦 Bundle
         uses: stateful/runme-action@v2
         with:


### PR DESCRIPTION
## Summary
- update `app-tests` to build and sync the Codex WASM bundle from `openai/codex` on `dev/jlewi/wasm`
- update the generic `test` workflow to do the same so CI does not rely on stale checked-in wasm artifacts

## Testing
- rebased onto `origin/main` at `5a588c3`
- final diff is limited to `.github/workflows/app-tests.yaml` and `.github/workflows/test.yaml`

## Notes
- the releaser-side Codex WASM branch wiring is already present on current `main`, so this PR now focuses only on the remaining test CI gaps