### PR TITLE
[codex] Fix notebook SDK race after createLocal

### DIFF
--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -1210,15 +1210,72 @@ describe("NotebookData.runCodeCell", () => {
   });
 
   it("supports drive.saveAsCurrentNotebook in appkernel cells", async () => {
+    const notebooksByUri = new Map<string, InstanceType<typeof NotebookData>>();
+    const savedNotebooksByUri = new Map<string, parser_pb.Notebook>();
+    let activeUri = "local://file/original";
+
+    const resolveNotebook = (target?: unknown) => {
+      if (!target) {
+        return notebooksByUri.get(activeUri) ?? null;
+      }
+      if (typeof target === "string") {
+        return notebooksByUri.get(target) ?? null;
+      }
+      if (
+        typeof target === "object" &&
+        target &&
+        "uri" in target &&
+        typeof (target as { uri?: string }).uri === "string"
+      ) {
+        return notebooksByUri.get((target as { uri: string }).uri) ?? null;
+      }
+      if (
+        typeof target === "object" &&
+        target &&
+        "handle" in target &&
+        (target as { handle?: { uri?: string } }).handle?.uri
+      ) {
+        return (
+          notebooksByUri.get((target as { handle: { uri: string } }).handle.uri) ??
+          null
+        );
+      }
+      return null;
+    };
+
+    const listNotebooks = () => Array.from(notebooksByUri.values());
+
     const createRemote = vi.fn().mockResolvedValue({
       uri: "https://drive.google.com/file/d/saveas123/view",
     });
     const saveContent = vi.fn().mockResolvedValue(undefined);
     appState.setDriveNotebookStore({ create: createRemote, saveContent } as any);
     const addFile = vi.fn().mockResolvedValue("local://file/saveas-copy");
-    const saveLocal = vi.fn().mockResolvedValue(undefined);
+    const saveLocal = vi.fn().mockImplementation(
+      async (uri: string, notebook: parser_pb.Notebook) => {
+        savedNotebooksByUri.set(uri, create(parser_pb.NotebookSchema, notebook));
+      }
+    );
     appState.setLocalNotebooks({ addFile, save: saveLocal } as any);
-    const openNotebook = vi.fn().mockResolvedValue(undefined);
+    const openNotebook = vi.fn().mockImplementation(async (uri: string) => {
+      activeUri = uri;
+      setTimeout(() => {
+        const saved = savedNotebooksByUri.get(uri);
+        if (!saved) {
+          return;
+        }
+        const createdModel = new NotebookData({
+          notebook: create(parser_pb.NotebookSchema, saved),
+          uri,
+          name: "copy.json",
+          notebookStore: null,
+          loaded: true,
+          resolveNotebookForAppKernel: resolveNotebook,
+          listNotebooksForAppKernel: listNotebooks,
+        });
+        notebooksByUri.set(uri, createdModel);
+      }, 0);
+    });
     appState.setOpenNotebookHandler(openNotebook);
 
     const cell = create(parser_pb.CellSchema, {
@@ -1242,7 +1299,10 @@ describe("NotebookData.runCodeCell", () => {
       name: "saveas-source.json",
       notebookStore: null,
       loaded: true,
+      resolveNotebookForAppKernel: resolveNotebook,
+      listNotebooksForAppKernel: listNotebooks,
     });
+    notebooksByUri.set(model.getUri(), model);
 
     model.runCodeCell(cell);
     await waitForCondition(() => {
@@ -1269,6 +1329,7 @@ describe("NotebookData.runCodeCell", () => {
 
   it("supports notebook creation and append helpers in appkernel cells", async () => {
     const notebooksByUri = new Map<string, InstanceType<typeof NotebookData>>();
+    const savedNotebooksByUri = new Map<string, parser_pb.Notebook>();
     let activeUri = "nb://seed";
 
     const resolveNotebook = (target?: unknown) => {
@@ -1306,21 +1367,30 @@ describe("NotebookData.runCodeCell", () => {
       uri: "local://file/helloworld",
       name: "helloworld",
     });
-    const saveLocal = vi.fn().mockImplementation(async (uri: string, notebook: parser_pb.Notebook) => {
-      const createdModel = new NotebookData({
-        notebook,
-        uri,
-        name: "helloworld",
-        notebookStore: null,
-        loaded: true,
-        resolveNotebookForAppKernel: resolveNotebook,
-        listNotebooksForAppKernel: listNotebooks,
-      });
-      notebooksByUri.set(uri, createdModel);
-    });
+    const saveLocal = vi.fn().mockImplementation(
+      async (uri: string, notebook: parser_pb.Notebook) => {
+        savedNotebooksByUri.set(uri, create(parser_pb.NotebookSchema, notebook));
+      }
+    );
     appState.setLocalNotebooks({ create: createLocal, save: saveLocal } as any);
     const openNotebook = vi.fn().mockImplementation(async (uri: string) => {
       activeUri = uri;
+      setTimeout(() => {
+        const saved = savedNotebooksByUri.get(uri);
+        if (!saved) {
+          return;
+        }
+        const createdModel = new NotebookData({
+          notebook: create(parser_pb.NotebookSchema, saved),
+          uri,
+          name: "helloworld",
+          notebookStore: null,
+          loaded: true,
+          resolveNotebookForAppKernel: resolveNotebook,
+          listNotebooksForAppKernel: listNotebooks,
+        });
+        notebooksByUri.set(uri, createdModel);
+      }, 0);
     });
     appState.setOpenNotebookHandler(openNotebook);
 

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -120,6 +120,13 @@ function createEmptyNotebook(): parser_pb.Notebook {
   return create(parser_pb.NotebookSchema, { cells: [], metadata: {} })
 }
 
+const NOTEBOOK_OPEN_RESOLVE_TIMEOUT_MS = 1500
+const NOTEBOOK_OPEN_RESOLVE_POLL_MS = 10
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 function defaultEnsureFilesystemStore(): FilesystemNotebookStore | null {
   if (appState.filesystemStore) {
     return appState.filesystemStore
@@ -174,12 +181,30 @@ export function createAppJsGlobals({
     appState.removeWorkspaceItem(uri)
   }
   const resolveStore = () => resolveNotebookStore?.() ?? appState.localNotebooks
+  const waitForOpenedNotebook = async (uri: string) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < NOTEBOOK_OPEN_RESOLVE_TIMEOUT_MS) {
+      const candidates = [
+        resolveNotebook?.(uri),
+        resolveNotebook?.({ uri }),
+        resolveNotebook?.(),
+        runme.getCurrentNotebook(),
+      ]
+      if (candidates.some((notebook) => notebook?.getUri() === uri)) {
+        return
+      }
+      await sleep(NOTEBOOK_OPEN_RESOLVE_POLL_MS)
+    }
+    throw new Error(`Timed out waiting for notebook ${uri} to load after opening.`)
+  }
   const openNotebookForRuntime = async (uri: string) => {
     if (openNotebook) {
       await openNotebook(uri)
+      await waitForOpenedNotebook(uri)
       return
     }
     await appState.openNotebook(uri)
+    await waitForOpenedNotebook(uri)
   }
   const resolveLocalMirrorStore = () => {
     if (!appState.localNotebooks) {

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -120,7 +120,6 @@ function createEmptyNotebook(): parser_pb.Notebook {
   return create(parser_pb.NotebookSchema, { cells: [], metadata: {} })
 }
 
-const NOTEBOOK_OPEN_RESOLVE_TIMEOUT_MS = 1500
 const NOTEBOOK_OPEN_RESOLVE_POLL_MS = 10
 
 function sleep(ms: number): Promise<void> {
@@ -182,8 +181,11 @@ export function createAppJsGlobals({
   }
   const resolveStore = () => resolveNotebookStore?.() ?? appState.localNotebooks
   const waitForOpenedNotebook = async (uri: string) => {
-    const startedAt = Date.now()
-    while (Date.now() - startedAt < NOTEBOOK_OPEN_RESOLVE_TIMEOUT_MS) {
+    // Notebook navigation only updates current-doc first. The concrete
+    // NotebookData model is created later by React effects, so callers that
+    // need to operate on the opened notebook must wait for eventual
+    // materialization instead of failing on a fixed timeout window.
+    while (true) {
       const candidates = [
         resolveNotebook?.(uri),
         resolveNotebook?.({ uri }),
@@ -195,7 +197,6 @@ export function createAppJsGlobals({
       }
       await sleep(NOTEBOOK_OPEN_RESOLVE_POLL_MS)
     }
-    throw new Error(`Timed out waiting for notebook ${uri} to load after opening.`)
   }
   const openNotebookForRuntime = async (uri: string) => {
     if (openNotebook) {


### PR DESCRIPTION
## Summary
- wait for a newly opened notebook to become resolvable before runtime helpers return
- cover the async notebook materialization path in appkernel regression tests

## Root cause
`notebooks.createLocal()` opened the new notebook and immediately called `notebooks.get({ uri })`. In the app runtime, opening a notebook only updates `currentDoc` first, while `NotebookContext` creates the `NotebookData` model later in an effect. That left a short window where `resolveNotebook(uri)` returned `null`, causing `No notebook found for the requested target.` even though creation and saving had already succeeded.

## Impact
- `await notebooks.createLocal("...")` now returns reliably in App Console / appkernel flows
- helpers that switch notebooks and then keep operating on the opened notebook use a consistent readiness contract

## Validation
- `pnpm -C app exec vitest run src/lib/notebookData.test.ts`
- `runme run build --project /Users/jlewi/git_runmeweb --ignore-pattern .worktrees`
- `runme run test --project /Users/jlewi/git_runmeweb --ignore-pattern .worktrees`