### PR TITLE
Add HTML notebook cells

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -320,6 +320,7 @@ describe("Action component", () => {
     expect(screen.getByTestId("html-rendered")).toBeTruthy();
     const frame = screen.getByTestId("html-preview-frame") as HTMLIFrameElement;
     expect(frame.getAttribute("srcdoc")).toBe("<div><strong>Hello HTML</strong></div>");
+    expect(frame.getAttribute("sandbox")).toBe("");
     expect(screen.queryByLabelText("Run code")).toBeNull();
   });
 

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -281,6 +281,48 @@ describe("Action component", () => {
     expect(updatedCell.languageId).toBe("markdown");
   });
 
+  it("converts markdown cells to html code cells", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-html-convert",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "",
+    });
+    const stub = new StubCellData(cell);
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+
+    const selector = screen.getByRole("combobox");
+    fireEvent.change(selector, { target: { value: "html" } });
+
+    expect(stub.update).toHaveBeenCalledTimes(1);
+    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell;
+    expect(updatedCell.kind).toBe(parser_pb.CellKind.CODE);
+    expect(updatedCell.languageId).toBe("html");
+  });
+
+  it("renders html cells in-place without the code run toolbar", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-html-rendered",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "html",
+      outputs: [],
+      metadata: {},
+      value: "<div><strong>Hello HTML</strong></div>",
+    });
+    const stub = new StubCellData(cell);
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+
+    expect(screen.getByTestId("html-action")).toBeTruthy();
+    expect(screen.getByTestId("html-rendered")).toBeTruthy();
+    const frame = screen.getByTestId("html-preview-frame") as HTMLIFrameElement;
+    expect(frame.getAttribute("srcdoc")).toBe("<div><strong>Hello HTML</strong></div>");
+    expect(screen.queryByLabelText("Run code")).toBeNull();
+  });
+
   it("shows browser/sandbox runner selector for javascript cells", () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-runner-select",

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -26,10 +26,12 @@ import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { useOutput } from "../../contexts/OutputContext";
 import CellConsole, { fontSettings } from "./CellConsole";
 import Editor from "./Editor";
+import HtmlCell from "./HtmlCell";
 import MarkdownCell from "./MarkdownCell";
 import { IOPUB_INCOMPLETE_METADATA_KEY } from "../../lib/ipykernel";
 import { appLogger } from "../../lib/logging/runtime";
 import { copyNotebookShareUrl } from "../../lib/shareLinks";
+import { isHtmlLanguageId, isMarkdownLanguageId } from "../../lib/cellContent";
 import {
   PlayIcon,
   PlusIcon,
@@ -269,6 +271,7 @@ function RunActionButton({
 // Action is an editor and an optional Runme console
 const LANGUAGE_OPTIONS = [
   { label: "Markdown", value: "markdown" },
+  { label: "HTML", value: "html" },
   { label: "Bash", value: "bash" },
   { label: "Jupyter", value: "jupyter" },
   { label: "Python", value: "python" },
@@ -282,6 +285,7 @@ const JAVASCRIPT_RUNNER_OPTIONS = [
 
 type SupportedLanguage =
   | "bash"
+  | "html"
   | "jupyter"
   | "javascript"
   | "markdown"
@@ -289,6 +293,13 @@ type SupportedLanguage =
 
 const outputTextDecoder = new TextDecoder();
 const ALWAYS_SKIP_MIMES = new Set<string>([MimeType.StatefulRunmeTerminal]);
+
+function normalizeBinaryData(data?: Uint8Array | ArrayLike<number> | null): Uint8Array {
+  if (!data) {
+    return new Uint8Array();
+  }
+  return data instanceof Uint8Array ? data : Uint8Array.from(data);
+}
 
 function isGoogleDriveFileUri(uri: string | null | undefined): uri is string {
   if (!uri) {
@@ -317,8 +328,11 @@ function normalizeLanguageId(
   switch (kind) {
     case parser_pb.CellKind.CODE:
       const normalized = (languageId ?? "").toLowerCase();
-      if (normalized === "markdown") {
+      if (isMarkdownLanguageId(normalized)) {
         return "markdown";
+      }
+      if (isHtmlLanguageId(normalized)) {
+        return "html";
       }
       if (normalized === "python" || normalized === "py") {
         return "python";
@@ -344,26 +358,28 @@ function normalizeLanguageId(
   }
 }
 
-function decodeOutputText(data: Uint8Array): string {
-  if (!(data instanceof Uint8Array) || data.length === 0) {
+function decodeOutputText(data?: Uint8Array | ArrayLike<number> | null): string {
+  const normalized = normalizeBinaryData(data);
+  if (normalized.length === 0) {
     return "";
   }
   try {
-    return outputTextDecoder.decode(data);
+    return outputTextDecoder.decode(normalized);
   } catch {
     return "";
   }
 }
 
-function uint8ArrayToBase64(data: Uint8Array): string {
-  if (!(data instanceof Uint8Array) || data.length === 0) {
+function uint8ArrayToBase64(data?: Uint8Array | ArrayLike<number> | null): string {
+  const normalized = normalizeBinaryData(data);
+  if (normalized.length === 0) {
     return "";
   }
 
   let binary = "";
   const chunkSize = 0x8000;
-  for (let i = 0; i < data.length; i += chunkSize) {
-    const chunk = data.subarray(i, i + chunkSize);
+  for (let i = 0; i < normalized.length; i += chunkSize) {
+    const chunk = normalized.subarray(i, i + chunkSize);
     binary += String.fromCharCode(...chunk);
   }
 
@@ -457,7 +473,7 @@ export function ActionOutputItems({ outputs }: { outputs: parser_pb.CellOutput[]
         ) {
           return null;
         }
-        if (!(item.data instanceof Uint8Array)) {
+        if (normalizeBinaryData(item.data).length === 0) {
           return null;
         }
         return (
@@ -528,6 +544,7 @@ export function Action({
     y: number;
   } | null>(null);
   const [shareRemoteUri, setShareRemoteUri] = useState<string | null>(null);
+  const [htmlEditRequest, setHtmlEditRequest] = useState(0);
   const [markdownEditRequest, setMarkdownEditRequest] = useState(0);
   const [pid, setPid] = useState<number | null>(null);
   const [exitCode, setExitCode] = useState<number | null>(null);
@@ -668,6 +685,8 @@ export function Action({
 
   const editorLanguage = useMemo(() => {
     switch (selectedLanguage) {
+      case "html":
+        return "html";
       case "markdown":
         return "markdown";
       case "javascript":
@@ -765,6 +784,15 @@ export function Action({
       return;
     }
     if (selectedLanguage === "markdown") {
+      if (initialRunnerName !== DEFAULT_RUNNER_PLACEHOLDER) {
+        cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER);
+      }
+      if (hasJupyterSelection) {
+        cellData.clearJupyterKernel();
+      }
+      return;
+    }
+    if (selectedLanguage === "html") {
       if (initialRunnerName !== DEFAULT_RUNNER_PLACEHOLDER) {
         cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER);
       }
@@ -892,21 +920,26 @@ export function Action({
 
       const updatedCell = create(parser_pb.CellSchema, cell);
       updatedCell.metadata ??= {};
+      const clearRuntimeMetadata = () => {
+        delete updatedCell.metadata[RunmeMetadataKey.RunnerName];
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
+      };
       if (nextValue === "markdown") {
         setMarkdownEditRequest((request) => request + 1);
         updatedCell.kind = parser_pb.CellKind.MARKUP;
         updatedCell.languageId = "markdown";
-        delete updatedCell.metadata[RunmeMetadataKey.RunnerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
+        clearRuntimeMetadata();
+      } else if (nextValue === "html") {
+        setHtmlEditRequest((request) => request + 1);
+        updatedCell.kind = parser_pb.CellKind.CODE;
+        updatedCell.languageId = "html";
+        clearRuntimeMetadata();
       } else if (nextValue === "jupyter") {
         updatedCell.kind = parser_pb.CellKind.CODE;
         updatedCell.languageId = "jupyter";
-        delete updatedCell.metadata[RunmeMetadataKey.RunnerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
+        clearRuntimeMetadata();
       } else if (nextValue === "javascript") {
         updatedCell.kind = parser_pb.CellKind.CODE;
         updatedCell.languageId = "javascript";
@@ -944,11 +977,12 @@ export function Action({
   // Determine if this cell is a markdown cell (either MARKUP kind or CODE with markdown language)
   const isMarkdownCell = useMemo(() => {
     if (!cell) return false;
-    // Check if cell kind is MARKUP
     if (cell.kind === parser_pb.CellKind.MARKUP) return true;
-    // Check if cell is CODE but with markdown language
-    const lang = (cell.languageId ?? "").toLowerCase();
-    return lang === "markdown" || lang === "md";
+    return isMarkdownLanguageId(cell.languageId);
+  }, [cell]);
+  const isHtmlCell = useMemo(() => {
+    if (!cell) return false;
+    return cell.kind === parser_pb.CellKind.CODE && isHtmlLanguageId(cell.languageId);
   }, [cell]);
 
   if (!cell) {
@@ -996,6 +1030,89 @@ export function Action({
               forceEditRequest={markdownEditRequest}
             />
             {/* Trash icon on the right, visible on hover */}
+            <button
+              type="button"
+              aria-label="Delete cell"
+              className="icon-btn absolute right-2 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+              onClick={handleRemoveCell}
+            >
+              <TrashIcon />
+            </button>
+          </div>
+        </div>
+        {adjustedContextMenu && (
+          <div
+            className="ctx-menu"
+            style={{
+              top: adjustedContextMenu.y,
+              left: adjustedContextMenu.x,
+            }}
+            onContextMenu={(event) => event.preventDefault()}
+          >
+            {shareRemoteUri && (
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void handleCopyShareLink();
+                }}
+              >
+                Copy Share Link
+              </button>
+            )}
+            <button
+              type="button"
+              className="ctx-menu-item text-red-600"
+              onClick={(event) => {
+                event.stopPropagation();
+                handleRemoveCell();
+              }}
+            >
+              Remove Cell
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (isHtmlCell) {
+    return (
+      <div
+        id={`html-action-${cell.refId}`}
+        className="group/cell relative flex min-w-0"
+        onContextMenu={handleContextMenu}
+        data-testid="html-action"
+      >
+        <div id={`html-gutter-${cell.refId}`} className="flex w-7 shrink-0 flex-col items-center justify-between py-1">
+          <button
+            type="button"
+            aria-label="Add cell above"
+            className="cell-add-btn h-5 w-5"
+            onClick={handleAddCodeCellBefore}
+          >
+            <PlusIcon width={10} height={10} />
+          </button>
+          <button
+            type="button"
+            aria-label="Add cell below"
+            className="cell-add-btn h-5 w-5"
+            onClick={handleAddCodeCellAfter}
+          >
+            <PlusIcon width={10} height={10} />
+          </button>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="relative w-full min-w-0 max-w-full overflow-hidden">
+            <HtmlCell
+              cellData={cellData}
+              selectedLanguage={selectedLanguage}
+              languageSelectId={languageSelectId}
+              languageOptions={LANGUAGE_OPTIONS}
+              onLanguageChange={handleLanguageChange}
+              forceEditRequest={htmlEditRequest}
+            />
             <button
               type="button"
               aria-label="Delete cell"

--- a/app/src/components/Actions/HtmlCell.tsx
+++ b/app/src/components/Actions/HtmlCell.tsx
@@ -1,0 +1,214 @@
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type FocusEvent,
+  type KeyboardEvent,
+} from "react";
+
+import { create } from "@bufbuild/protobuf";
+import { parser_pb } from "../../runme/client";
+import type { CellData } from "../../lib/notebookData";
+import Editor from "./Editor";
+import { fontSettings } from "./CellConsole";
+
+interface HtmlCellProps {
+  cellData: CellData;
+  selectedLanguage: string;
+  languageSelectId: string;
+  languageOptions: readonly { label: string; value: string }[];
+  onLanguageChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  forceEditRequest?: number;
+}
+
+const HtmlCell = memo(
+  ({
+    cellData,
+    selectedLanguage,
+    languageSelectId,
+    languageOptions,
+    onLanguageChange,
+    forceEditRequest = 0,
+  }: HtmlCellProps) => {
+    const cell = useSyncExternalStore(
+      useCallback(
+        (listener) => cellData.subscribeToContentChange(listener),
+        [cellData],
+      ),
+      useCallback(() => cellData.snapshot, [cellData]),
+      useCallback(() => cellData.snapshot, [cellData]),
+    );
+
+    const [rendered, setRendered] = useState(() => {
+      const value = cell?.value ?? "";
+      return value.trim().length > 0;
+    });
+
+    const value = cell?.value ?? "";
+
+    useEffect(() => {
+      if (!value.trim() && rendered) {
+        setRendered(false);
+      }
+    }, [rendered, value]);
+
+    useEffect(() => {
+      if (forceEditRequest > 0) {
+        setRendered(false);
+      }
+    }, [forceEditRequest]);
+
+    const handleRenderedKeyDown = useCallback(
+      (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          setRendered(false);
+        }
+      },
+      [],
+    );
+
+    const handleBlur = useCallback(
+      (event: FocusEvent<HTMLDivElement>) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          return;
+        }
+        if (!value.trim()) {
+          return;
+        }
+        setRendered(true);
+      },
+      [value],
+    );
+
+    const handleEditorKeyDown = useCallback(
+      (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Escape" && value.trim()) {
+          setRendered(true);
+        }
+      },
+      [value],
+    );
+
+    const handleEditorChange = useCallback(
+      (newValue: string) => {
+        if (!cell) {
+          return;
+        }
+        const updated = create(parser_pb.CellSchema, cell);
+        updated.value = newValue;
+        cellData.update(updated);
+      },
+      [cell, cellData],
+    );
+
+    const handlePreview = useCallback(() => {
+      if (value.trim()) {
+        setRendered(true);
+      }
+    }, [value]);
+
+    const previewIframe = useMemo(
+      () => (
+        <iframe
+          title={`html-preview-${cell?.refId ?? "cell"}`}
+          sandbox="allow-scripts"
+          srcDoc={value}
+          className="h-[420px] w-full rounded-b-nb-md bg-white"
+          data-testid="html-preview-frame"
+        />
+      ),
+      [cell?.refId, value],
+    );
+
+    if (!cell) {
+      return null;
+    }
+
+    return (
+      <div
+        id={`html-cell-${cell.refId}`}
+        className="relative w-full min-w-0"
+        data-testid="html-cell"
+        data-rendered={rendered}
+      >
+        {rendered ? (
+          <div
+            id={`html-rendered-${cell.refId}`}
+            className="overflow-hidden rounded-nb-md border border-nb-border bg-white shadow-nb-xs"
+            onKeyDown={handleRenderedKeyDown}
+            tabIndex={0}
+            role="button"
+            aria-label="Press Enter to edit HTML"
+            data-testid="html-rendered"
+          >
+            <div className="flex items-center justify-between border-b border-nb-border bg-nb-surface-2 px-3 py-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-nb-text-faint">
+                HTML preview
+              </span>
+              <button
+                type="button"
+                className="rounded border border-nb-border-strong px-2 py-1 text-xs text-nb-text-muted transition-colors hover:border-nb-accent hover:text-nb-accent"
+                onClick={() => setRendered(false)}
+                data-testid="html-edit-button"
+              >
+                Edit HTML
+              </button>
+            </div>
+            {previewIframe}
+          </div>
+        ) : (
+          <div
+            id={`html-editor-${cell.refId}`}
+            className="rounded-nb-md border border-nb-accent shadow-nb-sm overflow-hidden w-full min-w-0 max-w-full transition-shadow duration-200"
+            onBlur={handleBlur}
+            onKeyDown={handleEditorKeyDown}
+            data-testid="html-editor"
+          >
+            <Editor
+              id={`html-editor-${cell.refId}`}
+              value={value}
+              language="html"
+              fontSize={fontSettings.fontSize}
+              fontFamily={fontSettings.fontFamily}
+              onChange={handleEditorChange}
+              onEnter={handlePreview}
+            />
+            <div className="cell-toolbar">
+              <div className="flex items-center gap-3">
+                <select
+                  id={languageSelectId}
+                  value={selectedLanguage}
+                  onChange={onLanguageChange}
+                  className="toolbar-select"
+                >
+                  {languageOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="text-xs text-nb-text-muted">
+                Press <kbd className="px-1 py-0.5 bg-nb-surface-3 rounded">Esc</kbd>{" "}
+                or click away to preview
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+  (prevProps, nextProps) => prevProps.cellData === nextProps.cellData,
+);
+
+HtmlCell.displayName = "HtmlCell";
+
+export default HtmlCell;

--- a/app/src/components/Actions/HtmlCell.tsx
+++ b/app/src/components/Actions/HtmlCell.tsx
@@ -119,7 +119,7 @@ const HtmlCell = memo(
       () => (
         <iframe
           title={`html-preview-${cell?.refId ?? "cell"}`}
-          sandbox="allow-scripts"
+          sandbox=""
           srcDoc={value}
           className="h-[420px] w-full rounded-b-nb-md bg-white"
           data-testid="html-preview-frame"

--- a/app/src/lib/cellContent.ts
+++ b/app/src/lib/cellContent.ts
@@ -1,0 +1,10 @@
+const MARKDOWN_LANGUAGE_IDS = new Set(["markdown", "md"]);
+const HTML_LANGUAGE_IDS = new Set(["html", "htm"]);
+
+export function isMarkdownLanguageId(languageId?: string | null): boolean {
+  return MARKDOWN_LANGUAGE_IDS.has((languageId ?? "").trim().toLowerCase());
+}
+
+export function isHtmlLanguageId(languageId?: string | null): boolean {
+  return HTML_LANGUAGE_IDS.has((languageId ?? "").trim().toLowerCase());
+}

--- a/app/src/lib/markdown/serializeNotebookToMarkdown.test.ts
+++ b/app/src/lib/markdown/serializeNotebookToMarkdown.test.ts
@@ -77,6 +77,22 @@ describe('serializeNotebookToMarkdown', () => {
     )
   })
 
+  it('serializes html cells as authored content instead of fenced code', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'html',
+          value: '<div><svg><text>Hello</text></svg></div>',
+        }),
+      ],
+    })
+
+    expect(serializeNotebookToMarkdown(notebook)).toBe(
+      '<div><svg><text>Hello</text></svg></div>\n'
+    )
+  })
+
   it('skips binary and internal output payloads', () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [

--- a/app/src/lib/markdown/serializeNotebookToMarkdown.ts
+++ b/app/src/lib/markdown/serializeNotebookToMarkdown.ts
@@ -1,14 +1,21 @@
 import { MimeType, parser_pb } from '../../runme/client'
+import { isHtmlLanguageId, isMarkdownLanguageId } from '../cellContent'
 
 const IOPUB_MIME_TYPE = 'application/vnd.jupyter.iopub+json'
 
 const outputTextDecoder = new TextDecoder()
 
-const MARKDOWN_LANGUAGES = new Set(['markdown', 'md'])
 const INTERNAL_SKIP_MIMES = new Set<string>([
   MimeType.StatefulRunmeOutputItems,
   MimeType.StatefulRunmeTerminal,
 ])
+
+function normalizeBinaryData(data?: Uint8Array | ArrayLike<number> | null): Uint8Array {
+  if (!data) {
+    return new Uint8Array()
+  }
+  return data instanceof Uint8Array ? data : Uint8Array.from(data)
+}
 
 export function serializeNotebookToMarkdown(
   notebook: parser_pb.Notebook
@@ -25,21 +32,23 @@ export function serializeNotebookToMarkdown(
 }
 
 function serializeCell(cell: parser_pb.Cell): string {
-  const body = isMarkupCell(cell)
-    ? normalizeMarkupCell(cell.value)
+  const body = isAuthoredContentCell(cell)
+    ? normalizeContentCell(cell.value)
     : renderFencedBlock(cell.value, normalizeCodeFenceLanguage(cell.languageId))
   const outputs = serializeCellOutputs(cell.outputs ?? [])
   return [body, outputs].filter(Boolean).join('\n\n')
 }
 
-function isMarkupCell(cell: parser_pb.Cell): boolean {
+function isAuthoredContentCell(cell: parser_pb.Cell): boolean {
   if (cell.kind === parser_pb.CellKind.MARKUP) {
     return true
   }
-  return MARKDOWN_LANGUAGES.has(cell.languageId.trim().toLowerCase())
+  return (
+    isMarkdownLanguageId(cell.languageId) || isHtmlLanguageId(cell.languageId)
+  )
 }
 
-function normalizeMarkupCell(value: string): string {
+function normalizeContentCell(value: string): string {
   return value.replace(/\s+$/u, '')
 }
 
@@ -144,12 +153,13 @@ function languageForOutputMime(mime: string): string {
   }
 }
 
-function decodeOutputText(data: Uint8Array): string {
-  if (!(data instanceof Uint8Array) || data.length === 0) {
+function decodeOutputText(data?: Uint8Array | ArrayLike<number> | null): string {
+  const normalized = normalizeBinaryData(data)
+  if (normalized.length === 0) {
     return ''
   }
   try {
-    return outputTextDecoder.decode(data).replace(/\s+$/u, '')
+    return outputTextDecoder.decode(normalized).replace(/\s+$/u, '')
   } catch {
     return ''
   }

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -579,6 +579,28 @@ describe("NotebookData.runCodeCell", () => {
     expect(runID).toBe("");
   });
 
+  it("returns empty run id for html content cells", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-html",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "html",
+      outputs: [],
+      metadata: {},
+      value: "<div>Hello</div>",
+    });
+    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
+    const model = new NotebookData({
+      notebook,
+      uri: "nb://test",
+      name: "test",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    const runID = model.runCodeCell(cell);
+    expect(runID).toBe("");
+  });
+
   it("executes javascript locally with appkernel and records stdout + exit code", async () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-appkernel",

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -5,6 +5,7 @@ import {
   RunmeMetadataKey,
   MimeType,
 } from "../contexts/CellContext";
+import { isHtmlLanguageId } from "./cellContent";
 
 /**
  * Minimal store interface used by NotebookData for auto-saving.
@@ -676,6 +677,10 @@ export class NotebookData {
     }
 
     const normalizedLanguage = (cell.languageId ?? "").trim().toLowerCase();
+    if (isHtmlLanguageId(normalizedLanguage)) {
+      console.warn("Cannot run HTML content cell", cell.refId);
+      return "";
+    }
     const requestedRunnerName =
       (cell.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ?? "";
     const appKernelMode = resolveAppKernelRunnerMode(requestedRunnerName);

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -143,6 +143,7 @@ function codeCell(
   refId: string,
   value: string,
   opts: {
+    languageId?: string;
     outputs?: parser_pb.CellOutput[];
     metadata?: Record<string, string>;
   } = {},
@@ -150,7 +151,7 @@ function codeCell(
   return create(parser_pb.CellSchema, {
     refId,
     kind: parser_pb.CellKind.CODE,
-    languageId: "bash",
+    languageId: opts.languageId ?? "bash",
     value,
     outputs: opts.outputs ?? [],
     metadata: opts.metadata ?? {},
@@ -265,6 +266,25 @@ describe("createRunmeConsoleApi", () => {
     expect(clearMessage).toContain("Cleared 1 output item group(s) across 1 cell(s)");
     expect(runMessage).toContain("Started 1/1 code cell(s)");
     expect(model.getCell("cell-a")?.calls).toBe(1);
+  });
+
+  it("skips html content cells in runAll", () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        codeCell("cell-a", "echo a"),
+        codeCell("cell-html", "<div>Hello</div>", { languageId: "html" }),
+      ],
+    });
+    const model = new FakeNotebookData("local://one", "Notebook One", notebook);
+    const api = createRunmeConsoleApi({
+      resolveNotebook: () => model,
+    });
+
+    const message = api.runAll();
+
+    expect(message).toContain("Started 1/1 code cell(s)");
+    expect(model.getCell("cell-a")?.calls).toBe(1);
+    expect(model.getCell("cell-html")?.calls).toBe(0);
   });
 
   it("reruns notebook by clearing outputs before running cells", () => {
@@ -582,6 +602,30 @@ describe("createNotebooksApi", () => {
 
     expect(completed).toBe(true);
     expect(runner.calls).toBe(1);
+  });
+
+  it("rejects notebooks.execute for html cells before starting any runs", async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        codeCell("cell-a", "echo a"),
+        codeCell("cell-html", "<div>Hello</div>", { languageId: "html" }),
+      ],
+    });
+    const model = new FakeNotebookData("local://one", "One", notebook);
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    });
+
+    await expect(
+      api.execute({
+        target: { uri: "local://one" },
+        refIds: ["cell-a", "cell-html"],
+      }),
+    ).rejects.toThrow("HTML cells are not runnable: cell-html");
+
+    expect(model.getCell("cell-a")?.calls).toBe(0);
+    expect(model.getCell("cell-html")?.calls).toBe(0);
   });
 
   it("rejects notebooks.execute without an explicit target", async () => {

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -2,11 +2,19 @@ import { create } from "@bufbuild/protobuf";
 import md5 from "md5";
 
 import { RunmeMetadataKey, parser_pb } from "../../runme/client";
+import { isHtmlLanguageId } from "../cellContent";
 
 type CellRunnerLike = {
   run: () => void | Promise<void>;
   getRunID: () => string;
 };
+
+function isRunnableNotebookCodeCell(cell: parser_pb.Cell | null | undefined): boolean {
+  if (!cell || cell.kind !== parser_pb.CellKind.CODE) {
+    return false;
+  }
+  return !isHtmlLanguageId(cell.languageId);
+}
 
 export type NotebookDataLike = {
   getUri: () => string;
@@ -522,16 +530,29 @@ export function createNotebooksApi({
     execute: async (args) => {
       const notebook = resolveNotebookByRequiredTarget("execute", args.target);
       const executedCells: parser_pb.Cell[] = [];
+      const pendingRuns: Array<{ refId: string; runner: CellRunnerLike; cell: parser_pb.Cell }> = [];
       for (const refId of args.refIds ?? []) {
+        const cell = notebook.getNotebook().cells.find((candidate) => candidate.refId === refId);
+        if (!cell) {
+          throw new Error(`Cell not found: ${refId}`);
+        }
+        if (!isRunnableNotebookCodeCell(cell)) {
+          throw new Error(`HTML cells are not runnable: ${refId}`);
+        }
         const cellRunner = notebook.getCell(refId);
         if (!cellRunner) {
           throw new Error(`Cell not found: ${refId}`);
         }
-        const runResult = cellRunner.run();
+        pendingRuns.push({ refId, runner: cellRunner, cell });
+      }
+      for (const pending of pendingRuns) {
+        const runResult = pending.runner.run();
         if (isPromiseLike(runResult)) {
           await runResult;
         }
-        const cell = notebook.getNotebook().cells.find((candidate) => candidate.refId === refId);
+        const cell =
+          notebook.getNotebook().cells.find((candidate) => candidate.refId === pending.refId) ??
+          pending.cell;
         if (cell) {
           executedCells.push(cell);
         }
@@ -621,7 +642,7 @@ export function createRunmeConsoleApi({
     let failedToStart = 0;
 
     for (const cell of cells) {
-      if (!cell?.refId || cell.kind !== parser_pb.CellKind.CODE) {
+      if (!cell?.refId || !isRunnableNotebookCodeCell(cell)) {
         continue;
       }
       if ((cell.value ?? "").trim().length === 0) {

--- a/app/src/routes/run.tsx
+++ b/app/src/routes/run.tsx
@@ -779,7 +779,7 @@ function NotebookCellView({
             </div>
             <iframe
               title={`cell-preview-${cell.refId || index}`}
-              sandbox="allow-scripts"
+              sandbox=""
               srcDoc={cell.value || ""}
               className="h-[420px] w-full bg-white"
             />

--- a/app/src/routes/run.tsx
+++ b/app/src/routes/run.tsx
@@ -47,6 +47,7 @@ import {
   IOPUB_INCOMPLETE_METADATA_KEY,
   IOPUB_MIME_TYPE,
 } from "../lib/ipykernel.js";
+import { isHtmlLanguageId } from "../lib/cellContent.js";
 
 const POLL_INTERVAL_MS = 5e3;
 
@@ -771,7 +772,19 @@ function NotebookCellView({
         ) : null}
       </summary>
       <div className="mt-3 text-sm text-gray-900">
-        {cell.kind === CellKind.CODE ? (
+        {cell.kind === CellKind.CODE && isHtmlLanguageId(cell.languageId) ? (
+          <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+            <div className="border-b border-gray-200 bg-gray-100 px-3 py-2 text-xs font-medium uppercase tracking-wide text-gray-700">
+              HTML preview
+            </div>
+            <iframe
+              title={`cell-preview-${cell.refId || index}`}
+              sandbox="allow-scripts"
+              srcDoc={cell.value || ""}
+              className="h-[420px] w-full bg-white"
+            />
+          </div>
+        ) : cell.kind === CellKind.CODE ? (
           <pre className="max-h-120 overflow-auto whitespace-pre-wrap break-words rounded-md border border-gray-200 bg-gray-100 p-3 text-xs leading-relaxed">
             <code>{cell.value}</code>
           </pre>

--- a/app/test/browser/run-cuj-scenarios.ts
+++ b/app/test/browser/run-cuj-scenarios.ts
@@ -79,6 +79,7 @@ function fetchWithTimeout(
 }
 
 const SCENARIO_DRIVERS = [
+  join(SCRIPT_DIR, "test-scenario-html-cell.ts"),
   join(SCRIPT_DIR, "test-scenario-hello-world.ts"),
   join(SCRIPT_DIR, "test-scenario-open-shared-drive-link.ts"),
   join(SCRIPT_DIR, "test-scenario-appkernel-javascript.ts"),

--- a/app/test/browser/test-scenario-html-cell.ts
+++ b/app/test/browser/test-scenario-html-cell.ts
@@ -257,7 +257,7 @@ const convertAndPopulateRaw = run(
   `agent-browser eval "${escapeDoubleQuotes(`(() => {
     const editorContainer = document.getElementById('html-editor-cell_html_author');
     if (!(editorContainer instanceof HTMLElement)) {
-      return JSON.stringify({ status: 'missing-html-editor-container', srcdoc: '' });
+      return JSON.stringify({ status: 'missing-html-editor-container', srcdoc: '', sandbox: '' });
     }
     editorContainer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     const deadline = Date.now() + 5000;
@@ -269,6 +269,7 @@ const convertAndPopulateRaw = run(
           resolve(JSON.stringify({
             status: frame && rendered ? 'ok' : 'missing-preview',
             srcdoc: frame instanceof HTMLIFrameElement ? frame.getAttribute('srcdoc') || '' : '',
+            sandbox: frame instanceof HTMLIFrameElement ? frame.getAttribute('sandbox') || '' : '',
           }));
           return;
         }
@@ -282,12 +283,14 @@ const convertAndPopulateText = `${convertAndPopulateRaw.stdout}\n${convertAndPop
 writeArtifact("scenario-html-cell-02-opened.txt", convertAndPopulateText);
 
 let previewSrcdoc = "";
+let previewSandbox = "";
 try {
   const parsedOnce = JSON.parse(convertAndPopulateRaw.stdout.trim()) as unknown;
   const parsed = (typeof parsedOnce === "string"
     ? JSON.parse(parsedOnce)
-    : parsedOnce) as { status?: string; srcdoc?: string };
+    : parsedOnce) as { status?: string; srcdoc?: string; sandbox?: string };
   previewSrcdoc = parsed.srcdoc ?? "";
+  previewSandbox = parsed.sandbox ?? "";
   if (parsed.status === "ok") {
     pass("Converted markdown cell to HTML and populated inline SVG source");
   } else {
@@ -306,6 +309,12 @@ if (previewSrcdoc.includes("Hello SVG") && previewSrcdoc.includes("<svg")) {
   pass("Observed inline SVG markup in HTML preview srcdoc");
 } else {
   fail("HTML preview srcdoc did not contain expected SVG markup");
+}
+
+if (previewSandbox === "") {
+  pass("Rendered HTML preview without allow-scripts in the iframe sandbox");
+} else {
+  fail(`HTML preview iframe sandbox was not locked down as expected: ${previewSandbox}`);
 }
 
 try {

--- a/app/test/browser/test-scenario-html-cell.ts
+++ b/app/test/browser/test-scenario-html-cell.ts
@@ -1,0 +1,326 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND_URL = process.env.CUJ_FRONTEND_URL?.trim() || "http://localhost:5173";
+const SCENARIO_NOTEBOOK_NAME = "scenario-html-cell.runme.md";
+
+const CURRENT_FILE_DIR = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_DIR =
+  CURRENT_FILE_DIR.endsWith("/.generated") || CURRENT_FILE_DIR.endsWith("\\.generated")
+    ? dirname(CURRENT_FILE_DIR)
+    : CURRENT_FILE_DIR;
+const OUTPUT_DIR = join(SCRIPT_DIR, "test-output");
+const MOVIE_PATH = join(OUTPUT_DIR, "scenario-html-cell-walkthrough.webm");
+const AGENT_BROWSER_SESSION = process.env.AGENT_BROWSER_SESSION?.trim() ?? "";
+const AGENT_BROWSER_PROFILE = process.env.AGENT_BROWSER_PROFILE?.trim() ?? "";
+const AGENT_BROWSER_HEADED = (process.env.AGENT_BROWSER_HEADED ?? "false")
+  .trim()
+  .toLowerCase() === "true";
+const AGENT_BROWSER_KEEP_OPEN = (process.env.AGENT_BROWSER_KEEP_OPEN ?? "false")
+  .trim()
+  .toLowerCase() === "true";
+
+let passCount = 0;
+let failCount = 0;
+let totalCount = 0;
+
+function run(command: string): { status: number; stdout: string; stderr: string } {
+  const effectiveCommand = withAgentBrowserOptions(command);
+  const timeoutMs = Number(process.env.CUJ_SCENARIO_CMD_TIMEOUT_MS ?? "20000");
+  const result = spawnSync(effectiveCommand, {
+    shell: true,
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
+  });
+  const errorCode =
+    typeof result.error === "object" && result.error !== null && "code" in result.error
+      ? String((result.error as { code?: string }).code ?? "")
+      : "";
+  const timedOut = errorCode === "ETIMEDOUT";
+  const timeoutHint = timedOut
+    ? `\n[scenario-timeout] command timed out after ${timeoutMs}ms: ${effectiveCommand}\n`
+    : "";
+  if (timedOut && effectiveCommand.trim().startsWith("agent-browser ")) {
+    throw new Error(timeoutHint.trim());
+  }
+  return {
+    status: result.status ?? (timedOut ? 124 : 1),
+    stdout: result.stdout ?? "",
+    stderr: `${result.stderr ?? ""}${timeoutHint}`,
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function withAgentBrowserOptions(command: string): string {
+  const trimmed = command.trimStart();
+  if (!trimmed.startsWith("agent-browser ")) {
+    return command;
+  }
+  const leadingWhitespace = command.slice(0, command.length - trimmed.length);
+  const subcommand = trimmed.slice("agent-browser ".length);
+  const args: string[] = [];
+  if (AGENT_BROWSER_SESSION) {
+    args.push("--session", shellQuote(AGENT_BROWSER_SESSION));
+  }
+  if (AGENT_BROWSER_PROFILE) {
+    args.push("--profile", shellQuote(AGENT_BROWSER_PROFILE));
+  }
+  if (AGENT_BROWSER_HEADED) {
+    args.push("--headed");
+  }
+  const prefix = ["agent-browser", ...args].join(" ");
+  return `${leadingWhitespace}${prefix} ${subcommand}`;
+}
+
+function escapeDoubleQuotes(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function pass(message: string): void {
+  totalCount += 1;
+  passCount += 1;
+  console.log(`[PASS] ${message}`);
+}
+
+function fail(message: string): void {
+  totalCount += 1;
+  failCount += 1;
+  console.log(`[FAIL] ${message}`);
+}
+
+function writeArtifact(name: string, content: string): void {
+  writeFileSync(join(OUTPUT_DIR, name), content, "utf-8");
+}
+
+function runWithRetry(command: string, attempts = 3, waitMs = 1200): void {
+  let lastError = "";
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const result = run(command);
+    if (result.status === 0) {
+      return;
+    }
+    lastError = result.stderr || result.stdout || `exit ${result.status}`;
+    if (attempt < attempts - 1) {
+      run(`agent-browser wait ${waitMs}`);
+    }
+  }
+  throw new Error(`Command failed after ${attempts} attempts: ${command}\n${lastError}`);
+}
+
+mkdirSync(OUTPUT_DIR, { recursive: true });
+rmSync(join(OUTPUT_DIR, "scenario-html-cell-01-initial.txt"), { force: true });
+rmSync(join(OUTPUT_DIR, "scenario-html-cell-02-opened.txt"), { force: true });
+rmSync(join(OUTPUT_DIR, "scenario-html-cell-03-preview.txt"), { force: true });
+rmSync(join(OUTPUT_DIR, "scenario-html-cell-03-preview.png"), { force: true });
+rmSync(MOVIE_PATH, { force: true });
+
+if (run("command -v agent-browser").status !== 0) {
+  console.error("ERROR: agent-browser is required on PATH");
+  process.exit(2);
+}
+
+if (run(`curl -sf ${FRONTEND_URL}`).status !== 0) {
+  console.error(`ERROR: frontend is not running at ${FRONTEND_URL}`);
+  process.exit(1);
+}
+
+runWithRetry(`agent-browser open ${FRONTEND_URL}`);
+runWithRetry(`agent-browser record restart ${MOVIE_PATH}`);
+run("agent-browser wait 2500");
+
+const seedResult = run(
+  `agent-browser eval "(async () => {
+    const ln = window.app?.localNotebooks;
+    if (!ln) return 'missing-local-notebooks';
+    const notebook = {
+      metadata: {},
+      cells: [
+        {
+          refId: 'cell_html_author',
+          kind: 2,
+          languageId: 'markdown',
+          value: '',
+          metadata: {},
+          outputs: []
+        }
+      ]
+    };
+    await ln.files.put({
+      id: 'local://file/${SCENARIO_NOTEBOOK_NAME}',
+      uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}',
+      name: '${SCENARIO_NOTEBOOK_NAME}',
+      doc: JSON.stringify(notebook),
+      updatedAt: new Date().toISOString(),
+      parent: 'local://folder/local',
+      lastSynced: '',
+      remoteId: '',
+      lastRemoteChecksum: ''
+    });
+    localStorage.setItem('runme/openNotebooks', JSON.stringify([
+      { uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }
+    ]));
+    localStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
+    return 'ok';
+  })()"`,
+).stdout;
+
+if (seedResult.includes("ok")) {
+  pass("Created local notebook fixture for HTML cell scenario");
+} else {
+  fail("Failed to create local notebook fixture for HTML cell scenario");
+}
+
+run("agent-browser reload");
+run("agent-browser wait 2200");
+
+let snapshot = run("agent-browser snapshot -i").stdout;
+writeArtifact("scenario-html-cell-01-initial.txt", snapshot);
+
+const notebookProbe = run(
+  `agent-browser eval "(async () => {
+    return document.getElementById('language-select-cell_html_author') ? 'ok' : 'missing-language-select';
+  })()"`,
+);
+const notebookProbeText = `${notebookProbe.stdout}\n${notebookProbe.stderr}`.trim();
+if (notebookProbe.status === 0 && notebookProbeText.includes("ok")) {
+  pass("Opened notebook with editable markdown cell");
+} else {
+  fail("Did not find editable markdown cell for HTML scenario");
+}
+
+const htmlSource = [
+  "<div style='padding: 24px; background: linear-gradient(135deg, #fef3c7, #dbeafe);'>",
+  "  <svg width='320' height='120' viewBox='0 0 320 120' xmlns='http://www.w3.org/2000/svg'>",
+  "    <rect x='8' y='8' width='304' height='104' rx='18' fill='#0f172a' />",
+  "    <circle cx='64' cy='60' r='26' fill='#22c55e' />",
+  "    <text x='112' y='68' fill='white' font-size='28' font-family='Arial, sans-serif'>Hello SVG</text>",
+  "  </svg>",
+  "</div>",
+].join("\n");
+
+const htmlSelectRaw = run(
+  `agent-browser eval "${escapeDoubleQuotes(`(() => {
+    const select = document.getElementById('language-select-cell_html_author');
+    if (!(select instanceof HTMLSelectElement)) {
+      return JSON.stringify({ status: 'missing-language-select' });
+    }
+    select.value = 'html';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    const waitForHtmlEditor = () =>
+      new Promise((resolve) => {
+        const deadline = Date.now() + 5000;
+        const tick = () => {
+          const editor = document.getElementById('html-editor-cell_html_author');
+          if (editor || Date.now() > deadline) {
+            resolve(editor);
+            return;
+          }
+          setTimeout(tick, 50);
+        };
+        tick();
+      });
+    return waitForHtmlEditor().then((editor) =>
+      JSON.stringify({ status: editor ? 'ok' : 'missing-html-editor-container' })
+    );
+  })()`)}"`,
+);
+const htmlSelectText = `${htmlSelectRaw.stdout}\n${htmlSelectRaw.stderr}`.trim();
+writeArtifact("scenario-html-cell-02-opened.txt", htmlSelectText);
+
+let htmlEditorReady = false;
+try {
+  const parsedOnce = JSON.parse(htmlSelectRaw.stdout.trim()) as unknown;
+  const parsed = (typeof parsedOnce === "string"
+    ? JSON.parse(parsedOnce)
+    : parsedOnce) as { status?: string };
+  htmlEditorReady = parsed.status === "ok";
+} catch {
+  htmlEditorReady = false;
+}
+
+if (!htmlEditorReady) {
+  fail("HTML conversion/population did not complete: missing-html-editor-container");
+} else {
+  runWithRetry(
+    `agent-browser fill 'textarea[aria-label="Editor content"]' "${escapeDoubleQuotes(htmlSource)}"`,
+  );
+  run("agent-browser wait 600");
+}
+
+const convertAndPopulateRaw = run(
+  `agent-browser eval "${escapeDoubleQuotes(`(() => {
+    const editorContainer = document.getElementById('html-editor-cell_html_author');
+    if (!(editorContainer instanceof HTMLElement)) {
+      return JSON.stringify({ status: 'missing-html-editor-container', srcdoc: '' });
+    }
+    editorContainer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    const deadline = Date.now() + 5000;
+    return new Promise((resolve) => {
+      const tick = () => {
+        const frame = document.querySelector('[data-testid="html-preview-frame"]');
+        const rendered = document.querySelector('[data-testid="html-rendered"]');
+        if ((frame && rendered) || Date.now() > deadline) {
+          resolve(JSON.stringify({
+            status: frame && rendered ? 'ok' : 'missing-preview',
+            srcdoc: frame instanceof HTMLIFrameElement ? frame.getAttribute('srcdoc') || '' : '',
+          }));
+          return;
+        }
+        setTimeout(tick, 50);
+      };
+      tick();
+    });
+  })()`)}"`,
+);
+const convertAndPopulateText = `${convertAndPopulateRaw.stdout}\n${convertAndPopulateRaw.stderr}`.trim();
+writeArtifact("scenario-html-cell-02-opened.txt", convertAndPopulateText);
+
+let previewSrcdoc = "";
+try {
+  const parsedOnce = JSON.parse(convertAndPopulateRaw.stdout.trim()) as unknown;
+  const parsed = (typeof parsedOnce === "string"
+    ? JSON.parse(parsedOnce)
+    : parsedOnce) as { status?: string; srcdoc?: string };
+  previewSrcdoc = parsed.srcdoc ?? "";
+  if (parsed.status === "ok") {
+    pass("Converted markdown cell to HTML and populated inline SVG source");
+  } else {
+    fail(`HTML conversion/population did not complete: ${parsed.status ?? "unknown"}`);
+  }
+} catch {
+  fail("Could not parse HTML conversion result");
+}
+
+run("agent-browser wait 1200");
+run(`agent-browser screenshot ${join(OUTPUT_DIR, "scenario-html-cell-03-preview.png")}`);
+snapshot = run("agent-browser snapshot -i").stdout;
+writeArtifact("scenario-html-cell-03-preview.txt", snapshot);
+
+if (previewSrcdoc.includes("Hello SVG") && previewSrcdoc.includes("<svg")) {
+  pass("Observed inline SVG markup in HTML preview srcdoc");
+} else {
+  fail("HTML preview srcdoc did not contain expected SVG markup");
+}
+
+try {
+  run("agent-browser record stop");
+} catch (error) {
+  console.warn(`[WARN] Failed to stop agent-browser recording: ${String(error)}`);
+}
+
+if (!AGENT_BROWSER_KEEP_OPEN) {
+  try {
+    run("agent-browser close");
+  } catch (error) {
+    console.warn(`[WARN] Failed to close agent-browser session: ${String(error)}`);
+  }
+}
+
+console.log(`[SUMMARY] assertions=${totalCount} passed=${passCount} failed=${failCount}`);
+process.exit(failCount > 0 ? 1 : 0);

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -12,6 +12,7 @@ const backendProxyTarget =
 export default defineConfig({
   // Use root-relative assets so LB rewrites to /index.html still load bundles from /.
   base: "/",
+  cacheDir: ".vite",
   publicDir: "assets",
   optimizeDeps: {
     exclude: ["@runmedev/renderers"],

--- a/app/vitest.config.mts
+++ b/app/vitest.config.mts
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  cacheDir: '.vite',
   plugins: [react()],
   test: {
     environment: 'jsdom',

--- a/docs-dev/design/20260513_html_cells.md
+++ b/docs-dev/design/20260513_html_cells.md
@@ -1,0 +1,273 @@
+# 2026-05-13: HTML Cells
+
+## Status
+
+Proposed and implemented in this branch.
+
+## Summary
+
+Add an `html` notebook cell mode that behaves like the existing markdown cell
+mode:
+
+- edit mode shows the raw HTML source in Monaco,
+- render mode previews the result in place,
+- the cell does not execute through a runner,
+- switching between source and preview is local UI behavior, not notebook
+  execution.
+
+We will represent HTML cells as existing `CODE` cells with
+`languageId: "html"`.
+
+We will not introduce a new protobuf `CellKind`.
+
+The rendered preview will use a sandboxed `iframe` with `srcDoc`, matching the
+existing trusted rendering path already used for `text/html` cell outputs.
+
+## Motivation
+
+Today a user can render HTML or SVG in a notebook only indirectly:
+
+- code cells can emit `text/html` or `image/svg+xml` output bundles,
+- markdown cells render prose in place, but raw HTML is intentionally disabled
+  in the editable notebook UI.
+
+That leaves a product gap for authored rich content:
+
+- users cannot paste HTML or inline SVG as notebook source and preview it
+  directly,
+- the only current workaround is a runnable cell that emits the markup as
+  output,
+- that is heavier than necessary when the content is static or illustrative.
+
+An explicit HTML cell addresses that gap without weakening markdown safety.
+
+## Goals
+
+- Let users author HTML directly in notebook cells.
+- Support inline SVG through HTML source such as `<svg>...</svg>`.
+- Preserve the markdown cell trust model. Markdown remains sanitized and does
+  not render raw HTML in the main notebook editor.
+- Avoid schema changes to the notebook protobuf model.
+- Reuse the existing HTML preview trust boundary where possible.
+- Keep HTML cells visible in source form when notebooks are serialized to
+  Markdown sidecars.
+
+## Non-Goals
+
+- Executing HTML cells through Runme runners, Jupyter, or AppKernel.
+- Adding a general-purpose raw-HTML mode to markdown cells.
+- Adding a separate `svg` cell type.
+- Building a full HTML document editor with assets, dependency management, or a
+  live dev server.
+- Introducing cross-cell scripting or access from preview iframes back into the
+  app shell.
+
+## Current State
+
+The existing notebook UI has two relevant behaviors.
+
+Markdown cells:
+
+- use `CellKind.MARKUP` or `languageId=markdown`,
+- render in place with `react-markdown`,
+- explicitly disable raw HTML in the editable notebook experience.
+
+Code cells:
+
+- render Monaco source,
+- may show rich outputs below the source,
+- already render `text/html` outputs inside a sandboxed `iframe srcDoc`.
+
+The existing notebook data model also hard-codes markup cells to markdown.
+
+That means the cleanest way to add HTML authoring is not to repurpose
+`CellKind.MARKUP`, but to recognize `languageId=html` as a notebook-native
+non-executing authored-content mode.
+
+## Decision
+
+We are choosing Option B:
+
+1. Represent HTML cells as `CellKind.CODE` with `languageId: "html"`.
+2. Add a dedicated in-place `HtmlCell` component with edit/render behavior
+   parallel to `MarkdownCell`.
+3. Render the preview through a sandboxed `iframe srcDoc`.
+4. Treat HTML cells as non-runnable content cells in the notebook UI.
+5. Serialize HTML cells into Markdown sidecars as raw HTML, not fenced code.
+
+## Why Reuse `CODE` + `languageId=html`
+
+Reasons:
+
+- No protobuf/schema migration is required.
+- Existing notebook APIs and storage already preserve arbitrary code
+  `languageId` values.
+- Monaco already understands `html`.
+- Language switching can convert between `markdown`, `html`, and runnable code
+  languages without inventing a third structural cell kind.
+- It keeps the meaning explicit: markdown is markup prose, html is raw trusted
+  DOM content.
+
+We explicitly do not reuse `CellKind.MARKUP` for HTML, because that kind is
+already semantically and programmatically tied to markdown behavior across the
+app.
+
+## UX
+
+### Authoring
+
+HTML cells should feel like markdown cells:
+
+- empty HTML cells start in edit mode,
+- non-empty HTML cells start in rendered mode,
+- double-click rendered preview enters edit mode,
+- `Esc` or blur returns to preview when non-empty,
+- `Shift+Enter` or the editor's existing run gesture should preview rather than
+  execute.
+
+Edit mode uses Monaco with `language="html"`.
+
+### Language switching
+
+The language selector should add `HTML`.
+
+Conversions:
+
+- `markdown` -> `html`
+  - convert to `CellKind.CODE`
+  - set `languageId` to `html`
+- `html` -> runnable language
+  - keep `CellKind.CODE`
+  - change `languageId`
+  - clear runner/kernel metadata as needed
+- runnable language -> `html`
+  - keep `CellKind.CODE`
+  - set `languageId` to `html`
+  - clear runner/kernel metadata
+
+We keep `markdown` special because it still maps to `CellKind.MARKUP`.
+
+### Empty notebook affordance
+
+The existing "add first cell" button currently creates a markdown cell.
+
+We will keep that behavior. HTML is an opt-in language choice, not the default
+for new notebooks.
+
+## Rendering and Security
+
+HTML preview is trusted-but-contained content.
+
+We will render the preview with:
+
+- `iframe`
+- `srcDoc={cell.value}`
+- `sandbox="allow-scripts"`
+
+This matches the existing rendering path for `text/html` cell outputs.
+
+Rationale:
+
+- It isolates CSS and DOM from the notebook shell.
+- It lets inline SVG work naturally.
+- It avoids `dangerouslySetInnerHTML` in the main React tree.
+
+This is intentionally different from markdown:
+
+- markdown remains a constrained authoring surface,
+- html is an explicit raw-content mode with a visibly different trust boundary.
+
+This proposal does not add `allow-same-origin` or message-passing from the
+preview back into the app.
+
+## Notebook Serialization
+
+Markdown sidecars currently serialize:
+
+- markdown cells as prose,
+- code cells as fenced code blocks.
+
+HTML cells are authored content, not executable source, so fenced-code output is
+the wrong projection for search/readability.
+
+We will serialize HTML cells as raw HTML text with trailing whitespace trimmed,
+similar to how markdown cells are emitted directly.
+
+Consequences:
+
+- Drive sidecars remain readable.
+- Search can index text inside HTML and SVG source.
+- An exported sidecar keeps a faithful authored representation.
+
+We are not trying to sanitize or pretty-print the HTML during serialization.
+
+## Read-Only Notebook Views
+
+Any read-only notebook presentation that currently distinguishes only between
+code and markdown should also recognize `languageId=html`.
+
+For those views, HTML cells should render as authored content instead of showing
+only a code block.
+
+That keeps shared/opened notebooks consistent with the main editor experience.
+
+## Testing
+
+Required coverage:
+
+1. Unit tests for notebook cell language switching.
+2. Unit tests for notebook serialization of HTML cells.
+3. UI tests for rendering/editing behavior where practical in JSDOM.
+4. Browser scenario validation that:
+   - creates or opens a notebook,
+   - switches a cell to HTML,
+   - enters HTML containing inline SVG,
+   - exits edit mode,
+   - verifies the preview renders expected text/SVG markers,
+   - records a `.webm` walkthrough.
+
+## Alternatives Considered
+
+### Option A: Enable raw HTML in markdown cells
+
+Rejected.
+
+Reasons:
+
+- It weakens the markdown safety model.
+- It mixes two trust levels into one cell type.
+- It makes it harder for users to understand whether a cell is prose or raw
+  DOM content.
+
+### Option B: New protobuf `CellKind.HTML`
+
+Rejected for now.
+
+Reasons:
+
+- Requires schema and compatibility work with little immediate benefit.
+- The existing `languageId` field already provides enough expressiveness.
+
+### Option C: SVG-only cells
+
+Rejected.
+
+Reasons:
+
+- HTML already covers inline SVG.
+- A separate SVG-only mode creates unnecessary surface area.
+
+## Rollout Notes
+
+This design is intentionally minimal.
+
+If we later find strong demand for richer embedded documents, we can extend the
+preview shell with:
+
+- default sizing helpers,
+- resize affordances,
+- safer preview metadata,
+- optional source formatting.
+
+Those are follow-on improvements, not prerequisites for the first HTML cell
+feature.

--- a/docs-dev/design/20260513_html_cells.md
+++ b/docs-dev/design/20260513_html_cells.md
@@ -21,7 +21,8 @@ We will represent HTML cells as existing `CODE` cells with
 We will not introduce a new protobuf `CellKind`.
 
 The rendered preview will use a sandboxed `iframe` with `srcDoc`, matching the
-existing trusted rendering path already used for `text/html` cell outputs.
+existing trusted rendering path already used for `text/html` cell outputs, but
+with stricter script handling for authored cell content.
 
 ## Motivation
 
@@ -94,6 +95,9 @@ We are choosing Option B:
 3. Render the preview through a sandboxed `iframe srcDoc`.
 4. Treat HTML cells as non-runnable content cells in the notebook UI.
 5. Serialize HTML cells into Markdown sidecars as raw HTML, not fenced code.
+6. In the first version, do not allow scripts in authored HTML previews.
+7. Gate execution on both `kind` and `languageId`, so `languageId=html` is
+   skipped by notebook execution APIs.
 
 ## Why Reuse `CODE` + `languageId=html`
 
@@ -156,21 +160,25 @@ for new notebooks.
 
 ## Rendering and Security
 
-HTML preview is trusted-but-contained content.
+HTML preview is contained content, but it should not be treated as trusted by
+default.
 
 We will render the preview with:
 
 - `iframe`
 - `srcDoc={cell.value}`
-- `sandbox="allow-scripts"`
+- `sandbox` with no `allow-scripts` token in the first version
 
-This matches the existing rendering path for `text/html` cell outputs.
+This is intentionally stricter than the current `text/html` output path.
 
 Rationale:
 
 - It isolates CSS and DOM from the notebook shell.
 - It lets inline SVG work naturally.
 - It avoids `dangerouslySetInnerHTML` in the main React tree.
+- It still supports the immediate HTML-cell use case of static HTML, CSS, and
+  inline SVG.
+- It avoids automatically executing JavaScript just by opening a notebook.
 
 This is intentionally different from markdown:
 
@@ -179,6 +187,39 @@ This is intentionally different from markdown:
 
 This proposal does not add `allow-same-origin` or message-passing from the
 preview back into the app.
+
+### Future trust model
+
+Longer term, we should add an explicit notebook trust model instead of treating
+all HTML cells the same.
+
+Recommended direction:
+
+- notebooks opened from local disk, Drive, or shared links start untrusted,
+- untrusted notebooks render HTML cells with scripts disabled,
+- users can explicitly mark a notebook trusted,
+- trusted notebooks may opt into richer preview capabilities, including script
+  execution, if product demand justifies it.
+
+The closest existing precedent is Jupyter's notebook trust model. JupyterLab's
+current user docs say that JavaScript and HTML from notebooks created on other
+machines are not trusted by default, that interactive outputs are blocked until
+the notebook is explicitly trusted, and that markdown cells are always
+sanitized. The classic Notebook security docs make the same distinction: for
+untrusted notebooks, HTML is sanitized, JavaScript is not executed, and users
+can explicitly trust a notebook later.
+
+Sources:
+
+- [JupyterLab user docs: Trust](https://jupyterlab.readthedocs.io/en/stable/user/notebook.html#trust)
+- [Jupyter Notebook security docs](https://jupyter-server.readthedocs.io/en/latest/operators/security.html)
+
+We do not need to build Jupyter's full signature-based trust model in the first
+HTML-cell iteration, but its policy shape is a useful reference:
+
+- safe default on open,
+- explicit upgrade to trusted,
+- no raw HTML/JS execution in markdown.
 
 ## Notebook Serialization
 
@@ -211,6 +252,43 @@ only a code block.
 
 That keeps shared/opened notebooks consistent with the main editor experience.
 
+For the first version, read-only views should use the same no-scripts preview
+policy as the editable notebook view. Opening a shared notebook should not
+execute authored JavaScript automatically.
+
+## Execution Semantics
+
+HTML cells are stored as `CellKind.CODE` for compatibility, but they are not
+semantically runnable code cells.
+
+Short-term recommendation:
+
+- keep `CellKind.CODE` plus `languageId=html`,
+- treat `languageId=html` as a non-runnable subtype everywhere execution is
+  dispatched,
+- gate execution on both cell kind and normalized language, not cell kind
+  alone.
+
+That means at minimum:
+
+- the per-cell editor should not show run affordances for HTML cells,
+- `runme.runAll()` should skip HTML cells,
+- `notebooks.execute({ target, refIds })` should skip or reject HTML cells
+  explicitly,
+- any future bulk execution helper should follow the same rule.
+
+Why this is the right short-term tradeoff:
+
+- it avoids a schema migration,
+- it keeps language-switching simple,
+- it preserves the existing storage model,
+- it prevents accidental execution of raw markup through shell, Jupyter, or
+  AppKernel paths.
+
+If we later find that `kind=CODE` creates too much branching or ambiguity, we
+can revisit a dedicated protobuf kind. That should be a follow-on cleanup, not a
+prerequisite for the initial feature.
+
 ## Testing
 
 Required coverage:
@@ -225,6 +303,10 @@ Required coverage:
    - exits edit mode,
    - verifies the preview renders expected text/SVG markers,
    - records a `.webm` walkthrough.
+5. Execution-path tests proving that HTML cells are skipped by `runAll` and
+   rejected or ignored by `notebooks.execute(...)`.
+6. Trust-boundary tests proving that authored scripts do not run in HTML cell
+   previews in the first version.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
## Summary
- add a dedicated in-place HTML cell mode backed by 
- render HTML cells through a sandboxed iframe preview, including inline SVG content
- add design documentation, serialization coverage, and a browser CUJ that records a walkthrough video

## Testing
- runme run build test
- pnpm exec vitest run src/components/Actions/Actions.test.tsx src/lib/markdown/serializeNotebookToMarkdown.test.ts
- CUJ_UPLOAD=false CUJ_FRONTEND_URL=http://localhost:5174 CUJ_USE_AUTH=false CUJ_DRIVE_FAKE_ENABLED=false CUJ_FAKE_CHATKIT_ENABLED=false CUJ_SCENARIOS=html-cell AGENT_BROWSER_HEADED=true pnpm -C app run cuj:run