### PR TITLE
[codex] Replace App Console with append-only cells

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -430,7 +430,7 @@ function ActionOutputItemView({
   );
 }
 
-function ActionOutputItems({ outputs }: { outputs: parser_pb.CellOutput[] }) {
+export function ActionOutputItems({ outputs }: { outputs: parser_pb.CellOutput[] }) {
   const hasTerminalOutput = outputs.some((output) =>
     (output.items ?? []).some((item) => item?.mime === MimeType.StatefulRunmeTerminal),
   );

--- a/app/src/components/Actions/Editor.tsx
+++ b/app/src/components/Actions/Editor.tsx
@@ -14,16 +14,24 @@ const Editor = memo(
     language,
     fontSize = 12.6,
     fontFamily = "Fira Mono, monospace",
+    readOnly = false,
+    ariaLabel,
+    autoFocusWhenEmpty = true,
     onChange,
     onEnter,
+    onMount,
   }: {
     id: string;
     value: string;
     language: string;
     fontSize?: number;
     fontFamily?: string;
+    readOnly?: boolean;
+    ariaLabel?: string;
+    autoFocusWhenEmpty?: boolean;
     onChange: (value: string) => void;
     onEnter: () => void;
+    onMount?: (editor: any, monaco: any) => void;
   }) => {
     // Store the latest onEnter in a ref to ensure late binding
     const onEnterRef = useRef(onEnter);
@@ -130,7 +138,7 @@ const Editor = memo(
         }
       });
       // if the value is empty, focus the editor
-      if (value === "") {
+      if (!readOnly && autoFocusWhenEmpty && value === "") {
         editor.focus();
       }
 
@@ -138,6 +146,7 @@ const Editor = memo(
       contentSizeListener.current = editor.onDidContentSizeChange(() => {
         adjustHeight();
       });
+      onMount?.(editor, monaco);
     };
 
     useEffect(() => {
@@ -173,6 +182,8 @@ const Editor = memo(
             value={value}
             options={{
               automaticLayout: false,
+              ariaLabel,
+              readOnly,
               scrollbar: {
                 alwaysConsumeMouseWheel: false,
                 vertical: isClamped ? "auto" : "hidden",
@@ -190,11 +201,9 @@ const Editor = memo(
               padding: { top: 3, bottom: 3 },
             }}
             onChange={(v) => {
-              if (!v) {
-                return;
-              }
-              value = v;
-              onChange?.(v);
+              const nextValue = v ?? "";
+              value = nextValue;
+              onChange?.(nextValue);
             }}
             onMount={editorDidMount}
             className=""
@@ -205,7 +214,14 @@ const Editor = memo(
     );
   },
   (prevProps, nextProps) => {
-    return prevProps.value === nextProps.value;
+    return (
+      prevProps.id === nextProps.id &&
+      prevProps.value === nextProps.value &&
+      prevProps.language === nextProps.language &&
+      prevProps.readOnly === nextProps.readOnly &&
+      prevProps.ariaLabel === nextProps.ariaLabel &&
+      prevProps.autoFocusWhenEmpty === nextProps.autoFocusWhenEmpty
+    );
   },
 );
 

--- a/app/src/components/AppConsole/AppConsole.test.tsx
+++ b/app/src/components/AppConsole/AppConsole.test.tsx
@@ -1,0 +1,338 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useEffect, useMemo, useRef } from "react";
+
+import type { ConsoleCell, PersistedConsoleCellRow } from "./model";
+
+const SHIFT = 1 << 10;
+const ENTER = 1;
+const UP = 2;
+const DOWN = 3;
+
+let storedSessionId = "session-1";
+let storedCells: PersistedConsoleCellRow[] = [];
+const touchedSessions: string[] = [];
+
+const kernelBehavior = vi.fn(
+  async (hooks: { onStdout?: (data: string) => void; onStderr?: (data: string) => void }, code: string) => {
+    hooks.onStdout?.(`ran:${code}\n`);
+    return {
+      exitCode: 0,
+      result: undefined,
+    };
+  },
+);
+
+vi.mock("../../contexts/RunnersContext", () => ({
+  useRunners: () => ({
+    updateRunner: vi.fn(),
+    deleteRunner: vi.fn(),
+    setDefaultRunner: vi.fn(),
+  }),
+}));
+
+vi.mock("../../contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({
+    getItems: () => [],
+    addItem: vi.fn(),
+    removeItem: vi.fn(),
+  }),
+}));
+
+vi.mock("../../contexts/CurrentDocContext", () => ({
+  useCurrentDoc: () => ({
+    getCurrentDoc: () => null,
+    setCurrentDoc: vi.fn(),
+  }),
+}));
+
+vi.mock("../../contexts/NotebookContext", () => ({
+  useNotebookContext: () => ({
+    getNotebookData: () => null,
+    useNotebookList: () => [],
+  }),
+}));
+
+vi.mock("../../contexts/FilesystemStoreContext", () => ({
+  useFilesystemStore: () => ({
+    fsStore: null,
+    setFsStore: vi.fn(),
+  }),
+}));
+
+vi.mock("../../contexts/NotebookStoreContext", () => ({
+  useNotebookStore: () => ({
+    store: null,
+  }),
+}));
+
+vi.mock("../../lib/runtime/AppState", () => ({
+  appState: {
+    localNotebooks: null,
+    setFilesystemStore: vi.fn(),
+  },
+}));
+
+vi.mock("../../lib/runtime/runmeConsole", () => ({
+  createRunmeConsoleApi: () => ({}),
+}));
+
+vi.mock("../../lib/runtime/appJsGlobals", () => ({
+  createAppJsGlobals: () => ({}),
+}));
+
+vi.mock("../../storage/fs", () => ({
+  FilesystemNotebookStore: class {},
+  isFileSystemAccessSupported: () => false,
+}));
+
+vi.mock("../../lib/runner", () => ({
+  Runner: class {
+    constructor(public readonly args: Record<string, unknown>) {}
+  },
+}));
+
+vi.mock("../../lib/runtime/jsKernel", () => ({
+  JSKernel: class {
+    private readonly hooks: Record<string, unknown>;
+
+    constructor(args: { hooks?: Record<string, unknown> }) {
+      this.hooks = args.hooks ?? {};
+    }
+
+    async run(code: string) {
+      return kernelBehavior(this.hooks, code);
+    }
+  },
+}));
+
+vi.mock("../Actions/Actions", () => ({
+  ActionOutputItems: ({ outputs }: { outputs: Array<{ items?: Array<{ data?: Uint8Array }> }> }) => {
+    const decoder = new TextDecoder();
+    const text = outputs
+      .flatMap((output) => output.items ?? [])
+      .map((item) => decoder.decode(item?.data ?? new Uint8Array()))
+      .join("");
+    return <div data-testid="mock-output-items">{text}</div>;
+  },
+}));
+
+vi.mock("./storage", () => ({
+  appConsoleStorage: {
+    async createSession() {
+      return {
+        id: storedSessionId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    },
+    async loadLatestSession() {
+      if (storedCells.length === 0) {
+        return null;
+      }
+      return {
+        session: {
+          id: storedSessionId,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        cells: storedCells,
+      };
+    },
+    async saveCells(rows: PersistedConsoleCellRow[]) {
+      storedCells = rows.map((row) => ({ ...row }));
+    },
+    async touchSession(sessionId: string) {
+      touchedSessions.push(sessionId);
+    },
+  },
+}));
+
+vi.mock("../Actions/Editor", () => ({
+  default: ({
+    id,
+    value,
+    readOnly,
+    ariaLabel,
+    onChange,
+    onMount,
+  }: {
+    id: string;
+    value: string;
+    readOnly?: boolean;
+    ariaLabel?: string;
+    onChange: (value: string) => void;
+    onMount?: (editor: any, monaco: any) => void;
+  }) => {
+    const commandsRef = useRef(new Map<number, () => void>());
+    const editorRef = useMemo(
+      () => ({
+        addCommand: (key: number, handler: () => void) => {
+          commandsRef.current.set(key, handler);
+        },
+        focus: vi.fn(),
+      }),
+      [],
+    );
+
+    useEffect(() => {
+      onMount?.(editorRef, {
+        KeyMod: { Shift: SHIFT },
+        KeyCode: {
+          Enter: ENTER,
+          UpArrow: UP,
+          DownArrow: DOWN,
+        },
+      });
+    }, [editorRef, onMount]);
+
+    return (
+      <textarea
+        aria-label={ariaLabel}
+        data-testid={id}
+        readOnly={readOnly}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        onKeyDown={(event) => {
+          if (!event.shiftKey) {
+            return;
+          }
+          const code =
+            event.key === "Enter"
+              ? ENTER
+              : event.key === "ArrowUp"
+                ? UP
+                : event.key === "ArrowDown"
+                  ? DOWN
+                  : null;
+          if (!code) {
+            return;
+          }
+          event.preventDefault();
+          commandsRef.current.get(SHIFT | code)?.();
+        }}
+      />
+    );
+  },
+}));
+
+import AppConsole from "./AppConsole";
+
+function getCurrentCell(): HTMLElement {
+  const current = document.querySelector(
+    '[data-testid="app-console-cell"][data-current="true"]',
+  );
+  if (!(current instanceof HTMLElement)) {
+    throw new Error("Current app console cell not found");
+  }
+  return current;
+}
+
+function currentInput(): HTMLTextAreaElement {
+  const input = screen.getByLabelText("App Console input");
+  if (!(input instanceof HTMLTextAreaElement)) {
+    throw new Error("Current app console input not found");
+  }
+  return input;
+}
+
+async function flushPersistence() {
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+  });
+}
+
+describe("AppConsole", () => {
+  beforeEach(() => {
+    storedSessionId = "session-1";
+    storedCells = [];
+    touchedSessions.length = 0;
+    kernelBehavior.mockReset();
+    kernelBehavior.mockImplementation(async (hooks, code: string) => {
+      hooks.onStdout?.(`ran:${code}\n`);
+      return {
+        exitCode: 0,
+        result: undefined,
+      };
+    });
+  });
+
+  it("runs draft cells append-only and creates a new draft", async () => {
+    render(<AppConsole showHeader={false} />);
+
+    await screen.findByLabelText("App Console input");
+    fireEvent.change(currentInput(), { target: { value: 'console.log("hello")' } });
+    fireEvent.keyDown(currentInput(), { key: "Enter", shiftKey: true });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("app-console-cell")).toHaveLength(2);
+    });
+
+    const cells = screen.getAllByTestId("app-console-cell");
+    expect(cells[0].getAttribute("data-status")).toBe("success");
+    expect(cells[1].getAttribute("data-status")).toBe("draft");
+    expect(cells[1].getAttribute("data-current")).toBe("true");
+    expect(screen.getByText('ran:console.log("hello")')).toBeTruthy();
+  });
+
+  it("preserves the in-progress draft while browsing history", async () => {
+    render(<AppConsole showHeader={false} />);
+
+    await screen.findByLabelText("App Console input");
+
+    fireEvent.change(currentInput(), { target: { value: "first()" } });
+    fireEvent.keyDown(currentInput(), { key: "Enter", shiftKey: true });
+    await waitFor(() => expect(screen.getAllByTestId("app-console-cell")).toHaveLength(2));
+
+    fireEvent.change(currentInput(), { target: { value: "second()" } });
+    fireEvent.keyDown(currentInput(), { key: "Enter", shiftKey: true });
+    await waitFor(() => expect(screen.getAllByTestId("app-console-cell")).toHaveLength(3));
+
+    fireEvent.change(currentInput(), { target: { value: "partial draft" } });
+
+    fireEvent.keyDown(currentInput(), { key: "ArrowUp", shiftKey: true });
+    expect(currentInput().value).toBe("second()");
+
+    fireEvent.keyDown(currentInput(), { key: "ArrowUp", shiftKey: true });
+    expect(currentInput().value).toBe("first()");
+
+    fireEvent.keyDown(currentInput(), { key: "ArrowDown", shiftKey: true });
+    expect(currentInput().value).toBe("second()");
+
+    fireEvent.keyDown(currentInput(), { key: "ArrowDown", shiftKey: true });
+    expect(currentInput().value).toBe("partial draft");
+  });
+
+  it("copies a frozen cell back into the current draft", async () => {
+    render(<AppConsole showHeader={false} />);
+
+    await screen.findByLabelText("App Console input");
+    fireEvent.change(currentInput(), { target: { value: "app.runners.get()" } });
+    fireEvent.click(screen.getByTestId("app-console-cell-run"));
+
+    await waitFor(() => expect(screen.getAllByTestId("app-console-cell")).toHaveLength(2));
+    fireEvent.click(screen.getAllByTestId("app-console-cell-copy-to-draft")[0]);
+
+    expect(currentInput().value).toBe("app.runners.get()");
+  });
+
+  it("restores persisted cells after remount", async () => {
+    const firstRender = render(<AppConsole showHeader={false} />);
+
+    await screen.findByLabelText("App Console input");
+    fireEvent.change(currentInput(), { target: { value: "persisted()" } });
+    fireEvent.keyDown(currentInput(), { key: "Enter", shiftKey: true });
+    await waitFor(() => expect(screen.getAllByTestId("app-console-cell")).toHaveLength(2));
+    await flushPersistence();
+
+    firstRender.unmount();
+    render(<AppConsole showHeader={false} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("app-console-cell")).toHaveLength(2);
+    });
+    expect(screen.getByText("persisted()")).toBeTruthy();
+    expect(getCurrentCell().getAttribute("data-status")).toBe("draft");
+  });
+});

--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -1,41 +1,142 @@
+import { create } from "@bufbuild/protobuf";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
-import { ClientMessages, setContext } from "@runmedev/renderers";
-import type { RendererContext } from "vscode-notebook-renderer";
-
-import { JSKernel } from "../../lib/runtime/jsKernel";
-import { createAppJsGlobals } from "../../lib/runtime/appJsGlobals";
-import { useRunners } from "../../contexts/RunnersContext";
-import { useWorkspace } from "../../contexts/WorkspaceContext";
-import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
 import { useCurrentDoc } from "../../contexts/CurrentDocContext";
+import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
 import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
+import { useRunners } from "../../contexts/RunnersContext";
+import { useWorkspace } from "../../contexts/WorkspaceContext";
 import { appState } from "../../lib/runtime/AppState";
-import {
-  FilesystemNotebookStore,
-  isFileSystemAccessSupported,
-} from "../../storage/fs";
-import { Runner } from "../../lib/runner";
+import { createAppJsGlobals } from "../../lib/runtime/appJsGlobals";
+import { JSKernel } from "../../lib/runtime/jsKernel";
 import {
   createRunmeConsoleApi,
   type NotebookDataLike,
 } from "../../lib/runtime/runmeConsole";
+import { Runner } from "../../lib/runner";
+import {
+  FilesystemNotebookStore,
+  isFileSystemAccessSupported,
+} from "../../storage/fs";
+import { parser_pb } from "../../runme/client";
+import { ActionOutputItems } from "../Actions/Actions";
+import Editor from "../Actions/Editor";
+import {
+  coerceRestoredCells,
+  createDraftCell,
+  createResultOutput,
+  createStdTextOutputs,
+  type ConsoleCell,
+} from "./model";
+import { appConsoleStorage } from "./storage";
 
-const PROMPT = "> ";
-const ERASE_TO_END = "\u001b[K";
-const MOVE_CURSOR_COL = (col: number) => `\u001b[${col}G`;
 const STORAGE_KEY = "runme.appConsoleCollapsed";
 const LEGACY_STORAGE_KEY = "aisre.appConsoleCollapsed";
-const MAX_CONSOLE_OUTPUT = 8000;
+const PERSIST_DEBOUNCE_MS = 150;
+const textDecoder = new TextDecoder();
 
-/**
- * AppConsole wired to JSKernel. Input entered in console-view is executed
- * via JSKernel and stdout/stderr are written back to the terminal.
- */
+type OutputKind = "stdout" | "stderr" | "result";
+
+function buildOutputGroups(outputs: parser_pb.CellOutput[]): Array<{
+  key: string;
+  kind: OutputKind;
+  outputs: parser_pb.CellOutput[];
+}> {
+  const groups: Array<{
+    key: string;
+    kind: OutputKind;
+    outputs: parser_pb.CellOutput[];
+  }> = [];
+
+  outputs.forEach((output, outputIndex) => {
+    (output.items ?? []).forEach((item, itemIndex) => {
+      if (!item) {
+        return;
+      }
+
+      const mime = item.mime || "";
+      const decoded = textDecoder.decode(item.data ?? new Uint8Array());
+      if (
+        (mime === "application/vnd.code.notebook.stdout" ||
+          mime === "application/vnd.code.notebook.stderr") &&
+        decoded.length === 0
+      ) {
+        return;
+      }
+
+      let kind: OutputKind = "result";
+      if (mime === "application/vnd.code.notebook.stdout") {
+        kind = "stdout";
+      } else if (mime === "application/vnd.code.notebook.stderr") {
+        kind = "stderr";
+      }
+
+      groups.push({
+        key: `${outputIndex}-${itemIndex}-${kind}`,
+        kind,
+        outputs: [
+          create(parser_pb.CellOutputSchema, {
+            items: [item],
+          }),
+        ],
+      });
+    });
+  });
+
+  return groups;
+}
+
+function StatusPill({ status }: { status: ConsoleCell["status"] }) {
+  const className =
+    status === "success"
+      ? "bg-emerald-500/15 text-emerald-200 ring-1 ring-emerald-400/30"
+      : status === "error"
+        ? "bg-rose-500/15 text-rose-200 ring-1 ring-rose-400/30"
+        : status === "running"
+          ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-300/30"
+          : "bg-sky-500/15 text-sky-100 ring-1 ring-sky-300/30";
+
+  return (
+    <span
+      data-testid="app-console-cell-status"
+      className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] ${className}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function OutputGroups({ outputs }: { outputs: parser_pb.CellOutput[] }) {
+  const groups = useMemo(() => buildOutputGroups(outputs), [outputs]);
+  if (groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="app-console-cell-outputs"
+      className="space-y-2"
+    >
+      {groups.map((group) => (
+        <div
+          key={group.key}
+          data-testid="app-console-cell-output"
+          data-output-kind={group.kind}
+          className="rounded-nb-sm border border-white/10 bg-black/15 p-3"
+        >
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.18em] text-slate-400">
+            {group.kind}
+          </div>
+          <ActionOutputItems outputs={group.outputs} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function AppConsole({ showHeader = true }: { showHeader?: boolean }) {
-  const elemRef = useRef<any>(null);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === "undefined") {
       return false;
@@ -50,9 +151,19 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
       return false;
     }
   });
-  // Track recent console output so automated tests can assert command results
-  // without scraping the xterm canvas.
-  const [consoleOutput, setConsoleOutput] = useState("");
+  const [cells, setCells] = useState<ConsoleCell[]>(() => [createDraftCell(1)]);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const draftEditorRef = useRef<any>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const historyBrowseRef = useRef<{ index: number | null; draftBuffer: string }>({
+    index: null,
+    draftBuffer: "",
+  });
+  const pendingFocusCellIdRef = useRef<string | null>(null);
+  const persistenceEnabledRef = useRef(true);
 
   useEffect(() => {
     try {
@@ -63,48 +174,18 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
     }
   }, [collapsed]);
 
-  const consoleId = useMemo(
-    () => `console-${Math.random().toString(36).substring(2, 9)}`,
-    [],
-  );
   const { updateRunner, deleteRunner, setDefaultRunner } = useRunners();
-  // WorkspaceContext provides the persisted list of workspace URIs so we can
-  // mount/unmount folders from the App Console without drilling props.
   const { getItems, addItem, removeItem } = useWorkspace();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
   const { getNotebookData, useNotebookList } = useNotebookContext();
   const openNotebooks = useNotebookList();
-  // FilesystemStoreContext owns the File System Access API store instance that
-  // actually opens folders and produces fs:// workspace URIs.
   const { fsStore, setFsStore } = useFilesystemStore();
   const { store: notebookStore } = useNotebookStore();
+
   const resolveNotebookStore = useCallback(() => {
     return notebookStore ?? appState.localNotebooks;
   }, [notebookStore]);
 
-  // Message pump to deliver stdout/stderr back into console-view.
-  const messageListenerRef = useRef<((message: unknown) => void) | undefined>(
-    undefined,
-  );
-  const sendStdout = useCallback((data: string) => {
-    setConsoleOutput((prev) => {
-      const next = prev + data;
-      return next.length > MAX_CONSOLE_OUTPUT
-        ? next.slice(-MAX_CONSOLE_OUTPUT)
-        : next;
-    });
-    messageListenerRef.current?.({
-      type: ClientMessages.terminalStdout,
-      output: {
-        "runme.dev/id": consoleId,
-        data,
-      },
-    } as any);
-  }, [consoleId]);
-
-  // Lazily create the FilesystemNotebookStore if the provider has not
-  // initialized it yet. This keeps the App Console usable even if a user
-  // runs commands before the App initializer finishes.
   const ensureFilesystemStore = useCallback(() => {
     if (fsStore) {
       return fsStore;
@@ -174,87 +255,419 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
     [resolveNotebookData],
   );
 
-  const kernel = useMemo(
-    () =>
-      new JSKernel({
-        globals: createAppJsGlobals({
-          runme,
-          sendOutput: sendStdout,
-          resolveNotebookStore,
-          ensureFilesystemStore,
-          workspace: {
-            getItems,
-            addItem,
-            removeItem,
-          },
-          openNotebook: (uri) => {
-            setCurrentDoc(uri);
-          },
-          resolveNotebook: resolveNotebookData,
-          listNotebooks: () =>
-            openNotebooks
-              .map((item) => getNotebookData(item.uri))
-              .filter((item): item is NotebookDataLike => Boolean(item)),
-          runnerSync: {
-            onUpdated: (runner) => {
-              updateRunner(
-                new Runner({
-                  name: runner.name,
-                  endpoint: runner.endpoint,
-                  reconnect: runner.reconnect,
-                  interceptors: [],
-                }),
-              );
-            },
-            onDeleted: deleteRunner,
-            onDefaultSet: setDefaultRunner,
-          },
-        }),
-        hooks: {
-          onStdout: (data) => {
-            sendStdout(data);
-          },
-          onStderr: (data) => {
-            sendStdout(data);
-          },
-          onExit: (code) => {
-            const suffix = code === 0 ? "" : ` (exit code ${code})`;
-            sendStdout(`\r\n${suffix ? `Command finished${suffix}` : ""}\r\n${PROMPT}`);
-          },
-        },
-      }),
-    [
-      addItem,
-      deleteRunner,
-      getItems,
-      getNotebookData,
-      openNotebooks,
-      resolveNotebookStore,
-      ensureFilesystemStore,
-      removeItem,
-      resolveNotebookData,
-      runme,
-      sendStdout,
-      setDefaultRunner,
-      updateRunner,
-    ],
+  const currentCell = cells[cells.length - 1] ?? null;
+
+  const persistCells = useCallback(
+    async (rows: ConsoleCell[]) => {
+      if (!sessionId || !persistenceEnabledRef.current) {
+        return;
+      }
+      const updatedAt = new Date().toISOString();
+      await appConsoleStorage.saveCells(
+        rows.map((row) => ({
+          ...row,
+          sessionId,
+          updatedAt,
+        })),
+      );
+      await appConsoleStorage.touchSession(sessionId, updatedAt);
+    },
+    [sessionId],
   );
 
-  // Line editor state (buffer + cursor index).
-  const lineState = useRef<{ buffer: string; cursor: number }>({
-    buffer: "",
-    cursor: 0,
-  });
-  const history = useRef<string[]>([]);
-  const historyIndex = useRef<number>(-1); // -1 means current line (not history)
+  useEffect(() => {
+    let cancelled = false;
 
-  const redrawLine = () => {
-    const { buffer, cursor } = lineState.current;
-    const promptLen = PROMPT.length;
-    sendStdout(`\r${PROMPT}${buffer}${ERASE_TO_END}`);
-    // Move cursor to absolute column (1-based)
-    sendStdout(MOVE_CURSOR_COL(promptLen + cursor + 1));
-  };
+    void (async () => {
+      const now = new Date().toISOString();
+      try {
+        const restored = await appConsoleStorage.loadLatestSession();
+        if (cancelled) {
+          return;
+        }
+
+        if (!restored) {
+          const session = await appConsoleStorage.createSession(now);
+          if (cancelled) {
+            return;
+          }
+          const nextCells = [createDraftCell(1)];
+          await appConsoleStorage.saveCells(
+            nextCells.map((cell) => ({
+              ...cell,
+              sessionId: session.id,
+              updatedAt: now,
+            })),
+          );
+          setSessionId(session.id);
+          setCells(nextCells);
+          pendingFocusCellIdRef.current = nextCells[0].id;
+          setHydrated(true);
+          return;
+        }
+
+        const recovered = coerceRestoredCells(restored.cells, now);
+        if (recovered.mutated) {
+          await appConsoleStorage.saveCells(
+            recovered.cells.map((cell) => ({
+              ...cell,
+              sessionId: restored.session.id,
+              updatedAt: now,
+            })),
+          );
+          await appConsoleStorage.touchSession(restored.session.id, now);
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        setSessionId(restored.session.id);
+        setCells(recovered.cells);
+        pendingFocusCellIdRef.current =
+          recovered.cells[recovered.cells.length - 1]?.id ?? null;
+        setHydrated(true);
+      } catch (error) {
+        console.error("Failed to restore App Console session", error);
+        persistenceEnabledRef.current = false;
+        const fallbackSessionId =
+          globalThis.crypto?.randomUUID?.() ?? `app-console-fallback-${Date.now()}`;
+        const fallbackCells = [createDraftCell(1)];
+        if (!cancelled) {
+          setLoadError("Console history is unavailable for this session.");
+          setSessionId(fallbackSessionId);
+          setCells(fallbackCells);
+          pendingFocusCellIdRef.current = fallbackCells[0].id;
+          setHydrated(true);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated || !sessionId || !persistenceEnabledRef.current) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      void persistCells(cells).catch((error) => {
+        console.error("Failed to persist App Console state", error);
+      });
+    }, PERSIST_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [cells, hydrated, persistCells, sessionId]);
+
+  useEffect(() => {
+    if (!currentCell || currentCell.status !== "draft") {
+      return;
+    }
+    if (pendingFocusCellIdRef.current !== currentCell.id) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      draftEditorRef.current?.focus?.();
+      pendingFocusCellIdRef.current = null;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [currentCell]);
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    if (!body || typeof body.scrollTo !== "function") {
+      return;
+    }
+    body.scrollTo({
+      top: body.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [cells]);
+
+  const setCurrentSource = useCallback(
+    (source: string, clearHistoryBrowse = true) => {
+      setCells((prev) => {
+        if (prev.length === 0) {
+          return prev;
+        }
+        const lastIndex = prev.length - 1;
+        const target = prev[lastIndex];
+        if (target.source === source) {
+          return prev;
+        }
+        const next = [...prev];
+        next[lastIndex] = {
+          ...target,
+          source,
+        };
+        return next;
+      });
+
+      if (clearHistoryBrowse) {
+        historyBrowseRef.current = {
+          index: null,
+          draftBuffer: "",
+        };
+      }
+    },
+    [],
+  );
+
+  const browseHistory = useCallback(
+    (direction: "previous" | "next") => {
+      setCells((prev) => {
+        if (prev.length === 0) {
+          return prev;
+        }
+        const draft = prev[prev.length - 1];
+        if (draft.status !== "draft") {
+          return prev;
+        }
+
+        const history = prev
+          .filter((cell) => cell.status !== "draft")
+          .map((cell) => cell.source)
+          .filter((source) => source.trim() !== "");
+
+        if (history.length === 0) {
+          return prev;
+        }
+
+        const state = historyBrowseRef.current;
+        if (direction === "previous") {
+          const nextIndex =
+            state.index === null ? 0 : Math.min(state.index + 1, history.length - 1);
+          const draftBuffer = state.index === null ? draft.source : state.draftBuffer;
+          const nextSource = history[history.length - 1 - nextIndex] ?? draft.source;
+          historyBrowseRef.current = {
+            index: nextIndex,
+            draftBuffer,
+          };
+          if (nextSource === draft.source) {
+            return prev;
+          }
+          const next = [...prev];
+          next[next.length - 1] = {
+            ...draft,
+            source: nextSource,
+          };
+          return next;
+        }
+
+        if (state.index === null) {
+          return prev;
+        }
+
+        const nextIndex = state.index - 1;
+        const nextSource =
+          nextIndex >= 0
+            ? history[history.length - 1 - nextIndex] ?? draft.source
+            : state.draftBuffer;
+
+        historyBrowseRef.current =
+          nextIndex >= 0
+            ? {
+                index: nextIndex,
+                draftBuffer: state.draftBuffer,
+              }
+            : {
+                index: null,
+                draftBuffer: "",
+              };
+
+        if (nextSource === draft.source) {
+          return prev;
+        }
+
+        const next = [...prev];
+        next[next.length - 1] = {
+          ...draft,
+          source: nextSource,
+        };
+        return next;
+      });
+    },
+    [],
+  );
+
+  const executeCurrentCell = useCallback(async () => {
+    if (!currentCell || currentCell.status !== "draft") {
+      return;
+    }
+    if (currentCell.source.trim() === "") {
+      return;
+    }
+
+    historyBrowseRef.current = {
+      index: null,
+      draftBuffer: "",
+    };
+
+    const startedAt = new Date().toISOString();
+    const runningId = currentCell.id;
+    let stdout = "";
+    let stderr = "";
+
+    const updateStreamingOutputs = (kind: "stdout" | "stderr", chunk: string) => {
+      if (kind === "stdout") {
+        stdout += chunk;
+      } else {
+        stderr += chunk;
+      }
+
+      setCells((prev) =>
+        prev.map((cell) =>
+          cell.id === runningId
+            ? {
+                ...cell,
+                outputs: createStdTextOutputs(stdout, stderr),
+              }
+            : cell,
+        ),
+      );
+    };
+
+    setCells((prev) =>
+      prev.map((cell) =>
+        cell.id === runningId
+          ? {
+              ...cell,
+              status: "running",
+              startedAt,
+              completedAt: undefined,
+              exitCode: undefined,
+              outputs: [],
+            }
+          : cell,
+      ),
+    );
+
+    const globals = createAppJsGlobals({
+      runme,
+      sendOutput: (data) => updateStreamingOutputs("stdout", data),
+      resolveNotebookStore,
+      ensureFilesystemStore,
+      workspace: {
+        getItems,
+        addItem,
+        removeItem,
+      },
+      openNotebook: (uri) => {
+        setCurrentDoc(uri);
+      },
+      resolveNotebook: resolveNotebookData,
+      listNotebooks: () =>
+      openNotebooks
+          .reduce<NotebookDataLike[]>((items, notebook) => {
+            const resolved = getNotebookData(notebook.uri);
+            if (resolved) {
+              items.push(resolved);
+            }
+            return items;
+          }, []),
+      runnerSync: {
+        onUpdated: (runner) => {
+          updateRunner(
+            new Runner({
+              name: runner.name,
+              endpoint: runner.endpoint,
+              reconnect: runner.reconnect,
+              interceptors: [],
+            }),
+          );
+        },
+        onDeleted: deleteRunner,
+        onDefaultSet: setDefaultRunner,
+      },
+    });
+
+    const kernel = new JSKernel({
+      globals,
+      hooks: {
+        onStdout: (data) => updateStreamingOutputs("stdout", data),
+        onStderr: (data) => updateStreamingOutputs("stderr", data),
+      },
+    });
+
+    const { exitCode, result } = await kernel.run(currentCell.source);
+    const completedAt = new Date().toISOString();
+    const nextDraft = createDraftCell(currentCell.index + 1);
+    const nextStatus: ConsoleCell["status"] = exitCode === 0 ? "success" : "error";
+
+    pendingFocusCellIdRef.current = nextDraft.id;
+    setCells((prev) => {
+      const next = prev.map((cell) => {
+        if (cell.id !== runningId) {
+          return cell;
+        }
+        return {
+          ...cell,
+          status: nextStatus,
+          completedAt,
+          exitCode,
+          outputs: [
+            ...createStdTextOutputs(stdout, stderr),
+            ...createResultOutput(result),
+          ],
+        };
+      });
+      next.push(nextDraft);
+      return next;
+    });
+  }, [
+    addItem,
+    currentCell,
+    deleteRunner,
+    ensureFilesystemStore,
+    getItems,
+    getNotebookData,
+    openNotebooks,
+    removeItem,
+    resolveNotebookData,
+    resolveNotebookStore,
+    runme,
+    setCurrentDoc,
+    setDefaultRunner,
+    updateRunner,
+  ]);
+
+  const registerDraftEditor = useCallback(
+    (editor: any, monaco: any) => {
+      draftEditorRef.current = editor;
+      if (!monaco?.KeyMod || !monaco?.KeyCode) {
+        return;
+      }
+
+      editor.addCommand(
+        monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+        () => {
+          void executeCurrentCell();
+        },
+      );
+      editor.addCommand(
+        monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
+        () => {
+          browseHistory("previous");
+        },
+      );
+      editor.addCommand(
+        monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,
+        () => {
+          browseHistory("next");
+        },
+      );
+    },
+    [browseHistory, executeCurrentCell],
+  );
 
   const isBodyHidden = showHeader && collapsed;
 
@@ -276,209 +689,142 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
             style={{ backgroundColor: "transparent" }}
             onClick={() => setCollapsed((prev) => !prev)}
           >
-            {collapsed ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
+            {collapsed ? (
+              <ChevronUpIcon className="h-4 w-4" />
+            ) : (
+              <ChevronDownIcon className="h-4 w-4" />
+            )}
           </button>
         </div>
       )}
       <div
         id="app-console-body"
-        className={`${isBodyHidden ? "hidden" : "flex"} flex-1 bg-[#0f1014]`}
+        className={`${isBodyHidden ? "hidden" : "flex"} min-h-[220px] flex-1 flex-col bg-[#0f1014]`}
       >
         <div
-          id="app-console-view"
-          className="flex-1 min-h-[220px] w-full"
-          ref={(el) => {
-            if (!el || el.hasChildNodes()) {
-              return;
-            }
-            const elem = document.createElement("console-view") as any;
-            elem.style.height = "100%";
-            elem.style.width = "100%";
-            elem.style.display = "block";
-
-            elemRef.current = elem;
-
-            const ctxBridge = {
-              postMessage: (message: any) => {
-                if (message?.type === ClientMessages.terminalStdin) {
-                  const input = (message.output?.input as string) ?? "";
-                  const state = lineState.current;
-                  for (let i = 0; i < input.length; i++) {
-                    const ch = input[i];
-
-                    // Handle escape sequences (arrow keys)
-                    if (ch === "\u001b" && input[i + 1] === "[") {
-                      const code = input[i + 2];
-                      if (code === "D") {
-                        // Left
-                        if (state.cursor > 0) {
-                          state.cursor -= 1;
-                          redrawLine();
-                        }
-                        i += 2;
-                        continue;
-                      }
-                      if (code === "C") {
-                        // Right
-                        if (state.cursor < state.buffer.length) {
-                          state.cursor += 1;
-                          redrawLine();
-                        }
-                        i += 2;
-                        continue;
-                      }
-                      if (code === "H") {
-                        // Home
-                        state.cursor = 0;
-                        redrawLine();
-                        i += 2;
-                        continue;
-                      }
-                      if (code === "F") {
-                        // End
-                        state.cursor = state.buffer.length;
-                        redrawLine();
-                        i += 2;
-                        continue;
-                      }
-                      if (code === "A") {
-                        // Up: history prev
-                        if (history.current.length === 0) {
-                          i += 2;
-                          continue;
-                        }
-                        const nextIndex =
-                          historyIndex.current < history.current.length - 1
-                            ? historyIndex.current + 1
-                            : history.current.length - 1;
-                        historyIndex.current = nextIndex;
-                        state.buffer =
-                          history.current[history.current.length - 1 - nextIndex] ?? "";
-                        state.cursor = state.buffer.length;
-                        redrawLine();
-                        i += 2;
-                        continue;
-                      }
-                      if (code === "B") {
-                        // Down: history next
-                        if (history.current.length === 0) {
-                          i += 2;
-                          continue;
-                        }
-                        const nextIndex =
-                          historyIndex.current > 0 ? historyIndex.current - 1 : -1;
-                        historyIndex.current = nextIndex;
-                        if (nextIndex === -1) {
-                          state.buffer = "";
-                          state.cursor = 0;
-                        } else {
-                          state.buffer =
-                            history.current[history.current.length - 1 - nextIndex] ?? "";
-                          state.cursor = state.buffer.length;
-                        }
-                        redrawLine();
-                        i += 2;
-                        continue;
-                      }
-                    }
-
-                    if (ch === "\r" || ch === "\n") {
-                      const command = state.buffer.trim();
-                      sendStdout("\r\n");
-                      if (command.length > 0) {
-                        history.current.push(command);
-                        historyIndex.current = -1;
-                        void kernel.run(command);
-                      } else {
-                        sendStdout(PROMPT);
-                      }
-                      state.buffer = "";
-                      state.cursor = 0;
-                      continue;
-                    }
-
-                    if (ch === "\u0008" || ch === "\u007f") {
-                      if (state.cursor > 0) {
-                        state.buffer =
-                          state.buffer.slice(0, state.cursor - 1) +
-                          state.buffer.slice(state.cursor);
-                        state.cursor -= 1;
-                        redrawLine();
-                      }
-                      continue;
-                    }
-
-                    // Ignore other control characters
-                    if (ch < " ") {
-                      continue;
-                    }
-
-                    // Insert printable character at cursor position
-                    state.buffer =
-                      state.buffer.slice(0, state.cursor) +
-                      ch +
-                      state.buffer.slice(state.cursor);
-                    state.cursor += 1;
-                    redrawLine();
-                  }
-                }
-              },
-              onDidReceiveMessage: (listener: (message: unknown) => void) => {
-                messageListenerRef.current = listener;
-                listener({
-                  type: ClientMessages.terminalStdout,
-                  output: {
-                    "runme.dev/id": consoleId,
-                    data: `runme JS console. Type help() to see available commands.\n${PROMPT}`,
-                  },
-                } as any);
-                return {
-                  dispose: () => {},
-                };
-              },
-            } as RendererContext<void>;
-
-            const activateConsoleContext = () => {
-              setContext(ctxBridge);
-            };
-
-            // console-view currently resolves messaging through the renderer
-            // global context, so ensure this bridge is active for app-console input.
-            activateConsoleContext();
-            (elem as any).context = ctxBridge;
-            elem.addEventListener("pointerdown", activateConsoleContext);
-            elem.addEventListener("focusin", activateConsoleContext);
-            // Some terminal events (for example selection/annotation updates)
-            // can be emitted before focus is moved to the element. Re-arming
-            // the bridge on keydown keeps AppConsole interactive even when
-            // another console recently replaced the shared renderer context.
-            elem.addEventListener("keydown", activateConsoleContext, true);
-
-            elem.setAttribute("id", consoleId);
-            elem.setAttribute("buttons", "false");
-            elem.setAttribute("initialContent", "");
-            elem.setAttribute("theme", "dark");
-            elem.setAttribute("fontFamily", "Fira Mono, monospace");
-            elem.setAttribute("fontSize", "12.6");
-            elem.setAttribute("cursorStyle", "block");
-            elem.setAttribute("cursorBlink", "true");
-            elem.setAttribute("cursorWidth", "1");
-            elem.setAttribute("smoothScrollDuration", "0");
-            elem.setAttribute("scrollback", "4000");
-
-            el.appendChild(elem);
-            // Re-apply once after attachment so the global messaging context is
-            // deterministic even if another component changed it during mount.
-            queueMicrotask(activateConsoleContext);
-          }}
-        ></div>
-        <pre
-          id="app-console-output"
-          data-testid="app-console-output"
-          className="sr-only"
+          ref={bodyRef}
+          data-testid="app-console-cells"
+          className="flex min-h-[220px] flex-1 flex-col gap-3 overflow-y-auto px-3 py-3"
         >
-          {consoleOutput}
-        </pre>
+          {loadError ? (
+            <div className="rounded-nb-sm border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+              {loadError}
+            </div>
+          ) : null}
+          {cells.map((cell) => {
+            const isCurrent = currentCell?.id === cell.id;
+            const isEditable = isCurrent && cell.status === "draft";
+            const isFrozen = cell.status === "success" || cell.status === "error";
+
+            return (
+              <article
+                key={cell.id}
+                data-testid="app-console-cell"
+                data-console-cell-id={cell.id}
+                data-console-cell-index={`${cell.index}`}
+                data-status={cell.status}
+                data-current={isCurrent ? "true" : "false"}
+                className={`rounded-nb-md border p-3 shadow-sm ${
+                  isCurrent
+                    ? "border-sky-400/40 bg-[#151a27]"
+                    : "border-white/10 bg-[#12151e]"
+                }`}
+              >
+                <div
+                  data-testid="app-console-cell-header"
+                  className="mb-3 flex items-center justify-between gap-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      data-testid="app-console-cell-index"
+                      className="rounded-full bg-white/8 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-300"
+                    >
+                      Cell {cell.index}
+                    </span>
+                    <StatusPill status={cell.status} />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {isFrozen ? (
+                      <button
+                        type="button"
+                        data-testid="app-console-cell-copy-to-draft"
+                        disabled={currentCell?.status !== "draft"}
+                        className="rounded border border-white/15 px-2 py-1 text-[11px] font-medium text-slate-200 transition hover:border-sky-300/50 hover:bg-sky-400/10 disabled:cursor-not-allowed disabled:opacity-40"
+                        onClick={() => {
+                          setCurrentSource(cell.source);
+                          draftEditorRef.current?.focus?.();
+                        }}
+                      >
+                        Copy to draft
+                      </button>
+                    ) : null}
+                    {isEditable ? (
+                      <button
+                        type="button"
+                        data-testid="app-console-cell-run"
+                        className="rounded border border-sky-300/40 bg-sky-400/10 px-2 py-1 text-[11px] font-medium text-sky-100 transition hover:bg-sky-400/20"
+                        onClick={() => {
+                          void executeCurrentCell();
+                        }}
+                      >
+                        Run
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div
+                  data-testid="app-console-cell-input"
+                  className="rounded-nb-sm border border-white/10 bg-[#0e1320] p-2"
+                >
+                  {isEditable || cell.status === "running" ? (
+                    <Editor
+                      id={`app-console-cell-${cell.id}`}
+                      value={cell.source}
+                      language="javascript"
+                      ariaLabel={
+                        isEditable
+                          ? "App Console input"
+                          : `App Console cell ${cell.index} source`
+                      }
+                      autoFocusWhenEmpty={isEditable}
+                      readOnly={!isEditable}
+                      onChange={(value) => {
+                        if (!isEditable) {
+                          return;
+                        }
+                        setCurrentSource(value);
+                      }}
+                      onEnter={() => {
+                        void executeCurrentCell();
+                      }}
+                      onMount={isEditable ? registerDraftEditor : undefined}
+                    />
+                  ) : (
+                    <pre
+                      data-testid="app-console-cell-source"
+                      className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-[#141b2b] px-3 py-3 text-xs leading-relaxed text-slate-100"
+                    >
+                      {cell.source}
+                    </pre>
+                  )}
+                </div>
+
+                <OutputGroups outputs={cell.outputs} />
+
+                {isCurrent && cell.status === "draft" ? (
+                  <div className="mt-3 text-[11px] text-slate-400">
+                    <span className="font-semibold text-slate-300">Shortcuts:</span>{" "}
+                    <span>Shift+Enter to run, Shift+Up/Shift+Down to browse history.</span>
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+          {!hydrated ? (
+            <div className="text-xs text-slate-400">Loading console history…</div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/app/src/components/AppConsole/model.test.ts
+++ b/app/src/components/AppConsole/model.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { coerceRestoredCells, createDraftCell, type PersistedConsoleCellRow } from "./model";
+
+describe("coerceRestoredCells", () => {
+  it("converts running cells into recovered errors and appends a new draft", () => {
+    const restored: PersistedConsoleCellRow[] = [
+      {
+        ...createDraftCell(1, "app.runners.get()"),
+        sessionId: "session-1",
+        status: "running",
+        updatedAt: "2026-05-02T12:00:00.000Z",
+      },
+    ];
+
+    const result = coerceRestoredCells(restored, "2026-05-02T12:05:00.000Z");
+
+    expect(result.mutated).toBe(true);
+    expect(result.cells).toHaveLength(2);
+    expect(result.cells[0].status).toBe("error");
+    expect(result.cells[0].exitCode).toBe(1);
+    expect(result.cells[1].status).toBe("draft");
+  });
+});

--- a/app/src/components/AppConsole/model.ts
+++ b/app/src/components/AppConsole/model.ts
@@ -1,0 +1,180 @@
+import { create } from "@bufbuild/protobuf";
+
+import { MimeType, parser_pb } from "../../runme/client";
+
+export type ConsoleCellStatus = "draft" | "running" | "success" | "error";
+
+export type ConsoleCell = {
+  id: string;
+  index: number;
+  source: string;
+  status: ConsoleCellStatus;
+  startedAt?: string;
+  completedAt?: string;
+  exitCode?: number;
+  outputs: parser_pb.CellOutput[];
+};
+
+export type PersistedConsoleSessionRow = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PersistedConsoleCellRow = ConsoleCell & {
+  sessionId: string;
+  updatedAt: string;
+};
+
+const textEncoder = new TextEncoder();
+
+function encodeOutputText(text: string): Uint8Array {
+  return textEncoder.encode(text);
+}
+
+export function createDraftCell(index: number, source = ""): ConsoleCell {
+  return {
+    id: globalThis.crypto?.randomUUID?.() ?? `app-console-${index}-${Date.now()}`,
+    index,
+    source,
+    status: "draft",
+    outputs: [],
+  };
+}
+
+export function createTextOutputItem(
+  mime: string,
+  text: string,
+): parser_pb.CellOutputItem {
+  return create(parser_pb.CellOutputItemSchema, {
+    mime,
+    type: "Buffer",
+    data: encodeOutputText(text),
+  });
+}
+
+export function createStdTextOutputs(
+  stdout: string,
+  stderr: string,
+): parser_pb.CellOutput[] {
+  if (!stdout && !stderr) {
+    return [];
+  }
+
+  return [
+    create(parser_pb.CellOutputSchema, {
+      items: [
+        createTextOutputItem(MimeType.VSCodeNotebookStdOut, stdout),
+        createTextOutputItem(MimeType.VSCodeNotebookStdErr, stderr),
+      ],
+    }),
+  ];
+}
+
+export function createResultOutput(result: unknown): parser_pb.CellOutput[] {
+  if (typeof result === "undefined") {
+    return [];
+  }
+
+  const text =
+    typeof result === "string"
+      ? result
+      : (() => {
+          try {
+            return JSON.stringify(
+              result,
+              (_key, value) => (typeof value === "bigint" ? value.toString() : value),
+              2,
+            );
+          } catch {
+            return String(result);
+          }
+        })();
+
+  return [
+    create(parser_pb.CellOutputSchema, {
+      items: [createTextOutputItem("text/plain", `${text}\n`)],
+    }),
+  ];
+}
+
+export function appendRecoveryNote(
+  outputs: parser_pb.CellOutput[],
+  note: string,
+): parser_pb.CellOutput[] {
+  const recovered = createStdTextOutputs("", note);
+  if (recovered.length === 0) {
+    return outputs;
+  }
+  return [...outputs, ...recovered];
+}
+
+export function coerceRestoredCells(
+  rows: PersistedConsoleCellRow[],
+  now: string,
+): { cells: ConsoleCell[]; mutated: boolean } {
+  let mutated = false;
+  const sorted = [...rows].sort((left, right) => left.index - right.index);
+  const cells = sorted.map<ConsoleCell>((row) => {
+    if (row.status !== "running") {
+      return {
+        id: row.id,
+        index: row.index,
+        source: row.source,
+        status: row.status,
+        startedAt: row.startedAt,
+        completedAt: row.completedAt,
+        exitCode: row.exitCode,
+        outputs: row.outputs ?? [],
+      };
+    }
+
+    mutated = true;
+    return {
+      id: row.id,
+      index: row.index,
+      source: row.source,
+      status: "error",
+      startedAt: row.startedAt,
+      completedAt: now,
+      exitCode: 1,
+      outputs: appendRecoveryNote(
+        row.outputs ?? [],
+        "[runme] App Console execution was interrupted by a page reload.\n",
+      ),
+    };
+  });
+
+  const draftCells = cells.filter((cell) => cell.status === "draft");
+  if (draftCells.length === 0) {
+    mutated = true;
+    const nextIndex = cells.length > 0 ? cells[cells.length - 1].index + 1 : 1;
+    cells.push(createDraftCell(nextIndex));
+  } else if (draftCells.length > 1) {
+    mutated = true;
+    const latestDraftId = draftCells[draftCells.length - 1].id;
+    for (let i = 0; i < cells.length; i += 1) {
+      if (cells[i].status === "draft" && cells[i].id !== latestDraftId) {
+        cells[i] = {
+          ...cells[i],
+          status: "error",
+          completedAt: now,
+          exitCode: 1,
+          outputs: appendRecoveryNote(
+            cells[i].outputs,
+            "[runme] Recovered duplicate draft cell after reload.\n",
+          ),
+        };
+      }
+    }
+  }
+
+  return { cells, mutated };
+}
+
+export function getHistorySources(cells: ConsoleCell[]): string[] {
+  return cells
+    .filter((cell) => cell.status !== "draft")
+    .map((cell) => cell.source)
+    .filter((source) => source.trim() !== "");
+}

--- a/app/src/components/AppConsole/storage.ts
+++ b/app/src/components/AppConsole/storage.ts
@@ -1,0 +1,87 @@
+import Dexie, { type Table } from "dexie";
+
+import type {
+  PersistedConsoleCellRow,
+  PersistedConsoleSessionRow,
+} from "./model";
+
+export type LoadedConsoleSession = {
+  session: PersistedConsoleSessionRow;
+  cells: PersistedConsoleCellRow[];
+};
+
+export interface AppConsoleStorageLike {
+  createSession(now?: string): Promise<PersistedConsoleSessionRow>;
+  loadLatestSession(): Promise<LoadedConsoleSession | null>;
+  saveCells(rows: PersistedConsoleCellRow[]): Promise<void>;
+  touchSession(sessionId: string, updatedAt?: string): Promise<void>;
+}
+
+class AppConsoleDatabase extends Dexie implements AppConsoleStorageLike {
+  sessions!: Table<PersistedConsoleSessionRow, string>;
+  cells!: Table<PersistedConsoleCellRow, string>;
+
+  constructor(databaseName = "runme-app-console") {
+    super(databaseName);
+
+    this.version(1).stores({
+      sessions: "&id, updatedAt, createdAt",
+      cells: "&id, sessionId, [sessionId+index], updatedAt",
+    });
+
+    this.sessions = this.table("sessions");
+    this.cells = this.table("cells");
+  }
+
+  async createSession(now = new Date().toISOString()): Promise<PersistedConsoleSessionRow> {
+    const session: PersistedConsoleSessionRow = {
+      id: globalThis.crypto?.randomUUID?.() ?? `app-console-session-${Date.now()}`,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.sessions.put(session);
+    return session;
+  }
+
+  async loadLatestSession(): Promise<LoadedConsoleSession | null> {
+    const session = await this.sessions.orderBy("updatedAt").last();
+    if (!session) {
+      return null;
+    }
+    const cells = await this.cells
+      .where("sessionId")
+      .equals(session.id)
+      .sortBy("index");
+    return { session, cells };
+  }
+
+  async saveCells(rows: PersistedConsoleCellRow[]): Promise<void> {
+    if (rows.length === 0) {
+      return;
+    }
+    await this.transaction("rw", this.cells, async () => {
+      await this.cells.bulkPut(rows);
+    });
+  }
+
+  async touchSession(
+    sessionId: string,
+    updatedAt = new Date().toISOString(),
+  ): Promise<void> {
+    const existing = await this.sessions.get(sessionId);
+    if (!existing) {
+      await this.sessions.put({
+        id: sessionId,
+        createdAt: updatedAt,
+        updatedAt,
+      });
+      return;
+    }
+    await this.sessions.put({
+      ...existing,
+      updatedAt,
+    });
+  }
+}
+
+export const appConsoleStorage: AppConsoleStorageLike = new AppConsoleDatabase();

--- a/app/src/lib/runtime/jsKernel.ts
+++ b/app/src/lib/runtime/jsKernel.ts
@@ -14,6 +14,11 @@ type RunOptions = {
   container?: HTMLElement | null;
 };
 
+export type JSKernelRunResult = {
+  exitCode: number;
+  result?: unknown;
+};
+
 type RunnersApi = {
   get: () => string;
   update: (name: string, endpoint: string) => string;
@@ -59,7 +64,7 @@ export class JSKernel {
     };
   }
 
-  async run(code: string, options: RunOptions = {}): Promise<void> {
+  async run(code: string, options: RunOptions = {}): Promise<JSKernelRunResult> {
     const runId = ++this.runCounter;
     this.activeRunId = runId;
 
@@ -130,13 +135,14 @@ export class JSKernel {
     const argValues = argNames.map((key) => mergedGlobals[key]);
 
     let exitCode = 0;
+    let result: unknown;
     try {
       // eslint-disable-next-line @typescript-eslint/no-implied-eval
       const runner = new Function(
         ...argNames,
         `"use strict"; return (async () => {\n${code}\n})();`,
       );
-      await runner(...argValues);
+      result = await runner(...argValues);
     } catch (err) {
       exitCode = 1;
       appLogger.error("JSKernel execution failed", {
@@ -154,6 +160,10 @@ export class JSKernel {
       }
       this.hooks.onExit(exitCode);
     }
+    return {
+      exitCode,
+      result,
+    };
   }
 
   // Proxy console that routes messages into the kernel's stdout/stderr hooks.

--- a/app/test/browser/README.md
+++ b/app/test/browser/README.md
@@ -36,8 +36,9 @@ cd app/test/browser
 ./test-app-console-commands.sh
 ```
 
-The script relies on the hidden `#app-console-output` element added to
-`AppConsole.tsx` to read console output without scraping the xterm canvas.
+The script reads output from the public App Console cell DOM contract
+(`data-testid="app-console-cell"` plus per-cell status markers) instead of a
+hidden transcript mirror.
 `showDirectoryPicker()` commands still require a manual OS dialog interaction.
 If you skip the picker, the script expects `explorer.listFolders()` to report
 no mounted folders.

--- a/app/test/browser/test-app-console-commands.sh
+++ b/app/test/browser/test-app-console-commands.sh
@@ -117,8 +117,7 @@ fi
 
 log ""
 log "=== Test 2: Run explorer.addFolder() ==="
-agent-browser click "$console_input_ref" 2>/dev/null || true
-agent-browser type "$console_input_ref" "explorer.addFolder()" 2>/dev/null || true
+agent-browser fill 'textarea[aria-label="App Console input"]' "explorer.addFolder()" 2>/dev/null || true
 click_run_button >/dev/null
 agent-browser wait 1500 2>/dev/null || true
 screenshot "console-02-addfolder"
@@ -140,8 +139,7 @@ fi
 
 log ""
 log "=== Test 4: Run explorer.listFolders() ==="
-agent-browser click "$console_input_ref" 2>/dev/null || true
-agent-browser type "$console_input_ref" "explorer.listFolders()" 2>/dev/null || true
+agent-browser fill 'textarea[aria-label="App Console input"]' "explorer.listFolders()" 2>/dev/null || true
 click_run_button >/dev/null
 agent-browser wait 1500 2>/dev/null || true
 screenshot "console-03-listfolders"

--- a/app/test/browser/test-app-console-commands.sh
+++ b/app/test/browser/test-app-console-commands.sh
@@ -54,6 +54,26 @@ screenshot() {
     fi
 }
 
+read_console_output() {
+    agent-browser eval "(() => {
+      const completed = Array.from(document.querySelectorAll('[data-testid=\"app-console-cell\"]'))
+        .filter((cell) => cell.getAttribute('data-status') !== 'draft');
+      const last = completed[completed.length - 1];
+      return last ? (last.textContent || '') : '';
+    })()" 2>/dev/null || true
+}
+
+click_run_button() {
+    agent-browser eval "(() => {
+      const runButton = document.querySelector('[data-testid=\"app-console-cell\"][data-current=\"true\"] [data-testid=\"app-console-cell-run\"]');
+      if (!(runButton instanceof HTMLButtonElement)) {
+        return 'missing-run-button';
+      }
+      runButton.click();
+      return 'ok';
+    })()" 2>/dev/null || true
+}
+
 log "=== Pre-flight Checks ==="
 mkdir -p "$OUTPUT_DIR"
 rm -f "$OUTPUT_DIR"/console-*.png
@@ -86,7 +106,7 @@ screenshot "console-01-initial"
 snapshot_output=$(agent-browser snapshot -i 2>/dev/null || true)
 echo "$snapshot_output" > "$OUTPUT_DIR/console-01-snapshot.txt"
 
-console_input_ref=$(echo "$snapshot_output" | grep -i "Terminal input" | grep -oE '@[a-zA-Z0-9]+' | head -1 || true)
+console_input_ref=$(echo "$snapshot_output" | grep -i "App Console input" | grep -oE '@[a-zA-Z0-9]+' | head -1 || true)
 if [ -n "$console_input_ref" ]; then
     pass "Found App Console input"
 else
@@ -99,13 +119,13 @@ log ""
 log "=== Test 2: Run explorer.addFolder() ==="
 agent-browser click "$console_input_ref" 2>/dev/null || true
 agent-browser type "$console_input_ref" "explorer.addFolder()" 2>/dev/null || true
-agent-browser press Enter 2>/dev/null || true
+click_run_button >/dev/null
 agent-browser wait 1500 2>/dev/null || true
 screenshot "console-02-addfolder"
 
 log ""
 log "=== Test 3: Verify console output hook ==="
-console_output=$(agent-browser get text "#app-console-output" 2>/dev/null || true)
+console_output=$(read_console_output)
 if echo "$console_output" | grep -q "Added local folder"; then
     pass "Console output contains local folder confirmation"
 elif echo "$console_output" | grep -q "File System Access API is not supported"; then
@@ -122,11 +142,11 @@ log ""
 log "=== Test 4: Run explorer.listFolders() ==="
 agent-browser click "$console_input_ref" 2>/dev/null || true
 agent-browser type "$console_input_ref" "explorer.listFolders()" 2>/dev/null || true
-agent-browser press Enter 2>/dev/null || true
+click_run_button >/dev/null
 agent-browser wait 1500 2>/dev/null || true
 screenshot "console-03-listfolders"
 
-console_output=$(agent-browser get text "#app-console-output" 2>/dev/null || true)
+console_output=$(read_console_output)
 if echo "$console_output" | grep -q "fs://"; then
     pass "Console output lists fs:// entries"
 elif echo "$console_output" | grep -q "No folders in workspace"; then

--- a/app/test/browser/test-scenario-ai-codex.ts
+++ b/app/test/browser/test-scenario-ai-codex.ts
@@ -153,21 +153,37 @@ function escapeDoubleQuotes(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+function readAppConsoleOutput(): string {
+  return normalizeAgentBrowserString(
+    run(
+      `agent-browser eval "${escapeDoubleQuotes(`(() => {
+        const completed = Array.from(
+          document.querySelectorAll('[data-testid="app-console-cell"]'),
+        ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
+        const last = completed[completed.length - 1];
+        return last ? (last.textContent || '') : '';
+      })()`)}"`,
+    ).stdout,
+  );
+}
+
 function runAppConsoleCommand(consoleRef: string, command: string): string {
   run(`agent-browser click ${consoleRef}`);
   run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
-  run("agent-browser press Enter");
-  run("agent-browser wait 900");
-  return normalizeAgentBrowserString(
-    run(
-      `agent-browser eval "${escapeDoubleQuotes(
-        `(() => {
-          const el = document.querySelector('#app-console-output');
-          return el ? (el.textContent || '') : '';
-        })()`,
-      )}"`,
-    ).stdout,
+  run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const runButton = document.querySelector(
+        '[data-testid="app-console-cell"][data-current="true"] [data-testid="app-console-cell-run"]',
+      );
+      if (!(runButton instanceof HTMLButtonElement)) {
+        return 'missing-run-button';
+      }
+      runButton.click();
+      return 'ok';
+    })()`)}"`,
   );
+  run("agent-browser wait 900");
+  return readAppConsoleOutput();
 }
 
 function hasCommandError(output: string): boolean {
@@ -774,11 +790,11 @@ try {
   }
 
   let snapshot = run("agent-browser snapshot -i").stdout;
-  const consoleRef = firstRef(snapshot, /Terminal input/i);
+  const consoleRef = firstRef(snapshot, /App Console input/i);
   if (!consoleRef) {
-    fail("Did not find AppConsole terminal input");
+    fail("Did not find App Console input");
   } else {
-    pass("Found AppConsole terminal input");
+    pass("Found App Console input");
 
     const runnerName = "local";
     const runnerEndpoint = "ws://localhost:9977/ws";

--- a/app/test/browser/test-scenario-ai-codex.ts
+++ b/app/test/browser/test-scenario-ai-codex.ts
@@ -168,8 +168,10 @@ function readAppConsoleOutput(): string {
 }
 
 function runAppConsoleCommand(consoleRef: string, command: string): string {
-  run(`agent-browser click ${consoleRef}`);
-  run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
+  void consoleRef;
+  run(
+    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`,
+  );
   run(
     `agent-browser eval "${escapeDoubleQuotes(`(() => {
       const runButton = document.querySelector(

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -411,6 +411,9 @@ function switchToSidePanelOrThrow({
   const deadline = Date.now() + 10000
   let lastError = 'unknown error'
   while (Date.now() < deadline) {
+    if (waitForActiveSidePanel(activePanel, 200)) {
+      return
+    }
     const snapshot = run('agent-browser snapshot').stdout
     const ref = firstRef(snapshot, buttonPattern)
     if (!ref) {

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -264,9 +264,20 @@ function tryTypeChatMessage(message: string): string {
     let activeDoc = null;
     let composer = null;
     for (const doc of docs) {
-      const candidate = doc.querySelector('textarea') ||
-        doc.querySelector('[contenteditable="true"][role="textbox"]') ||
-        doc.querySelector('[contenteditable="true"]');
+      const candidate = Array.from(
+        doc.querySelectorAll('textarea, [contenteditable="true"][role="textbox"], [contenteditable="true"]'),
+      ).find((element) => {
+        if (!(element instanceof HTMLElement)) {
+          return false;
+        }
+        if (element.getAttribute('aria-label') === 'App Console input') {
+          return false;
+        }
+        if (element.closest('[data-testid="app-console-cell"]')) {
+          return false;
+        }
+        return true;
+      }) ?? null;
       if (candidate) {
         activeDoc = doc;
         composer = candidate;

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -399,6 +399,27 @@ function waitForActiveSidePanel(
   return false
 }
 
+function ensureChatKitPanelOpen(timeoutMs = 5000): boolean {
+  if (readSidePanelPressedState().chatkitPressed === 'true') {
+    return true
+  }
+  const clickScript = `(() => {
+    const button = document.querySelector('button[aria-label="Toggle ChatKit panel"]');
+    if (!(button instanceof HTMLButtonElement)) {
+      return 'missing-chatkit-toggle';
+    }
+    button.click();
+    return 'clicked';
+  })()`
+  const clickResult = normalizeAgentBrowserString(
+    run(`agent-browser eval "${escapeDoubleQuotes(clickScript)}"`).stdout
+  )
+  if (clickResult === 'missing-chatkit-toggle') {
+    return false
+  }
+  return waitForActiveSidePanel('chatkit', timeoutMs)
+}
+
 function switchToSidePanelOrThrow({
   name,
   buttonPattern,
@@ -727,14 +748,13 @@ try {
   }
 
   if (chatRef) {
-    switchToSidePanelOrThrow({
-      name: 'ChatKit',
-      buttonPattern: /AI Chat|ChatKit panel|Toggle ChatKit panel/i,
-      activePanel: 'chatkit',
-    })
-    run('agent-browser wait 1000')
-    installChatkitEventProbe()
-    pass('Opened ChatKit panel')
+    if (ensureChatKitPanelOpen()) {
+      run('agent-browser wait 1000')
+      installChatkitEventProbe()
+      pass('Opened ChatKit panel')
+    } else {
+      fail('Failed to open ChatKit panel')
+    }
   }
 
   const message = 'hello from ai cuj'

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -153,8 +153,10 @@ function readAppConsoleOutput(): string {
 }
 
 function runAppConsoleCommand(consoleRef: string, command: string): string {
-  run(`agent-browser click ${consoleRef}`);
-  run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
+  void consoleRef;
+  run(
+    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`,
+  );
   run(
     `agent-browser eval "${escapeDoubleQuotes(`(() => {
       const runButton = document.querySelector(

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -1,162 +1,190 @@
-import { spawnSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const FRONTEND_URL = process.env.CUJ_FRONTEND_URL ?? "http://localhost:5173";
-const CUJ_ID_TOKEN = process.env.CUJ_ID_TOKEN?.trim() ?? "";
-const CUJ_ACCESS_TOKEN = process.env.CUJ_ACCESS_TOKEN?.trim() ?? CUJ_ID_TOKEN;
-const tokenExpiresAtEnv = Number(process.env.CUJ_TOKEN_EXPIRES_AT ?? "");
-const CUJ_TOKEN_EXPIRES_AT = Number.isFinite(tokenExpiresAtEnv) && tokenExpiresAtEnv > Date.now()
-  ? tokenExpiresAtEnv
-  : Date.now() + 5 * 60 * 1000;
-const FAKE_CHATKIT_BASE_URL = process.env.CUJ_FAKE_CHATKIT_BASE_URL ?? "http://127.0.0.1:19989";
-const FAKE_CHATKIT_HEALTH_URL = process.env.CUJ_FAKE_CHATKIT_HEALTH_URL ?? `${FAKE_CHATKIT_BASE_URL}/healthz`;
-const FAKE_CHATKIT_RESET_URL = process.env.CUJ_FAKE_CHATKIT_RESET_URL ?? `${FAKE_CHATKIT_BASE_URL}/reset`;
-const FAKE_CHATKIT_REQUESTS_URL = process.env.CUJ_FAKE_CHATKIT_REQUESTS_URL ?? `${FAKE_CHATKIT_BASE_URL}/requests`;
-const EXPECTED_RESPONSE_TEXT = "Fake assistant response from CUJ server.";
+const FRONTEND_URL = process.env.CUJ_FRONTEND_URL ?? 'http://localhost:5173'
+const CUJ_ID_TOKEN = process.env.CUJ_ID_TOKEN?.trim() ?? ''
+const CUJ_ACCESS_TOKEN = process.env.CUJ_ACCESS_TOKEN?.trim() ?? CUJ_ID_TOKEN
+const tokenExpiresAtEnv = Number(process.env.CUJ_TOKEN_EXPIRES_AT ?? '')
+const CUJ_TOKEN_EXPIRES_AT =
+  Number.isFinite(tokenExpiresAtEnv) && tokenExpiresAtEnv > Date.now()
+    ? tokenExpiresAtEnv
+    : Date.now() + 5 * 60 * 1000
+const FAKE_CHATKIT_BASE_URL =
+  process.env.CUJ_FAKE_CHATKIT_BASE_URL ?? 'http://127.0.0.1:19989'
+const FAKE_CHATKIT_HEALTH_URL =
+  process.env.CUJ_FAKE_CHATKIT_HEALTH_URL ?? `${FAKE_CHATKIT_BASE_URL}/healthz`
+const FAKE_CHATKIT_RESET_URL =
+  process.env.CUJ_FAKE_CHATKIT_RESET_URL ?? `${FAKE_CHATKIT_BASE_URL}/reset`
+const FAKE_CHATKIT_REQUESTS_URL =
+  process.env.CUJ_FAKE_CHATKIT_REQUESTS_URL ??
+  `${FAKE_CHATKIT_BASE_URL}/requests`
+const EXPECTED_RESPONSE_TEXT = 'Fake assistant response from CUJ server.'
 
-const CURRENT_FILE_DIR = dirname(fileURLToPath(import.meta.url));
+const CURRENT_FILE_DIR = dirname(fileURLToPath(import.meta.url))
 const SCRIPT_DIR =
-  CURRENT_FILE_DIR.endsWith("/.generated") || CURRENT_FILE_DIR.endsWith("\\.generated")
+  CURRENT_FILE_DIR.endsWith('/.generated') ||
+  CURRENT_FILE_DIR.endsWith('\\.generated')
     ? dirname(CURRENT_FILE_DIR)
-    : CURRENT_FILE_DIR;
-const OUTPUT_DIR = join(SCRIPT_DIR, "test-output");
-const MOVIE_PATH = join(OUTPUT_DIR, "scenario-ai-walkthrough.webm");
-const AGENT_BROWSER_SESSION = process.env.AGENT_BROWSER_SESSION?.trim() ?? "";
-const AGENT_BROWSER_PROFILE = process.env.AGENT_BROWSER_PROFILE?.trim() ?? "";
-const AGENT_BROWSER_HEADED = (process.env.AGENT_BROWSER_HEADED ?? "false")
-  .trim()
-  .toLowerCase() === "true";
-const AGENT_BROWSER_KEEP_OPEN = (process.env.AGENT_BROWSER_KEEP_OPEN ?? "false")
-  .trim()
-  .toLowerCase() === "true";
+    : CURRENT_FILE_DIR
+const OUTPUT_DIR = join(SCRIPT_DIR, 'test-output')
+const MOVIE_PATH = join(OUTPUT_DIR, 'scenario-ai-walkthrough.webm')
+const AGENT_BROWSER_SESSION = process.env.AGENT_BROWSER_SESSION?.trim() ?? ''
+const AGENT_BROWSER_PROFILE = process.env.AGENT_BROWSER_PROFILE?.trim() ?? ''
+const AGENT_BROWSER_HEADED =
+  (process.env.AGENT_BROWSER_HEADED ?? 'false').trim().toLowerCase() === 'true'
+const AGENT_BROWSER_KEEP_OPEN =
+  (process.env.AGENT_BROWSER_KEEP_OPEN ?? 'false').trim().toLowerCase() ===
+  'true'
 
 type HarnessStorage = {
   harnesses?: Array<{
-    name?: string;
-    baseUrl?: string;
-    adapter?: string;
-  }>;
-  defaultHarnessName?: string | null;
-};
+    name?: string
+    baseUrl?: string
+    adapter?: string
+  }>
+  defaultHarnessName?: string | null
+}
 
-let passCount = 0;
-let failCount = 0;
-let totalCount = 0;
+let passCount = 0
+let failCount = 0
+let totalCount = 0
 
-function run(command: string): { status: number; stdout: string; stderr: string } {
-  const effectiveCommand = withAgentBrowserOptions(command);
-  const timeoutMs = Number(process.env.CUJ_SCENARIO_CMD_TIMEOUT_MS ?? "10000");
+function run(command: string): {
+  status: number
+  stdout: string
+  stderr: string
+} {
+  const effectiveCommand = withAgentBrowserOptions(command)
+  const timeoutMs = Number(process.env.CUJ_SCENARIO_CMD_TIMEOUT_MS ?? '10000')
   const result = spawnSync(effectiveCommand, {
     shell: true,
-    encoding: "utf-8",
+    encoding: 'utf-8',
     timeout: timeoutMs,
-    killSignal: "SIGKILL",
-  });
+    killSignal: 'SIGKILL',
+  })
   const errorCode =
-    typeof result.error === "object" && result.error !== null && "code" in result.error
-      ? String((result.error as { code?: string }).code ?? "")
-      : "";
-  const timedOut = errorCode === "ETIMEDOUT";
+    typeof result.error === 'object' &&
+    result.error !== null &&
+    'code' in result.error
+      ? String((result.error as { code?: string }).code ?? '')
+      : ''
+  const timedOut = errorCode === 'ETIMEDOUT'
   const timeoutHint = timedOut
     ? `\n[scenario-timeout] command timed out after ${timeoutMs}ms: ${effectiveCommand}\n`
-    : "";
-  if (timedOut && effectiveCommand.trim().startsWith("agent-browser ")) {
-    throw new Error(timeoutHint.trim());
+    : ''
+  if (timedOut && effectiveCommand.trim().startsWith('agent-browser ')) {
+    throw new Error(timeoutHint.trim())
   }
   return {
     status: result.status ?? (timedOut ? 124 : 1),
-    stdout: result.stdout ?? "",
-    stderr: `${result.stderr ?? ""}${timeoutHint}`,
-  };
+    stdout: result.stdout ?? '',
+    stderr: `${result.stderr ?? ''}${timeoutHint}`,
+  }
 }
 
 function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`
 }
 
 function withAgentBrowserOptions(command: string): string {
-  const trimmed = command.trimStart();
-  if (!trimmed.startsWith("agent-browser ")) {
-    return command;
+  const trimmed = command.trimStart()
+  if (!trimmed.startsWith('agent-browser ')) {
+    return command
   }
-  const leadingWhitespace = command.slice(0, command.length - trimmed.length);
-  const subcommand = trimmed.slice("agent-browser ".length);
-  const args: string[] = [];
+  const leadingWhitespace = command.slice(0, command.length - trimmed.length)
+  const subcommand = trimmed.slice('agent-browser '.length)
+  const args: string[] = []
   if (AGENT_BROWSER_SESSION) {
-    args.push("--session", shellQuote(AGENT_BROWSER_SESSION));
+    args.push('--session', shellQuote(AGENT_BROWSER_SESSION))
   }
   if (AGENT_BROWSER_PROFILE) {
-    args.push("--profile", shellQuote(AGENT_BROWSER_PROFILE));
+    args.push('--profile', shellQuote(AGENT_BROWSER_PROFILE))
   }
   if (AGENT_BROWSER_HEADED) {
-    args.push("--headed");
+    args.push('--headed')
   }
-  const prefix = ["agent-browser", ...args].join(" ");
-  return `${leadingWhitespace}${prefix} ${subcommand}`;
+  const prefix = ['agent-browser', ...args].join(' ')
+  return `${leadingWhitespace}${prefix} ${subcommand}`
 }
 
 function runOrThrow(command: string): string {
-  const result = run(command);
+  const result = run(command)
   if (result.status !== 0) {
-    throw new Error(`Command failed: ${command}\n${result.stderr}`);
+    throw new Error(`Command failed: ${command}\n${result.stderr}`)
   }
-  return result.stdout;
+  return result.stdout
 }
 
 function pass(message: string): void {
-  totalCount += 1;
-  passCount += 1;
-  console.log(`[PASS] ${message}`);
+  totalCount += 1
+  passCount += 1
+  console.log(`[PASS] ${message}`)
 }
 
 function fail(message: string): void {
-  totalCount += 1;
-  failCount += 1;
-  console.log(`[FAIL] ${message}`);
+  totalCount += 1
+  failCount += 1
+  console.log(`[FAIL] ${message}`)
 }
 
 function writeArtifact(name: string, content: string): void {
-  writeFileSync(join(OUTPUT_DIR, name), content, "utf-8");
+  writeFileSync(join(OUTPUT_DIR, name), content, 'utf-8')
 }
 
 function firstRef(snapshot: string, pattern: RegExp): string | null {
-  const line = snapshot
-    .split("\n")
-    .find((entry) => pattern.test(entry));
+  const line = snapshot.split('\n').find((entry) => pattern.test(entry))
   if (!line) {
-    return null;
+    return null
   }
-  const legacyRef = line.match(/@[a-zA-Z0-9]+/);
+  const legacyRef = line.match(/@[a-zA-Z0-9]+/)
   if (legacyRef) {
-    return legacyRef[0];
+    return legacyRef[0]
   }
-  const currentRef = line.match(/\[ref=([^\]]+)\]/);
-  return currentRef ? currentRef[1] : null;
+  const currentRef = line.match(/\[ref=([^\]]+)\]/)
+  return currentRef ? currentRef[1] : null
+}
+
+function normalizeAgentBrowserString(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    return ''
+  }
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (typeof parsed === 'string') {
+      return parsed
+    }
+  } catch {
+    // Keep the raw output when it is not JSON encoded.
+  }
+  return trimmed
 }
 
 function escapeDoubleQuotes(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
 function readAppConsoleOutput(): string {
-  return run(
-    `agent-browser eval "${escapeDoubleQuotes(`(() => {
-      const completed = Array.from(
-        document.querySelectorAll('[data-testid="app-console-cell"]'),
-      ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
-      const last = completed[completed.length - 1];
-      return last ? (last.textContent || '') : '';
-    })()`)}"`,
-  ).stdout;
+  return normalizeAgentBrowserString(
+    run(
+      `agent-browser eval "${escapeDoubleQuotes(`(() => {
+        const completed = Array.from(
+          document.querySelectorAll('[data-testid="app-console-cell"]'),
+        ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
+        const last = completed[completed.length - 1];
+        return last ? (last.textContent || '') : '';
+      })()`)}"`
+    ).stdout
+  )
 }
 
 function runAppConsoleCommand(consoleRef: string, command: string): string {
-  void consoleRef;
+  void consoleRef
   run(
-    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`,
-  );
+    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`
+  )
   run(
     `agent-browser eval "${escapeDoubleQuotes(`(() => {
       const runButton = document.querySelector(
@@ -167,33 +195,33 @@ function runAppConsoleCommand(consoleRef: string, command: string): string {
       }
       runButton.click();
       return 'ok';
-    })()`)}"`,
-  );
-  run("agent-browser wait 900");
-  return readAppConsoleOutput();
+    })()`)}"`
+  )
+  run('agent-browser wait 900')
+  return readAppConsoleOutput()
 }
 
 function parseJsonMaybeString(raw: string): unknown {
-  const parsed = JSON.parse(raw) as unknown;
-  if (typeof parsed === "string") {
-    return JSON.parse(parsed);
+  const parsed = JSON.parse(raw) as unknown
+  if (typeof parsed === 'string') {
+    return JSON.parse(parsed)
   }
-  return parsed;
+  return parsed
 }
 
 function readHarnessStorage(): HarnessStorage {
-  const script = "localStorage.getItem('runme/harness') || '{}'";
-  const result = run(`agent-browser eval "${escapeDoubleQuotes(script)}"`);
+  const script = "localStorage.getItem('runme/harness') || '{}'"
+  const result = run(`agent-browser eval "${escapeDoubleQuotes(script)}"`)
   try {
-    return parseJsonMaybeString(result.stdout.trim()) as HarnessStorage;
+    return parseJsonMaybeString(result.stdout.trim()) as HarnessStorage
   } catch {
-    return {};
+    return {}
   }
 }
 
 function resetFakeChatkitRequests(): boolean {
-  const result = run(`curl -sf -X POST ${FAKE_CHATKIT_RESET_URL}`);
-  return result.status === 0;
+  const result = run(`curl -sf -X POST ${FAKE_CHATKIT_RESET_URL}`)
+  return result.status === 0
 }
 
 function installChatkitEventProbe(): void {
@@ -202,12 +230,16 @@ function installChatkitEventProbe(): void {
     if (!chat) return 'missing-chatkit-element';
     if (!window.__cujChatkitProbeInstalled) {
       window.__cujChatkitEvents = [];
+      window.__cujChatkitReady = false;
       const push = (name, detail) => {
         const events = Array.isArray(window.__cujChatkitEvents) ? window.__cujChatkitEvents : [];
         events.push({ name, detail: detail ?? null, ts: Date.now() });
         window.__cujChatkitEvents = events.slice(-200);
       };
-      chat.addEventListener('chatkit.ready', () => push('chatkit.ready', null));
+      chat.addEventListener('chatkit.ready', () => {
+        window.__cujChatkitReady = true;
+        push('chatkit.ready', null);
+      });
       chat.addEventListener('chatkit.response.start', () => push('chatkit.response.start', null));
       chat.addEventListener('chatkit.response.end', () => push('chatkit.response.end', null));
       chat.addEventListener(
@@ -217,55 +249,147 @@ function installChatkitEventProbe(): void {
       window.__cujChatkitProbeInstalled = true;
     }
     return 'ok';
-  })()`;
-  run(`agent-browser eval "${escapeDoubleQuotes(script)}"`);
+  })()`
+  run(`agent-browser eval "${escapeDoubleQuotes(script)}"`)
 }
 
 function readChatkitEventsRaw(): string {
-  const script = `(() => JSON.stringify(window.__cujChatkitEvents || []))()`;
-  return run(`agent-browser eval "${escapeDoubleQuotes(script)}"`).stdout.trim();
+  const script = `(() => JSON.stringify(window.__cujChatkitEvents || []))()`
+  return run(`agent-browser eval "${escapeDoubleQuotes(script)}"`).stdout.trim()
 }
 
 function waitForChatkitEvent(name: string, timeoutMs = 25000): boolean {
-  const deadline = Date.now() + timeoutMs;
+  const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    const raw = readChatkitEventsRaw();
+    const raw = readChatkitEventsRaw()
     try {
-      const parsed = parseJsonMaybeString(raw);
-      if (Array.isArray(parsed) && parsed.some((entry) => entry && typeof entry === "object" && (entry as { name?: string }).name === name)) {
-        return true;
+      const parsed = parseJsonMaybeString(raw)
+      if (
+        Array.isArray(parsed) &&
+        parsed.some(
+          (entry) =>
+            entry &&
+            typeof entry === 'object' &&
+            (entry as { name?: string }).name === name
+        )
+      ) {
+        return true
       }
     } catch {
       // retry
     }
-    run("agent-browser wait 400");
+    run('agent-browser wait 400')
   }
-  return false;
+  return false
 }
 
 function readFakeChatkitRequests(): string {
-  return run(`curl -sf ${FAKE_CHATKIT_REQUESTS_URL}`).stdout.trim();
+  return run(`curl -sf ${FAKE_CHATKIT_REQUESTS_URL}`).stdout.trim()
+}
+
+function waitForChatComposer(timeoutMs = 20000): boolean {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const state = normalizeAgentBrowserString(
+      run(
+        `agent-browser eval "${escapeDoubleQuotes(`(() => {
+          const collectRoots = () => {
+            const roots = [];
+            const seen = new Set();
+            const visit = (root) => {
+              if (!root || seen.has(root)) return;
+              seen.add(root);
+              roots.push(root);
+              if (typeof root.querySelectorAll !== 'function') return;
+              for (const el of Array.from(root.querySelectorAll('*'))) {
+                if (el && el.shadowRoot) visit(el.shadowRoot);
+              }
+            };
+            const chat = document.querySelector('openai-chatkit');
+            if (chat && chat.shadowRoot) {
+              visit(chat.shadowRoot);
+            }
+            for (const frame of Array.from(document.querySelectorAll('iframe'))) {
+              try {
+                const doc = frame.contentDocument;
+                if (doc) visit(doc);
+              } catch {
+                // Ignore cross-origin frames.
+              }
+            }
+            visit(document);
+            return roots;
+          };
+          for (const root of collectRoots()) {
+            const composer = Array.from(
+              root.querySelectorAll(
+                'textarea, [contenteditable="true"][role="textbox"], [contenteditable="true"]',
+              ),
+            ).find((element) => {
+              if (!(element instanceof HTMLElement)) {
+                return false;
+              }
+              if (element.getAttribute('aria-label') === 'App Console input') {
+                return false;
+              }
+              if (element.closest('[data-testid="app-console-cell"]')) {
+                return false;
+              }
+              return true;
+            });
+            if (composer) {
+              return 'composer-ready';
+            }
+          }
+          return window.__cujChatkitReady ? 'ready-event-only' : 'missing-composer';
+        })()`)}"`
+      ).stdout
+    )
+    if (state === 'composer-ready' || state === 'ready-event-only') {
+      return true
+    }
+    run('agent-browser wait 500')
+  }
+  return false
 }
 
 function tryTypeChatMessage(message: string): string {
   const script = `(() => {
-    const docs = [document];
-    for (const frame of Array.from(document.querySelectorAll('iframe'))) {
-      try {
-        const doc = frame.contentDocument;
-        if (doc) {
-          docs.push(doc);
+    const collectRoots = () => {
+      const roots = [];
+      const seen = new Set();
+      const visit = (root) => {
+        if (!root || seen.has(root)) return;
+        seen.add(root);
+        roots.push(root);
+        if (typeof root.querySelectorAll !== 'function') return;
+        for (const el of Array.from(root.querySelectorAll('*'))) {
+          if (el && el.shadowRoot) visit(el.shadowRoot);
         }
-      } catch {
-        // Ignore cross-origin frames.
+      };
+      const chat = document.querySelector('openai-chatkit');
+      if (chat && chat.shadowRoot) {
+        visit(chat.shadowRoot);
       }
-    }
+      for (const frame of Array.from(document.querySelectorAll('iframe'))) {
+        try {
+          const doc = frame.contentDocument;
+          if (doc) visit(doc);
+        } catch {
+          // Ignore cross-origin frames.
+        }
+      }
+      visit(document);
+      return roots;
+    };
 
-    let activeDoc = null;
+    let activeRoot = null;
     let composer = null;
-    for (const doc of docs) {
+    for (const root of collectRoots()) {
       const candidate = Array.from(
-        doc.querySelectorAll('textarea, [contenteditable="true"][role="textbox"], [contenteditable="true"]'),
+        root.querySelectorAll(
+          'textarea, [contenteditable="true"][role="textbox"], [contenteditable="true"]',
+        ),
       ).find((element) => {
         if (!(element instanceof HTMLElement)) {
           return false;
@@ -279,13 +403,13 @@ function tryTypeChatMessage(message: string): string {
         return true;
       }) ?? null;
       if (candidate) {
-        activeDoc = doc;
+        activeRoot = root;
         composer = candidate;
         break;
       }
     }
 
-    if (!composer || !activeDoc) {
+    if (!composer || !activeRoot) {
       return 'missing-composer';
     }
 
@@ -317,27 +441,27 @@ function tryTypeChatMessage(message: string): string {
     composer.dispatchEvent(new KeyboardEvent('keyup', eventInit));
 
     const sendButton =
-      activeDoc.querySelector('button[aria-label*="Send"]') ||
-      activeDoc.querySelector('button[type="submit"]');
+      activeRoot.querySelector('button[aria-label*="Send"]') ||
+      activeRoot.querySelector('button[type="submit"]');
     if (sendButton instanceof HTMLElement) {
       sendButton.click();
     }
     return 'typed';
-  })()`;
-  const result = run(`agent-browser eval "${escapeDoubleQuotes(script)}"`);
-  return `${result.stdout}\n${result.stderr}`.trim();
+  })()`
+  const result = run(`agent-browser eval "${escapeDoubleQuotes(script)}"`)
+  return `${result.stdout}\n${result.stderr}`.trim()
 }
 
 function typeChatMessageWithRetry(message: string, timeoutMs = 15000): string {
-  const deadline = Date.now() + timeoutMs;
-  let lastOutput = "";
+  const deadline = Date.now() + timeoutMs
+  let lastOutput = ''
   while (Date.now() < deadline) {
-    const output = tryTypeChatMessage(message);
-    lastOutput = output;
-    if (output.includes("typed")) {
-      return output;
+    const output = tryTypeChatMessage(message)
+    lastOutput = output
+    if (output.includes('typed')) {
+      return output
     }
-    run("agent-browser wait 400");
+    run('agent-browser wait 400')
   }
   const fallbackScript = `(async () => {
     const chat = document.querySelector('openai-chatkit');
@@ -360,10 +484,12 @@ function typeChatMessageWithRetry(message: string, timeoutMs = 15000): string {
     } catch (error) {
       return 'fallback-error:' + String(error);
     }
-  })()`;
-  const fallback = run(`agent-browser eval "${escapeDoubleQuotes(fallbackScript)}"`);
-  const fallbackOutput = `${fallback.stdout}\n${fallback.stderr}`.trim();
-  return `${lastOutput}\n${fallbackOutput}`.trim();
+  })()`
+  const fallback = run(
+    `agent-browser eval "${escapeDoubleQuotes(fallbackScript)}"`
+  )
+  const fallbackOutput = `${fallback.stdout}\n${fallback.stderr}`.trim()
+  return `${lastOutput}\n${fallbackOutput}`.trim()
 }
 
 function readChatPanelText(): string {
@@ -383,82 +509,82 @@ function readChatPanelText(): string {
       .map((doc) => doc.body?.innerText || '')
       .filter((text) => text.length > 0)
       .join('\\n');
-  })()`;
-  const result = run(`agent-browser eval "${escapeDoubleQuotes(script)}"`);
-  return `${result.stdout}`.trim();
+  })()`
+  const result = run(`agent-browser eval "${escapeDoubleQuotes(script)}"`)
+  return `${result.stdout}`.trim()
 }
 
 function waitForVisibleResponse(
   expectedText: string,
-  timeoutMs = 20000,
+  timeoutMs = 20000
 ): { found: boolean; panelText: string; snapshot: string } {
-  const deadline = Date.now() + timeoutMs;
-  let lastPanelText = "";
-  let lastSnapshot = "";
+  const deadline = Date.now() + timeoutMs
+  let lastPanelText = ''
+  let lastSnapshot = ''
   while (Date.now() < deadline) {
-    const snapshot = run("agent-browser snapshot").stdout;
-    lastSnapshot = snapshot;
+    const snapshot = run('agent-browser snapshot').stdout
+    lastSnapshot = snapshot
     if (snapshot.includes(expectedText)) {
-      return { found: true, panelText: lastPanelText, snapshot };
+      return { found: true, panelText: lastPanelText, snapshot }
     }
-    const panelText = readChatPanelText();
-    lastPanelText = panelText;
+    const panelText = readChatPanelText()
+    lastPanelText = panelText
     if (panelText.includes(expectedText)) {
-      return { found: true, panelText, snapshot: lastSnapshot };
+      return { found: true, panelText, snapshot: lastSnapshot }
     }
-    run("agent-browser wait 500");
+    run('agent-browser wait 500')
   }
-  return { found: false, panelText: lastPanelText, snapshot: lastSnapshot };
+  return { found: false, panelText: lastPanelText, snapshot: lastSnapshot }
 }
 
-mkdirSync(OUTPUT_DIR, { recursive: true });
-rmSync(MOVIE_PATH, { force: true });
+mkdirSync(OUTPUT_DIR, { recursive: true })
+rmSync(MOVIE_PATH, { force: true })
 for (const file of [
-  "scenario-ai-01-snapshot.txt",
-  "scenario-ai-02-console.txt",
-  "scenario-ai-03-send.txt",
-  "scenario-ai-04-panel-text.txt",
-  "scenario-ai-05-snapshot-after-send.txt",
-  "scenario-ai-06-after-send.png",
-  "scenario-ai-07-chatkit-events.json",
-  "scenario-ai-08-chatkit-requests.json",
+  'scenario-ai-01-snapshot.txt',
+  'scenario-ai-02-console.txt',
+  'scenario-ai-03-send.txt',
+  'scenario-ai-04-panel-text.txt',
+  'scenario-ai-05-snapshot-after-send.txt',
+  'scenario-ai-06-after-send.png',
+  'scenario-ai-07-chatkit-events.json',
+  'scenario-ai-08-chatkit-requests.json',
 ]) {
-  rmSync(join(OUTPUT_DIR, file), { force: true });
+  rmSync(join(OUTPUT_DIR, file), { force: true })
 }
 
-if (run("command -v agent-browser").status !== 0) {
-  console.error("ERROR: agent-browser is required on PATH");
-  process.exit(2);
+if (run('command -v agent-browser').status !== 0) {
+  console.error('ERROR: agent-browser is required on PATH')
+  process.exit(2)
 }
 
 if (run(`curl -sf ${FRONTEND_URL}`).status !== 0) {
-  console.error(`ERROR: frontend is not running at ${FRONTEND_URL}`);
-  process.exit(1);
+  console.error(`ERROR: frontend is not running at ${FRONTEND_URL}`)
+  process.exit(1)
 }
 
 if (run(`curl -sf ${FAKE_CHATKIT_HEALTH_URL}`).status === 0) {
-  pass(`AI service is healthy at ${FAKE_CHATKIT_HEALTH_URL}`);
+  pass(`AI service is healthy at ${FAKE_CHATKIT_HEALTH_URL}`)
 } else {
-  fail(`AI service is not reachable at ${FAKE_CHATKIT_HEALTH_URL}`);
+  fail(`AI service is not reachable at ${FAKE_CHATKIT_HEALTH_URL}`)
 }
 
 if (resetFakeChatkitRequests()) {
-  pass("Reset AI service request state");
+  pass('Reset AI service request state')
 } else {
-  fail("Failed to reset AI service request state");
+  fail('Failed to reset AI service request state')
 }
 
-let startedRecording = false;
+let startedRecording = false
 
 try {
-  runOrThrow(`agent-browser open ${FRONTEND_URL}`);
-  runOrThrow(`agent-browser record restart ${MOVIE_PATH}`);
-  startedRecording = true;
-  run("agent-browser wait 2200");
+  runOrThrow(`agent-browser open ${FRONTEND_URL}`)
+  runOrThrow(`agent-browser record restart ${MOVIE_PATH}`)
+  startedRecording = true
+  run('agent-browser wait 2200')
 
   if (CUJ_ID_TOKEN) {
-    const idTokenLiteral = `'${CUJ_ID_TOKEN.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
-    const accessTokenLiteral = `'${CUJ_ACCESS_TOKEN.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+    const idTokenLiteral = `'${CUJ_ID_TOKEN.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+    const accessTokenLiteral = `'${CUJ_ACCESS_TOKEN.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
     const authSeed = run(
       `agent-browser eval "(async () => {
         localStorage.setItem('oidc-auth', JSON.stringify({
@@ -469,117 +595,151 @@ try {
           expires_at: ${CUJ_TOKEN_EXPIRES_AT}
         }));
         return localStorage.getItem('oidc-auth') ? 'ok' : 'missing';
-      })()"`,
-    );
-    if (authSeed.status === 0 && authSeed.stdout.includes("ok")) {
-      pass("Injected OIDC auth token");
-      run("agent-browser reload");
-      run("agent-browser wait 2200");
+      })()"`
+    )
+    if (authSeed.status === 0 && authSeed.stdout.includes('ok')) {
+      pass('Injected OIDC auth token')
+      run('agent-browser reload')
+      run('agent-browser wait 2200')
     } else {
-      fail("Failed to inject OIDC auth token");
+      fail('Failed to inject OIDC auth token')
     }
   }
 
-  const snapshot = run("agent-browser snapshot").stdout;
-  writeArtifact("scenario-ai-01-snapshot.txt", snapshot);
+  const snapshot = run('agent-browser snapshot').stdout
+  writeArtifact('scenario-ai-01-snapshot.txt', snapshot)
 
-  const chatRef = firstRef(snapshot, /AI Chat|ChatKit panel/i);
+  const chatRef = firstRef(snapshot, /AI Chat|ChatKit panel/i)
   if (!chatRef) {
-    fail("Could not find AI Chat button in side panel");
+    fail('Could not find AI Chat button in side panel')
   }
 
-  const consoleRef = firstRef(snapshot, /app console input|console-input/i);
+  const consoleRef = firstRef(snapshot, /app console input|console-input/i)
   if (!consoleRef) {
-    fail("Could not find App Console input");
+    fail('Could not find App Console input')
   } else {
-    pass("Found App Console input");
-    runAppConsoleCommand(consoleRef, `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses-direct")`);
-    runAppConsoleCommand(consoleRef, 'app.harness.setDefault("fake")');
-    const consoleOutput = runAppConsoleCommand(consoleRef, "app.harness.get()");
-    const harnessStorage = readHarnessStorage();
+    pass('Found App Console input')
+    runAppConsoleCommand(
+      consoleRef,
+      `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses-direct")`
+    )
+    runAppConsoleCommand(consoleRef, 'app.harness.setDefault("fake")')
+    const consoleOutput = runAppConsoleCommand(consoleRef, 'app.harness.get()')
+    const harnessStorage = readHarnessStorage()
     writeArtifact(
-      "scenario-ai-02-console.txt",
-      `${consoleOutput}\n---\n${JSON.stringify(harnessStorage, null, 2)}`,
-    );
-    const activeHarness = (harnessStorage.harnesses ?? []).find((entry) => entry?.name === "fake");
-    const isDefault = harnessStorage.defaultHarnessName === "fake";
-    const validHarness = activeHarness?.baseUrl === FAKE_CHATKIT_BASE_URL &&
-      activeHarness?.adapter === "responses-direct";
+      'scenario-ai-02-console.txt',
+      `${consoleOutput}\n---\n${JSON.stringify(harnessStorage, null, 2)}`
+    )
+    const activeHarness = (harnessStorage.harnesses ?? []).find(
+      (entry) => entry?.name === 'fake'
+    )
+    const isDefault = harnessStorage.defaultHarnessName === 'fake'
+    const validHarness =
+      activeHarness?.baseUrl === FAKE_CHATKIT_BASE_URL &&
+      activeHarness?.adapter === 'responses-direct'
     if (isDefault && validHarness) {
-      pass("Configured assistant harness via AppConsole");
+      pass('Configured assistant harness via AppConsole')
     } else {
-      fail("Failed to configure assistant harness via AppConsole");
+      fail('Failed to configure assistant harness via AppConsole')
     }
   }
 
   if (chatRef) {
-    run(`agent-browser click ${chatRef}`);
-    run("agent-browser wait 1400");
-    installChatkitEventProbe();
-    pass("Opened ChatKit panel");
+    run(
+      `agent-browser eval "${escapeDoubleQuotes(`(() => {
+        const button = document.querySelector('button[aria-label="Toggle ChatKit panel"]');
+        if (!(button instanceof HTMLButtonElement)) {
+          return 'missing-chatkit-toggle';
+        }
+        if (button.getAttribute('aria-pressed') !== 'true') {
+          button.click();
+        }
+        return button.getAttribute('aria-pressed') === 'true' ? 'open' : 'clicked';
+      })()`)}"`
+    )
+    run('agent-browser wait 1400')
+    installChatkitEventProbe()
+    pass('Opened ChatKit panel')
   }
 
-  const message = "hello from ai cuj";
-  const sendOutput = typeChatMessageWithRetry(message);
-  writeArtifact("scenario-ai-03-send.txt", sendOutput);
-  if (sendOutput.includes("typed")) {
-    pass("Typed and submitted a message in the ChatKit panel");
+  const message = 'hello from ai cuj'
+  const chatComposerReady = waitForChatComposer()
+  const sendOutput = chatComposerReady
+    ? typeChatMessageWithRetry(message)
+    : 'chatkit-not-ready'
+  writeArtifact('scenario-ai-03-send.txt', sendOutput)
+  if (sendOutput.includes('typed')) {
+    pass('Typed and submitted a message in the ChatKit panel')
   } else {
-    fail(`Failed to type message in ChatKit panel (${sendOutput || "no output"})`);
+    fail(
+      `Failed to type message in ChatKit panel (${sendOutput || 'no output'})`
+    )
   }
 
-  const responseResult = waitForVisibleResponse(EXPECTED_RESPONSE_TEXT);
-  const sawResponseEndEvent = waitForChatkitEvent("chatkit.response.end", 30000);
-  const chatkitEventsRaw = readChatkitEventsRaw();
-  const chatkitRequestsRaw = readFakeChatkitRequests();
-  writeArtifact("scenario-ai-04-panel-text.txt", responseResult.panelText);
-  writeArtifact("scenario-ai-05-snapshot-after-send.txt", responseResult.snapshot);
-  run(`agent-browser screenshot ${join(OUTPUT_DIR, "scenario-ai-06-after-send.png")}`);
-  writeArtifact("scenario-ai-07-chatkit-events.json", chatkitEventsRaw || "[]");
-  writeArtifact("scenario-ai-08-chatkit-requests.json", chatkitRequestsRaw || "[]");
+  const responseResult = waitForVisibleResponse(EXPECTED_RESPONSE_TEXT)
+  const sawResponseEndEvent = waitForChatkitEvent('chatkit.response.end', 30000)
+  const chatkitEventsRaw = readChatkitEventsRaw()
+  const chatkitRequestsRaw = readFakeChatkitRequests()
+  writeArtifact('scenario-ai-04-panel-text.txt', responseResult.panelText)
+  writeArtifact(
+    'scenario-ai-05-snapshot-after-send.txt',
+    responseResult.snapshot
+  )
+  run(
+    `agent-browser screenshot ${join(OUTPUT_DIR, 'scenario-ai-06-after-send.png')}`
+  )
+  writeArtifact('scenario-ai-07-chatkit-events.json', chatkitEventsRaw || '[]')
+  writeArtifact(
+    'scenario-ai-08-chatkit-requests.json',
+    chatkitRequestsRaw || '[]'
+  )
 
   const sawChatkitError = (() => {
     try {
-      const parsed = parseJsonMaybeString(chatkitEventsRaw);
+      const parsed = parseJsonMaybeString(chatkitEventsRaw)
       if (!Array.isArray(parsed)) {
-        return false;
+        return false
       }
       return parsed.some(
         (entry) =>
           entry &&
-          typeof entry === "object" &&
-          (entry as { name?: string }).name === "chatkit.error",
-      );
+          typeof entry === 'object' &&
+          (entry as { name?: string }).name === 'chatkit.error'
+      )
     } catch {
-      return false;
+      return false
     }
-  })();
+  })()
   const postedChatkitRequest =
-    chatkitRequestsRaw.includes("\"path\":\"/v1/responses\"") ||
-    chatkitRequestsRaw.includes("\"path\":\"/responses/direct/chatkit\"");
+    chatkitRequestsRaw.includes('"path":"/v1/responses"') ||
+    chatkitRequestsRaw.includes('"path":"/responses/direct/chatkit"')
 
   if (responseResult.found) {
-    pass("User-visible assistant response appeared in ChatKit panel");
-    run("agent-browser wait 1200");
+    pass('User-visible assistant response appeared in ChatKit panel')
+    run('agent-browser wait 1200')
   } else if (sawResponseEndEvent && postedChatkitRequest && !sawChatkitError) {
-    pass("Assistant response completed (DOM text probe did not expose rendered text in this runtime)");
+    pass(
+      'Assistant response completed (DOM text probe did not expose rendered text in this runtime)'
+    )
   } else {
-    fail("Assistant response text did not appear in ChatKit panel");
+    fail('Assistant response text did not appear in ChatKit panel')
   }
 } catch (error) {
-  fail(`Scenario execution error: ${String(error)}`);
+  fail(`Scenario execution error: ${String(error)}`)
 } finally {
   if (startedRecording) {
-    run("agent-browser record stop");
+    run('agent-browser record stop')
   }
   if (CUJ_ID_TOKEN) {
-    run(`agent-browser eval "localStorage.removeItem('oidc-auth'); 'ok'"`);
+    run(`agent-browser eval "localStorage.removeItem('oidc-auth'); 'ok'"`)
   }
   if (!AGENT_BROWSER_KEEP_OPEN) {
-    run("agent-browser close");
+    run('agent-browser close')
   }
 }
 
-console.log(`Movie: ${MOVIE_PATH}`);
-console.log(`Assertions: ${totalCount}, Passed: ${passCount}, Failed: ${failCount}`);
-process.exit(failCount > 0 ? 1 : 0);
+console.log(`Movie: ${MOVIE_PATH}`)
+console.log(
+  `Assertions: ${totalCount}, Passed: ${passCount}, Failed: ${failCount}`
+)
+process.exit(failCount > 0 ? 1 : 0)

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -140,12 +140,35 @@ function escapeDoubleQuotes(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+function readAppConsoleOutput(): string {
+  return run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const completed = Array.from(
+        document.querySelectorAll('[data-testid="app-console-cell"]'),
+      ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
+      const last = completed[completed.length - 1];
+      return last ? (last.textContent || '') : '';
+    })()`)}"`,
+  ).stdout;
+}
+
 function runAppConsoleCommand(consoleRef: string, command: string): string {
   run(`agent-browser click ${consoleRef}`);
   run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
-  run("agent-browser press Enter");
+  run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const runButton = document.querySelector(
+        '[data-testid="app-console-cell"][data-current="true"] [data-testid="app-console-cell-run"]',
+      );
+      if (!(runButton instanceof HTMLButtonElement)) {
+        return 'missing-run-button';
+      }
+      runButton.click();
+      return 'ok';
+    })()`)}"`,
+  );
   run("agent-browser wait 900");
-  return run("agent-browser get text '#app-console-output'").stdout;
+  return readAppConsoleOutput();
 }
 
 function parseJsonMaybeString(raw: string): unknown {
@@ -452,11 +475,11 @@ try {
     fail("Could not find AI Chat button in side panel");
   }
 
-  const consoleRef = firstRef(snapshot, /console-input|terminal input/i);
+  const consoleRef = firstRef(snapshot, /app console input|console-input/i);
   if (!consoleRef) {
-    fail("Could not find AppConsole terminal input");
+    fail("Could not find App Console input");
   } else {
-    pass("Found AppConsole terminal input");
+    pass("Found App Console input");
     runAppConsoleCommand(consoleRef, `app.harness.update("fake", "${FAKE_CHATKIT_BASE_URL}", "responses-direct")`);
     runAppConsoleCommand(consoleRef, 'app.harness.setDefault("fake")');
     const consoleOutput = runAppConsoleCommand(consoleRef, "app.harness.get()");

--- a/app/test/browser/test-scenario-ai.ts
+++ b/app/test/browser/test-scenario-ai.ts
@@ -287,70 +287,149 @@ function readFakeChatkitRequests(): string {
   return run(`curl -sf ${FAKE_CHATKIT_REQUESTS_URL}`).stdout.trim()
 }
 
-function waitForChatComposer(timeoutMs = 20000): boolean {
+function readComposerValue(): string {
+  const script = `(() => {
+    const collectRoots = () => {
+      const roots = [];
+      const seen = new Set();
+      const visit = (root) => {
+        if (!root || seen.has(root)) return;
+        seen.add(root);
+        roots.push(root);
+        if (typeof root.querySelectorAll !== 'function') return;
+        for (const el of Array.from(root.querySelectorAll('*'))) {
+          if (el && el.shadowRoot) visit(el.shadowRoot);
+        }
+      };
+      const chat = document.querySelector('openai-chatkit');
+      if (chat && chat.shadowRoot) {
+        visit(chat.shadowRoot);
+      }
+      for (const frame of Array.from(document.querySelectorAll('iframe'))) {
+        try {
+          const doc = frame.contentDocument;
+          if (doc) visit(doc);
+        } catch {}
+      }
+      visit(document);
+      return roots;
+    };
+    for (const root of collectRoots()) {
+      const composer = root.querySelector('textarea') ||
+        root.querySelector('[contenteditable="true"][role="textbox"]') ||
+        root.querySelector('[contenteditable="true"]');
+      if (!composer) continue;
+      if (composer instanceof HTMLTextAreaElement) {
+        return composer.value || '';
+      }
+      return composer.textContent || '';
+    }
+    return '__missing_composer__';
+  })()`
+  return normalizeAgentBrowserString(
+    run(`agent-browser eval "${escapeDoubleQuotes(script)}"`).stdout
+  )
+}
+
+function waitForComposer(timeoutMs = 15000): boolean {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    const state = normalizeAgentBrowserString(
-      run(
-        `agent-browser eval "${escapeDoubleQuotes(`(() => {
-          const collectRoots = () => {
-            const roots = [];
-            const seen = new Set();
-            const visit = (root) => {
-              if (!root || seen.has(root)) return;
-              seen.add(root);
-              roots.push(root);
-              if (typeof root.querySelectorAll !== 'function') return;
-              for (const el of Array.from(root.querySelectorAll('*'))) {
-                if (el && el.shadowRoot) visit(el.shadowRoot);
-              }
-            };
-            const chat = document.querySelector('openai-chatkit');
-            if (chat && chat.shadowRoot) {
-              visit(chat.shadowRoot);
-            }
-            for (const frame of Array.from(document.querySelectorAll('iframe'))) {
-              try {
-                const doc = frame.contentDocument;
-                if (doc) visit(doc);
-              } catch {
-                // Ignore cross-origin frames.
-              }
-            }
-            visit(document);
-            return roots;
-          };
-          for (const root of collectRoots()) {
-            const composer = Array.from(
-              root.querySelectorAll(
-                'textarea, [contenteditable="true"][role="textbox"], [contenteditable="true"]',
-              ),
-            ).find((element) => {
-              if (!(element instanceof HTMLElement)) {
-                return false;
-              }
-              if (element.getAttribute('aria-label') === 'App Console input') {
-                return false;
-              }
-              if (element.closest('[data-testid="app-console-cell"]')) {
-                return false;
-              }
-              return true;
-            });
-            if (composer) {
-              return 'composer-ready';
-            }
-          }
-          return window.__cujChatkitReady ? 'ready-event-only' : 'missing-composer';
-        })()`)}"`
-      ).stdout
-    )
-    if (state === 'composer-ready' || state === 'ready-event-only') {
+    const current = readComposerValue()
+    if (current !== '__missing_composer__') {
       return true
     }
-    run('agent-browser wait 500')
+    run('agent-browser wait 400')
   }
   return false
+}
+
+type SidePanelName = 'explorer' | 'chatkit'
+
+function readSidePanelPressedState(): {
+  explorerPressed: string | null
+  chatkitPressed: string | null
+} {
+  const script = `(() => JSON.stringify({
+    explorerPressed: document.querySelector('button[aria-label="Toggle Explorer panel"]')?.getAttribute('aria-pressed') ?? null,
+    chatkitPressed: document.querySelector('button[aria-label="Toggle ChatKit panel"]')?.getAttribute('aria-pressed') ?? null,
+  }))()`
+  const raw = normalizeAgentBrowserString(
+    run(`agent-browser eval "${escapeDoubleQuotes(script)}"`).stdout
+  )
+  try {
+    const parsed = JSON.parse(raw) as {
+      explorerPressed?: string | null
+      chatkitPressed?: string | null
+    }
+    return {
+      explorerPressed: parsed.explorerPressed ?? null,
+      chatkitPressed: parsed.chatkitPressed ?? null,
+    }
+  } catch {
+    return {
+      explorerPressed: null,
+      chatkitPressed: null,
+    }
+  }
+}
+
+function waitForActiveSidePanel(
+  panel: SidePanelName,
+  timeoutMs = 5000
+): boolean {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const state = readSidePanelPressedState()
+    if (
+      panel === 'explorer' &&
+      state.explorerPressed === 'true' &&
+      state.chatkitPressed === 'false'
+    ) {
+      return true
+    }
+    if (
+      panel === 'chatkit' &&
+      state.chatkitPressed === 'true' &&
+      state.explorerPressed === 'false'
+    ) {
+      return true
+    }
+    run('agent-browser wait 300')
+  }
+  return false
+}
+
+function switchToSidePanelOrThrow({
+  name,
+  buttonPattern,
+  activePanel,
+}: {
+  name: string
+  buttonPattern: RegExp
+  activePanel: SidePanelName
+}): void {
+  const deadline = Date.now() + 10000
+  let lastError = 'unknown error'
+  while (Date.now() < deadline) {
+    const snapshot = run('agent-browser snapshot').stdout
+    const ref = firstRef(snapshot, buttonPattern)
+    if (!ref) {
+      lastError = `missing ${name} button ref`
+      run('agent-browser wait 300')
+      continue
+    }
+    const clickResult = run(`agent-browser click ${ref}`)
+    if (clickResult.status !== 0) {
+      lastError = `click failed (${clickResult.status}): ${clickResult.stderr || clickResult.stdout || 'no output'}`
+      run('agent-browser wait 300')
+      continue
+    }
+    if (waitForActiveSidePanel(activePanel, 4000)) {
+      return
+    }
+    lastError = `side panel did not become active after click (${name})`
+  }
+  throw new Error(`Failed to switch to ${name}: ${lastError}`)
 }
 
 function tryTypeChatMessage(message: string): string {
@@ -645,25 +724,18 @@ try {
   }
 
   if (chatRef) {
-    run(
-      `agent-browser eval "${escapeDoubleQuotes(`(() => {
-        const button = document.querySelector('button[aria-label="Toggle ChatKit panel"]');
-        if (!(button instanceof HTMLButtonElement)) {
-          return 'missing-chatkit-toggle';
-        }
-        if (button.getAttribute('aria-pressed') !== 'true') {
-          button.click();
-        }
-        return button.getAttribute('aria-pressed') === 'true' ? 'open' : 'clicked';
-      })()`)}"`
-    )
-    run('agent-browser wait 1400')
+    switchToSidePanelOrThrow({
+      name: 'ChatKit',
+      buttonPattern: /AI Chat|ChatKit panel|Toggle ChatKit panel/i,
+      activePanel: 'chatkit',
+    })
+    run('agent-browser wait 1000')
     installChatkitEventProbe()
     pass('Opened ChatKit panel')
   }
 
   const message = 'hello from ai cuj'
-  const chatComposerReady = waitForChatComposer()
+  const chatComposerReady = waitForComposer()
   const sendOutput = chatComposerReady
     ? typeChatMessageWithRetry(message)
     : 'chatkit-not-ready'

--- a/app/test/browser/test-scenario-chatkit-thread-persistence.ts
+++ b/app/test/browser/test-scenario-chatkit-thread-persistence.ts
@@ -157,12 +157,37 @@ function escapeDoubleQuotes(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+function readAppConsoleOutput(): string {
+  return normalizeAgentBrowserString(
+    run(
+      `agent-browser eval "${escapeDoubleQuotes(`(() => {
+        const completed = Array.from(
+          document.querySelectorAll('[data-testid="app-console-cell"]'),
+        ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
+        const last = completed[completed.length - 1];
+        return last ? (last.textContent || '') : '';
+      })()`)}"`,
+    ).stdout,
+  );
+}
+
 function runAppConsoleCommand(consoleRef: string, command: string): string {
   run(`agent-browser click ${consoleRef}`);
   run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
-  run("agent-browser press Enter");
+  run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const runButton = document.querySelector(
+        '[data-testid="app-console-cell"][data-current="true"] [data-testid="app-console-cell-run"]',
+      );
+      if (!(runButton instanceof HTMLButtonElement)) {
+        return 'missing-run-button';
+      }
+      runButton.click();
+      return 'ok';
+    })()`)}"`,
+  );
   run("agent-browser wait 900");
-  return normalizeAgentBrowserString(run("agent-browser get text '#app-console-output'").stdout);
+  return readAppConsoleOutput();
 }
 
 function readHarnessStorage(): string {
@@ -440,9 +465,9 @@ try {
   const initialSnapshot = run("agent-browser snapshot").stdout;
   writeArtifact("scenario-chatkit-thread-persistence-01-snapshot.txt", initialSnapshot);
 
-  const consoleRef = firstRef(initialSnapshot, /console-input|terminal input/i);
+  const consoleRef = firstRef(initialSnapshot, /app console input|console-input/i);
   if (!consoleRef) {
-    fail("Could not find AppConsole terminal input");
+    fail("Could not find App Console input");
   }
 
   if (consoleRef) {

--- a/app/test/browser/test-scenario-chatkit-thread-persistence.ts
+++ b/app/test/browser/test-scenario-chatkit-thread-persistence.ts
@@ -172,8 +172,10 @@ function readAppConsoleOutput(): string {
 }
 
 function runAppConsoleCommand(consoleRef: string, command: string): string {
-  run(`agent-browser click ${consoleRef}`);
-  run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
+  void consoleRef;
+  run(
+    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`,
+  );
   run(
     `agent-browser eval "${escapeDoubleQuotes(`(() => {
       const runButton = document.querySelector(

--- a/app/test/browser/test-scenario-hello-world.ts
+++ b/app/test/browser/test-scenario-hello-world.ts
@@ -170,15 +170,34 @@ function escapeDoubleQuotes(value: string): string {
 /**
  * Execute one AppConsole command and return the captured console output.
  *
- * The helper centralizes how we drive the terminal widget so runner setup
+ * The helper centralizes how we drive the current draft cell so runner setup
  * assertions remain stable and every command appears in the walkthrough video.
  */
 function runAppConsoleCommand(consoleRef: string, command: string): string {
   run(`agent-browser click ${consoleRef}`);
   run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
-  run("agent-browser press Enter");
+  run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const runButton = document.querySelector(
+        '[data-testid="app-console-cell"][data-current="true"] [data-testid="app-console-cell-run"]',
+      );
+      if (!(runButton instanceof HTMLButtonElement)) {
+        return 'missing-run-button';
+      }
+      runButton.click();
+      return 'ok';
+    })()`)}"`,
+  );
   run("agent-browser wait 900");
-  return run("agent-browser get text '#app-console-output'").stdout;
+  return run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const completed = Array.from(
+        document.querySelectorAll('[data-testid="app-console-cell"]'),
+      ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
+      const last = completed[completed.length - 1];
+      return last ? (last.textContent || '') : '';
+    })()`)}"`,
+  ).stdout;
 }
 
 function runWithRetry(command: string, attempts = 3, waitMs = 1200): void {
@@ -310,13 +329,20 @@ if (seedResult.includes("ok")) {
 let snapshot = run("agent-browser snapshot -i").stdout;
 writeArtifact("scenario-hello-world-02-after-seed.txt", snapshot);
 
-const consoleRef = firstRef(snapshot, /Terminal input/i);
+const consoleRef = firstRef(snapshot, /App Console input/i);
 if (!consoleRef) {
-  fail("Did not find AppConsole terminal input");
+  fail("Did not find App Console input");
 } else {
-  const consoleOutput = run("agent-browser get text '#app-console-output'").stdout;
+  const consoleOutput = run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const current = document.querySelector(
+        '[data-testid="app-console-cell"][data-current="true"]',
+      );
+      return current ? (current.textContent || '') : '';
+    })()`)}"`,
+  ).stdout;
   writeArtifact("scenario-hello-world-03-console-output.txt", consoleOutput);
-  pass("Found AppConsole terminal input");
+  pass("Found App Console input");
 
   const runnerName = "local";
   const runnerEndpoint = "ws://localhost:9977/ws";

--- a/app/test/browser/test-scenario-hello-world.ts
+++ b/app/test/browser/test-scenario-hello-world.ts
@@ -174,8 +174,10 @@ function escapeDoubleQuotes(value: string): string {
  * assertions remain stable and every command appears in the walkthrough video.
  */
 function runAppConsoleCommand(consoleRef: string, command: string): string {
-  run(`agent-browser click ${consoleRef}`);
-  run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
+  void consoleRef;
+  run(
+    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`,
+  );
   run(
     `agent-browser eval "${escapeDoubleQuotes(`(() => {
       const runButton = document.querySelector(

--- a/app/test/browser/test-scenario-no-runner-logs.ts
+++ b/app/test/browser/test-scenario-no-runner-logs.ts
@@ -145,8 +145,10 @@ function readAppConsoleOutput(): string {
 }
 
 function runAppConsoleCommand(consoleRef: string, command: string): string {
-  run(`agent-browser click ${consoleRef}`);
-  run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
+  void consoleRef;
+  run(
+    `agent-browser fill 'textarea[aria-label="App Console input"]' "${escapeDoubleQuotes(command)}"`,
+  );
   run(
     `agent-browser eval "${escapeDoubleQuotes(`(() => {
       const runButton = document.querySelector(

--- a/app/test/browser/test-scenario-no-runner-logs.ts
+++ b/app/test/browser/test-scenario-no-runner-logs.ts
@@ -132,12 +132,35 @@ function escapeDoubleQuotes(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+function readAppConsoleOutput(): string {
+  return run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const completed = Array.from(
+        document.querySelectorAll('[data-testid="app-console-cell"]'),
+      ).filter((cell) => cell.getAttribute('data-status') !== 'draft');
+      const last = completed[completed.length - 1];
+      return last ? (last.textContent || '') : '';
+    })()`)}"`,
+  ).stdout;
+}
+
 function runAppConsoleCommand(consoleRef: string, command: string): string {
   run(`agent-browser click ${consoleRef}`);
   run(`agent-browser type ${consoleRef} "${escapeDoubleQuotes(command)}"`);
-  run("agent-browser press Enter");
+  run(
+    `agent-browser eval "${escapeDoubleQuotes(`(() => {
+      const runButton = document.querySelector(
+        '[data-testid="app-console-cell"][data-current="true"] [data-testid="app-console-cell-run"]',
+      );
+      if (!(runButton instanceof HTMLButtonElement)) {
+        return 'missing-run-button';
+      }
+      runButton.click();
+      return 'ok';
+    })()`)}"`,
+  );
   run("agent-browser wait 900");
-  return run("agent-browser get text '#app-console-output'").stdout;
+  return readAppConsoleOutput();
 }
 
 function runWithRetry(command: string, attempts = 3, waitMs = 1200): void {
@@ -330,9 +353,9 @@ if (seedResult.includes("ok")) {
 let snapshot = run("agent-browser snapshot -i").stdout;
 writeArtifact("scenario-no-runner-logs-02-after-seed.txt", snapshot);
 
-const consoleRef = firstRef(snapshot, /Terminal input/i);
+const consoleRef = firstRef(snapshot, /App Console input/i);
 if (!consoleRef) {
-  fail("Did not find AppConsole terminal input");
+  fail("Did not find App Console input");
 } else {
   const firstDelete = runAppConsoleCommand(consoleRef, 'app.runners.delete("default")');
   const secondDelete = runAppConsoleCommand(consoleRef, 'app.runners.delete("local")');

--- a/docs-dev/design/20260502_app_console_cells.md
+++ b/docs-dev/design/20260502_app_console_cells.md
@@ -1,0 +1,534 @@
+# 2026-05-02: Append-Only App Console Cells
+
+## Status
+
+Draft proposal.
+
+## Summary
+
+We will replace the current terminal-style App Console with an append-only
+sequence of JavaScript cells.
+
+Each executed cell becomes immutable. Only the last draft cell is editable.
+Running the draft cell freezes it, appends a new empty draft cell, and focuses
+that new draft cell.
+
+We will keep the existing AppKernel execution path. We will replace the
+terminal emulation layer and `console-view` integration with a React cell list,
+Monaco input editors, and notebook-style output rendering.
+
+This design addresses the long-standing UX problems captured in
+[issue #35](https://github.com/runmedev/web/issues/35). It also gives
+agent-browser style automation a stable DOM contract for finding the current
+input cell, execution state, and outputs.
+
+## Motivation
+
+The current App Console behaves like a terminal implemented inside a web app.
+That creates two classes of problems.
+
+The first problem is UX. Editing prior commands, navigating history, and
+understanding where input ends and output begins all inherit the friction of a
+character device UI.
+
+The second problem is structure. The current console flattens input and output
+into one stream. That makes it harder for automation to identify:
+
+- the current editable command,
+- the boundary between commands,
+- whether a command is still running,
+- which output belongs to which command.
+
+The terminal implementation also duplicates behavior we already model better in
+the notebook UI:
+
+- a source editor,
+- explicit execution state,
+- typed outputs,
+- append-only history.
+
+## Current Design
+
+`AppConsole` currently combines two separate concerns:
+
+1. useful runtime logic we want to keep,
+2. terminal emulation we want to remove.
+
+Useful logic we should keep:
+
+- `JSKernel` execution for browser-mode JavaScript
+- `createAppJsGlobals(...)`
+- `createRunmeConsoleApi(...)`
+- workspace and notebook resolution
+- filesystem-store lazy initialization
+
+This logic lives in [AppConsole.tsx](/Users/jlewi/git_runmeweb/app/src/components/AppConsole/AppConsole.tsx:37),
+[jsKernel.ts](/Users/jlewi/git_runmeweb/app/src/lib/runtime/jsKernel.ts:1),
+[appJsGlobals.ts](/Users/jlewi/git_runmeweb/app/src/lib/runtime/appJsGlobals.ts:140), and
+[runmeConsole.ts](/Users/jlewi/git_runmeweb/app/src/lib/runtime/runmeConsole.ts:565).
+
+Terminal behavior we should remove:
+
+- `console-view`
+- prompt rendering (`> `)
+- cursor math
+- ANSI erase/move control sequences
+- terminal stdin message handling
+- terminal-style command history bound to arrow keys
+
+That logic is concentrated in
+[AppConsole.tsx](/Users/jlewi/git_runmeweb/app/src/components/AppConsole/AppConsole.tsx:243).
+
+## Goals
+
+- Make the App Console feel like an append-only notebook, not a terminal.
+- Keep AppKernel JavaScript execution semantics unchanged.
+- Make the current draft cell obvious.
+- Make prior inputs and outputs easy to inspect.
+- Make the DOM stable enough for automation to locate the current input cell,
+  execution status, and outputs without parsing a terminal transcript.
+- Reuse existing editor and output-rendering code where it fits.
+
+## Non-Goals
+
+- Turning the App Console into a persisted notebook document.
+- Supporting arbitrary post-execution edits to old cells.
+- Reproducing every terminal keybinding.
+- Adding remote-runner terminal support to the App Console.
+
+## Proposal
+
+### UI model
+
+The App Console will render a list of console cells.
+
+Each console cell has:
+
+- one JavaScript input editor,
+- zero or more output blocks,
+- explicit execution state,
+- immutable source after execution,
+- an optional action row for history-oriented actions such as copying a frozen
+  cell back into the draft cell.
+
+The final cell in the list is the draft cell. It is the only editable cell.
+
+Executed cells are frozen records of what ran and what it produced. They are
+history, not live editors.
+
+### Editing semantics
+
+We will not allow editing an executed cell and rerunning it in place.
+
+We will use this rule consistently:
+
+- draft cell: editable
+- executed cell: immutable
+
+Rationale:
+
+- Immutable history is easier to reason about.
+- Output remains tied to the exact input that produced it.
+- Automation can trust that a completed cell will not silently change.
+- The model matches chat and notebook history better than terminal rewrite
+  behavior.
+
+To re-run or modify prior work, the user edits the current draft cell.
+
+### Execution semantics
+
+When the user executes the current draft cell:
+
+1. the draft cell status becomes `running`
+2. execution starts through the existing AppKernel path
+3. stdout/stderr/result blocks stream into that cell
+4. the cell status becomes `success` or `error`
+5. the cell becomes immutable
+6. a new empty draft cell is appended and focused
+
+The new draft cell is created even if the prior run fails. Failure is output and
+status on the frozen cell, not a special editing mode.
+
+### Keyboard semantics
+
+The draft editor uses Monaco.
+
+Execution shortcut:
+
+- `Shift+Enter` runs the current draft cell
+
+History shortcuts:
+
+- `Shift+UpArrow` replaces the current draft contents with the previous command
+- `Shift+DownArrow` moves forward through history
+
+History navigation must preserve the user's in-progress draft buffer.
+
+Required behavior:
+
+1. If the user starts with a partially edited draft and presses
+   `Shift+UpArrow`, we enter history-browse mode.
+2. While browsing history, repeated `Shift+UpArrow` and `Shift+DownArrow`
+   cycle through prior executed cell inputs.
+3. When the user returns past the newest history item, the editor restores the
+   exact draft buffer they had before entering history-browse mode.
+
+This gives us the useful part of terminal history without making old cells
+editable.
+
+### Frozen-cell actions
+
+Frozen cells should expose at least one explicit action:
+
+- `Copy to draft`
+
+`Copy to draft` replaces the contents of the current draft cell with the frozen
+cell's source and focuses the draft editor.
+
+This is complementary to keyboard history navigation.
+
+Rationale:
+
+- it is easier to discover than history shortcuts,
+- it works even when the user wants to inspect an older cell visually before
+  reusing it,
+- it gives automation a clear UI affordance for reusing a prior command without
+  mutating history.
+
+### Data model
+
+We should introduce a dedicated `ConsoleCellModel` instead of reusing the full
+notebook document model.
+
+Recommended shape:
+
+```ts
+type ConsoleCellStatus = "draft" | "running" | "success" | "error";
+
+type ConsoleCell = {
+  id: string;
+  index: number;
+  source: string;
+  status: ConsoleCellStatus;
+  startedAt?: string;
+  completedAt?: string;
+  exitCode?: number;
+  outputs: parser_pb.CellOutput[];
+};
+```
+
+We should reuse `parser_pb.CellOutput[]` for output payloads. That lets us reuse
+existing output rendering and existing MIME conventions for stdout/stderr.
+
+We should persist console cells in IndexedDB.
+
+Recommended persistence model:
+
+- one IndexedDB object store for console sessions,
+- one object store for console cells,
+- one row per cell,
+- append-only writes for completed cells,
+- one mutable row for the current draft cell,
+- monotonic `index` within a session.
+
+Recommended shape:
+
+```ts
+type PersistedConsoleCellRow = {
+  sessionId: string;
+  id: string;
+  index: number;
+  source: string;
+  status: ConsoleCellStatus;
+  outputs: parser_pb.CellOutput[];
+  exitCode?: number;
+  startedAt?: string;
+  completedAt?: string;
+  updatedAt: string;
+};
+```
+
+This should persist across reloads for the same browser profile.
+
+On reload:
+
+1. load the latest console session,
+2. restore frozen cells in order,
+3. restore the draft cell contents if a draft row exists,
+4. reset any previously `running` cells to `error` or `interrupted` with a
+   short recovery note because browser reload terminates in-flight execution.
+
+We should not reuse `NotebookData` itself:
+
+- App Console cells are app-scoped scratch state, not document cells.
+- Notebook persistence, revisioning, and runner assignment add complexity we do
+  not need here.
+- The console needs exactly one mutable draft cell, which is not a notebook
+  concept.
+
+## Reuse Plan
+
+### Logic we should keep
+
+- `JSKernel`
+- `createAppJsGlobals(...)`
+- `createRunmeConsoleApi(...)`
+- notebook/workspace resolution helpers from `AppConsole`
+- filesystem-store initialization from `AppConsole`
+
+We should extract those parts of `AppConsole` into a smaller hook or controller
+that drives console cell execution.
+
+### React/UI pieces we should keep
+
+- Monaco editor wrapper from
+  [Editor.tsx](/Users/jlewi/git_runmeweb/app/src/components/Actions/Editor.tsx:1)
+- output rendering from
+  [Actions.tsx](/Users/jlewi/git_runmeweb/app/src/components/Actions/Actions.tsx:433)
+
+The existing `ActionOutputItems` renderer already understands notebook-style
+output items and skips terminal-only MIME types when needed. Reusing that path
+keeps App Console outputs visually aligned with notebook outputs.
+
+### Pieces we should remove
+
+- `console-view`
+- terminal renderer context wiring
+- ANSI prompt rendering
+- terminal cursor movement logic
+- terminal stdin parsing
+- hidden transcript mirror used for test assertions
+
+That hidden transcript mirror exists today at
+[AppConsole.tsx](/Users/jlewi/git_runmeweb/app/src/components/AppConsole/AppConsole.tsx:475)
+because the real UI is hard to inspect. The new design should make the visible
+DOM itself the test and automation surface.
+
+## Execution Controller
+
+We should implement a small `AppConsoleController` that owns:
+
+- the ordered list of console cells
+- history browsing state
+- the preserved draft buffer while browsing history
+- the active run id for the current executing cell
+- transitions from `draft -> running -> success|error`
+
+It should call the same execution stack the current App Console uses today.
+
+That means:
+
+- build globals with `createAppJsGlobals(...)`
+- run code with `JSKernel`
+- capture stdout/stderr
+- convert output into `parser_pb.CellOutput[]`
+- store exit status on the console cell
+
+This keeps the behavioral contract of AppKernel console execution stable while
+letting us replace the UI.
+
+## Automation Contract
+
+The new App Console must expose explicit DOM semantics. Automation should not
+need to infer state from visual order, CSS classes, or merged text blobs.
+
+Each rendered cell should expose:
+
+- stable `data-testid`
+- stable cell id
+- stable cell index
+- explicit status
+- explicit "current draft" marker
+
+Recommended DOM shape:
+
+```html
+<section data-testid="app-console-cells">
+  <article
+    data-testid="app-console-cell"
+    data-console-cell-id="c17"
+    data-console-cell-index="17"
+    data-status="draft"
+    data-current="true"
+  >
+    <div data-testid="app-console-cell-header">
+      <span data-testid="app-console-cell-index">17</span>
+      <span data-testid="app-console-cell-status">draft</span>
+    </div>
+
+    <div data-testid="app-console-cell-input">
+      <!-- Monaco host -->
+    </div>
+
+    <div data-testid="app-console-cell-actions">
+      <button data-testid="app-console-cell-copy-to-draft">
+        Copy to draft
+      </button>
+    </div>
+
+    <div data-testid="app-console-cell-outputs">
+      <div
+        data-testid="app-console-cell-output"
+        data-output-kind="stdout"
+      ></div>
+      <div
+        data-testid="app-console-cell-output"
+        data-output-kind="stderr"
+      ></div>
+      <div
+        data-testid="app-console-cell-output"
+        data-output-kind="result"
+      ></div>
+    </div>
+  </article>
+</section>
+```
+
+Required automation guarantees:
+
+- Exactly one cell has `data-current="true"`.
+- Exactly one editable input exists at a time.
+- Every non-draft cell has stable source text and stable outputs.
+- A running cell has `data-status="running"` until execution completes.
+- Outputs are nested under the cell that produced them.
+- Output blocks remain in the DOM after completion.
+- Frozen-cell actions remain in the DOM after completion.
+
+This makes common automation tasks straightforward:
+
+- find the draft cell
+- read the latest completed cell
+- poll for completion
+- read stdout/stderr/result separately
+- copy a frozen cell into the draft cell through a visible control
+
+### Validation against the current UI
+
+We validated the current app with browser automation against
+`http://localhost:5173/`.
+
+Observed behavior:
+
+- notebook and chat controls are exposed as normal DOM controls,
+- runner state is readable from standard combobox-backed UI,
+- harness state is readable from standard combobox-backed UI,
+- the current App Console is not exposed as structured per-command DOM.
+
+In the current implementation, App Console automation depends on a hidden
+`data-testid="app-console-output"` mirror while the real console behavior lives
+inside `console-view`. That mirror is useful for narrow assertions, but it does
+not expose:
+
+- command boundaries,
+- current editable input,
+- per-command status,
+- outputs grouped by command.
+
+The proposed append-only cell design fixes that gap by making the visible DOM
+the primary inspection surface.
+
+### Monaco-specific requirement
+
+The automation contract must not depend on typing directly into Monaco internals
+by class name.
+
+We should wrap the Monaco host in a container with a stable test id and mark the
+current editable cell at the cell container level. Automation can then:
+
+1. find the current cell by `data-current="true"`
+2. scope to `data-testid="app-console-cell-input"`
+3. type into the editor using standard browser automation
+
+## User Flow
+
+Expected user flow:
+
+1. User opens App Console.
+2. App Console shows one empty draft cell.
+3. User types JavaScript.
+4. User presses `Shift+Enter`.
+5. Cell runs and freezes.
+6. A new empty draft cell appears below it.
+7. User presses `Shift+UpArrow` to recall a previous command if needed.
+8. User edits the recalled command in the current draft cell.
+9. User presses `Shift+Enter` again.
+
+This preserves fast command iteration without mutating history.
+
+## Alternatives Considered
+
+### Keep the terminal and improve it
+
+We should not do this.
+
+The terminal model is the source of the current UX and automation problems. It
+keeps input and output flattened into one stream and forces us to keep solving
+cursor and transcript edge cases in the browser.
+
+### Allow editing executed cells in place
+
+We should not do this.
+
+That makes history ambiguous. One cell could represent multiple executions over
+time, which weakens both the UX and the automation model.
+
+### Reuse notebook document state directly
+
+We should not do this in v0.
+
+The App Console is not a notebook file. It needs a simpler controller with one
+draft cell and append-only history. Reusing notebook output payload types is
+useful. Reusing the full notebook document model is not.
+
+### Allow non-JavaScript or markdown console cells
+
+We should not do this in v0.
+
+The App Console should stay JavaScript-only for now. That keeps the execution
+model, editor configuration, persistence model, and automation contract simple.
+
+## Migration Plan
+
+1. Extract the current AppKernel execution setup from `AppConsole` into a
+   controller or hook.
+2. Define `ConsoleCell` state and transitions.
+3. Build a new React cell-list UI behind a temporary feature flag.
+4. Reuse the shared Monaco editor wrapper for the draft cell.
+5. Reuse notebook-style output rendering for completed cells.
+6. Add history navigation with preserved draft-buffer semantics.
+7. Add stable `data-testid` and `data-*` automation attributes.
+8. Remove `console-view` and terminal-only transcript plumbing once the new UI
+   is complete.
+
+## Testing
+
+We should test three layers.
+
+Unit tests:
+
+- controller transitions
+- history navigation semantics
+- draft-buffer restore behavior
+- execution status transitions
+
+Component tests:
+
+- only one editable cell exists
+- executed cells render immutable source and outputs
+- `Shift+Enter` runs the draft cell
+- `Shift+UpArrow` / `Shift+DownArrow` browse history correctly
+
+Browser tests:
+
+- append-only execution flow
+- output is rendered under the correct cell
+- `Copy to draft` copies frozen source into the current draft cell
+- persisted cells are restored after reload in the same browser profile
+- automation can locate current cell, status, and outputs using only the
+  public DOM contract
+
+## Decisions
+
+- Console history will persist across reloads in IndexedDB.
+- Frozen cells will expose a `Copy to draft` action in v0.
+- The App Console will stay JavaScript-only in v0.


### PR DESCRIPTION
## Summary
- replace the terminal-backed App Console with append-only JavaScript cells
- persist console sessions in IndexedDB and add history recall plus Copy to draft
- update browser automation helpers to use the new public App Console DOM contract

## Why
- the old App Console flattened input and output into a terminal transcript that was hard to inspect and automate
- the new cell model keeps execution history immutable and exposes stable per-cell status and output structure

## Validation
- `runme run --filename README.md build test`
- `pnpm -C app exec vitest run src/components/AppConsole/AppConsole.test.tsx src/components/AppConsole/model.test.ts`
- launched `pnpm -C app run dev -- --host 127.0.0.1` and verified in Chrome that App Console commands run successfully, including `app.runners.update(...)` and `app.runners.get()`

Closes #35
