### PR TITLE
Add notebook stdin UX design docs

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -231,6 +231,34 @@ describe("Action component", () => {
     expect(screen.queryByTestId("cell-console")).toBeNull();
   });
 
+  it("suppresses duplicate stdout output items while a live console stream is active", () => {
+    const stdoutOutput = create(parser_pb.CellOutputSchema, {
+      items: [
+        create(parser_pb.CellOutputItemSchema, {
+          mime: "application/vnd.code.notebook.stdout",
+          type: "Buffer",
+          data: new TextEncoder().encode("prompt"),
+        }),
+      ],
+    });
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-live-stdout",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [stdoutOutput],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "run-live-stdout",
+      },
+      value: "echo hi",
+    });
+    const stub = new StubCellData(cell) as unknown as CellData;
+
+    render(<Action cellData={stub} isFirst={false} />);
+
+    expect(screen.getByTestId("cell-console")).toBeTruthy();
+    expect(screen.queryByText(/mime=application\/vnd\.code\.notebook\.stdout/)).toBeNull();
+  });
+
   it("shows language selector in markdown edit mode and converts to code language", () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-md",

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -460,7 +460,13 @@ function ActionOutputItemView({
   );
 }
 
-export function ActionOutputItems({ outputs }: { outputs: parser_pb.CellOutput[] }) {
+export function ActionOutputItems({
+  outputs,
+  suppressStdText = false,
+}: {
+  outputs: parser_pb.CellOutput[];
+  suppressStdText?: boolean;
+}) {
   const hasTerminalOutput = outputs.some((output) =>
     (output.items ?? []).some((item) => item?.mime === MimeType.StatefulRunmeTerminal),
   );
@@ -476,7 +482,7 @@ export function ActionOutputItems({ outputs }: { outputs: parser_pb.CellOutput[]
           return null;
         }
         if (
-          hasTerminalOutput &&
+          (hasTerminalOutput || suppressStdText) &&
           (mime === MimeType.VSCodeNotebookStdOut || mime === MimeType.VSCodeNotebookStdErr)
         ) {
           return null;
@@ -962,8 +968,13 @@ export function Action({
     if (!cell?.outputs || cell.outputs.length === 0) {
       return null;
     }
-    return <ActionOutputItems outputs={cell.outputs} />;
-  }, [cell?.outputs]);
+    return (
+      <ActionOutputItems
+        outputs={cell.outputs}
+        suppressStdText={Boolean(cellData.getStreams())}
+      />
+    );
+  }, [cell?.outputs, cellData]);
 
   const handleLanguageChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {

--- a/app/src/components/Actions/CellConsole.test.tsx
+++ b/app/src/components/Actions/CellConsole.test.tsx
@@ -182,8 +182,12 @@ describe("CellConsole", () => {
     const input = screen.getByTestId("cell-stdin-input") as HTMLInputElement;
     const submit = screen.getByTestId("cell-stdin-submit") as HTMLButtonElement;
     expect(screen.getByText("Provide input")).toBeTruthy();
+    expect(screen.queryByTestId("cell-stdin-help")).toBeNull();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Explain standard input"));
+    });
     expect(
-      screen.getByLabelText(/Send one line of standard input to the running process/),
+      screen.getByText(/Send one line of standard input to the running process/),
     ).toBeTruthy();
     expect(submit.disabled).toBe(true);
 

--- a/app/src/components/Actions/CellConsole.test.tsx
+++ b/app/src/components/Actions/CellConsole.test.tsx
@@ -181,6 +181,10 @@ describe("CellConsole", () => {
 
     const input = screen.getByTestId("cell-stdin-input") as HTMLInputElement;
     const submit = screen.getByTestId("cell-stdin-submit") as HTMLButtonElement;
+    expect(screen.getByText("Provide input")).toBeTruthy();
+    expect(
+      screen.getByLabelText(/Send one line of standard input to the running process/),
+    ).toBeTruthy();
     expect(submit.disabled).toBe(true);
 
     await act(async () => {

--- a/app/src/components/Actions/CellConsole.test.tsx
+++ b/app/src/components/Actions/CellConsole.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
 
 // Mock runmedev/renderers to avoid registering the real web component,
 // which depends on adoptedStyleSheets and other browser-only APIs.
@@ -19,9 +20,11 @@ import CellConsole from "./CellConsole";
 
 class FakeCellData {
   snapshot: parser_pb.Cell;
+  private readonly stream: any;
 
-  constructor(cell: parser_pb.Cell) {
+  constructor(cell: parser_pb.Cell, stream?: any) {
     this.snapshot = cell;
+    this.stream = stream;
   }
 
   subscribe(_listener: () => void): () => void {
@@ -29,13 +32,39 @@ class FakeCellData {
   }
 
   getStreams() {
-    return undefined;
+    return this.stream;
   }
 
   getRunID() {
     const runID = this.snapshot.metadata?.[RunmeMetadataKey.LastRunID];
     return typeof runID === "string" ? runID : "";
   }
+}
+
+function createSubject<T>() {
+  const listeners = new Set<(value: T) => void>();
+  return {
+    subscribe(listener: (value: T) => void) {
+      listeners.add(listener);
+      return {
+        unsubscribe: () => listeners.delete(listener),
+      };
+    },
+    emit(value: T) {
+      listeners.forEach((listener) => listener(value));
+    },
+  };
+}
+
+function createFakeStream() {
+  return {
+    stdout: createSubject<Uint8Array>(),
+    stderr: createSubject<Uint8Array>(),
+    pid: createSubject<number>(),
+    exitCode: createSubject<number>(),
+    sendExecuteRequest: vi.fn(),
+    setCallback: vi.fn(),
+  };
 }
 
 // Minimal console-view stub so the component can construct it.
@@ -62,6 +91,30 @@ class FakeConsoleView extends HTMLElement {
 }
 
 describe("CellConsole", () => {
+  const roots: Array<ReactDOM.Root> = [];
+
+  function renderConsole(cellData: FakeCellData) {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const root = ReactDOM.createRoot(div);
+    roots.push(root);
+    act(() => {
+      root.render(
+        <CellConsole cellData={cellData as any} onExitCode={() => {}} onPid={() => {}} />,
+      );
+    });
+    return div;
+  }
+
+  afterEach(() => {
+    act(() => {
+      while (roots.length > 0) {
+        roots.pop()?.unmount();
+      }
+    });
+    document.body.innerHTML = "";
+  });
+
   it("renders existing stdout content from cell outputs", async () => {
     if (!customElements.get("console-view")) {
       customElements.define("console-view", FakeConsoleView);
@@ -95,15 +148,10 @@ describe("CellConsole", () => {
     });
 
     const cellData = new FakeCellData(cell);
-    const div = document.createElement("div");
-    document.body.appendChild(div);
+
+    const div = renderConsole(cellData);
 
     await act(async () => {
-      const root = ReactDOM.createRoot(div);
-      root.render(
-        <CellConsole cellData={cellData as any} onExitCode={() => {}} onPid={() => {}} />,
-      );
-      // Let effects flush
       await Promise.resolve();
     });
 
@@ -112,5 +160,73 @@ describe("CellConsole", () => {
     const spans = consoleEl?.querySelectorAll(".xterm-rows span") ?? [];
     const texts = Array.from(spans).map((s) => s.textContent);
     expect(texts.join("")).toContain("hello world");
+  });
+
+  it("shows a stdin composer for active streams and sends a newline-terminated write", async () => {
+    const stream = createFakeStream();
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-stdin",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "run-stdin",
+      },
+    });
+
+    await act(async () => {
+      renderConsole(new FakeCellData(cell, stream));
+      await Promise.resolve();
+    });
+
+    const input = screen.getByTestId("cell-stdin-input") as HTMLInputElement;
+    const submit = screen.getByTestId("cell-stdin-submit") as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "y" } });
+    });
+
+    expect(submit.disabled).toBe(false);
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("cell-stdin-form"));
+    });
+
+    expect(stream.sendExecuteRequest).toHaveBeenCalledTimes(1);
+    const request = stream.sendExecuteRequest.mock.calls[0][0] as {
+      inputData?: Uint8Array;
+    };
+    expect(new TextDecoder().decode(request.inputData)).toBe("y\n");
+    expect(input.value).toBe("");
+  });
+
+  it("renders partial stdout chunks immediately while the process is still running", async () => {
+    const stream = createFakeStream();
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-live-prompt",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "run-live",
+      },
+    });
+
+    let div: HTMLDivElement;
+    await act(async () => {
+      div = renderConsole(new FakeCellData(cell, stream));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      stream.stdout.emit(new TextEncoder().encode("Password:"));
+      await Promise.resolve();
+    });
+
+    const consoleEl = div!.querySelector("console-view") as FakeConsoleView | null;
+    const spans = consoleEl?.querySelectorAll(".xterm-rows span") ?? [];
+    const texts = Array.from(spans).map((s) => s.textContent).join("");
+    expect(texts).toContain("Password:");
   });
 });

--- a/app/src/components/Actions/CellConsole.tsx
+++ b/app/src/components/Actions/CellConsole.tsx
@@ -23,6 +23,8 @@ export const fontSettings = {
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
+const stdinHelpText =
+  "Send one line of standard input to the running process. This control is available while the process is active, even if it is not currently waiting for input.";
 
 function decodeOutputs(outputs: parser_pb.CellOutput[]): string {
   const parts: string[] = [];
@@ -253,8 +255,16 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
           data-testid="cell-stdin-form"
           onSubmit={handleSubmit}
         >
-          <div className="mb-2 text-[10px] font-medium uppercase tracking-wide text-[#8a5a2b]">
-            Waiting for input
+          <div className="mb-2 flex items-center gap-2 text-[10px] font-medium uppercase tracking-wide text-[#8a5a2b]">
+            <span>Provide input</span>
+            <button
+              type="button"
+              aria-label={stdinHelpText}
+              className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#c9b08f] bg-white text-[10px] leading-none text-[#8a5a2b]"
+              title={stdinHelpText}
+            >
+              ?
+            </button>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">
             <input

--- a/app/src/components/Actions/CellConsole.tsx
+++ b/app/src/components/Actions/CellConsole.tsx
@@ -102,6 +102,7 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
   const winsizeRef = useRef<{ cols: number; rows: number }>({ cols: 0, rows: 0 });
   const wroteInitialForRun = useRef<string | null>(null);
   const [stdinValue, setStdinValue] = useState("");
+  const [showStdinHelp, setShowStdinHelp] = useState(false);
 
   const cell =
     useSyncExternalStore(
@@ -255,16 +256,28 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
           data-testid="cell-stdin-form"
           onSubmit={handleSubmit}
         >
-          <div className="mb-2 flex items-center gap-2 text-[10px] font-medium uppercase tracking-wide text-[#8a5a2b]">
+          <div className="relative mb-2 flex items-center gap-2 text-[10px] font-medium uppercase tracking-wide text-[#8a5a2b]">
             <span>Provide input</span>
             <button
               type="button"
-              aria-label={stdinHelpText}
+              aria-controls={`stdin-help-${cell.refId}`}
+              aria-expanded={showStdinHelp}
+              aria-label="Explain standard input"
               className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#c9b08f] bg-white text-[10px] leading-none text-[#8a5a2b]"
-              title={stdinHelpText}
+              onClick={() => setShowStdinHelp((visible) => !visible)}
             >
               ?
             </button>
+            {showStdinHelp ? (
+              <div
+                className="absolute left-0 top-6 z-10 max-w-sm rounded-nb-xs border border-[#c9b08f] bg-white p-2 text-[11px] font-normal normal-case leading-relaxed tracking-normal text-nb-text shadow-nb-sm"
+                data-testid="cell-stdin-help"
+                id={`stdin-help-${cell.refId}`}
+                role="tooltip"
+              >
+                {stdinHelpText}
+              </div>
+            ) : null}
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">
             <input

--- a/app/src/components/Actions/CellConsole.tsx
+++ b/app/src/components/Actions/CellConsole.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useRef,
+  useState,
   useSyncExternalStore,
   type MutableRefObject,
 } from "react";
@@ -10,44 +11,15 @@ import {
   ExecuteRequestSchema,
   WinsizeSchema,
 } from "@buf/stateful_runme.bufbuild_es/runme/runner/v2/runner_pb";
-import { ClientMessages, setContext } from "@runmedev/renderers";
+import { ClientMessages } from "@runmedev/renderers";
 
 import { MimeType, RunmeMetadataKey, parser_pb } from "../../runme/client";
 import { CellData } from "../../lib/notebookData";
-import { maybeParseIPykernelMessage, type IPykernelMessage } from "../../lib/ipykernel";
 
 export const fontSettings = {
   fontSize: 12.6,
   fontFamily: "Fira Mono, monospace",
 };
-
-/**
- * Extract displayable text from an IPykernel message.
- * - "stream" messages contain print() output in content.text
- * - "error" messages contain exception info in content.ename/evalue/traceback
- * Returns the text to write to the terminal, or null if the message
- * is a control message that should be silently ignored.
- */
-function extractIopubText(msg: IPykernelMessage): string | null {
-  const msgType = msg.header?.msg_type ?? (msg as any).msg_type;
-
-  if (msgType === "stream") {
-    const text = typeof msg.content?.text === "string" ? msg.content.text : "";
-    return text || null;
-  }
-
-  if (msgType === "error") {
-    const ename = (msg.content as any)?.ename ?? "";
-    const evalue = (msg.content as any)?.evalue ?? "";
-    const traceback: string[] = Array.isArray((msg.content as any)?.traceback)
-      ? (msg.content as any).traceback
-      : [];
-    const text = [ename, evalue, ...traceback].filter(Boolean).join("\n");
-    return text ? text + "\n" : null;
-  }
-
-  return null;
-}
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
@@ -127,7 +99,7 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
   const pendingWrites = useRef<Uint8Array[]>([]);
   const winsizeRef = useRef<{ cols: number; rows: number }>({ cols: 0, rows: 0 });
   const wroteInitialForRun = useRef<string | null>(null);
-  const stdoutBufferRef = useRef("");
+  const [stdinValue, setStdinValue] = useState("");
 
   const cell =
     useSyncExternalStore(
@@ -136,6 +108,7 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
     ) || undefined;
 
   const runID = cellData.getRunID();
+  const stream = cellData.getStreams() as any;
 
   if (!cell || cell.kind !== parser_pb.CellKind.CODE) {
     return null;
@@ -185,7 +158,6 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
     // Write any recovered output into the terminal once it is ready.
     consoleEl.initialContent = "";
 
-    const stream = cellData.getStreams() as any;
     const disposers: Array<() => void> = [];
 
     const flushPending = () => {
@@ -224,42 +196,9 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
       }
     };
 
-    const flushStdoutBuffer = () => {
-      const pending = stdoutBufferRef.current;
-      if (!pending) {
-        return;
-      }
-      stdoutBufferRef.current = "";
-      const parsed = maybeParseIPykernelMessage(pending);
-      if (parsed) {
-        const text = extractIopubText(parsed);
-        if (text) {
-          writeToTerminal(textEncoder.encode(text));
-        }
-      } else {
-        writeToTerminal(textEncoder.encode(pending));
-      }
-    };
-
-    if (stream) { 
+    if (stream) {
       const stdoutSub = stream.stdout.subscribe((data: Uint8Array) => {
-        const chunkText = textDecoder.decode(data);
-        stdoutBufferRef.current += chunkText;
-
-        const lines = stdoutBufferRef.current.split("\n");
-        stdoutBufferRef.current = lines.pop() ?? "";
-
-        lines.forEach((line) => {
-          const parsed = maybeParseIPykernelMessage(line);
-          if (parsed) {
-            const text = extractIopubText(parsed);
-            if (text) {
-              writeToTerminal(textEncoder.encode(text));
-            }
-            return;
-          }
-          writeToTerminal(textEncoder.encode(`${line}\n`));
-        });
+        writeToTerminal(data);
       });
       disposers.push(() => stdoutSub.unsubscribe());
 
@@ -274,7 +213,6 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
       disposers.push(() => pidSub.unsubscribe());
 
       const exitSub = stream.exitCode.subscribe((code: number) => {
-        flushStdoutBuffer();
         onExitCode(code);
       });
       disposers.push(() => exitSub.unsubscribe());
@@ -285,15 +223,61 @@ const CellConsole = ({ cellData, onExitCode, onPid }: CellConsoleProps) => {
     };
     // Only recreate subscriptions/console when the run changes; callbacks are stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runID]);
+  }, [cellData, onExitCode, onPid, runID, stream]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const activeStream = cellData.getStreams() as any;
+    if (!activeStream) {
+      return;
+    }
+    const input = stdinValue.endsWith("\n") ? stdinValue : `${stdinValue}\n`;
+    const req = create(ExecuteRequestSchema, {
+      inputData: textEncoder.encode(input),
+    });
+    activeStream.sendExecuteRequest(req);
+    setStdinValue("");
+  };
 
   return (
-    <div
-      className="w-full"
-      data-runkey={`console-${cell.refId}-${runID ?? "idle"}`}
-      data-testid="cell-console"
-      ref={containerRef}
-    />
+    <div className="space-y-3">
+      <div
+        className="w-full"
+        data-runkey={`console-${cell.refId}-${runID ?? "idle"}`}
+        data-testid="cell-console"
+        ref={containerRef}
+      />
+      {stream ? (
+        <form
+          className="rounded-nb-sm border border-nb-border bg-[#fff8ef] p-3"
+          data-testid="cell-stdin-form"
+          onSubmit={handleSubmit}
+        >
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-wide text-[#8a5a2b]">
+            Waiting for input
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <input
+              aria-label="Cell stdin input"
+              className="min-w-0 flex-1 rounded-nb-xs border border-[#c9b08f] bg-white px-3 py-2 font-mono text-xs text-nb-text focus:outline-none focus:ring-1 focus:ring-nb-accent"
+              data-testid="cell-stdin-input"
+              onChange={(event) => setStdinValue(event.currentTarget.value)}
+              placeholder="Type one response and press Enter"
+              type="text"
+              value={stdinValue}
+            />
+            <button
+              className="rounded-nb-xs bg-[#9f4d2f] px-3 py-2 font-mono text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="cell-stdin-submit"
+              disabled={stdinValue.length === 0}
+              type="submit"
+            >
+              Send
+            </button>
+          </div>
+        </form>
+      ) : null}
+    </div>
   );
 };
 

--- a/app/src/lib/markdown/serializeNotebookToMarkdown.test.ts
+++ b/app/src/lib/markdown/serializeNotebookToMarkdown.test.ts
@@ -77,7 +77,7 @@ describe('serializeNotebookToMarkdown', () => {
     )
   })
 
-  it('serializes html cells as authored content instead of fenced code', () => {
+  it('serializes html cells as fenced code to preserve the language id', () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
         create(parser_pb.CellSchema, {
@@ -89,7 +89,9 @@ describe('serializeNotebookToMarkdown', () => {
     })
 
     expect(serializeNotebookToMarkdown(notebook)).toBe(
-      '<div><svg><text>Hello</text></svg></div>\n'
+      ['```html', '<div><svg><text>Hello</text></svg></div>', '```', ''].join(
+        '\n'
+      )
     )
   })
 

--- a/app/src/lib/markdown/serializeNotebookToMarkdown.ts
+++ b/app/src/lib/markdown/serializeNotebookToMarkdown.ts
@@ -1,5 +1,5 @@
 import { MimeType, parser_pb } from '../../runme/client'
-import { isHtmlLanguageId, isMarkdownLanguageId } from '../cellContent'
+import { isMarkdownLanguageId } from '../cellContent'
 
 const IOPUB_MIME_TYPE = 'application/vnd.jupyter.iopub+json'
 
@@ -43,9 +43,7 @@ function isAuthoredContentCell(cell: parser_pb.Cell): boolean {
   if (cell.kind === parser_pb.CellKind.MARKUP) {
     return true
   }
-  return (
-    isMarkdownLanguageId(cell.languageId) || isHtmlLanguageId(cell.languageId)
-  )
+  return isMarkdownLanguageId(cell.languageId)
 }
 
 function normalizeContentCell(value: string): string {

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -483,6 +483,36 @@ describe("NotebookData.getActiveStream", () => {
     expect(stream.sequence).toBe(7);
   });
 
+  it("clears recovered streams after the run exits", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-finished",
+      kind: parser_pb.CellKind.CODE,
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.Pid]: "1234",
+        [RunmeMetadataKey.LastRunID]: "existing-run",
+        [RunmeMetadataKey.Sequence]: "7",
+      },
+    });
+    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
+    const model = new NotebookData({
+      notebook,
+      uri: "nb://test",
+      name: "test",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    const stream = model.getActiveStream(cell.refId) as {
+      exitCode: Subject<number>;
+    };
+    expect(stream).toBeTruthy();
+
+    stream.exitCode.next(0);
+
+    expect(model.getActiveStream(cell.refId)).toBeUndefined();
+  });
+
   it("does not recover when exit code metadata is present", () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-exit",

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -135,6 +135,7 @@ export type StreamBinder = (args: {
     cell: parser_pb.Cell,
     options?: { transient?: boolean },
   ) => void;
+  onClose?: (refId: string) => void;
 }) => { dispose(): void };
 
 /**
@@ -150,6 +151,7 @@ export const bindStreamsToCell: StreamBinder = ({
   streams,
   getCell,
   updateCell,
+  onClose,
 }) => {
   // Track the most recent error toast so we don't spam the user during
   // repeated reconnect attempts for the same cell run.
@@ -163,6 +165,7 @@ export const bindStreamsToCell: StreamBinder = ({
   let stdoutBuffer = "";
   const textDecoder = new TextDecoder();
   const textEncoder = new TextEncoder();
+  let finished = false;
 
   const appendBuffer = (mime: MimeType, chunk: Uint8Array) => {
     const updated = getCell(refId);
@@ -345,6 +348,16 @@ export const bindStreamsToCell: StreamBinder = ({
     }
   };
 
+  const finish = () => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    onClose?.(refId);
+    streams.close();
+    subs.forEach((s) => s.unsubscribe());
+  };
+
   const subs = [
     streams.stdout.subscribe((data) => appendStdoutChunk(data)),
     streams.stderr.subscribe((data) =>
@@ -364,8 +377,7 @@ export const bindStreamsToCell: StreamBinder = ({
       updateCell(updated);
       flushStdoutBuffer();
       finalizeIopubStream();
-      streams.close();
-      subs.forEach((s) => s.unsubscribe());
+      finish();
     }),
     streams.mimeType.subscribe(() => {
       // no-op for now
@@ -383,8 +395,7 @@ export const bindStreamsToCell: StreamBinder = ({
       }
       flushStdoutBuffer();
       finalizeIopubStream();
-      streams.close();
-      subs.forEach((s) => s.unsubscribe());
+      finish();
     }),
   ];
 
@@ -392,8 +403,7 @@ export const bindStreamsToCell: StreamBinder = ({
 
   return {
     dispose() {
-      subs.forEach((s) => s.unsubscribe());
-      streams.close();
+      finish();
     },
   };
 };
@@ -802,7 +812,16 @@ export class NotebookData {
 
   getActiveStream(refId: string): StreamsLike | undefined {
     const existing = this.activeStreams.get(refId);
+    const cell = this.getCellProto(refId);
+    const metadata = cell?.metadata ?? {};
+    const hasExitCode =
+      typeof metadata[RunmeMetadataKey.ExitCode] === "string" &&
+      metadata[RunmeMetadataKey.ExitCode].length > 0;
     if (existing) {
+      if (hasExitCode) {
+        this.activeStreams.delete(refId);
+        return undefined;
+      }
       return existing;
     }
 
@@ -810,14 +829,9 @@ export class NotebookData {
     // If there is a PID and lastRunID is set but no exit code we interpret that
     // as an active run.
 
-    const cell = this.getCellProto(refId);
-    const metadata = cell?.metadata ?? {};
     const hasPid =
       typeof metadata[RunmeMetadataKey.Pid] === "string" &&
       metadata[RunmeMetadataKey.Pid].length > 0;
-    const hasExitCode =
-      typeof metadata[RunmeMetadataKey.ExitCode] === "string" &&
-      metadata[RunmeMetadataKey.ExitCode].length > 0;
     const runID =
       typeof metadata[RunmeMetadataKey.LastRunID] === "string"
         ? metadata[RunmeMetadataKey.LastRunID]
@@ -1479,6 +1493,9 @@ export class NotebookData {
       streams,
       getCell: (ref) => this.getCellProto(ref),
       updateCell: (next, options) => this.updateCell(next, options),
+      onClose: (refId) => {
+        this.activeStreams.delete(refId);
+      },
     });
 
     return streams;

--- a/docs-dev/design/20260513_notebook_stdin_mocks.html
+++ b/docs-dev/design/20260513_notebook_stdin_mocks.html
@@ -1,0 +1,491 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Notebook stdin UX mocks</title>
+    <style>
+      :root {
+        --bg: #f3efe6;
+        --paper: #fffdf8;
+        --paper-2: #f8f4ec;
+        --ink: #1e1c18;
+        --muted: #6f685e;
+        --border: #d8cec0;
+        --border-strong: #b7ab98;
+        --accent: #9f4d2f;
+        --accent-soft: #f3d9cc;
+        --success: #2f6b4f;
+        --warning: #7c5b12;
+        --shadow: 0 14px 40px rgba(42, 31, 18, 0.08);
+        --mono: "SFMono-Regular", "Menlo", "Consolas", monospace;
+        --sans: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background:
+          radial-gradient(circle at top left, rgba(159, 77, 47, 0.12), transparent 32rem),
+          linear-gradient(180deg, #f6f1e8 0%, var(--bg) 100%);
+        color: var(--ink);
+        font-family: var(--sans);
+      }
+
+      .page {
+        width: min(1200px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 40px 0 72px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin: 0;
+      }
+
+      .hero {
+        display: grid;
+        gap: 12px;
+        margin-bottom: 28px;
+      }
+
+      .eyebrow {
+        color: var(--accent);
+        font: 700 12px/1.2 var(--mono);
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .hero h1 {
+        font-size: clamp(32px, 4vw, 52px);
+        line-height: 0.96;
+        letter-spacing: -0.03em;
+      }
+
+      .hero p {
+        max-width: 820px;
+        color: var(--muted);
+        font-size: 18px;
+        line-height: 1.5;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 18px;
+      }
+
+      .mock {
+        display: grid;
+        gap: 14px;
+        background: rgba(255, 255, 255, 0.58);
+        border: 1px solid rgba(183, 171, 152, 0.6);
+        border-radius: 24px;
+        padding: 18px;
+        backdrop-filter: blur(8px);
+        box-shadow: var(--shadow);
+      }
+
+      .mock header {
+        display: grid;
+        gap: 6px;
+      }
+
+      .mock h2 {
+        font-size: 22px;
+        line-height: 1.08;
+      }
+
+      .mock .subtitle {
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 1.45;
+      }
+
+      .notebook {
+        background: var(--paper);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        overflow: hidden;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 10px 14px;
+        background: linear-gradient(180deg, #fdfbf6 0%, #f6efe4 100%);
+        border-bottom: 1px solid var(--border);
+        color: var(--muted);
+        font: 600 12px/1.2 var(--mono);
+      }
+
+      .toolbar .pill {
+        padding: 4px 8px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.85);
+      }
+
+      .cell {
+        display: grid;
+        grid-template-columns: 64px minmax(0, 1fr);
+        align-items: start;
+      }
+
+      .prompt-col {
+        padding: 16px 10px 16px 16px;
+        color: #847968;
+        font: 700 12px/1.3 var(--mono);
+        text-align: right;
+      }
+
+      .cell-body {
+        min-width: 0;
+        padding: 14px 16px 18px 6px;
+      }
+
+      .code {
+        margin: 0;
+        padding: 12px 14px;
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        background: #fbf8f2;
+        color: #27231d;
+        font: 14px/1.55 var(--mono);
+        white-space: pre-wrap;
+      }
+
+      .output-block {
+        margin-top: 12px;
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        background: var(--paper-2);
+        overflow: hidden;
+      }
+
+      .stream {
+        padding: 12px 14px;
+        border-bottom: 1px solid rgba(216, 206, 192, 0.75);
+        font: 14px/1.5 var(--mono);
+        white-space: pre-wrap;
+      }
+
+      .stream:last-child {
+        border-bottom: 0;
+      }
+
+      .stream.stderr {
+        color: #8a2f2f;
+      }
+
+      .stream.stdin {
+        background: #fff6ef;
+      }
+
+      .stdin-inline {
+        display: grid;
+        gap: 10px;
+        padding: 12px 14px;
+        background: linear-gradient(180deg, #fffaf4 0%, #fff4ea 100%);
+        border-top: 1px solid rgba(216, 206, 192, 0.8);
+      }
+
+      .stdin-prompt {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        color: #503f2d;
+        font: 14px/1.45 var(--mono);
+      }
+
+      .stdin-prompt .badge {
+        flex: 0 0 auto;
+        padding: 3px 6px;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .stdin-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+      }
+
+      .stdin-row input {
+        width: 100%;
+        min-width: 0;
+        height: 40px;
+        padding: 0 12px;
+        border: 1px solid var(--border-strong);
+        border-radius: 12px;
+        background: #fffefc;
+        color: var(--ink);
+        font: 14px/1 var(--mono);
+      }
+
+      .stdin-row input[type="password"] {
+        letter-spacing: 0.14em;
+      }
+
+      .stdin-row button,
+      .action-chip {
+        border: 0;
+        border-radius: 12px;
+        background: var(--accent);
+        color: #fff7f1;
+        padding: 10px 14px;
+        font: 700 12px/1 var(--mono);
+        letter-spacing: 0.02em;
+      }
+
+      .action-chip.secondary {
+        background: #ece3d6;
+        color: #604f3d;
+      }
+
+      .helper {
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      .banner {
+        margin-top: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 10px 12px;
+        border: 1px solid #e7c991;
+        border-radius: 14px;
+        background: linear-gradient(180deg, #fff8e6 0%, #ffefc0 100%);
+        color: #6a4f13;
+        font: 700 12px/1.4 var(--mono);
+      }
+
+      .legend {
+        display: grid;
+        gap: 8px;
+        padding: 14px;
+        border: 1px dashed var(--border-strong);
+        border-radius: 16px;
+        background: rgba(255, 253, 248, 0.72);
+      }
+
+      .legend h3 {
+        font-size: 14px;
+        font-family: var(--mono);
+      }
+
+      .legend ul {
+        margin: 0;
+        padding-left: 18px;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.5;
+      }
+
+      .footer-note {
+        margin-top: 24px;
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 1.55;
+      }
+
+      @media (max-width: 720px) {
+        .cell {
+          grid-template-columns: 1fr;
+        }
+
+        .prompt-col {
+          padding: 14px 16px 0;
+          text-align: left;
+        }
+
+        .cell-body {
+          padding-left: 16px;
+        }
+
+        .stdin-row {
+          flex-direction: column;
+          align-items: stretch;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section class="hero">
+        <div class="eyebrow">Mock Study</div>
+        <h1>Notebook stdin UX directions</h1>
+        <p>
+          These mocks compare what upstream Jupyter does today with a more explicit
+          notebook-native input flow for Runme. All three keep stdin inside the cell
+          output area. The difference is how obvious the waiting state is and whether
+          input feels like a terminal or a form submission.
+        </p>
+      </section>
+
+      <section class="grid">
+        <article class="mock">
+          <header>
+            <h2>Mock A: JupyterLab / Notebook 7 style</h2>
+            <p class="subtitle">
+              Inline stdin widget inside the output area. Prompt text and input live
+              together as part of cell output.
+            </p>
+          </header>
+          <div class="notebook">
+            <div class="toolbar">
+              <span class="pill">Notebook 7 / JupyterLab</span>
+              <span>kernel: Python 3</span>
+            </div>
+            <div class="cell">
+              <div class="prompt-col">In&nbsp;[12]:</div>
+              <div class="cell-body">
+                <pre class="code">name = input("Name: ")
+print(f"Hello {name}")</pre>
+                <div class="output-block">
+                  <div class="stdin-inline">
+                    <div class="stdin-prompt">
+                      <span>Name:&nbsp;</span>
+                    </div>
+                    <div class="stdin-row">
+                      <input value="Ada" aria-label="stdin input" />
+                    </div>
+                  </div>
+                  <div class="stream stdin">Name: Ada</div>
+                  <div class="stream">Hello Ada</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <h3>Why teams copy this</h3>
+            <ul>
+              <li>It matches upstream behavior closely.</li>
+              <li>It keeps input in the transcript instead of in a separate terminal.</li>
+              <li>It works for ordinary `input()` prompts and debugger input.</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="mock">
+          <header>
+            <h2>Mock B: Runme proposed v1</h2>
+            <p class="subtitle">
+              More explicit waiting state. Prompt stays in the transcript, but the
+              editable input is a clearer submit box with a button.
+            </p>
+          </header>
+          <div class="notebook">
+            <div class="toolbar">
+              <span class="pill">Runme notebook</span>
+              <span>runner: bash</span>
+            </div>
+            <div class="cell">
+              <div class="prompt-col">In&nbsp;[7]:</div>
+              <div class="cell-body">
+                <pre class="code">printf "Continue? [y/N] "
+read -r answer
+printf "\nanswer=%s\n" "$answer"</pre>
+                <div class="output-block">
+                  <div class="stream">Continue? [y/N] </div>
+                  <div class="stdin-inline">
+                    <div class="stdin-prompt">
+                      <span class="badge">Waiting</span>
+                      <span>Process is blocked on stdin.</span>
+                    </div>
+                    <div class="stdin-row">
+                      <input placeholder="Type one response and press Enter" aria-label="stdin input" />
+                      <button>Send</button>
+                    </div>
+                    <div class="helper">
+                      One submit sends a single stdin write ending with a newline.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <h3>Why this is stronger for Runme</h3>
+            <ul>
+              <li>The waiting state is explicit instead of implied by cursor focus.</li>
+              <li>It avoids terminal-style key-by-key UX inside notebook cells.</li>
+              <li>It scales better to browser tests and automation.</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="mock">
+          <header>
+            <h2>Mock C: Password-safe variant</h2>
+            <p class="subtitle">
+              Same inline model, but with a masked field when the runtime can say
+              the prompt should not echo.
+            </p>
+          </header>
+          <div class="notebook">
+            <div class="toolbar">
+              <span class="pill">Secret input</span>
+              <span>runner: shell</span>
+            </div>
+            <div class="cell">
+              <div class="prompt-col">In&nbsp;[19]:</div>
+              <div class="cell-body">
+                <pre class="code">sudo something-that-prompts</pre>
+                <div class="banner">
+                  <span>stdin requested</span>
+                  <span>echo disabled</span>
+                </div>
+                <div class="output-block">
+                  <div class="stream">Xcode Command Line Tools is already installed.
+Password: </div>
+                  <div class="stdin-inline">
+                    <div class="stdin-prompt">
+                      <span class="badge">Secure</span>
+                      <span>Password input is masked and not echoed into output.</span>
+                    </div>
+                    <div class="stdin-row">
+                      <input type="password" value="hunter2" aria-label="password stdin input" />
+                      <button>Send</button>
+                    </div>
+                    <div class="helper">
+                      This needs an explicit backend signal. The UI should not guess.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <h3>Boundary</h3>
+            <ul>
+              <li>This is only viable if the runtime tells us `password=true` or `echo=false`.</li>
+              <li>Without that signal, notebook stdin should stay visible text only.</li>
+              <li>If we need raw TTY behavior, it belongs in a real terminal surface.</li>
+            </ul>
+          </div>
+        </article>
+      </section>
+
+      <p class="footer-note">
+        File path:
+        <code>/Users/jlewi/.codex/worktrees/5ff2/web/docs-dev/design/20260513_notebook_stdin_mocks.html</code>
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs-dev/design/20260513_notebook_stdin_output.md
+++ b/docs-dev/design/20260513_notebook_stdin_output.md
@@ -1,0 +1,402 @@
+# 2026-05-13: Notebook stdin and Output UX
+
+## Status
+
+Draft proposal.
+
+## Summary
+
+Notebook code cells should not use raw terminal emulation as the primary UX
+for interactive stdin.
+
+We will switch notebook cells to a document-style transcript plus an explicit
+stdin composer. The user will type input into a dedicated field and submit it
+as one write instead of sending every keystroke into a terminal widget.
+
+This fixes the main failure reported in
+[#99](https://github.com/runmedev/web/issues/99):
+
+- prompts without a trailing newline are currently invisible while the process
+  waits for input
+- notebook output can appear cut off because terminal rendering suppresses the
+  normal stdout/stderr view and applies terminal scrollback limits
+
+[#191](https://github.com/runmedev/web/pull/191) removed renderer callbacks
+from notebook mutation paths. It did not change the notebook interaction model.
+This document covers that follow-on work. It also overlaps with the broader
+output-rendering cleanup tracked in
+[#190](https://github.com/runmedev/web/issues/190).
+
+## Problem
+
+The current notebook cell experience mixes document rendering and terminal
+emulation in a way that is hard to reason about and easy to break.
+
+Today:
+
+- `Actions.tsx` renders `CellConsole` when a cell has
+  `StatefulRunmeTerminal` output or an active stream
+- `ActionOutputItems` suppresses normal stdout/stderr blocks when terminal
+  output is present
+- `CellConsole` mounts `console-view` and forwards `terminal:stdin`
+  keystrokes to the runner one chunk at a time
+- both `CellConsole` and `bindStreamsToCell(...)` buffer trailing stdout until
+  newline or process exit
+- `CellConsole` sets terminal scrollback to `4000`
+
+That creates three concrete problems.
+
+### 1. Waiting-for-input is invisible
+
+The issue report includes a prompt like:
+
+```text
+Xcode Command Line Tools is already installed.
+Password:
+```
+
+`Password:` does not end with a newline. The current buffering logic keeps that
+text in a pending buffer and does not render it until a newline arrives or the
+process exits. If the process is waiting on stdin, the user sees no prompt and
+cannot tell why execution stopped.
+
+This is not a small rendering detail. It breaks the basic interaction loop for
+stdin-driven execution.
+
+### 2. Notebook output can appear cut off
+
+Notebook output is supposed to be part of the document. Terminal scrollback is
+not.
+
+The current terminal path can hide or drop visible output in several ways:
+
+- stdout/stderr document rendering is suppressed when terminal output is
+  present
+- `console-view` has a scrollback cap of `4000`
+- terminal state is imperative UI state rather than a pure rendering of the
+  notebook model
+
+That means a notebook cell can have a fuller persisted transcript than the user
+can actually see in the notebook UI.
+
+### 3. Character-at-a-time terminal input is the wrong notebook UX
+
+Notebook cells are structured documents. They already separate source from
+output. They should not behave like a remote PTY by default.
+
+For notebook cells, the useful interaction is usually:
+
+1. read the prompt
+2. type a response
+3. submit that response
+
+The useful interaction is not:
+
+1. focus a terminal widget
+2. stream raw keystrokes
+3. infer prompt state from cursor position and terminal paint state
+
+The raw-terminal model also makes replay, testing, and automation harder than
+necessary.
+
+## Goals
+
+- Make waiting for stdin obvious.
+- Preserve complete notebook output without terminal scrollback loss.
+- Use the notebook model as the source of truth for rendered output.
+- Support ordinary line-oriented stdin for runner-backed notebook cells.
+- Align notebook execution UX with the append-only, document-style direction
+  already used elsewhere in the app.
+
+## Non-Goals
+
+- Full TTY emulation inside notebook cells.
+- Support for curses or full-screen terminal apps in notebook cells.
+- Jupyter `input_request` support in this change.
+- Password masking without explicit backend signal.
+- Replacing App Console or other dedicated terminal-like surfaces.
+
+## Decision
+
+We will use a submit-oriented stdin composer for notebook cells.
+
+We will not use raw terminal typing as the primary notebook input UX.
+
+We will render notebook stdout/stderr from notebook state, not from xterm
+paint state.
+
+We will surface partial trailing stdout immediately instead of waiting for a
+newline.
+
+We will keep true terminal UX for App Console or a future dedicated terminal
+surface, not for notebook cells.
+
+## Why This Is The Right Boundary
+
+Notebook cells and terminal sessions have different product contracts.
+
+Notebook cells should provide:
+
+- complete, replayable output
+- stable input/output boundaries
+- deterministic rerender from model state
+- DOM structure that tests and automation can inspect directly
+
+Terminal sessions should provide:
+
+- raw keystroke streaming
+- cursor-oriented rendering
+- terminal scrollback semantics
+- support for full-screen terminal apps
+
+The current implementation tries to make notebook cells act like terminals.
+That is the wrong abstraction boundary.
+
+## Proposal
+
+### 1. Replace notebook `CellConsole` input with an explicit stdin composer
+
+When a notebook cell has an active runner stream, the output area should render:
+
+- the transcript
+- run status
+- an input composer
+
+The input composer is the only editable element for stdin.
+
+Recommended v1 behavior:
+
+- render a single-line text input
+- render a `Send` button
+- pressing `Enter` submits the current value
+- submission sends one `ExecuteRequest.inputData` write containing the entered
+  text plus `\n`
+- clear the composer after submit
+- do not locally echo the submitted text; rely on the remote process to echo if
+  that is part of its behavior
+
+The composer can remain visible for any active interactive run. We do not need
+perfect blocked-on-stdin detection in v1 to make the UX usable.
+
+### 2. Render partial stdout immediately
+
+Generic runner stdout should be appended to the notebook transcript as it
+arrives.
+
+We should not keep generic stdout in a hidden partial-line buffer waiting for a
+newline. That buffering makes sense only for protocols that are actually
+line-delimited control streams. It is wrong for terminal-like stdout where
+unterminated prompts are meaningful UI.
+
+This is the concrete fix for the missing `Password:` prompt.
+
+### 3. Stop relying on terminal scrollback for notebook history
+
+Notebook transcript rendering should come from notebook outputs, not from xterm
+state.
+
+Once the notebook transcript is rendered directly:
+
+- output is no longer capped by terminal scrollback
+- rerender after reload is exact
+- output testing no longer depends on terminal DOM internals
+- stdout/stderr fallback rendering is always available
+
+This is also the cleanest fix for the “output is cut off” class of bugs.
+
+### 4. Keep Jupyter handling separate
+
+Jupyter is already handled through a different path. Its `input_request` flow
+is explicitly unsupported today.
+
+We should keep that boundary clear:
+
+- runner-backed shell-like cells get the new stdin composer
+- Jupyter cells continue to reject `input_request` in v1
+
+We should not mix Jupyter message parsing requirements into the generic runner
+stdout path.
+
+### 5. Treat terminal markers as compatibility hints, not as rendering truth
+
+`StatefulRunmeTerminal` should not force notebook cells into xterm rendering.
+
+Short term:
+
+- continue to read existing terminal markers so older notebooks still render in
+  a compatible way
+- use the marker only as a hint that the cell may have interactive runner
+  behavior
+
+Long term:
+
+- stop using the marker as a model-level rendering switch
+- infer notebook output presentation from notebook output items and active run
+  state instead
+
+This aligns with the direction already described in #190.
+
+## Implementation Plan
+
+### Phase 1: Fix the UX without a backend protocol change
+
+1. Replace notebook-cell terminal input with a dedicated React stdin composer.
+2. Route submitted input through `ExecuteRequest.inputData`.
+3. Render generic runner stdout/stderr directly from notebook outputs.
+4. Remove newline-delayed buffering from the generic runner stdout path.
+5. Stop depending on `console-view` scrollback for notebook output visibility.
+6. Keep Jupyter behavior unchanged.
+
+This phase should solve the practical user problem in #99.
+
+### Phase 2: Add optional explicit stdin request metadata
+
+Phase 1 makes stdin usable. It does not make it precise.
+
+The remaining gap is prompt semantics. The UI still cannot know:
+
+- whether the process is truly blocked on stdin
+- whether the input should be masked
+- whether the input is line-oriented or raw
+
+If Runme can surface that information, we should add an explicit event or state
+shape such as:
+
+```ts
+type StdinRequest = {
+  active: boolean;
+  prompt?: string;
+  echo?: boolean;
+  mode?: "line" | "raw";
+};
+```
+
+That would let the UI show:
+
+- `Waiting for input`
+- a masked field when `echo === false`
+- better affordances for non-default submission behavior
+
+This is useful future work, but it should not block Phase 1.
+
+## Affected Areas
+
+The change will primarily affect:
+
+- `app/src/components/Actions/Actions.tsx`
+- `app/src/components/Actions/CellConsole.tsx`
+- `app/src/lib/notebookData.ts`
+
+Expected structural changes:
+
+- move notebook stdin UI into a React component instead of `console-view`
+- limit generic runner stream handling to transcript updates
+- keep any protocol-specific parsing scoped to the protocol that needs it
+
+## Password Prompts
+
+Password prompts are a special case.
+
+The example in #99 is a password prompt. A browser text input should not guess
+whether input needs masking. The runtime must tell us.
+
+Therefore:
+
+- v1 should support visible line input only
+- notebook cells remain a poor place for secret-entry workflows until the
+  runtime can signal `echo: false`
+- if secret entry matters before then, we should direct users to a true
+  terminal surface
+
+This limitation should be explicit in the shipped UX and in tests.
+
+## Alternatives Considered
+
+### Keep `console-view` and only flush partial stdout earlier
+
+This fixes the missing prompt, but it does not fix the architectural problem.
+
+We would still have:
+
+- terminal scrollback limits in notebook history
+- output rendering split between notebook state and xterm state
+- raw keystroke stdin as the primary notebook interaction model
+
+This is not enough.
+
+### Keep raw terminal input but add a “waiting” banner
+
+A banner helps a little, but the user still has to interact with a terminal
+widget inside a notebook cell.
+
+That does not improve replay, testing, automation, or output completeness.
+
+### Route interactive notebook cells into a separate terminal pane
+
+This is cleaner than embedding xterm in the cell, but it is heavier than we
+need for ordinary prompts such as `y/n` or single-line input.
+
+It is a reasonable future option for true terminal workflows. It is not the
+best v1 fix for #99.
+
+## Testing
+
+We should add a focused interactive test notebook and browser coverage.
+
+Required cases:
+
+1. Prompt without trailing newline:
+
+```bash
+printf "Continue? [y/N] "
+read -r answer
+printf "\nanswer=%s\n" "$answer"
+```
+
+Expected behavior:
+
+- `Continue? [y/N] ` is visible before input is sent
+- user can submit `y`
+- final output includes `answer=y`
+
+2. Long output larger than terminal scrollback:
+
+```bash
+for i in $(seq 1 5005); do
+  printf "Line %04d\n" "$i"
+done
+```
+
+Expected behavior:
+
+- the notebook view shows the full transcript after completion
+- reload preserves the full transcript
+
+3. Interactive cell rerun:
+
+- rerun clears prior live output according to current semantics
+- prompt still appears correctly on the new run
+
+4. Legacy terminal marker notebook:
+
+- older cells with `StatefulRunmeTerminal` still render output correctly
+
+5. Jupyter `input_request`:
+
+- current unsupported message remains explicit
+
+## Open Questions
+
+- Should the v1 stdin composer include a `Send EOF` action?
+- Should we allow multi-line input submission, or keep notebook stdin strictly
+  line-oriented in v1?
+- Should the composer stay visible for the full duration of an active run, or
+  only after we have backend `stdinRequested` metadata?
+
+## Recommendation
+
+For notebook cells, we should model stdin as explicit submitted input, not as a
+terminal keystroke stream.
+
+That gives us the right UX for notebook documents, fixes the hidden-prompt bug,
+and removes terminal scrollback as a source of apparent output truncation.

--- a/docs-dev/design/20260513_notebook_stdin_output.md
+++ b/docs-dev/design/20260513_notebook_stdin_output.md
@@ -20,6 +20,8 @@ This fixes the main failure reported in
   waits for input
 - notebook output can appear cut off because terminal rendering suppresses the
   normal stdout/stderr view and applies terminal scrollback limits
+- notebook cells can render the same transcript twice as both a `CellConsole`
+  and normal stdout/stderr output items
 
 [#191](https://github.com/runmedev/web/pull/191) removed renderer callbacks
 from notebook mutation paths. It did not change the notebook interaction model.
@@ -44,7 +46,7 @@ Today:
   newline or process exit
 - `CellConsole` sets terminal scrollback to `4000`
 
-That creates three concrete problems.
+That creates four concrete problems.
 
 ### 1. Waiting-for-input is invisible
 
@@ -79,7 +81,34 @@ The current terminal path can hide or drop visible output in several ways:
 That means a notebook cell can have a fuller persisted transcript than the user
 can actually see in the notebook UI.
 
-### 3. Character-at-a-time terminal input is the wrong notebook UX
+### 3. The same transcript can render twice
+
+The current rendering policy uses two different signals:
+
+- `CellConsole` renders when the cell has terminal output or an active stream
+- `ActionOutputItems` suppresses stdout/stderr only when the cell has a
+  `StatefulRunmeTerminal` output marker
+
+That split creates a duplication bug.
+
+If a cell has an active stream but no terminal marker, the UI renders:
+
+- a live `CellConsole`
+- the same stdout/stderr as normal output items
+
+This is likely the follow-on regression after #191. That change stopped seeding
+terminal markers during mutation, but the output rendering policy still assumes
+that terminal suppression is keyed off the marker.
+
+The result is exactly the duplicated UI we now see:
+
+- `Output 0 / Item 0 - mime=application/vnd.code.notebook.stdout`
+- a console showing the same transcript
+
+Notebook cells must choose one transcript presentation path per run. They
+should not render both.
+
+### 4. Character-at-a-time terminal input is the wrong notebook UX
 
 Notebook cells are structured documents. They already separate source from
 output. They should not behave like a remote PTY by default.
@@ -105,6 +134,7 @@ necessary.
 - Preserve complete notebook output without terminal scrollback loss.
 - Use the notebook model as the source of truth for rendered output.
 - Support ordinary line-oriented stdin for runner-backed notebook cells.
+- Ensure each notebook transcript is rendered exactly once.
 - Align notebook execution UX with the append-only, document-style direction
   already used elsewhere in the app.
 
@@ -124,6 +154,8 @@ We will not use raw terminal typing as the primary notebook input UX.
 
 We will render notebook stdout/stderr from notebook state, not from xterm
 paint state.
+
+We will ensure notebook output has a single presentation path per run.
 
 We will surface partial trailing stdout immediately instead of waiting for a
 newline.
@@ -197,6 +229,8 @@ state.
 
 Once the notebook transcript is rendered directly:
 
+- console and stdout/stderr duplication goes away because there is only one
+  transcript renderer
 - output is no longer capped by terminal scrollback
 - rerender after reload is exact
 - output testing no longer depends on terminal DOM internals
@@ -244,8 +278,11 @@ This aligns with the direction already described in #190.
 2. Route submitted input through `ExecuteRequest.inputData`.
 3. Render generic runner stdout/stderr directly from notebook outputs.
 4. Remove newline-delayed buffering from the generic runner stdout path.
-5. Stop depending on `console-view` scrollback for notebook output visibility.
-6. Keep Jupyter behavior unchanged.
+5. Remove the split policy where active-stream cells render `CellConsole` while
+   stdout/stderr suppression still depends on terminal markers.
+6. Stop depending on `console-view` scrollback for notebook output visibility.
+7. Ensure notebook cells choose one transcript renderer, not both.
+8. Keep Jupyter behavior unchanged.
 
 This phase should solve the practical user problem in #99.
 

--- a/docs-dev/design/20260513_notebook_stdin_output.md
+++ b/docs-dev/design/20260513_notebook_stdin_output.md
@@ -2,16 +2,17 @@
 
 ## Status
 
-Draft proposal.
+Implemented on this branch. Ready to merge after review.
 
 ## Summary
 
-Notebook code cells should not use raw terminal emulation as the primary UX
-for interactive stdin.
+Notebook code cells should not use raw terminal typing as the primary UX for
+interactive stdin.
 
-We will switch notebook cells to a document-style transcript plus an explicit
-stdin composer. The user will type input into a dedicated field and submit it
-as one write instead of sending every keystroke into a terminal widget.
+This change keeps the live `CellConsole` transcript for active runner-backed
+runs, but replaces terminal-first stdin with an explicit submit-oriented input
+composer. The user types a response into a dedicated field and submits it as
+one write instead of streaming every keystroke into the terminal widget.
 
 This fixes the main failure reported in
 [#99](https://github.com/runmedev/web/issues/99):
@@ -34,7 +35,7 @@ output-rendering cleanup tracked in
 The current notebook cell experience mixes document rendering and terminal
 emulation in a way that is hard to reason about and easy to break.
 
-Today:
+Before this change:
 
 - `Actions.tsx` renders `CellConsole` when a cell has
   `StatefulRunmeTerminal` output or an active stream
@@ -152,8 +153,11 @@ We will use a submit-oriented stdin composer for notebook cells.
 
 We will not use raw terminal typing as the primary notebook input UX.
 
-We will render notebook stdout/stderr from notebook state, not from xterm
-paint state.
+We will keep `CellConsole` as the live transcript surface for active
+runner-backed runs.
+
+We will treat notebook outputs as the persisted source of truth after the run
+completes.
 
 We will ensure notebook output has a single presentation path per run.
 
@@ -192,9 +196,9 @@ That is the wrong abstraction boundary.
 
 ### 1. Replace notebook `CellConsole` input with an explicit stdin composer
 
-When a notebook cell has an active runner stream, the output area should render:
+When a notebook cell has an active runner stream, the output area renders:
 
-- the transcript
+- the live `CellConsole` transcript
 - run status
 - an input composer
 
@@ -220,7 +224,7 @@ right now."
 
 ### 2. Render partial stdout immediately
 
-Generic runner stdout should be appended to the notebook transcript as it
+Generic runner stdout should be written into the live console transcript as it
 arrives.
 
 We should not keep generic stdout in a hidden partial-line buffer waiting for a
@@ -232,19 +236,18 @@ This is the concrete fix for the missing `Password:` prompt.
 
 ### 3. Stop relying on terminal scrollback for notebook history
 
-Notebook transcript rendering should come from notebook outputs, not from xterm
-state.
+Notebook history should not depend on a stale terminal marker.
 
-Once the notebook transcript is rendered directly:
+The merged behavior is:
 
-- console and stdout/stderr duplication goes away because there is only one
-  transcript renderer
-- output is no longer capped by terminal scrollback
-- rerender after reload is exact
-- output testing no longer depends on terminal DOM internals
-- stdout/stderr fallback rendering is always available
+- active runs render exactly one live transcript path via `CellConsole`
+- normal stdout/stderr output items are suppressed only while that live stream
+  is active
+- after the run completes, the active stream is cleared and persisted output
+  items become the notebook-visible history again
 
-This is also the cleanest fix for the “output is cut off” class of bugs.
+This fixes the duplicate-rendering bug and avoids keeping the cell stuck in a
+false "still interactive" state after exit.
 
 ### 4. Keep Jupyter handling separate
 
@@ -263,42 +266,39 @@ stdout path.
 
 `StatefulRunmeTerminal` should not force notebook cells into xterm rendering.
 
-Short term:
+Merged behavior:
 
 - continue to read existing terminal markers so older notebooks still render in
   a compatible way
-- use the marker only as a hint that the cell may have interactive runner
-  behavior
-
-Long term:
-
-- stop using the marker as a model-level rendering switch
-- infer notebook output presentation from notebook output items and active run
-  state instead
+- use the marker only as a compatibility hint for legacy terminal-backed cells
+- do not rely on new runs seeding fresh terminal markers
+- determine live-vs-persisted rendering from active run state and normal output
+  items instead
 
 This aligns with the direction already described in #190.
 
 ## Implementation Plan
 
-### Phase 1: Fix the UX without a backend protocol change
+### Merged change
 
 1. Replace notebook-cell terminal input with a dedicated React stdin composer.
 2. Show that composer for active stdin-capable runs, even without a precise
    `stdinRequested` protocol event.
 3. Route submitted input through `ExecuteRequest.inputData`.
-4. Render generic runner stdout/stderr directly from notebook outputs.
+4. Keep the live transcript in `CellConsole` while the run is active.
 5. Remove newline-delayed buffering from the generic runner stdout path.
 6. Remove the split policy where active-stream cells render `CellConsole` while
    stdout/stderr suppression still depends on terminal markers.
-7. Stop depending on `console-view` scrollback for notebook output visibility.
+7. Clear the cached active stream on exit/error so the cell falls back to
+   persisted output items after completion.
 8. Ensure notebook cells choose one transcript renderer, not both.
 9. Keep Jupyter behavior unchanged.
 
-This phase should solve the practical user problem in #99.
+This is the change we intend to merge for #99.
 
-### Phase 2: Add optional explicit stdin request metadata
+### Future work to consider
 
-Phase 1 makes stdin usable. It does not make it precise.
+The merged change makes stdin usable. It does not make it precise.
 
 The remaining gap is prompt semantics. The UI still cannot know:
 
@@ -324,7 +324,7 @@ That would let the UI show:
 - a masked field when `echo === false`
 - better affordances for non-default submission behavior
 
-This is useful future work, but it should not block Phase 1.
+This is useful future work, but it is not required for the merged change.
 
 ## Affected Areas
 
@@ -336,8 +336,9 @@ The change will primarily affect:
 
 Expected structural changes:
 
-- move notebook stdin UI into a React component instead of `console-view`
-- limit generic runner stream handling to transcript updates
+- move notebook stdin UI into a React component adjacent to `CellConsole`
+- limit generic runner stream handling to live transcript updates plus normal
+  persisted outputs
 - keep any protocol-specific parsing scoped to the protocol that needs it
 
 ## Password Prompts
@@ -416,7 +417,7 @@ done
 
 Expected behavior:
 
-- the notebook view shows the full transcript after completion
+- the notebook view shows the full persisted transcript after completion
 - reload preserves the full transcript
 
 3. Interactive cell rerun:
@@ -439,6 +440,8 @@ Expected behavior:
   line-oriented in v1?
 - Should the composer stay visible for the full duration of an active run, or
   only after we have backend `stdinRequested` metadata?
+- Should we eventually stop rendering legacy `StatefulRunmeTerminal` output in
+  notebook cells once migration coverage is good enough?
 
 ## Recommendation
 

--- a/docs-dev/design/20260513_notebook_stdin_output.md
+++ b/docs-dev/design/20260513_notebook_stdin_output.md
@@ -157,6 +157,10 @@ paint state.
 
 We will ensure notebook output has a single presentation path per run.
 
+In v1, we will show the stdin affordance for active stdin-capable runs. We will
+not wait for a precise backend "blocked on stdin" signal before making input
+available.
+
 We will surface partial trailing stdout immediately instead of waiting for a
 newline.
 
@@ -200,6 +204,8 @@ Recommended v1 behavior:
 
 - render a single-line text input
 - render a `Send` button
+- show the composer whenever the process is still running on the stdin-capable
+  runner path
 - pressing `Enter` submits the current value
 - submission sends one `ExecuteRequest.inputData` write containing the entered
   text plus `\n`
@@ -208,7 +214,9 @@ Recommended v1 behavior:
   that is part of its behavior
 
 The composer can remain visible for any active interactive run. We do not need
-perfect blocked-on-stdin detection in v1 to make the UX usable.
+perfect blocked-on-stdin detection in v1 to make the UX usable. The v1 state is
+"stdin available while the run is active", not "stdin is definitely blocked
+right now."
 
 ### 2. Render partial stdout immediately
 
@@ -275,14 +283,16 @@ This aligns with the direction already described in #190.
 ### Phase 1: Fix the UX without a backend protocol change
 
 1. Replace notebook-cell terminal input with a dedicated React stdin composer.
-2. Route submitted input through `ExecuteRequest.inputData`.
-3. Render generic runner stdout/stderr directly from notebook outputs.
-4. Remove newline-delayed buffering from the generic runner stdout path.
-5. Remove the split policy where active-stream cells render `CellConsole` while
+2. Show that composer for active stdin-capable runs, even without a precise
+   `stdinRequested` protocol event.
+3. Route submitted input through `ExecuteRequest.inputData`.
+4. Render generic runner stdout/stderr directly from notebook outputs.
+5. Remove newline-delayed buffering from the generic runner stdout path.
+6. Remove the split policy where active-stream cells render `CellConsole` while
    stdout/stderr suppression still depends on terminal markers.
-6. Stop depending on `console-view` scrollback for notebook output visibility.
-7. Ensure notebook cells choose one transcript renderer, not both.
-8. Keep Jupyter behavior unchanged.
+7. Stop depending on `console-view` scrollback for notebook output visibility.
+8. Ensure notebook cells choose one transcript renderer, not both.
+9. Keep Jupyter behavior unchanged.
 
 This phase should solve the practical user problem in #99.
 


### PR DESCRIPTION
## Summary
- add a design doc for notebook stdin and output UX
- document current behavior, Jupyter comparisons, and a proposed submit-oriented stdin model
- add static HTML mocks for Jupyter-style and Runme-specific input UX

## Context
- Refs #99
- Related to #190
- Follow-up to #191

## Testing
- not run (docs-only change)
