### PR TITLE
Add WebMCP ExecuteCode registration

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -48,6 +48,7 @@ import { SidePanelProvider } from "./contexts/SidePanelContext";
 import { appState } from "./lib/runtime/AppState";
 import GlobalToast from "./components/Toast";
 import DriveLinkCoordinatorHost from "./components/DriveLinkCoordinatorHost";
+import WebMcpToolRegistrationHost from "./components/WebMcp/WebMcpToolRegistrationHost";
 import { appLogger } from "./lib/logging/runtime";
 import {
   getConfiguredAgentEndpoint,
@@ -166,6 +167,7 @@ function App({ branding }: AppProps) {
                     >
                       <OutputProvider>
                         <NotebookProvider>
+                          <WebMcpToolRegistrationHost />
                           <SidePanelProvider>
                             <GlobalToast />
                             <AppRouter />

--- a/app/src/components/ChatKit/ChatKitPanel.tsx
+++ b/app/src/components/ChatKit/ChatKitPanel.tsx
@@ -8,11 +8,6 @@ import {
 } from 'react'
 import { ChatKit, useChatKit } from '../../lib/runtime/chatkitReact'
 import {
-  parser_pb,
-} from '../../contexts/CellContext'
-import { useNotebookContext } from '../../contexts/NotebookContext'
-import { useCurrentDoc } from '../../contexts/CurrentDocContext'
-import {
   useHarness,
   getHarnessManager,
   buildChatkitUrl,
@@ -21,7 +16,6 @@ import {
 import {
   buildCodexChatKitFetchOptions,
 } from '../../lib/runtime/codexChatKitAdapter'
-import { createCodeModeExecutor } from '../../lib/runtime/codeModeExecutor'
 import { createChatKitFetchFromAdapter } from '../../lib/runtime/createChatKitFetchFromAdapter'
 import {
   getCodexConversationController,
@@ -48,6 +42,7 @@ import {
   responsesDirectConfigManager,
   useResponsesDirectConfigSnapshot,
 } from '../../lib/runtime/responsesDirectConfigManager'
+import { useCodeModeExecutor } from '../../lib/runtime/useCodeModeExecutor'
 
 import { getAccessToken, getAuthData } from '../../token'
 import { getBrowserAdapter } from '../../browserAdapter.client'
@@ -380,22 +375,11 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
   } | null>(null)
   const lastAppliedThreadRef = useRef<string | null>(null)
   const harnessRuntimeManager = useMemo(() => getHarnessRuntimeManager(), [])
-  const { getNotebookData, useNotebookList } =
-    useNotebookContext()
-  const { getCurrentDoc } = useCurrentDoc()
   const responsesDirectConfig = useResponsesDirectConfigSnapshot()
   const codexProjects = useCodexProjects()
   const { defaultProject } = codexProjects
   const codexConversation = useCodexConversationSnapshot()
   const conversationSnapshot = useConversationControllerSnapshot(activeController)
-  const currentDocUri = getCurrentDoc()
-  const openNotebookList = useNotebookList()
-  const getNotebookDataRef = useRef(getNotebookData)
-  getNotebookDataRef.current = getNotebookData
-  const openNotebookListRef = useRef(openNotebookList)
-  openNotebookListRef.current = openNotebookList
-  const currentDocUriRef = useRef(currentDocUri)
-  currentDocUriRef.current = currentDocUri
   const currentThreadId = conversationSnapshot?.currentThreadId ?? null
   const selectedModel =
     conversationSnapshot?.selectedModel ??
@@ -403,70 +387,7 @@ function ChatKitPanelInner({ defaultHarness }: ChatKitPanelInnerProps) {
     DEFAULT_CHAT_MODEL
   const drawerThreads = conversationSnapshot?.threads ?? []
 
-  const resolveCodeModeNotebook = useCallback(
-    (target?: unknown) => {
-      const targetUri =
-        typeof target === 'string'
-          ? target
-          : typeof target === 'object' && target && 'uri' in target
-            ? (target as { uri?: string }).uri
-            : typeof target === 'object' &&
-                target &&
-                'handle' in target &&
-                (target as { handle?: { uri?: string } }).handle?.uri
-              ? (target as { handle?: { uri?: string } }).handle?.uri
-              : currentDocUriRef.current
-      if (!targetUri) {
-        return null
-      }
-      const data = getNotebookDataRef.current(targetUri)
-      if (!data) {
-        return null
-      }
-
-      return {
-        getUri: () => data.getUri(),
-        getName: () => data.getName(),
-        getNotebook: () => data.getNotebook(),
-        updateCell: (cell: parser_pb.Cell) => data.updateCell(cell),
-        getCell: (refId: string) => data.getCell(refId),
-        appendCodeCell: data.appendCodeCell?.bind(data),
-        addCodeCellAfter: data.addCodeCellAfter?.bind(data),
-        addCodeCellBefore: data.addCodeCellBefore?.bind(data),
-        removeCell: data.removeCell?.bind(data),
-      }
-    },
-    []
-  )
-
-  const codeModeExecutor = useMemo(
-    () =>
-      createCodeModeExecutor({
-        mode: 'sandbox',
-        resolveNotebook: resolveCodeModeNotebook,
-        listNotebooks: () => {
-          const uris = new Set<string>()
-          for (const notebook of openNotebookListRef.current) {
-            if (typeof notebook?.uri === 'string' && notebook.uri.trim()) {
-              uris.add(notebook.uri)
-            }
-          }
-          if (currentDocUriRef.current) {
-            uris.add(currentDocUriRef.current)
-          }
-          return Array.from(uris)
-            .map((uri) => resolveCodeModeNotebook(uri))
-            .filter(
-              (
-                notebook
-              ): notebook is NonNullable<
-                ReturnType<typeof resolveCodeModeNotebook>
-              > => Boolean(notebook)
-            )
-        },
-      }),
-    [resolveCodeModeNotebook]
-  )
+  const codeModeExecutor = useCodeModeExecutor({ mode: 'sandbox' })
 
   const handleCodexBridgeToolCall = useMemo(
     () =>

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+const { executeMock, appLoggerMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  appLoggerMock: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../lib/runtime/useCodeModeExecutor", () => ({
+  useCodeModeExecutor: () => ({
+    execute: executeMock,
+  }),
+}));
+
+vi.mock("../../lib/logging/runtime", () => ({
+  appLogger: appLoggerMock,
+}));
+
+import WebMcpToolRegistrationHost from "./WebMcpToolRegistrationHost";
+
+describe("WebMcpToolRegistrationHost", () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    executeMock.mockResolvedValue({ output: "webmcp output" });
+    appLoggerMock.debug.mockReset();
+    appLoggerMock.info.mockReset();
+    appLoggerMock.error.mockReset();
+    delete (navigator as Navigator & { modelContext?: unknown }).modelContext;
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (navigator as Navigator & { modelContext?: unknown }).modelContext;
+  });
+
+  it("skips registration when navigator.modelContext is unavailable", () => {
+    render(<WebMcpToolRegistrationHost />);
+
+    expect(appLoggerMock.debug).toHaveBeenCalledWith(
+      "WebMCP unavailable; skipping tool registration",
+      expect.objectContaining({
+        attrs: expect.objectContaining({
+          scope: "webmcp",
+        }),
+      }),
+    );
+  });
+
+  it("registers ExecuteCode and unregisters it on cleanup", async () => {
+    let registered:
+      | {
+          tool: {
+            name: string;
+            title: string;
+            description: string;
+            inputSchema: Record<string, unknown>;
+            annotations: {
+              readOnlyHint: boolean;
+              untrustedContentHint: boolean;
+            };
+            execute: (input: { code?: unknown }) => Promise<string>;
+          };
+          signal?: AbortSignal;
+        }
+      | undefined;
+    const registerTool = vi.fn((tool, options?: { signal?: AbortSignal }) => {
+      registered = {
+        tool,
+        signal: options?.signal,
+      };
+    });
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: {
+        registerTool,
+      },
+    });
+
+    const rendered = render(<WebMcpToolRegistrationHost />);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registered?.tool.name).toBe("ExecuteCode");
+    expect(registered?.tool.title).toBe("Runme Execute Code");
+    expect(registered?.tool.annotations).toEqual({
+      readOnlyHint: false,
+      untrustedContentHint: true,
+    });
+    expect(registered?.tool.inputSchema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        code: { type: "string" },
+      },
+      required: ["code"],
+    });
+
+    await expect(
+      registered?.tool.execute({
+        code: "console.log('hello')",
+      }),
+    ).resolves.toBe("webmcp output");
+    expect(executeMock).toHaveBeenCalledWith({
+      code: "console.log('hello')",
+      source: "webmcp",
+    });
+
+    expect(registered?.signal?.aborted).toBe(false);
+    rendered.unmount();
+    expect(registered?.signal?.aborted).toBe(true);
+  });
+});

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -1,0 +1,116 @@
+import { useEffect } from "react";
+
+import { appLogger } from "../../lib/logging/runtime";
+import {
+  buildExecuteCodeInputSchema,
+  EXECUTE_CODE_TOOL_DESCRIPTION,
+  EXECUTE_CODE_TOOL_NAME,
+  EXECUTE_CODE_TOOL_TITLE,
+} from "../../lib/runtime/executeCodeTool";
+import { useCodeModeExecutor } from "../../lib/runtime/useCodeModeExecutor";
+
+type ModelContextClientLike = {
+  requestUserInteraction?: (callback: () => Promise<unknown> | unknown) => Promise<unknown>;
+};
+
+type ModelContextLike = {
+  registerTool: (
+    tool: {
+      name: string;
+      title: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+      annotations: {
+        readOnlyHint: boolean;
+        untrustedContentHint: boolean;
+      };
+      execute: (input: { code?: unknown }, client: ModelContextClientLike) => Promise<string>;
+    },
+    options?: { signal?: AbortSignal },
+  ) => void;
+};
+
+function getModelContext(): ModelContextLike | null {
+  if (typeof navigator === "undefined") {
+    return null;
+  }
+  const modelContext = (navigator as Navigator & {
+    modelContext?: Partial<ModelContextLike>;
+  }).modelContext;
+  if (!modelContext || typeof modelContext.registerTool !== "function") {
+    return null;
+  }
+  return modelContext as ModelContextLike;
+}
+
+export default function WebMcpToolRegistrationHost() {
+  const codeModeExecutor = useCodeModeExecutor({ mode: "sandbox" });
+
+  useEffect(() => {
+    const modelContext = getModelContext();
+    if (!modelContext) {
+      appLogger.debug("WebMCP unavailable; skipping tool registration", {
+        attrs: {
+          scope: "webmcp",
+        },
+      });
+      return;
+    }
+
+    const registrationController = new AbortController();
+
+    try {
+      modelContext.registerTool(
+        {
+          name: EXECUTE_CODE_TOOL_NAME,
+          title: EXECUTE_CODE_TOOL_TITLE,
+          description: EXECUTE_CODE_TOOL_DESCRIPTION,
+          inputSchema: buildExecuteCodeInputSchema(),
+          annotations: {
+            readOnlyHint: false,
+            untrustedContentHint: true,
+          },
+          execute: async (input) => {
+            const code =
+              typeof input?.code === "string" ? input.code : String(input?.code ?? "");
+            const result = await codeModeExecutor.execute({
+              code,
+              source: "webmcp",
+            });
+            return result.output;
+          },
+        },
+        {
+          signal: registrationController.signal,
+        },
+      );
+      appLogger.info("WebMCP ExecuteCode tool registered", {
+        attrs: {
+          scope: "webmcp",
+          toolName: EXECUTE_CODE_TOOL_NAME,
+        },
+      });
+    } catch (error) {
+      appLogger.error("Failed to register WebMCP tool", {
+        attrs: {
+          scope: "webmcp",
+          toolName: EXECUTE_CODE_TOOL_NAME,
+          error: String(error),
+        },
+      });
+      return;
+    }
+
+    return () => {
+      registrationController.abort();
+      appLogger.info("WebMCP ExecuteCode tool unregistered", {
+        attrs: {
+          scope: "webmcp",
+          toolName: EXECUTE_CODE_TOOL_NAME,
+        },
+      });
+    };
+  }, [codeModeExecutor]);
+
+  return null;
+}

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -17,7 +17,7 @@ import {
   SandboxJSKernel,
 } from './sandboxJsKernel'
 
-export type CodeModeSource = 'chatkit' | 'codex'
+export type CodeModeSource = 'chatkit' | 'codex' | 'webmcp'
 export type CodeModeRunnerMode = 'browser' | 'sandbox'
 
 const DEFAULT_TIMEOUT_MS = 15_000

--- a/app/src/lib/runtime/executeCodeTool.ts
+++ b/app/src/lib/runtime/executeCodeTool.ts
@@ -1,0 +1,29 @@
+type JsonRecord = Record<string, unknown>
+
+export const EXECUTE_CODE_TOOL_NAME = 'ExecuteCode'
+export const EXECUTE_CODE_TOOL_TITLE = 'Runme Execute Code'
+export const EXECUTE_CODE_TOOL_DESCRIPTION =
+  'Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr output string.'
+
+export function buildExecuteCodeInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      code: {
+        type: 'string',
+      },
+    },
+    required: ['code'],
+  }
+}
+
+export function buildResponsesExecuteCodeToolDefinition(): JsonRecord {
+  return {
+    type: 'function',
+    name: EXECUTE_CODE_TOOL_NAME,
+    description: EXECUTE_CODE_TOOL_DESCRIPTION,
+    strict: true,
+    parameters: buildExecuteCodeInputSchema(),
+  }
+}

--- a/app/src/lib/runtime/responsesDirectChatKitAdapter.ts
+++ b/app/src/lib/runtime/responsesDirectChatKitAdapter.ts
@@ -9,6 +9,10 @@ import type {
   ConversationStreamSink,
 } from './conversationController'
 import { createChatKitFetchFromAdapter } from './createChatKitFetchFromAdapter'
+import {
+  buildResponsesExecuteCodeToolDefinition,
+  EXECUTE_CODE_TOOL_NAME,
+} from './executeCodeTool'
 import type {
   HarnessChatKitAdapter,
   HarnessChatKitEventSink,
@@ -32,30 +36,9 @@ type StoredThread = {
 
 const DEFAULT_OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
 const DEFAULT_MODEL = 'gpt-5.2'
-const EXECUTE_CODE_TOOL_NAME = 'ExecuteCode'
-
-function buildCodeModeToolDefinition(): JsonRecord {
-  return {
-    type: 'function',
-    name: EXECUTE_CODE_TOOL_NAME,
-    description:
-      'Execute JavaScript in AppKernel and return one merged stdout/stderr output string.',
-    strict: true,
-    parameters: {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        code: {
-          type: 'string',
-        },
-      },
-      required: ['code'],
-    },
-  }
-}
 
 function buildResponsesTools(vectorStores: string[]): JsonRecord[] {
-  const tools: JsonRecord[] = [buildCodeModeToolDefinition()]
+  const tools: JsonRecord[] = [buildResponsesExecuteCodeToolDefinition()]
   if (vectorStores.length > 0) {
     tools.push({
       type: 'file_search',

--- a/app/src/lib/runtime/useCodeModeExecutor.ts
+++ b/app/src/lib/runtime/useCodeModeExecutor.ts
@@ -1,0 +1,88 @@
+import { useCallback, useMemo, useRef } from 'react'
+
+import { parser_pb } from '../../contexts/CellContext'
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useNotebookContext } from '../../contexts/NotebookContext'
+import {
+  type CodeModeExecutor,
+  type CodeModeRunnerMode,
+  createCodeModeExecutor,
+} from './codeModeExecutor'
+
+export function useCodeModeExecutor(options?: {
+  mode?: CodeModeRunnerMode
+}): CodeModeExecutor {
+  const mode = options?.mode ?? 'sandbox'
+  const { getNotebookData, useNotebookList } = useNotebookContext()
+  const { getCurrentDoc } = useCurrentDoc()
+  const currentDocUri = getCurrentDoc()
+  const openNotebookList = useNotebookList()
+  const getNotebookDataRef = useRef(getNotebookData)
+  getNotebookDataRef.current = getNotebookData
+  const openNotebookListRef = useRef(openNotebookList)
+  openNotebookListRef.current = openNotebookList
+  const currentDocUriRef = useRef(currentDocUri)
+  currentDocUriRef.current = currentDocUri
+
+  const resolveCodeModeNotebook = useCallback((target?: unknown) => {
+    const targetUri =
+      typeof target === 'string'
+        ? target
+        : typeof target === 'object' && target && 'uri' in target
+          ? (target as { uri?: string }).uri
+          : typeof target === 'object' &&
+              target &&
+              'handle' in target &&
+              (target as { handle?: { uri?: string } }).handle?.uri
+            ? (target as { handle?: { uri?: string } }).handle?.uri
+            : currentDocUriRef.current
+    if (!targetUri) {
+      return null
+    }
+    const data = getNotebookDataRef.current(targetUri)
+    if (!data) {
+      return null
+    }
+
+    return {
+      getUri: () => data.getUri(),
+      getName: () => data.getName(),
+      getNotebook: () => data.getNotebook(),
+      updateCell: (cell: parser_pb.Cell) => data.updateCell(cell),
+      getCell: (refId: string) => data.getCell(refId),
+      appendCodeCell: data.appendCodeCell?.bind(data),
+      addCodeCellAfter: data.addCodeCellAfter?.bind(data),
+      addCodeCellBefore: data.addCodeCellBefore?.bind(data),
+      removeCell: data.removeCell?.bind(data),
+    }
+  }, [])
+
+  return useMemo(
+    () =>
+      createCodeModeExecutor({
+        mode,
+        resolveNotebook: resolveCodeModeNotebook,
+        listNotebooks: () => {
+          const uris = new Set<string>()
+          for (const notebook of openNotebookListRef.current) {
+            if (typeof notebook?.uri === 'string' && notebook.uri.trim()) {
+              uris.add(notebook.uri)
+            }
+          }
+          if (currentDocUriRef.current) {
+            uris.add(currentDocUriRef.current)
+          }
+          return Array.from(uris)
+            .map((uri) => resolveCodeModeNotebook(uri))
+            .filter(
+              (
+                notebook
+              ): notebook is NonNullable<
+                ReturnType<typeof resolveCodeModeNotebook>
+              > => Boolean(notebook)
+            )
+        },
+      }),
+    [mode, resolveCodeModeNotebook]
+  )
+}

--- a/docs-dev/design/20260510_webmcp.md
+++ b/docs-dev/design/20260510_webmcp.md
@@ -1,0 +1,435 @@
+# 20260510 WebMCP Tool Support
+
+## Status
+
+Draft proposal.
+
+## Summary
+
+Add WebMCP support to the web app by registering one browser tool through
+`navigator.modelContext.registerTool(...)` when the API is available.
+
+The tool will reuse the existing AppKernel code-mode path:
+
+- input: `{ code: string }`
+- execution: AppKernel sandbox
+- result: one merged stdout/stderr string
+
+We will not add a new execution stack, a new backend endpoint, or a WebMCP-only
+tool contract. The main work is registration, lifecycle management, and
+reusing the existing browser executor outside `ChatKitPanel`.
+
+## Goals
+
+- Expose one WebMCP tool to browser agents.
+- Reuse the existing sandbox `CodeModeExecutor`.
+- Keep the tool contract aligned with the existing `ExecuteCode` capability.
+- Register the tool only when WebMCP is actually available in the browser.
+- Keep the feature inert in browsers that do not implement WebMCP.
+
+## Non-Goals
+
+- Supporting multiple WebMCP tools in v0.
+- Adding a backend or MCP transport for WebMCP.
+- Replacing the existing ChatKit, Responses, or Codex tool paths.
+- Designing a confirmation UI for tool execution in v0.
+- Using declarative WebMCP. We only need imperative registration.
+
+## Relevant Current State
+
+The execution path already exists.
+
+- `app/src/lib/runtime/codeModeExecutor.ts` executes JavaScript in AppKernel,
+  defaults to sandbox mode, merges stdout/stderr, enforces timeout and output
+  limits, and returns `{ output: string }`.
+- `app/src/lib/runtime/notebookToolHandlers.ts` already routes existing
+  `ExecuteCode`-style tool calls to `CodeModeExecutor`.
+- `app/src/lib/runtime/responsesDirectChatKitAdapter.ts` already defines a
+  single browser-local `ExecuteCode` tool for Responses.
+- `app/src/components/ChatKit/ChatKitPanel.tsx` already knows how to resolve
+  the current notebook and open notebook list, then build a shared
+  `CodeModeExecutor`.
+
+The missing piece is a browser-global registration path that is not coupled to
+opening the AI panel.
+
+## Why WebMCP Fits This Architecture
+
+The WebMCP spec is a browser API for exposing site-defined tools to browser
+agents. The current draft published on April 23, 2026 defines:
+
+- `navigator.modelContext` on `Navigator`
+- `modelContext.registerTool(tool, options?)`
+- imperative tool registration with a JSON-schema-like `inputSchema`
+- `AbortSignal`-driven unregistration
+
+That maps cleanly onto Runme's existing browser-local tool execution model. We
+already execute code in-browser and already have a narrow single-tool contract.
+WebMCP only needs a registration shell around that executor.
+
+## Proposal
+
+### Tool shape
+
+Register one tool named `ExecuteCode`.
+
+Reason:
+
+- the name already exists in `responsesDirectChatKitAdapter.ts`
+- the user asked for one execute-code tool
+- reusing the same name reduces drift across browser-agent entry points
+
+Proposed WebMCP registration object:
+
+```ts
+const tool = {
+  name: "ExecuteCode",
+  title: "Runme Execute Code",
+  description:
+    "Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr string.",
+  inputSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      code: { type: "string" },
+    },
+    required: ["code"],
+  },
+  annotations: {
+    readOnlyHint: false,
+    untrustedContentHint: true,
+  },
+  async execute(input: { code: string }) {
+    const result = await codeModeExecutor.execute({
+      code: input.code,
+      source: "webmcp",
+    });
+    return result.output;
+  },
+};
+```
+
+Notes:
+
+- `readOnlyHint` is false because executed code can mutate notebook state.
+- `untrustedContentHint` should be true because the returned string may contain
+  notebook content, network content, or arbitrary program output emitted by the
+  executed code.
+- The external WebMCP return value is a string. Internally we still reuse
+  `CodeModeExecutor` and its `{ output }` result.
+
+### Availability check
+
+Register only when all of these are true:
+
+```ts
+const isWebMcpAvailable =
+  typeof navigator !== "undefined" &&
+  typeof navigator.modelContext !== "undefined" &&
+  typeof navigator.modelContext?.registerTool === "function";
+```
+
+`navigator.modelContext` presence is the right first gate. Checking
+`registerTool` as a function keeps the detection resilient to partial or
+experimental browser implementations.
+
+The spec marks `navigator.modelContext` as a secure-context API. In practice,
+that means this should only work where the browser exposes it, typically under
+HTTPS or localhost-style development contexts.
+
+If the check fails, do nothing and log one debug event.
+
+### Registration lifecycle
+
+Register once near the app root, not inside `ChatKitPanel`.
+
+Reason:
+
+- WebMCP is a page capability, not an AI-panel capability.
+- Browser agents should be able to discover the tool whenever the app is open.
+- `ChatKitPanel` may never mount in a session.
+
+Use `AbortController` so cleanup automatically unregisters the tool:
+
+```ts
+const controller = new AbortController();
+navigator.modelContext.registerTool(tool, { signal: controller.signal });
+return () => controller.abort();
+```
+
+This follows the spec and keeps dev/HMR behavior manageable.
+
+### Execution ownership
+
+We should not duplicate the notebook-resolution logic currently embedded in
+`ChatKitPanel`.
+
+Instead, extract the shared executor setup into a reusable hook or helper, for
+example:
+
+```ts
+type UseCodeModeExecutorOptions = {
+  mode?: "browser" | "sandbox";
+};
+
+function useCodeModeExecutor(
+  options?: UseCodeModeExecutorOptions,
+): CodeModeExecutor;
+```
+
+This hook should own:
+
+- resolving the current notebook from `CurrentDocContext`
+- enumerating open notebooks from `NotebookContext`
+- adapting `NotebookData` into the `NotebookDataLike` shape expected by
+  `createCodeModeExecutor(...)`
+
+Then:
+
+- `ChatKitPanel` uses the shared hook
+- the new WebMCP registration host uses the same hook
+
+That is the main code reuse win in this design.
+
+## Proposed Components
+
+### 1. Shared tool-definition module
+
+Add a small shared module for the execute-code tool metadata so Responses and
+WebMCP do not drift.
+
+Example:
+
+```ts
+export const EXECUTE_CODE_TOOL_NAME = "ExecuteCode";
+
+export function buildExecuteCodeInputSchema() {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      code: { type: "string" },
+    },
+    required: ["code"],
+  };
+}
+
+export function getExecuteCodeDescription(): string {
+  return "Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr string.";
+}
+```
+
+Consumers:
+
+- `responsesDirectChatKitAdapter.ts`
+- new WebMCP registrar
+
+We do not need to refactor the proto-based Codex bridge in this change.
+
+### 1a. Explicit source for logs
+
+Extend `CodeModeSource` in `codeModeExecutor.ts` from:
+
+```ts
+type CodeModeSource = "chatkit" | "codex";
+```
+
+to:
+
+```ts
+type CodeModeSource = "chatkit" | "codex" | "webmcp";
+```
+
+This is not required for functionality, but it makes logs and future metrics
+honest. WebMCP should not be reported as ChatKit traffic.
+
+### 2. Shared executor hook
+
+Extract the executor-building logic from `ChatKitPanel.tsx` into a reusable hook
+under `app/src/lib/runtime/`, for example:
+
+- `useCodeModeExecutor.ts`
+
+This should wrap `createCodeModeExecutor(...)` and keep the current behavior:
+
+- sandbox mode by default
+- current notebook fallback
+- access to all open notebooks
+
+### 3. WebMCP registration host
+
+Add a small React host component, for example:
+
+- `app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx`
+
+Responsibilities:
+
+- feature-detect WebMCP
+- build the shared `CodeModeExecutor`
+- call `registerTool(...)` in an effect
+- unregister on cleanup
+- emit structured logs
+
+Mount it once inside `App.tsx` after the notebook/current-doc providers are
+available.
+
+Recommended placement:
+
+```tsx
+<NotebookProvider>
+  <WebMcpToolRegistrationHost />
+  <SidePanelProvider>
+    <GlobalToast />
+    <AppRouter />
+  </SidePanelProvider>
+</NotebookProvider>
+```
+
+This keeps registration independent of the side panel while preserving access
+to notebook state.
+
+## Execution Flow
+
+```mermaid
+flowchart TD
+    A["Browser loads Runme page"] --> B{"navigator.modelContext available?"}
+    B -- "no" --> C["No-op; feature remains disabled"]
+    B -- "yes" --> D["WebMcpToolRegistrationHost registers ExecuteCode"]
+    D --> E["Browser agent discovers tool"]
+    E --> F["Agent calls ExecuteCode { code }"]
+    F --> G["CodeModeExecutor.execute({ code, source: 'webmcp' })"]
+    G --> H["SandboxJSKernel runs AppKernel JS"]
+    H --> I["stdout/stderr merged into one string"]
+    I --> J["WebMCP tool returns string result"]
+```
+
+## Error Handling And Limits
+
+We should keep the same runtime limits already enforced by
+`createCodeModeExecutor(...)`.
+
+Current defaults:
+
+- timeout: 15 seconds
+- max output: 256 KB
+- max code payload: 64 KB
+
+Behavior:
+
+- normal completion returns the merged output string
+- execution failure throws, while preserving partial output inside the executor
+- WebMCP callback should convert failures into a returned string only if the
+  browser agent ecosystem proves incompatible with thrown tool errors
+
+Recommendation for v0:
+
+- start by letting the callback throw on execution failure
+- include structured logs with `source: "webmcp"`
+- only add special error wrapping if a target browser requires it
+
+## Security And Product Constraints
+
+- WebMCP registration must be opt-in by browser capability, not by user-agent
+  sniffing.
+- Execution stays in the existing AppKernel sandbox path.
+- The tool is intentionally powerful. It can read and mutate notebook state
+  through the same AppKernel APIs already used by ChatKit code mode.
+- We should not expose extra globals for WebMCP. It should inherit the exact
+  AppKernel environment already approved for `CodeModeExecutor`.
+
+## Backend Impact
+
+There should be no backend work in v0.
+
+- no new Runme endpoint
+- no new MCP server registration
+- no proto change required for the browser registration path
+- no Codex app-server change required
+
+This is strictly a browser-app integration that wraps existing local execution.
+
+## Logging
+
+Add one structured event for each of these cases:
+
+- WebMCP unavailable
+- WebMCP tool registered
+- WebMCP tool unregistered
+- WebMCP registration failed
+- WebMCP tool execution started/completed/failed
+
+Most execution logs already exist in `codeModeExecutor.ts`. The main gap is
+using a distinct `source: "webmcp"` value.
+
+## Test Plan
+
+### Unit
+
+- `isWebMcpAvailable` returns false when `navigator.modelContext` is missing
+- registrar calls `registerTool(...)` once when available
+- cleanup aborts the registration signal
+- registered callback invokes `CodeModeExecutor.execute(...)`
+- registered callback returns the merged output string
+
+### Integration
+
+- fake `navigator.modelContext` in jsdom and verify root registration
+- verify the registered tool can call notebook helpers through the existing
+  AppKernel sandbox bridge
+- verify the app does nothing in browsers without WebMCP support
+
+### Regression
+
+- `ChatKitPanel` still uses the same shared executor after extraction
+- Responses-direct `ExecuteCode` behavior remains unchanged
+
+## Rollout
+
+Phase 0:
+
+- Land the shared hook and WebMCP registration behind availability detection
+- no product UI required
+
+Phase 1:
+
+- Add light diagnostics in the Logs pane or App Console if we need easier
+  debugging for early browser implementations
+
+## Open Questions
+
+- Should we keep the tool name `ExecuteCode`, or use a namespaced variant such
+  as `runme.execute_code` for browser-agent clarity?
+- Do target browser-agent implementations treat thrown tool errors better than
+  stringified failure results?
+- Do we want an app-level feature flag in addition to capability detection, or
+  is capability detection sufficient for v0?
+- Should write-capable AppKernel helpers eventually request explicit user
+  interaction through `ModelContextClient.requestUserInteraction(...)` when that
+  part of the spec and browser behavior stabilizes?
+
+## Implementation Decision
+
+We will implement WebMCP as a thin browser registration layer over the existing
+sandbox code-mode executor.
+
+We will:
+
+- register one `ExecuteCode` tool through `navigator.modelContext`
+- reuse `createCodeModeExecutor(...)`
+- extract the executor setup from `ChatKitPanel` into a shared hook
+- mount a root-level registration host in `App.tsx`
+- no-op when `navigator.modelContext` is not defined
+
+We will not:
+
+- add a new backend service
+- add a parallel execution runtime
+- couple WebMCP registration to the AI panel
+
+## References
+
+- WebMCP draft, April 23, 2026: https://webmachinelearning.github.io/webmcp/
+- `app/src/lib/runtime/codeModeExecutor.ts`
+- `app/src/lib/runtime/notebookToolHandlers.ts`
+- `app/src/lib/runtime/responsesDirectChatKitAdapter.ts`
+- `app/src/components/ChatKit/ChatKitPanel.tsx`

--- a/docs-dev/index.md
+++ b/docs-dev/index.md
@@ -15,5 +15,6 @@ This directory organizes implementation-facing documentation.
 
 - CUJ: `docs-dev/CUJs/copy-current-notebook-to-drive.md`
 - Drive design: `docs-dev/design/20260224_drive.md`
+- WebMCP design: `docs-dev/design/20260510_webmcp.md`
 - Configuration architecture: `docs-dev/architecture/configuration.md`
 - Drive testing strategy: `testing.md`


### PR DESCRIPTION
## Summary
- register a browser-global WebMCP `ExecuteCode` tool when `navigator.modelContext.registerTool` is available
- reuse the existing sandbox `CodeModeExecutor` via a shared `useCodeModeExecutor` hook and shared execute-code tool metadata
- mount the registrar at the app root, keep ChatKit on the same executor path, and add design notes plus WebMCP registration tests

## Testing
- `pnpm exec vitest run app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx app/src/components/ChatKit/ChatKitPanel.test.tsx app/src/lib/runtime/responsesDirectChatKitAdapter.test.ts app/src/lib/runtime/codeModeExecutor.test.ts`
- `runme run build test`

## Notes
- `pnpm run lint` currently fails in this workspace because the `eslint` binary is not installed on PATH despite the script existing.