### PR TITLE
Remove synthetic cwd from codex wasm bootstrap

### DIFF
--- a/app/src/components/ChatKit/ChatKitPanel.test.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.test.tsx
@@ -375,7 +375,6 @@ describe("ChatKitPanel codex harness routing", () => {
       expect(proxyMock.connectWasm).toHaveBeenCalledWith({
         apiKey: "sk-test",
         sessionOptions: expect.objectContaining({
-          cwd: "/workspace",
           instructions: expect.objectContaining({
             developer: expect.stringContaining(
               "Executed JavaScript runs inside the Runme AppKernel runtime.",

--- a/app/src/lib/runtime/codexConversationController.test.ts
+++ b/app/src/lib/runtime/codexConversationController.test.ts
@@ -16,6 +16,7 @@ const project = {
 const notificationHandlers = new Set<(notification: any) => void>();
 const proxyClient = {
   sendRequest: vi.fn(),
+  getTransport: vi.fn(() => "proxy"),
   subscribeNotifications: vi.fn((handler: (notification: any) => void) => {
     notificationHandlers.add(handler);
     return () => {
@@ -285,6 +286,8 @@ describe("CodexConversationController", () => {
   beforeEach(() => {
     vi.useRealTimers();
     proxyClient.sendRequest.mockReset();
+    proxyClient.getTransport.mockReset();
+    proxyClient.getTransport.mockReturnValue("proxy");
     proxyClient.subscribeNotifications.mockClear();
     notificationHandlers.clear();
     projectManager.setDefault.mockClear();
@@ -308,6 +311,25 @@ describe("CodexConversationController", () => {
         id: "thread-1",
         title: "One",
         cwd: "/workspace",
+        previousResponseId: "turn-1",
+      }),
+    ]);
+  });
+
+  it("does not send project cwd when refreshing history in wasm mode", async () => {
+    proxyClient.getTransport.mockReturnValue("wasm");
+    proxyClient.sendRequest.mockResolvedValueOnce({
+      threads: [{ id: "thread-1", title: "One", last_turn_id: "turn-1" }],
+    });
+
+    const controller = createCodexConversationControllerForTests();
+    await controller.refreshHistory();
+
+    expect(proxyClient.sendRequest).toHaveBeenCalledWith("thread/list", undefined);
+    expect(controller.getSnapshot().threads).toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "One",
         previousResponseId: "turn-1",
       }),
     ]);
@@ -350,6 +372,49 @@ describe("CodexConversationController", () => {
       }),
     );
     expect(controller.getSnapshot().currentThreadId).toBe("thread-bootstrap");
+  });
+
+  it("omits project cwd when creating a thread in wasm mode", async () => {
+    proxyClient.getTransport.mockReturnValue("wasm");
+    proxyClient.sendRequest.mockImplementation(async (method: string) => {
+      if (method === "thread/start") {
+        return {
+          thread: {
+            id: "thread-bootstrap",
+            title: "Bootstrap Thread",
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const controller = createCodexConversationControllerForTests();
+    const thread = await controller.ensureActiveThread();
+
+    expect(proxyClient.sendRequest).toHaveBeenCalledWith(
+      "thread/start",
+      expect.not.objectContaining({
+        cwd: expect.anything(),
+      }),
+    );
+    expect(proxyClient.sendRequest).toHaveBeenCalledWith(
+      "thread/start",
+      expect.objectContaining({
+        projectId: "project-1",
+        model: "gpt-5.4",
+        approvalPolicy: "never",
+        sandboxPolicy: "workspace-write",
+        personality: "pragmatic",
+        developerInstructions: RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS,
+      }),
+    );
+    expect(thread).toEqual(
+      expect.objectContaining({
+        id: "thread-bootstrap",
+        title: "Bootstrap Thread",
+        cwd: "/workspace",
+      }),
+    );
   });
 
   it("uses a per-request model override for thread start and turn start", async () => {
@@ -703,6 +768,56 @@ describe("CodexConversationController", () => {
             threadId: "thread-1",
             cwd: "/workspace",
             developerInstructions: RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS,
+          }),
+        );
+        return { thread: { id: "thread-1" } };
+      }
+      if (method === "turn/start") {
+        queueMicrotask(() => {
+          notificationHandlers.forEach((handler) => {
+            handler({
+              jsonrpc: "2.0",
+              method: "turn.completed",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+              },
+            });
+          });
+        });
+        return { turnId: "turn-1" };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const controller = createCodexConversationControllerForTests();
+    await controller.selectThread("thread-1");
+    await controller.streamUserMessage("hello", { emit: vi.fn() });
+  });
+
+  it("omits project cwd when resuming a thread in wasm mode", async () => {
+    proxyClient.getTransport.mockReturnValue("wasm");
+    proxyClient.sendRequest.mockImplementation(async (method: string, params?: unknown) => {
+      if (method === "thread/read") {
+        return {
+          thread: {
+            id: "thread-1",
+            title: "Existing Thread",
+            cwd: "/workspace",
+            turns: [],
+          },
+        };
+      }
+      if (method === "thread/resume") {
+        expect(params).toEqual(
+          expect.objectContaining({
+            threadId: "thread-1",
+            developerInstructions: RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS,
+          }),
+        );
+        expect(params).toEqual(
+          expect.not.objectContaining({
+            cwd: expect.anything(),
           }),
         );
         return { thread: { id: "thread-1" } };

--- a/app/src/lib/runtime/codexConversationController.ts
+++ b/app/src/lib/runtime/codexConversationController.ts
@@ -7,6 +7,7 @@ import {
 import { RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS } from "./runmeChatkitPrompts";
 import {
   getCodexAppServerClient,
+  type CodexAppServerTransport,
   type CodexProxyJsonRpcNotification,
 } from "./codexAppServerClient";
 import { logCodexEvent } from "./codexLogging";
@@ -476,9 +477,10 @@ class CodexConversationController {
     this.historyError = null;
     this.notify();
     try {
-      const result = await proxy.sendRequest("thread/list", {
-        cwd: project.cwd,
-      });
+      const result = await proxy.sendRequest(
+        "thread/list",
+        this.buildThreadListParams(project, proxy.getTransport()),
+      );
       const record = asRecord(result);
       const entries = Array.isArray(record.threads)
         ? (record.threads as unknown[])
@@ -492,6 +494,7 @@ class CodexConversationController {
           const existing = this.threads.get(thread.id);
           this.threads.set(thread.id, {
             ...thread,
+            cwd: thread.cwd ?? existing?.cwd,
             items: existing?.items ?? [],
           });
         });
@@ -1124,9 +1127,9 @@ class CodexConversationController {
   }
 
   private buildProjectDefaults(project: CodexProject, modelOverride?: string): JsonRecord {
-    return {
+    const transport = this.getTransport();
+    const defaults: JsonRecord = {
       projectId: project.id,
-      cwd: project.cwd,
       model: asString(modelOverride) ?? project.model,
       approvalPolicy: project.approvalPolicy,
       sandboxPolicy: project.sandboxPolicy,
@@ -1134,6 +1137,31 @@ class CodexConversationController {
       developerInstructions: RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS,
       writableRoots: project.writableRoots,
     };
+    if (transport !== "wasm") {
+      defaults.cwd = project.cwd;
+    }
+    return defaults;
+  }
+
+  private buildThreadListParams(
+    project: CodexProject,
+    transport: CodexAppServerTransport,
+  ): JsonRecord | undefined {
+    if (transport === "wasm") {
+      return undefined;
+    }
+    return {
+      cwd: project.cwd,
+    };
+  }
+
+  private getTransport(): CodexAppServerTransport {
+    const client = getCodexAppServerClient() as {
+      getTransport?: () => CodexAppServerTransport;
+    };
+    return typeof client.getTransport === "function"
+      ? client.getTransport()
+      : "proxy";
   }
 
   private listThreadsForProject(projectId: string): CodexConversationThread[] {

--- a/app/src/lib/runtime/codexWasmAppServerClient.test.ts
+++ b/app/src/lib/runtime/codexWasmAppServerClient.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { appLoggerMock, getCodexWasmAssetUrlsMock } = vi.hoisted(() => ({
+  appLoggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  getCodexWasmAssetUrlsMock: vi.fn(() => ({
+    moduleUrl: "/generated/codex.js",
+    wasmUrl: "/generated/codex.wasm",
+  })),
+}));
+
+vi.mock("../logging/runtime", () => ({
+  appLogger: appLoggerMock,
+}));
+
+vi.mock("./codexWasmHarnessLoader", async () => {
+  const actual = await vi.importActual<typeof import("./codexWasmHarnessLoader")>(
+    "./codexWasmHarnessLoader",
+  );
+  return {
+    ...actual,
+    getCodexWasmAssetUrls: getCodexWasmAssetUrlsMock,
+  };
+});
+
+import { createCodexWasmAppServerClientForTests } from "./codexWasmAppServerClient";
+
+describe("CodexWasmAppServerClient", () => {
+  beforeEach(() => {
+    appLoggerMock.info.mockClear();
+    appLoggerMock.warn.mockClear();
+    appLoggerMock.error.mockClear();
+    getCodexWasmAssetUrlsMock.mockClear();
+  });
+
+  it("connects the worker with the provided session options", async () => {
+    const workerClient = {
+      subscribeNotifications: vi.fn(() => () => {}),
+      setCodeExecutor: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      request: vi.fn(),
+      getEventJournal: vi.fn(),
+    };
+
+    const client = createCodexWasmAppServerClientForTests({
+      workerClient: workerClient as never,
+    });
+
+    await client.connect({
+      apiKey: "sk-test",
+      sessionOptions: {
+        instructions: {
+          developer: "developer instructions",
+        },
+      },
+    });
+
+    expect(workerClient.connect).toHaveBeenCalledTimes(1);
+    expect(workerClient.connect).toHaveBeenCalledWith({
+      apiKey: "sk-test",
+      moduleUrl: "/generated/codex.js",
+      wasmUrl: "/generated/codex.wasm",
+      sessionOptions: {
+        instructions: {
+          developer: "developer instructions",
+        },
+      },
+    });
+    expect(client.getSnapshot()).toMatchObject({
+      state: "open",
+      lastError: null,
+    });
+    expect(appLoggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  it("surfaces connect failures without retrying", async () => {
+    const workerClient = {
+      subscribeNotifications: vi.fn(() => () => {}),
+      setCodeExecutor: vi.fn(),
+      connect: vi.fn().mockRejectedValue(new Error("network failed")),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      request: vi.fn(),
+      getEventJournal: vi.fn(),
+    };
+
+    const client = createCodexWasmAppServerClientForTests({
+      workerClient: workerClient as never,
+    });
+
+    await expect(
+      client.connect({
+        apiKey: "sk-test",
+        sessionOptions: {
+          instructions: {
+            developer: "developer instructions",
+          },
+        },
+      }),
+    ).rejects.toThrow("network failed");
+
+    expect(workerClient.connect).toHaveBeenCalledTimes(1);
+    expect(workerClient.shutdown).not.toHaveBeenCalled();
+    expect(client.getSnapshot()).toMatchObject({
+      state: "error",
+      lastError: "Error: network failed",
+    });
+  });
+});

--- a/app/src/lib/runtime/runmeChatkitPrompts.ts
+++ b/app/src/lib/runtime/runmeChatkitPrompts.ts
@@ -57,8 +57,6 @@ export const RUNME_RESPONSES_DIRECT_INSTRUCTIONS = [
   RUNME_SHARED_RUNTIME_INSTRUCTIONS,
 ].join('\n')
 
-export const RUNME_CODEX_WASM_CWD = '/workspace'
-
 const RUNME_CODEX_WASM_OVERLAY = [
   'When you need to inspect or modify notebooks, use Codex code mode.',
   'Codex code mode executes JavaScript in the same Runme AppKernel runtime described above.',
@@ -71,7 +69,6 @@ export const RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS = [
 
 export function buildRunmeCodexWasmSessionOptions(): BrowserSessionOptions {
   return {
-    cwd: RUNME_CODEX_WASM_CWD,
     instructions: {
       developer: RUNME_CODEX_WASM_DEVELOPER_INSTRUCTIONS,
     },

--- a/docs/12-agentic-search-and-codex.md
+++ b/docs/12-agentic-search-and-codex.md
@@ -63,12 +63,239 @@ credentials.openai.setAPIKey("sk-...")
 
 If the key is missing, the Logs pane should show a `chatkit.codex_wasm` error.
 
-## Codex project commands
+## Codex projects
+
+A Codex project is a named local configuration record that Runme uses as the
+default source of settings when it creates or resumes Codex threads.
+
+In practice, a project carries the common thread context for a workspace, such
+as:
+
+- the project name,
+- the current working directory,
+- the default model,
+- the sandbox policy,
+- the approval policy,
+- the agent personality.
+
+Project selection matters because new threads inherit their defaults from the
+selected project.
+
+For non-WASM Codex transports, the project `cwd` is sent as part of thread
+defaults. For `codex-wasm`, Runme still stores `cwd` on the project, but the
+browser app-server is not given that value as a filesystem cwd.
+
+## Codex project fields
+
+Every configured project has these fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `id` | yes | Unique project identifier. This is what `setDefault(projectId)` expects. |
+| `name` | yes | Human-readable project name shown in the UI and App Console output. |
+| `cwd` | yes | Project working directory. This is used as part of project identity and thread scoping. |
+| `model` | yes | Default model to use when starting or resuming Codex threads. |
+| `sandboxPolicy` | yes | Sandbox mode for Codex execution, for example `workspace-write`. |
+| `approvalPolicy` | yes | Approval behavior for Codex actions, for example `never`. |
+| `personality` | yes | Agent style. Allowed values normalize to `none`, `friendly`, or `pragmatic`. |
+| `writableRoots` | optional | Additional writable paths associated with the project. |
+| `workspaceUri` | optional | Workspace URI metadata associated with the project. |
+| `notebookUri` | optional | Notebook URI metadata associated with the project. |
+
+Important details:
+
+- The App Console `create(...)` helper currently takes the six required fields:
+  `name`, `cwd`, `model`, `sandboxPolicy`, `approvalPolicy`, `personality`.
+- `id` is generated automatically.
+- The default personality is effectively `pragmatic`. Passing `default` is
+  normalized to `pragmatic`.
+- `cwd` must be non-empty. `""` is rejected.
+
+## App Console project commands
+
+Useful commands:
 
 ```js
 app.codex.project.list()
 app.codex.project.create(name, cwd, model, sandboxPolicy, approvalPolicy, personality)
+app.codex.project.update(projectId, patch)
+app.codex.project.delete(projectId)
+app.codex.project.getDefault()
 app.codex.project.setDefault(projectId)
+```
+
+## Create a project
+
+Create a project for the current repo:
+
+```js
+app.codex.project.create(
+  "Runme Web",
+  "/Users/jlewi/code/runmecodex/web",
+  "gpt-5.4",
+  "workspace-write",
+  "never",
+  "pragmatic",
+)
+```
+
+Create a browser-oriented project with a relative cwd:
+
+```js
+app.codex.project.create(
+  "Codex Walkthrough",
+  ".",
+  "gpt-5",
+  "workspace-write",
+  "never",
+  "default",
+)
+```
+
+## List projects
+
+`app.codex.project.list()` returns one line per project in this format:
+
+```text
+<projectId>: <name> (<cwd>, model=<model>, sandbox=<sandboxPolicy>, approval=<approvalPolicy>)
+```
+
+Example:
+
+```js
+app.codex.project.list()
+```
+
+Possible output:
+
+```text
+project-1: Runme Web (/Users/jlewi/code/runmecodex/web, model=gpt-5.4, sandbox=workspace-write, approval=never) (default)
+project-2: Codex Walkthrough (., model=gpt-5, sandbox=workspace-write, approval=never)
+```
+
+## Get the `projectId` from the project name
+
+The simplest way is to list projects and parse the line that matches the name.
+
+```js
+const projectName = "Codex Walkthrough";
+const projectLines = String(app.codex.project.list())
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+let projectId = null;
+for (const line of projectLines) {
+  const match = line.match(/^([^:]+):\s*(.+?)\s+\(/);
+  if (!match) {
+    continue;
+  }
+  const [, id, name] = match;
+  if (name === projectName) {
+    projectId = id;
+    break;
+  }
+}
+
+console.log({ projectId });
+```
+
+If project names are not unique, match on both name and `cwd`:
+
+```js
+const projectName = "Codex Walkthrough";
+const projectCwd = ".";
+const projectLines = String(app.codex.project.list())
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+let projectId = null;
+for (const line of projectLines) {
+  const match = line.match(/^([^:]+):\s*(.+?)\s+\((.+?),\s*model=/);
+  if (!match) {
+    continue;
+  }
+  const [, id, name, cwd] = match;
+  if (name === projectName && cwd === projectCwd) {
+    projectId = id;
+    break;
+  }
+}
+
+console.log({ projectId });
+```
+
+## Create a project and set it as default
+
+This pattern creates the project if needed, resolves the `projectId`, and then
+marks it as default:
+
+```js
+const projectName = "Codex Walkthrough";
+const projectCwd = ".";
+const projectModel = "gpt-5";
+const projectSandboxPolicy = "workspace-write";
+const projectApprovalPolicy = "never";
+const projectPersonality = "default";
+
+const projectLines = String(app.codex.project.list())
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+let projectId = null;
+for (const line of projectLines) {
+  const match = line.match(/^([^:]+):\s*(.+?)\s+\((.+?),\s*model=/);
+  if (!match) {
+    continue;
+  }
+  const [, id, name, cwd] = match;
+  if (name === projectName && cwd === projectCwd) {
+    projectId = id;
+    break;
+  }
+}
+
+let projectCreateResult = "existing";
+if (!projectId) {
+  projectCreateResult = String(
+    app.codex.project.create(
+      projectName,
+      projectCwd,
+      projectModel,
+      projectSandboxPolicy,
+      projectApprovalPolicy,
+      projectPersonality,
+    ),
+  );
+  const match = projectCreateResult.match(/\(([^)]+)\)$/);
+  projectId = match?.[1] ?? null;
+}
+
+if (!projectId) {
+  throw new Error(`Could not resolve codex project id from: ${projectCreateResult}`);
+}
+
+console.log(app.codex.project.setDefault(projectId));
+console.log(app.codex.project.getDefault());
+```
+
+## Update a project
+
+You can patch a configured project by `projectId`:
+
+```js
+app.codex.project.update("project-1", {
+  model: "gpt-5-mini",
+  approvalPolicy: "on-request",
+})
+```
+
+## Delete a project
+
+```js
+app.codex.project.delete("project-1")
 ```
 
 ## Fetch the browser app-server logs


### PR DESCRIPTION
## Summary
- remove the synthetic `cwd: "/workspace"` from `codex-wasm` session bootstrap
- omit project `cwd` from wasm `thread/list`, `thread/start`, and `thread/resume` requests
- keep the existing `cwd` behavior for non-wasm transports
- add regression coverage for both the bootstrap path and the controller path

## Why
There were two independent ways the browser-hosted Codex WASM path could send an invalid cwd into the in-process app-server.

The first was the wasm session bootstrap, where the webapp was hardcoding `cwd: "/workspace"` into session options.

The second was the conversation controller, which still sent `project.cwd` on thread-scoped requests. For the default project, that is often `"."`, which is still a filesystem cwd and can trigger the same unsupported-platform resolution path inside the browser app-server.

This bug surfaced as:

`Failed to initialize harness: Error: resolve session cwd failed: operation not supported on this platform`

## Bug Trigger Sequence
1. Load the ChatKit panel with the default harness set to `codex-wasm`.
2. `ChatKitPanel` calls `runtime.start()` for the wasm harness.
3. `CodexWasmHarnessRuntime.start()` calls `connectWasm({ apiKey, sessionOptions })`.
4. Before this PR, `buildRunmeCodexWasmSessionOptions()` constructed `sessionOptions` with `cwd: "/workspace"` plus developer instructions.
5. The worker created `new BrowserAppServer(apiKey)` and called `app.setSessionOptions(sessionOptions)`.
6. The in-process WASM app-server attempted to resolve that session cwd.
7. On platforms where browser session cwd resolution is unsupported, bootstrap failed before any `thread/start` call with:
   `resolve session cwd failed: operation not supported on this platform`
8. Even after removing the synthetic session cwd, the conversation controller could still send `project.cwd` on `thread/list`, `thread/start`, or `thread/resume`.
9. For the default project, that value is commonly `"."`.
10. In wasm mode, that project cwd is not meaningful as a browser filesystem cwd either, so the same unsupported resolution path can still fail later in thread initialization.

## Fix
For `codex-wasm` only:
- do not send a session `cwd` during worker bootstrap
- do not send a project `cwd` on `thread/list`
- do not include `cwd` in the default params used for `thread/start` and `thread/resume`

For non-wasm transports, preserve the existing cwd behavior.

## Clarification On Worker Lifetime
This is not running in a service worker. `codex-wasm` uses a dedicated module Web Worker. A normal page refresh should tear that worker down and start a new one on the next bootstrap.

That means if a non-incognito profile still worked after refresh, the explanation is not that the old WASM app-server survived in a service worker. More likely explanations are:
- the normal profile had different persisted browser/profile state than incognito
- the failing path was only hit in the fresh incognito profile
- there is profile-specific storage or capability behavior inside the browser-hosted stack that we have not fully traced yet

## Longer Term Fix

* https://github.com/runmedev/web/issues/184

* Projects should really be tied to the agent harness runtime and we should be setting CWD appropriately for browser projects

## Testing
- `cd /Users/jlewi/code/runmecodex/web/app && pnpm run test -- --run src/lib/runtime/codexWasmAppServerClient.test.ts src/components/ChatKit/ChatKitPanel.test.tsx`
- `cd /Users/jlewi/code/runmecodex/web/app && pnpm run test -- --run src/lib/runtime/codexConversationController.test.ts src/lib/runtime/chatkitProtocolRender.test.tsx`
