### PR TITLE
Refactor notebook session state

### DIFF
--- a/app/design.md
+++ b/app/design.md
@@ -22,18 +22,57 @@ For rendering, codex suggested we should still produce snapshots of the data
 because REACT 18 and newer supports concurrent rendering which can lead to
 tearing if we don't have snapshots.
 
+### Notebook Session State
+
+`NotebookDataController` owns the notebook session state outside React.
+
+It is responsible for:
+
+* resolving requested notebook URIs to stable `local://file/...` URIs
+* tracking the open notebook list
+* owning loaded `NotebookData` instances
+* loading notebook content through `LocalNotebooks`
+* exposing snapshots and subscriptions for React adapters
+
+`NotebookContext` is a React adapter over `NotebookDataController`. It should
+not own the `NotebookData` registry itself.
+
+`CurrentDocContext` owns only the visible notebook selection. Setting the
+current doc should not load, mirror, or create notebook data. Callers that want
+to open a notebook should first call `openNotebook(uri)` and then select the
+returned local URI.
+
+The intended flow is:
+
+```text
+openNotebook(uri)
+  -> resolve or reserve stable local URI
+  -> create/load NotebookData when possible
+  -> return local URI plus load state
+setCurrentDoc(localUri)
+  -> update visible selection only
+```
+
 ## Global State and Singletons
 
 When should we rely on global singletons and storing state outside of React versus using React contexts?
 
 I think using global singletons makes more sense when
 * We want to access the data in library code that is independent of React
-* The UI isn't reactive to changes in the state
+* The UI reads the state through a subscription/snapshot adapter rather than
+  owning the state directly
+* The object coordinates business logic that should not be tied to React mount
+  order
 
 Example would be things like clients for talking to backend services (e.g. runme)
 * We can have a singleton ClientManager which provides methods for getting/setting the clients
 * Libraries that need a client can then get it via the ClientManager
 * When user changes a setting in the UI (E.g. backend URL) we can react and update the clients in the ClientManager
+
+`NotebookDataController` follows this pattern. It is a global singleton because
+runtime helpers, App Console, notebook views, and future multi-tab ownership
+logic all need one notebook session owner. React remains reactive by subscribing
+to the controller snapshot through `NotebookContext`.
 
 ## Unresolved Design Questions
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -73,6 +73,7 @@ function AppRouter() {
   const basename = getAppRouterBasename();
   return (
     <BrowserRouter basename={basename === "/" ? undefined : basename}>
+      <DriveLinkCoordinatorHost />
       <Routes>
         <Route path="/" element={<MainPage />} />
         <Route
@@ -166,7 +167,6 @@ function App({ branding }: AppProps) {
                     >
                       <OutputProvider>
                         <NotebookProvider>
-                          <DriveLinkCoordinatorHost />
                           <WebMcpToolRegistrationHost />
                           <SidePanelProvider>
                             <GlobalToast />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -150,7 +150,6 @@ function App({ branding }: AppProps) {
               <FilesystemStoreProvider>
               <CurrentDocProvider>
                   <NotebookStoreInitializer />
-                  <DriveLinkCoordinatorHost />
                   <SettingsProvider
                     agentEndpoint={configuredAgentEndpoint}
                     webApp={
@@ -167,6 +166,7 @@ function App({ branding }: AppProps) {
                     >
                       <OutputProvider>
                         <NotebookProvider>
+                          <DriveLinkCoordinatorHost />
                           <WebMcpToolRegistrationHost />
                           <SidePanelProvider>
                             <GlobalToast />

--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -180,7 +180,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
   const { updateRunner, deleteRunner, setDefaultRunner } = useRunners();
   const { getItems, addItem, removeItem } = useWorkspace();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
-  const { getNotebookData, useNotebookList } = useNotebookContext();
+  const { getNotebookData, openNotebook, useNotebookList } = useNotebookContext();
   const openNotebooks = useNotebookList();
   const { fsStore, setFsStore } = useFilesystemStore();
   const { store: notebookStore } = useNotebookStore();
@@ -394,8 +394,9 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
         addItem,
         removeItem,
       },
-      openNotebook: (uri) => {
-        setCurrentDoc(uri);
+      openNotebook: async (uri) => {
+        const result = await openNotebook(uri);
+        setCurrentDoc(result.localUri);
       },
       resolveNotebook: resolveNotebookData,
       listNotebooks: () =>
@@ -455,6 +456,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
     ensureFilesystemStore,
     getItems,
     getNotebookData,
+    openNotebook,
     openNotebooks,
     removeItem,
     resolveNotebookData,

--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -400,7 +400,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
       },
       resolveNotebook: resolveNotebookData,
       listNotebooks: () =>
-      openNotebooks
+        openNotebooks
           .reduce<NotebookDataLike[]>((items, notebook) => {
             const resolved = getNotebookData(notebook.uri);
             if (resolved) {

--- a/app/src/components/CurrentDocInitializer.test.tsx
+++ b/app/src/components/CurrentDocInitializer.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CurrentDocInitializer } from "./CurrentDocInitializer";
+
+const mocks = vi.hoisted(() => ({
+  getStore: vi.fn(() => null as unknown),
+  openNotebook: vi.fn(),
+  setCurrentDoc: vi.fn(),
+}));
+
+vi.mock("../contexts/CurrentDocContext", () => ({
+  useCurrentDoc: () => ({
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}));
+
+vi.mock("../contexts/NotebookContext", () => ({
+  useNotebookContext: () => ({
+    openNotebook: mocks.openNotebook,
+  }),
+}));
+
+vi.mock("../contexts/NotebookStoreContext", () => ({
+  useNotebookStore: () => ({
+    store: mocks.getStore(),
+  }),
+}));
+
+function setDocUrl(uri: string): void {
+  const url = new URL("http://localhost/?existing=1#section");
+  url.searchParams.set("doc", uri);
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+}
+
+describe("CurrentDocInitializer", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.getStore.mockReset();
+    mocks.getStore.mockReturnValue(null);
+    mocks.openNotebook.mockReset();
+    mocks.setCurrentDoc.mockReset();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("keeps remote doc params until the notebook store is ready", async () => {
+    setDocUrl("fs://workspace/demo/file/example.json");
+
+    render(<CurrentDocInitializer />);
+
+    await waitFor(() => {
+      expect(mocks.getStore).toHaveBeenCalled();
+    });
+    expect(mocks.openNotebook).not.toHaveBeenCalled();
+    expect(window.location.search).toContain("doc=");
+  });
+
+  it("keeps doc params when opening the notebook fails", async () => {
+    setDocUrl("fs://workspace/demo/file/example.json");
+    mocks.getStore.mockReturnValue({});
+    mocks.openNotebook.mockRejectedValue(new Error("Notebook store is not ready"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<CurrentDocInitializer />);
+
+    await waitFor(() => {
+      expect(mocks.openNotebook).toHaveBeenCalledWith(
+        "fs://workspace/demo/file/example.json",
+      );
+    });
+    expect(mocks.setCurrentDoc).not.toHaveBeenCalled();
+    expect(window.location.search).toContain("doc=");
+  });
+
+  it("selects the local URI and clears doc params after a successful open", async () => {
+    setDocUrl("fs://workspace/demo/file/example.json");
+    mocks.getStore.mockReturnValue({});
+    mocks.openNotebook.mockResolvedValue({
+      localUri: "local://file/example",
+      entry: {
+        uri: "local://file/example",
+        requestedUri: "fs://workspace/demo/file/example.json",
+        name: "example.json",
+        state: "loaded",
+      },
+    });
+
+    render(<CurrentDocInitializer />);
+
+    await waitFor(() => {
+      expect(mocks.setCurrentDoc).toHaveBeenCalledWith("local://file/example");
+    });
+    expect(window.location.search).toBe("?existing=1");
+    expect(window.location.hash).toBe("#section");
+  });
+});

--- a/app/src/components/CurrentDocInitializer.tsx
+++ b/app/src/components/CurrentDocInitializer.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useCurrentDoc } from "../contexts/CurrentDocContext";
 import { useNotebookContext } from "../contexts/NotebookContext";
+import { useNotebookStore } from "../contexts/NotebookStoreContext";
 
 function isNotebookDocParam(uri: string): boolean {
   return uri.startsWith("local://file/") || uri.startsWith("fs://");
@@ -16,38 +17,48 @@ function clearDocParam(): void {
   );
 }
 
+function requiresNotebookStore(uri: string): boolean {
+  return !uri.startsWith("local://file/");
+}
+
 export function CurrentDocInitializer() {
   const { setCurrentDoc } = useCurrentDoc();
   const { openNotebook } = useNotebookContext();
+  const { store } = useNotebookStore();
 
-  useEffect(() => { 
+  useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const docParam = params.get("doc");
     if (!docParam || !isNotebookDocParam(docParam)) {
       return;
     }
+    if (requiresNotebookStore(docParam) && !store) {
+      return;
+    }
 
     let cancelled = false;
-    void (async () => {
-      try {
-        const result = await openNotebook(docParam);
-        if (cancelled) {
-          return;
-        }
-        setCurrentDoc(result.localUri);
-      } catch (error) {
-        console.error("Failed to open notebook from URL", error);
-      } finally {
-        if (!cancelled) {
-          clearDocParam();
-        }
+    queueMicrotask(() => {
+      if (cancelled) {
+        return;
       }
-    })();
+      void (async () => {
+        try {
+          const result = await openNotebook(docParam);
+          if (cancelled) {
+            return;
+          }
+          setCurrentDoc(result.localUri);
+          clearDocParam();
+        } catch (error) {
+          console.error("Failed to open notebook from URL", error);
+        }
+      })();
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [openNotebook, setCurrentDoc]);
+  }, [openNotebook, setCurrentDoc, store]);
 
   return null;
 }

--- a/app/src/components/CurrentDocInitializer.tsx
+++ b/app/src/components/CurrentDocInitializer.tsx
@@ -1,21 +1,53 @@
 import { useEffect } from "react";
 import { useCurrentDoc } from "../contexts/CurrentDocContext";
+import { useNotebookContext } from "../contexts/NotebookContext";
 
-// Ensure we never start with a local:// document in the query param, since it
-// isn't shareable across sessions.
+function isNotebookDocParam(uri: string): boolean {
+  return uri.startsWith("local://file/") || uri.startsWith("fs://");
+}
+
+function clearDocParam(): void {
+  const nextUrl = new URL(window.location.href);
+  nextUrl.searchParams.delete("doc");
+  window.history.replaceState(
+    null,
+    "",
+    `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
+  );
+}
+
 export function CurrentDocInitializer() {
   const { setCurrentDoc } = useCurrentDoc();
+  const { openNotebook } = useNotebookContext();
 
   useEffect(() => { 
-    // At startup strip any local-only document references from the URL so
-    // downstream logic never tries to load them.
     const params = new URLSearchParams(window.location.search);
     const docParam = params.get("doc");
-    console.log("CurrentDocInitializer running", { docParam });
-    if (docParam && docParam.startsWith("local://")) {
-      setCurrentDoc(null);
+    if (!docParam || !isNotebookDocParam(docParam)) {
+      return;
     }
-  }, [setCurrentDoc]);
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await openNotebook(docParam);
+        if (cancelled) {
+          return;
+        }
+        setCurrentDoc(result.localUri);
+      } catch (error) {
+        console.error("Failed to open notebook from URL", error);
+      } finally {
+        if (!cancelled) {
+          clearDocParam();
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [openNotebook, setCurrentDoc]);
 
   return null;
 }

--- a/app/src/components/DriveLinkCoordinatorHost.test.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { useEffect } from "react";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DriveLinkCoordinatorHost from "./DriveLinkCoordinatorHost";
+
+const mocks = vi.hoisted(() => ({
+  addItem: vi.fn(),
+  configure: vi.fn(),
+  consumeUrlIntentFromLocation: vi.fn(),
+  ensureAccessToken: vi.fn(),
+  getItems: vi.fn(() => [] as string[]),
+  openNotebook: vi.fn(),
+  processPending: vi.fn(),
+  removeItem: vi.fn(),
+  setCurrentDoc: vi.fn(),
+  store: {
+    addFile: vi.fn(),
+    updateFolder: vi.fn(),
+  },
+}));
+
+vi.mock("../contexts/GoogleAuthContext", () => ({
+  useGoogleAuth: () => ({
+    ensureAccessToken: mocks.ensureAccessToken,
+  }),
+}));
+
+vi.mock("../contexts/NotebookStoreContext", () => ({
+  useNotebookStore: () => ({
+    store: mocks.store,
+  }),
+}));
+
+vi.mock("../contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({
+    addItem: mocks.addItem,
+    getItems: mocks.getItems,
+    removeItem: mocks.removeItem,
+  }),
+}));
+
+vi.mock("../contexts/CurrentDocContext", () => ({
+  useCurrentDoc: () => ({
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}));
+
+vi.mock("../contexts/NotebookContext", () => ({
+  useNotebookContext: () => ({
+    openNotebook: mocks.openNotebook,
+  }),
+}));
+
+vi.mock("../lib/driveLinkCoordinator", () => ({
+  driveLinkCoordinator: {
+    configure: mocks.configure,
+    consumeUrlIntentFromLocation: mocks.consumeUrlIntentFromLocation,
+    processPending: mocks.processPending,
+  },
+}));
+
+function NavigateTo({ to }: { to: string }) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate(to);
+  }, [navigate, to]);
+
+  return <DriveLinkCoordinatorHost />;
+}
+
+describe("DriveLinkCoordinatorHost", () => {
+  beforeEach(() => {
+    mocks.addItem.mockReset();
+    mocks.configure.mockReset();
+    mocks.consumeUrlIntentFromLocation.mockReset();
+    mocks.ensureAccessToken.mockReset();
+    mocks.getItems.mockReset();
+    mocks.getItems.mockReturnValue([]);
+    mocks.openNotebook.mockReset();
+    mocks.processPending.mockReset();
+    mocks.processPending.mockResolvedValue(undefined);
+    mocks.removeItem.mockReset();
+    mocks.setCurrentDoc.mockReset();
+    mocks.store.addFile.mockReset();
+    mocks.store.updateFolder.mockReset();
+  });
+
+  it("rechecks URL drive-link intents when the router location changes", async () => {
+    const firstUrl =
+      "/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview";
+    const secondUrl =
+      "/?doc=https%3A%2F%2Fdrive.google.com%2Fdrive%2Ffolders%2Ffolder123";
+    const rendered = render(
+      <MemoryRouter initialEntries={["/"]}>
+        <NavigateTo to={firstUrl} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.consumeUrlIntentFromLocation).toHaveBeenCalledTimes(2);
+    });
+    const callsAfterFirstUrl = mocks.consumeUrlIntentFromLocation.mock.calls.length;
+
+    rendered.rerender(
+      <MemoryRouter initialEntries={[firstUrl]}>
+        <NavigateTo to={secondUrl} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.consumeUrlIntentFromLocation.mock.calls.length).toBeGreaterThan(
+        callsAfterFirstUrl,
+      );
+    });
+  });
+});

--- a/app/src/components/DriveLinkCoordinatorHost.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.tsx
@@ -4,6 +4,7 @@ import { useGoogleAuth } from "../contexts/GoogleAuthContext";
 import { useNotebookStore } from "../contexts/NotebookStoreContext";
 import { useWorkspace } from "../contexts/WorkspaceContext";
 import { useCurrentDoc } from "../contexts/CurrentDocContext";
+import { useNotebookContext } from "../contexts/NotebookContext";
 import { driveLinkCoordinator } from "../lib/driveLinkCoordinator";
 
 export function DriveLinkCoordinatorHost() {
@@ -11,6 +12,7 @@ export function DriveLinkCoordinatorHost() {
   const { store } = useNotebookStore();
   const { addItem, getItems, removeItem } = useWorkspace();
   const { setCurrentDoc } = useCurrentDoc();
+  const { openNotebook } = useNotebookContext();
 
   useEffect(() => {
     if (!store) {
@@ -27,14 +29,23 @@ export function DriveLinkCoordinatorHost() {
       addWorkspaceItem: addItem,
       removeWorkspaceItem: removeItem,
       getWorkspaceItems: getItems,
-      openNotebook: (localUri: string) => {
-        setCurrentDoc(localUri);
+      openNotebook: async (localUri: string) => {
+        const result = await openNotebook(localUri);
+        setCurrentDoc(result.localUri);
       },
     });
 
     driveLinkCoordinator.consumeUrlIntentFromLocation();
     void driveLinkCoordinator.processPending();
-  }, [addItem, ensureAccessToken, getItems, removeItem, setCurrentDoc, store]);
+  }, [
+    addItem,
+    ensureAccessToken,
+    getItems,
+    openNotebook,
+    removeItem,
+    setCurrentDoc,
+    store,
+  ]);
 
   return null;
 }

--- a/app/src/components/DriveLinkCoordinatorHost.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
 import { useGoogleAuth } from "../contexts/GoogleAuthContext";
 import { useNotebookStore } from "../contexts/NotebookStoreContext";
@@ -8,6 +9,7 @@ import { useNotebookContext } from "../contexts/NotebookContext";
 import { driveLinkCoordinator } from "../lib/driveLinkCoordinator";
 
 export function DriveLinkCoordinatorHost() {
+  const location = useLocation();
   const { ensureAccessToken } = useGoogleAuth();
   const { store } = useNotebookStore();
   const { addItem, getItems, removeItem } = useWorkspace();
@@ -35,8 +37,23 @@ export function DriveLinkCoordinatorHost() {
       },
     });
 
-    driveLinkCoordinator.consumeUrlIntentFromLocation();
+    const consumeUrlIntent = () => {
+      if (driveLinkCoordinator.consumeUrlIntentFromLocation()) {
+        void driveLinkCoordinator.processPending();
+      }
+    };
+
+    consumeUrlIntent();
     void driveLinkCoordinator.processPending();
+    window.addEventListener("focus", consumeUrlIntent);
+    window.addEventListener("pageshow", consumeUrlIntent);
+    window.addEventListener("popstate", consumeUrlIntent);
+
+    return () => {
+      window.removeEventListener("focus", consumeUrlIntent);
+      window.removeEventListener("pageshow", consumeUrlIntent);
+      window.removeEventListener("popstate", consumeUrlIntent);
+    };
   }, [
     addItem,
     ensureAccessToken,
@@ -45,6 +62,8 @@ export function DriveLinkCoordinatorHost() {
     removeItem,
     setCurrentDoc,
     store,
+    location.pathname,
+    location.search,
   ]);
 
   return null;

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -35,6 +35,7 @@ import {
 import { LOCAL_FOLDER_URI } from "../../storage/local";
 import { useGoogleAuth } from "../../contexts/GoogleAuthContext";
 import { useCurrentDoc } from "../../contexts/CurrentDocContext";
+import { useNotebookContext } from "../../contexts/NotebookContext";
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
 
 interface ContextMenuState {
@@ -226,6 +227,7 @@ export function WorkspaceExplorer() {
   const { store } = useNotebookStore();
   const { fsStore } = useFilesystemStore();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
+  const { openNotebook } = useNotebookContext();
   const currentDoc = getCurrentDoc();
   const { ensureAccessToken } = useGoogleAuth();
   const handledDocRef = useRef<string | null>(null);
@@ -415,8 +417,11 @@ export function WorkspaceExplorer() {
             remoteUri: undefined,
           } as NotebookStoreItem);
 
-        setCurrentDoc(targetItem.uri);
-        handledDocRef.current = targetItem.uri;
+        const result = await openNotebook(targetItem.uri, {
+          name: targetItem.name,
+        });
+        setCurrentDoc(result.localUri);
+        handledDocRef.current = result.localUri;
       } catch (error) {
         console.error("Failed to load notebook from URL", error);
         setCurrentDoc(null);
@@ -427,6 +432,7 @@ export function WorkspaceExplorer() {
     addItem,
     currentDoc,
     ensureAccessToken,
+    openNotebook,
     setCurrentDoc,
     store,
     workspaceUris,
@@ -580,7 +586,8 @@ export function WorkspaceExplorer() {
           console.error("Notebook metadata missing for", uri);
           return;
         }
-        setCurrentDoc(item.uri);
+        const result = await openNotebook(item.uri, { name: item.name });
+        setCurrentDoc(result.localUri);
         setErrorMessage(null);
       } catch (error) {
         console.error("Failed to load notebook", error);
@@ -589,7 +596,7 @@ export function WorkspaceExplorer() {
         );
       }
     },
-    [fsStore, setCurrentDoc, store],
+    [fsStore, openNotebook, setCurrentDoc, store],
   );
 
   const handleCreateDocument = useCallback(

--- a/app/src/contexts/CurrentDocContext.test.tsx
+++ b/app/src/contexts/CurrentDocContext.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { useEffect } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CurrentDocProvider, useCurrentDoc } from "./CurrentDocContext";
+
+function SetCurrentDocOnMount({ uri }: { uri: string }) {
+  const { setCurrentDoc } = useCurrentDoc();
+
+  useEffect(() => {
+    setCurrentDoc(uri);
+  }, [setCurrentDoc, uri]);
+
+  return null;
+}
+
+describe("CurrentDocProvider", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.history.replaceState(
+      null,
+      "",
+      "/?doc=https%3A%2F%2Fdrive.google.com%2Fdrive%2Ffolders%2Ffolder123",
+    );
+  });
+
+  it("does not clear pending URL doc intents when selecting a current doc", async () => {
+    render(
+      <CurrentDocProvider>
+        <SetCurrentDocOnMount uri="local://file/restored" />
+      </CurrentDocProvider>,
+    );
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem("runme/currentDoc")).toBe(
+        "local://file/restored",
+      );
+    });
+    expect(window.location.search).toContain("doc=");
+  });
+});

--- a/app/src/contexts/CurrentDocContext.tsx
+++ b/app/src/contexts/CurrentDocContext.tsx
@@ -8,13 +8,7 @@ import {
   useState,
 } from "react";
 
-import { appState } from "../lib/runtime/AppState";
-
 const CURRENT_DOC_STORAGE_KEY = "runme/currentDoc";
-
-function isFsUri(uri: string): boolean {
-  return uri.startsWith("fs://");
-}
 
 interface CurrentDocContextValue {
   getCurrentDoc: () => string | null;
@@ -34,9 +28,6 @@ export function useCurrentDoc() {
 }
 
 export function CurrentDocProvider({ children }: { children: ReactNode }) {
-  // Helper that reads the current doc value straight from the URL. We call this
-  // exactly once on initialisation and again on popstate events so the context
-  // stays aligned with browser navigation.
   const [currentDoc, setCurrentDocState] = useState<string | null>(null);
 
   const loadStoredCurrentDoc = useCallback((): string | null => {
@@ -51,41 +42,9 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const resolveFromLocation = useCallback(async () => {
-    const params = new URLSearchParams(window.location.search);
-    const doc = params.get("doc");
-
-    if (!doc) {
-      setCurrentDocState(loadStoredCurrentDoc());
-      return;
-    }
-
-    if (doc.startsWith("local://")) {
-      setCurrentDocState(doc);
-      return;
-    }
-
-    if (isFsUri(doc)) {
-      setCurrentDocState(doc);
-      return;
-    }
-
-    // Shared Drive links are consumed by the Drive link coordinator. They are
-    // not treated as steady-state current-doc values.
-    setCurrentDocState(null);
+  useEffect(() => {
+    setCurrentDocState(loadStoredCurrentDoc());
   }, [loadStoredCurrentDoc]);
-
-  useEffect(() => {
-    void resolveFromLocation();
-  }, [resolveFromLocation]);
-
-  useEffect(() => {
-    const handlePopState = () => {
-      void resolveFromLocation();
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => window.removeEventListener("popstate", handlePopState);
-  }, [resolveFromLocation]);
 
   const getCurrentDoc = useCallback(() => {
     return currentDoc;
@@ -136,15 +95,6 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
     }),
     [getCurrentDoc, setCurrentDoc],
   );
-
-  useEffect(() => {
-    appState.setOpenNotebookHandler((uri: string) => {
-      setCurrentDoc(uri);
-    });
-    return () => {
-      appState.setOpenNotebookHandler(null);
-    };
-  }, [setCurrentDoc]);
 
   return (
     <CurrentDocContext.Provider value={value}>

--- a/app/src/contexts/CurrentDocContext.tsx
+++ b/app/src/contexts/CurrentDocContext.tsx
@@ -64,8 +64,6 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
       });
 
       const updateUrl = async () => {
-        const nextUrl = new URL(window.location.href);
-        nextUrl.searchParams.delete("doc");
         try {
           if (!localUri) {
             window.localStorage.removeItem(CURRENT_DOC_STORAGE_KEY);
@@ -75,12 +73,6 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
         } catch {
           // Ignore persistence failures for current-doc restore state.
         }
-
-        window.history.replaceState(
-          null,
-          "",
-          `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
-        );
       };
 
       void updateUrl();

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -68,14 +68,13 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
 
   const useNotebookSnapshot = useCallback(
     (uri: string) => {
-      const data = uri ? controller.getNotebookData(uri) : undefined;
       const subscribe = useCallback(
-        (listener: () => void) => (data ? data.subscribe(listener) : () => {}),
-        [data],
+        (listener: () => void) => controller.subscribe(listener),
+        [controller],
       );
       const getSnapshot = useCallback(
-        () => (data ? data.getSnapshot() : null as NotebookSnapshot | null),
-        [data],
+        () => (uri ? controller.getNotebookSnapshot(uri) : null),
+        [controller, uri],
       );
       return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
     },

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -6,26 +6,27 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState,
   useSyncExternalStore,
 } from "react";
 
-import { create } from "@bufbuild/protobuf";
-import { NotebookData, type NotebookSnapshot } from "../lib/notebookData";
-import { parser_pb } from "./CellContext";
-import { type NotebookDataLike } from "../lib/runtime/runmeConsole";
-import { useNotebookStore } from "./NotebookStoreContext";
-import { useFilesystemStore } from "./FilesystemStoreContext";
-import { useCurrentDoc } from "./CurrentDocContext";
+import { type NotebookData, type NotebookSnapshot } from "../lib/notebookData";
 import {
-  NotebookStoreItem,
-  NotebookStoreItemType,
-} from "../storage/notebook";
+  getNotebookDataController,
+  type OpenNotebookEntry,
+  type OpenNotebookResult,
+} from "../lib/notebookDataController";
+import { appState } from "../lib/runtime/AppState";
+import { useCurrentDoc } from "./CurrentDocContext";
+import { useNotebookStore } from "./NotebookStoreContext";
 
 type NotebookContextValue = {
   getNotebookData: (uri: string) => NotebookData | undefined;
+  openNotebook: (
+    uri: string,
+    options?: { name?: string },
+  ) => Promise<OpenNotebookResult>;
   useNotebookSnapshot: (uri: string) => NotebookSnapshot | null;
-  useNotebookList: () => { uri: string; name: string }[];
+  useNotebookList: () => OpenNotebookEntry[];
   removeNotebook: (uri: string) => string | null;
 };
 
@@ -39,573 +40,116 @@ export function useNotebookContext() {
   return ctx;
 }
 
-type StoreEntry = {
-  data: NotebookData;
-  unsubscribe: () => void;
-  loaded: boolean;
-};
-
-type NotebookLoadResult = {
-  uri: string;
-  name: string;
-  notebook: parser_pb.Notebook;
-};
-
-type EnsureNotebookArgs = {
-  /** Canonical URI that keys the NotebookData instance. */
-  uri: string;
-  /** Human-readable name for display; may be derived from the URI. */
-  name?: string;
-  /** Notebook payload to seed the model with (optional if not yet loaded). */
-  notebook?: parser_pb.Notebook;
-  /** Whether the payload represents a fully loaded notebook. Defaults false. */
-  loaded?: boolean;
-};
-
-const OPEN_NOTEBOOKS_STORAGE_KEY = "runme/openNotebooks";
-const LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY = "aisre/openNotebooks";
-
-function isNotFoundError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  const message = error.message.toLowerCase();
-  return message.includes("not found");
-}
-
-function isWaitingForUpstreamStore(
-  uri: string,
-  fsStore: unknown,
-): boolean {
-  return uri.startsWith("fs://") && !fsStore;
-}
-
-function loadStoredOpenNotebooks(): NotebookStoreItem[] {
-  if (typeof window === "undefined") {
-    return [];
-  }
-  try {
-    const raw =
-      window.localStorage.getItem(OPEN_NOTEBOOKS_STORAGE_KEY) ??
-      window.localStorage.getItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
-    if (!raw) {
-      return [];
-    }
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-    return parsed
-      .map((item) => {
-        if (!item || typeof item !== "object") {
-          return null;
-        }
-        const candidate = item as Partial<NotebookStoreItem>;
-        if (typeof candidate.uri !== "string" || candidate.uri.trim() === "") {
-          return null;
-        }
-        if (
-          candidate.type !== NotebookStoreItemType.File &&
-          candidate.type !== NotebookStoreItemType.Folder
-        ) {
-          return null;
-        }
-        return {
-          uri: candidate.uri,
-          name: candidate.name ?? candidate.uri,
-          type: candidate.type,
-          children: Array.isArray(candidate.children)
-            ? (candidate.children as string[])
-            : [],
-          remoteUri: candidate.remoteUri,
-          parents: Array.isArray(candidate.parents)
-            ? (candidate.parents as string[])
-            : [],
-        } satisfies NotebookStoreItem;
-      })
-      .filter((item): item is NotebookStoreItem => Boolean(item));
-  } catch (error) {
-    console.error("Failed to load open notebooks from storage", error);
-    return [];
-  }
-}
-
-function persistOpenNotebooks(list: NotebookStoreItem[]): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    const filtered = list.filter(
-      (item) => typeof item.uri === "string" && item.uri.trim() !== "",
-    );
-    window.localStorage.setItem(
-      OPEN_NOTEBOOKS_STORAGE_KEY,
-      JSON.stringify(filtered),
-    );
-    window.localStorage.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
-  } catch (error) {
-    console.error("Failed to persist open notebooks", error);
-  }
-}
-
 export function NotebookProvider({ children }: { children: ReactNode }) {
-  // NotebookContext is the owner of NotebookData instances. It keeps a map
-  // keyed by notebook URI so multiple tabs/documents can stay mounted
-  // simultaneously. Consumers (e.g., CellContext, Actions) should ask for a
-  // NotebookData by URI and subscribe via useNotebookSnapshot to drive renders.
-  // Note: storeRef is seeded from localStorage once so useNotebookSnapshot can
-  // subscribe immediately; async loads later populate the existing models.
-  //
-  // Responsibilities:
-  // - Construct/retrieve NotebookData for a given URI (ensureNotebook).
-  // - Expose a subscription-friendly snapshot hook (useNotebookSnapshot) so
-  //   React components can re-render when the underlying notebook changes.
-  // - Leave persistence/loading orchestration to higher layers (CellContext
-  //   will decide when to load/save); this context just owns in-memory data.
-  const storeRef = useRef<Map<string, StoreEntry>>(new Map());
-  const listenersRef = useRef<Set<() => void>>(new Set());
-  const listCacheRef = useRef<{ uri: string; name: string }[]>([]);
-  const [openNotebooks, setOpenNotebooks] = useState<NotebookStoreItem[]>([]);
-
-  const emit = useCallback(() => {
-    // emitter retained for future subscribers; currently unused by useNotebookList
-    listenersRef.current.forEach((listener) => {
-      try {
-        listener();
-      } catch (error) {
-        console.error("NotebookContext listener failed", error);
-      }
-    });
-  }, []);
-  const { store: notebookStore } = useNotebookStore();
-  const { fsStore } = useFilesystemStore();
+  const { store } = useNotebookStore();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
-  const hasRestoredNotebooks = useRef(false);
+  const controller = getNotebookDataController();
+  const restoredCurrentDocRef = useRef(false);
 
-  const ensureNotebook = useCallback(
-    ({ uri, name, notebook, loaded = false }: EnsureNotebookArgs) => {
-      const existing = storeRef.current.get(uri);
-      if (existing) {
-        existing.data.setNotebookStore(notebookStore ?? null);
-        return existing.data;
-      }
-      const resolvedName =
-        name ?? uri.split("/").filter(Boolean).pop() ?? uri;
-      console.log("[NotebookProvider] ensuring notebook", uri)
-      const initialNotebook =
-        notebook ??
-        create(parser_pb.NotebookSchema, {
-          cells: [],
-          metadata: {},
-        });
-      const resolveTargetUri = (target?: unknown): string | null => {
-        if (typeof target === "string" && target.trim() !== "") {
-          return target.trim();
-        }
-        if (
-          typeof target === "object" &&
-          target &&
-          "uri" in target &&
-          typeof (target as { uri?: unknown }).uri === "string" &&
-          (target as { uri: string }).uri.trim() !== ""
-        ) {
-          return (target as { uri: string }).uri.trim();
-        }
-        if (
-          typeof target === "object" &&
-          target &&
-          "handle" in target &&
-          typeof (target as { handle?: { uri?: unknown } }).handle?.uri ===
-            "string" &&
-          (
-            target as { handle: { uri: string } }
-          ).handle.uri.trim() !== ""
-        ) {
-          return (target as { handle: { uri: string } }).handle.uri.trim();
-        }
-        return null;
-      };
-      const data = new NotebookData({
-        uri,
-        name: resolvedName,
-        notebook: initialNotebook,
-        notebookStore: notebookStore ?? null,
-        loaded,
-        resolveNotebookForAppKernel: (target?: unknown) => {
-          const targetUri = resolveTargetUri(target)
-          if (!targetUri) {
-            return storeRef.current.get(uri)?.data ?? null
-          }
-          return storeRef.current.get(targetUri)?.data ?? null
-        },
-        listNotebooksForAppKernel: () => {
-          const notebooksByUri = new Map<string, NotebookDataLike>()
-          for (const entry of storeRef.current.values()) {
-            notebooksByUri.set(entry.data.getUri(), entry.data)
-          }
-          for (const item of listCacheRef.current) {
-            if (!item?.uri || notebooksByUri.has(item.uri)) {
-              continue
-            }
-            const emptyNotebook = create(parser_pb.NotebookSchema, {
-              cells: [],
-              metadata: {},
-            })
-            const placeholder = {
-              getUri: () => item.uri,
-              getName: () => item.name ?? item.uri,
-              getNotebook: () => emptyNotebook,
-              updateCell: () => {},
-              getCell: () => null,
-            } satisfies NotebookDataLike
-            notebooksByUri.set(item.uri, placeholder)
-          }
-          const current = storeRef.current.get(uri)?.data
-          if (current && !notebooksByUri.has(current.getUri())) {
-            notebooksByUri.set(current.getUri(), current)
-          }
-          return Array.from(notebooksByUri.values())
-        },
-      });
-      const unsubscribe = data.subscribe(() => emit());
-      storeRef.current.set(uri, { data, unsubscribe, loaded });
-      setOpenNotebooks((prev) => {
-        const exists = prev.some((item) => item.uri === uri);
-        if (exists) {
-          return prev;
-        }
-        const item: NotebookStoreItem = {
-          uri,
-          name: resolvedName,
-          type: NotebookStoreItemType.File,
-          children: [],
-          parents: [],
-        };
-        return [...prev, item];
-      });
-      emit();
-      return data;
-    },
-    [emit, notebookStore],
+  useEffect(() => {
+    controller.configureStores({ localNotebooks: store });
+  }, [controller, store]);
+
+  const getNotebookData = useCallback(
+    (uri: string) => controller.getNotebookData(uri),
+    [controller],
   );
 
-  const getNotebookData = useCallback((uri: string) => {
-    return storeRef.current.get(uri)?.data;
-  }, []);
-
-  // Subscribe to an existing NotebookData model and return its immutable snapshot.
-  // This hook assumes the provider has already created the model for the URI.
-  const useNotebookSnapshot = useCallback((uri: string) => {
-    const data = uri ? storeRef.current.get(uri)?.data : undefined;
-
-    const subscribe = useCallback(
-      (listener: () => void) => (data ? data.subscribe(listener) : () => {}),
-      [data],
-    );
-
-    const getSnapshot = useCallback(
-      () => (data ? data.getSnapshot() : null as NotebookSnapshot | null),
-      [data],
-    );
-
-    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-  }, []);
-
-  // On first availability of notebookStore, restore placeholders for any
-  // notebooks persisted in localStorage so subscribers can attach immediately.
-  useEffect(() => {
-    if (hasRestoredNotebooks.current) {
-      return;
-    }
-    const stored = loadStoredOpenNotebooks();
-    stored.forEach((item) => {
-      if (storeRef.current.has(item.uri)) {
-        return;
-      }
-      const empty = create(parser_pb.NotebookSchema, {
-        cells: [],
-        metadata: {},
-      });
-      ensureNotebook({
-        uri: item.uri,
-        name: item.name ?? item.uri,
-        notebook: empty,
-        loaded: false,
-      });
-    });
-    //setOpenNotebooks(stored);
-    hasRestoredNotebooks.current = true;
-  }, [ensureNotebook, notebookStore, fsStore]);
-
-  const useNotebookList = useCallback(() => {
-    return openNotebooks;
-  }, [openNotebooks]);
+  const openNotebook = useCallback(
+    (uri: string, options?: { name?: string }) =>
+      controller.openNotebook(uri, options),
+    [controller],
+  );
 
   const removeNotebook = useCallback(
-    (uri: string): string | null => {
-      const entries = Array.from(storeRef.current.keys());
-      const index = entries.findIndex((value) => value === uri);
-      let fallback: string | null = null;
-      if (index !== -1) {
-        if (index > 0) {
-          fallback = entries[index - 1];
-        } else if (index + 1 < entries.length) {
-          fallback = entries[index + 1];
-        }
-      }
-      const entry = storeRef.current.get(uri);
-      if (entry) {
-        entry.unsubscribe();
-      }
-      storeRef.current.delete(uri);
-      setOpenNotebooks((prev) => prev.filter((item) => item.uri !== uri));
-      emit();
-      return fallback;
-    },
-    [emit],
+    (uri: string) => controller.closeNotebook(uri),
+    [controller],
   );
 
-  const removeNotebookEntry = useCallback(
+  const useNotebookSnapshot = useCallback(
     (uri: string) => {
-      const entry = storeRef.current.get(uri);
-      if (entry) {
-        entry.unsubscribe();
-      }
-      storeRef.current.delete(uri);
-      setOpenNotebooks((prev) => prev.filter((item) => item.uri !== uri));
-      emit();
+      const data = uri ? controller.getNotebookData(uri) : undefined;
+      const subscribe = useCallback(
+        (listener: () => void) => (data ? data.subscribe(listener) : () => {}),
+        [data],
+      );
+      const getSnapshot = useCallback(
+        () => (data ? data.getSnapshot() : null as NotebookSnapshot | null),
+        [data],
+      );
+      return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
     },
-    [emit],
+    [controller],
   );
 
-  const dropStaleNotebook = useCallback(
-    (uri: string) => {
-      const fallback = removeNotebook(uri);
-      if (getCurrentDoc() === uri) {
-        setCurrentDoc(fallback);
-      }
+  const useNotebookList = useCallback(() => {
+    const subscribe = useCallback(
+      (listener: () => void) => controller.subscribe(listener),
+      [controller],
+    );
+    const getSnapshot = useCallback(
+      () => controller.getSnapshot().openNotebooks,
+      [controller],
+    );
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  }, [controller]);
+
+  const openAndSelectNotebook = useCallback(
+    async (uri: string, options?: { name?: string }) => {
+      const result = await controller.openNotebook(uri, options);
+      setCurrentDoc(result.localUri);
+      return result;
     },
-    [getCurrentDoc, removeNotebook, setCurrentDoc],
+    [controller, setCurrentDoc],
   );
 
-  const loadNotebookIntoLocalMirror = useCallback(
-    async (
-      uri: string,
-      fallbackName?: string,
-    ): Promise<NotebookLoadResult | null> => {
-      if (!notebookStore) {
-        return null;
-      }
-
-      if (uri.startsWith("local://file/")) {
-        const metadata = await notebookStore.getMetadata(uri);
-        if (!metadata || metadata.type !== NotebookStoreItemType.File) {
-          return null;
-        }
-        const notebook = await notebookStore.load(uri);
-        return {
-          uri,
-          name: metadata.name,
-          notebook,
-        };
-      }
-
-      const upstreamStore = uri.startsWith("fs://") ? fsStore : null;
-      if (!upstreamStore) {
-        return null;
-      }
-
-      const metadata = await upstreamStore.getMetadata(uri);
-      if (!metadata || metadata.type !== NotebookStoreItemType.File) {
-        return null;
-      }
-      const notebook = await upstreamStore.load(uri);
-      const name = metadata.name ?? fallbackName ?? uri;
-      const localUri = await notebookStore.addNotebook(uri, name, notebook);
-      const localNotebook = await notebookStore.load(localUri);
-
-      return {
-        uri: localUri,
-        name,
-        notebook: localNotebook,
-      };
-    },
-    [fsStore, notebookStore],
-  );
-
-  // Keep a cached list snapshot in sync for useSyncExternalStore consumers and persist to localStorage.
   useEffect(() => {
-    // hasRestoredNotebooks.current guards against updating localStorage before we've restored from localStorage on window load
-    if (!hasRestoredNotebooks.current) {
-      return;
-    }
-    listCacheRef.current = openNotebooks.map((item) => ({
-      uri: item.uri,
-      name: item.name ?? item.uri,
-    }));
-    persistOpenNotebooks(openNotebooks);
-  }, [openNotebooks]);
-
-  // If notebooks are open but no current document is selected, promote the first
-  // open notebook to be the active document so notebook helpers can resolve the
-  // UI's visible notebook by default.
-  useEffect(() => {
-    if (getCurrentDoc() || openNotebooks.length === 0) {
-      return;
-    }
-    const fallbackUri = openNotebooks[0]?.uri?.trim();
-    if (!fallbackUri) {
-      return;
-    }
-    setCurrentDoc(fallbackUri);
-  }, [getCurrentDoc, openNotebooks, setCurrentDoc]);
-
-  // Load any notebooks that were open last session once a store is available.
-  useEffect(() => {
-    if (!notebookStore) {
-      return;
-    }
-    const loadExisting = async () => {
-      for (const item of openNotebooks) {
-        let entry = storeRef.current.get(item.uri);
-        if (entry?.loaded) {
-          continue;
-        }
-        if (!entry) {
-          continue;
-        }
-        if (item.type !== NotebookStoreItemType.File) {
-          dropStaleNotebook(item.uri);
-          continue;
-        }
-        if (isWaitingForUpstreamStore(item.uri, fsStore)) {
-          continue;
-        }
-        entry.data.setNotebookStore(notebookStore);
-        try {
-          const loaded = await loadNotebookIntoLocalMirror(item.uri, item.name);
-          if (!loaded) {
-            dropStaleNotebook(item.uri);
-            continue;
-          }
-          if (loaded.uri !== item.uri) {
-            removeNotebookEntry(item.uri);
-            if (getCurrentDoc() === item.uri) {
-              setCurrentDoc(loaded.uri);
-            }
-            entry = undefined;
-          }
-          const data = entry?.data ?? ensureNotebook({
-            uri: loaded.uri,
-            name: loaded.name,
-            loaded: false,
-          });
-          data.setNotebookStore(notebookStore);
-          data.loadNotebook(loaded.notebook, { persist: false });
-          const loadedEntry = storeRef.current.get(loaded.uri);
-          if (loadedEntry) {
-            loadedEntry.loaded = true;
-          }
-        } catch (error) {
-          if (isNotFoundError(error)) {
-            dropStaleNotebook(item.uri);
-            continue;
-          }
-          console.error("Failed to load open notebook", item.uri, error);
-        }
-      }
+    appState.setOpenNotebookHandler(async (uri: string) => {
+      await openAndSelectNotebook(uri);
+    });
+    return () => {
+      appState.setOpenNotebookHandler(null);
     };
-    void loadExisting();
-  }, [
-    dropStaleNotebook,
-    ensureNotebook,
-    getCurrentDoc,
-    fsStore,
-    loadNotebookIntoLocalMirror,
-    notebookStore,
-    openNotebooks,
-    removeNotebookEntry,
-    setCurrentDoc,
-  ]);
+  }, [openAndSelectNotebook]);
 
-  // Ensure the current doc is loaded into NotebookData when it changes.
   useEffect(() => {
-    const uri = getCurrentDoc();
-    if (!uri) {
+    const openNotebooks = controller.getOpenNotebooks();
+    const currentDoc = getCurrentDoc();
+    if (!currentDoc && openNotebooks.length > 0) {
+      setCurrentDoc(openNotebooks[0]?.uri ?? null);
       return;
     }
-    if (!notebookStore) {
-      return;
-    }
-    if (isWaitingForUpstreamStore(uri, fsStore)) {
-      return;
-    }
-    let entry = storeRef.current.get(uri);
-    if (entry?.loaded) {
-      return;
-    }
-    const load = async () => {
-      try {
-        const loaded = await loadNotebookIntoLocalMirror(uri);
-        if (!loaded) {
-          dropStaleNotebook(uri);
-          return;
-        }
-        const targetUri = loaded.uri;
-        if (targetUri !== uri) {
-          removeNotebookEntry(uri);
-          setCurrentDoc(targetUri);
-          entry = storeRef.current.get(targetUri);
-        }
-
-        if (entry) {
-          entry.data.setNotebookStore(notebookStore);
-          entry.data.loadNotebook(loaded.notebook, { persist: false });
-          entry.loaded = true;
-        } else {
-          ensureNotebook({
-            uri: targetUri,
-            name: loaded.name,
-            notebook: loaded.notebook,
-            loaded: true,
-          });
-        }
-      } catch (error) {
-        if (isNotFoundError(error)) {
-          dropStaleNotebook(uri);
-          return;
-        }
-        console.error("Failed to load current document notebook", uri, error);
-        setCurrentDoc(null);
+    if (
+      currentDoc &&
+      !restoredCurrentDocRef.current &&
+      openNotebooks.length === 0
+    ) {
+      if (!currentDoc.startsWith("local://file/") && !store) {
+        return;
       }
-    };
-    void load();
-  }, [
-    dropStaleNotebook,
-    ensureNotebook,
-    getCurrentDoc,
-    fsStore,
-    loadNotebookIntoLocalMirror,
-    notebookStore,
-    removeNotebookEntry,
-    setCurrentDoc,
-  ]);
+      restoredCurrentDocRef.current = true;
+      void controller.openNotebook(currentDoc).catch((error) => {
+        console.error("Failed to restore selected notebook", error);
+      });
+    }
+  }, [controller, getCurrentDoc, setCurrentDoc, store]);
 
   const value = useMemo<NotebookContextValue>(
     () => ({
       getNotebookData,
+      openNotebook,
       useNotebookSnapshot,
       useNotebookList,
       removeNotebook,
     }),
-    [getNotebookData, removeNotebook, useNotebookList, useNotebookSnapshot],
+    [
+      getNotebookData,
+      openNotebook,
+      removeNotebook,
+      useNotebookList,
+      useNotebookSnapshot,
+    ],
   );
-
-  // Persist the active notebook on change. Callers are responsible for passing
-  // the right uri/notebook when saving; this provider simply exposes the store.
-  // Saving/loading coordination will be handled by CellContext / callers.
-  // We intentionally do not auto-save here to avoid hidden I/O.
 
   return <NotebookContext.Provider value={value}>{children}</NotebookContext.Provider>;
 }

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -190,6 +190,36 @@ describe("NotebookDataController", () => {
     ]);
   });
 
+  it("returns null and leaves selection candidates unchanged when closing a stale URI", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/a", {
+      id: "local://file/a",
+      name: "a.json",
+      remoteId: "local://file/a",
+      notebook: createNotebook("a"),
+    });
+    localStore.records.set("local://file/b", {
+      id: "local://file/b",
+      name: "b.json",
+      remoteId: "local://file/b",
+      notebook: createNotebook("b"),
+    });
+    const controller = getNotebookDataController();
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+    await controller.openNotebook("local://file/a");
+    await controller.openNotebook("local://file/b");
+
+    const fallback = controller.closeNotebook("local://file/missing");
+
+    expect(fallback).toBeNull();
+    expect(controller.getOpenNotebooks().map((item) => item.uri)).toEqual([
+      "local://file/a",
+      "local://file/b",
+    ]);
+  });
+
   it("restores legacy open-notebook storage without changing the storage shape", () => {
     window.localStorage.setItem(
       "runme/openNotebooks",

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -1,0 +1,226 @@
+import { create } from "@bufbuild/protobuf";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parser_pb } from "../contexts/CellContext";
+import type { LocalNotebooks } from "../storage/local";
+import { NotebookStoreItemType } from "../storage/notebook";
+import {
+  __resetNotebookDataControllerForTests,
+  getNotebookDataController,
+} from "./notebookDataController";
+
+vi.mock("@runmedev/renderers", () => ({
+  Streams: class {},
+  Heartbeat: { INITIAL: "INITIAL" },
+  genRunID: () => "run-generated",
+}));
+
+function createNotebook(value = ""): parser_pb.Notebook {
+  return create(parser_pb.NotebookSchema, {
+    cells: value
+      ? [
+          create(parser_pb.CellSchema, {
+            refId: "cell-1",
+            value,
+          }),
+        ]
+      : [],
+    metadata: {},
+  });
+}
+
+function createFakeLocalNotebooks() {
+  const records = new Map<
+    string,
+    {
+      id: string;
+      name: string;
+      remoteId: string;
+      notebook: parser_pb.Notebook;
+    }
+  >();
+  let nextId = 1;
+
+  return {
+    records,
+    addFile: vi.fn(async (remoteUri: string, name?: string) => {
+      for (const record of records.values()) {
+        if (record.remoteId === remoteUri) {
+          if (name) {
+            record.name = name;
+          }
+          return record.id;
+        }
+      }
+      const id = `local://file/${nextId++}`;
+      records.set(id, {
+        id,
+        name: name ?? remoteUri,
+        remoteId: remoteUri,
+        notebook: createNotebook(),
+      });
+      return id;
+    }),
+    getMetadata: vi.fn(async (uri: string) => {
+      const record = records.get(uri);
+      if (!record) {
+        return null;
+      }
+      return {
+        uri: record.id,
+        name: record.name,
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [],
+        remoteUri:
+          record.remoteId === record.id ? undefined : record.remoteId,
+      };
+    }),
+    load: vi.fn(async (uri: string) => {
+      const record = records.get(uri);
+      if (!record) {
+        throw new Error(`Local notebook record not found for ${uri}`);
+      }
+      return record.notebook;
+    }),
+    save: vi.fn(),
+  };
+}
+
+describe("NotebookDataController", () => {
+  beforeEach(() => {
+    __resetNotebookDataControllerForTests();
+    window.localStorage.clear();
+  });
+
+  it("opens a local notebook and loads NotebookData", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/demo", {
+      id: "local://file/demo",
+      name: "demo.json",
+      remoteId: "local://file/demo",
+      notebook: createNotebook("console.log('demo')"),
+    });
+
+    const controller = getNotebookDataController();
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+
+    const result = await controller.openNotebook("local://file/demo");
+
+    expect(result.localUri).toBe("local://file/demo");
+    expect(controller.getOpenNotebooks()).toEqual([
+      expect.objectContaining({
+        uri: "local://file/demo",
+        requestedUri: "local://file/demo",
+        name: "demo.json",
+        state: "loaded",
+      }),
+    ]);
+    expect(controller.getNotebookData("local://file/demo")?.getSnapshot()).toEqual(
+      expect.objectContaining({
+        uri: "local://file/demo",
+        name: "demo.json",
+        loaded: true,
+      }),
+    );
+  });
+
+  it("resolves a remote URI to a stable local URI before loading", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/existing", {
+      id: "local://file/existing",
+      name: "existing.json",
+      remoteId: "fs://workspace/demo/file/existing.json",
+      notebook: createNotebook("console.log('existing')"),
+    });
+    const controller = getNotebookDataController();
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+
+    const result = await controller.openNotebook(
+      "fs://workspace/demo/file/existing.json",
+      { name: "renamed.json" },
+    );
+
+    expect(localStore.addFile).toHaveBeenCalledWith(
+      "fs://workspace/demo/file/existing.json",
+      "renamed.json",
+    );
+    expect(result.localUri).toBe("local://file/existing");
+    expect(controller.getOpenNotebooks()[0]).toEqual(
+      expect.objectContaining({
+        uri: "local://file/existing",
+        requestedUri: "fs://workspace/demo/file/existing.json",
+        name: "renamed.json",
+        state: "loaded",
+      }),
+    );
+  });
+
+  it("closes a notebook, disposes its model, and returns a fallback URI", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/a", {
+      id: "local://file/a",
+      name: "a.json",
+      remoteId: "local://file/a",
+      notebook: createNotebook("a"),
+    });
+    localStore.records.set("local://file/b", {
+      id: "local://file/b",
+      name: "b.json",
+      remoteId: "local://file/b",
+      notebook: createNotebook("b"),
+    });
+    const controller = getNotebookDataController();
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+    await controller.openNotebook("local://file/a");
+    await controller.openNotebook("local://file/b");
+
+    const fallback = controller.closeNotebook("local://file/b");
+
+    expect(fallback).toBe("local://file/a");
+    expect(controller.getNotebookData("local://file/b")).toBeUndefined();
+    expect(controller.getOpenNotebooks().map((item) => item.uri)).toEqual([
+      "local://file/a",
+    ]);
+  });
+
+  it("restores legacy open-notebook storage without changing the storage shape", () => {
+    window.localStorage.setItem(
+      "runme/openNotebooks",
+      JSON.stringify([
+        {
+          uri: "local://file/restored",
+          name: "restored.json",
+          type: "file",
+          children: [],
+          parents: [],
+        },
+      ]),
+    );
+
+    const controller = getNotebookDataController();
+
+    expect(controller.getOpenNotebooks()).toEqual([
+      expect.objectContaining({
+        uri: "local://file/restored",
+        requestedUri: "local://file/restored",
+        name: "restored.json",
+        state: "loading",
+      }),
+    ]);
+    expect(controller.getNotebookData("local://file/restored")).toBeDefined();
+    expect(JSON.parse(window.localStorage.getItem("runme/openNotebooks") ?? "[]")).toEqual([
+      expect.objectContaining({
+        uri: "local://file/restored",
+        name: "restored.json",
+        type: "file",
+      }),
+    ]);
+  });
+});

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -1,0 +1,508 @@
+import { create } from "@bufbuild/protobuf";
+
+import { parser_pb } from "../contexts/CellContext";
+import { NotebookData, type NotebookSnapshot } from "./notebookData";
+import type { NotebookDataLike } from "./runtime/runmeConsole";
+import type { LocalNotebooks } from "../storage/local";
+import {
+  NotebookStoreItem,
+  NotebookStoreItemType,
+} from "../storage/notebook";
+
+const OPEN_NOTEBOOKS_STORAGE_KEY = "runme/openNotebooks";
+const LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY = "aisre/openNotebooks";
+
+export type NotebookTabState =
+  | "resolving"
+  | "loading"
+  | "loaded"
+  | "blocked"
+  | "error";
+
+export interface OpenNotebookEntry {
+  uri: string;
+  requestedUri: string;
+  name: string;
+  state: NotebookTabState;
+  errorMessage?: string;
+}
+
+export interface OpenNotebookResult {
+  localUri: string;
+  entry: OpenNotebookEntry;
+}
+
+export interface NotebookDataControllerSnapshot {
+  openNotebooks: OpenNotebookEntry[];
+}
+
+type NotebookDataHandle = {
+  data: NotebookData;
+  unsubscribe: () => void;
+  loaded: boolean;
+};
+
+function createEmptyNotebook(): parser_pb.Notebook {
+  return create(parser_pb.NotebookSchema, {
+    cells: [],
+    metadata: {},
+  });
+}
+
+function isLocalFileUri(uri: string): boolean {
+  return uri.startsWith("local://file/");
+}
+
+function deriveDisplayName(uri: string): string {
+  try {
+    const url = new URL(uri);
+    const tail = url.pathname.split("/").filter(Boolean).pop();
+    if (tail) {
+      return decodeURIComponent(tail);
+    }
+  } catch {
+    // Fall through to the URI segment heuristic.
+  }
+  return uri.split("/").filter(Boolean).pop() ?? uri;
+}
+
+function normalizeStoredOpenNotebook(item: unknown): OpenNotebookEntry | null {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const candidate = item as Partial<NotebookStoreItem & OpenNotebookEntry>;
+  if (typeof candidate.uri !== "string" || candidate.uri.trim() === "") {
+    return null;
+  }
+  if (
+    "type" in candidate &&
+    candidate.type !== undefined &&
+    candidate.type !== NotebookStoreItemType.File
+  ) {
+    return null;
+  }
+  return {
+    uri: candidate.uri,
+    requestedUri: candidate.requestedUri ?? candidate.uri,
+    name: candidate.name ?? candidate.uri,
+    state: candidate.state ?? "loading",
+    errorMessage: candidate.errorMessage,
+  };
+}
+
+function loadStoredOpenNotebooks(): OpenNotebookEntry[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  try {
+    const raw =
+      window.localStorage.getItem(OPEN_NOTEBOOKS_STORAGE_KEY) ??
+      window.localStorage.getItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map(normalizeStoredOpenNotebook)
+      .filter((item): item is OpenNotebookEntry => Boolean(item));
+  } catch (error) {
+    console.error("Failed to load open notebooks from storage", error);
+    return [];
+  }
+}
+
+function persistOpenNotebooks(list: OpenNotebookEntry[]): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    const legacyShape: NotebookStoreItem[] = list
+      .filter((item) => item.uri.trim() !== "")
+      .map((item) => ({
+        uri: item.uri,
+        name: item.name,
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [],
+      }));
+    window.localStorage.setItem(
+      OPEN_NOTEBOOKS_STORAGE_KEY,
+      JSON.stringify(legacyShape),
+    );
+    window.localStorage.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
+  } catch (error) {
+    console.error("Failed to persist open notebooks", error);
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.toLowerCase().includes("not found");
+}
+
+export class NotebookDataController {
+  private static instance: NotebookDataController | null = null;
+
+  static getInstance(): NotebookDataController {
+    if (!NotebookDataController.instance) {
+      NotebookDataController.instance = new NotebookDataController();
+    }
+    return NotebookDataController.instance;
+  }
+
+  static resetForTests(): void {
+    NotebookDataController.instance?.dispose();
+    NotebookDataController.instance = null;
+  }
+
+  private localNotebooks: LocalNotebooks | null = null;
+  private readonly notebooks = new Map<string, NotebookDataHandle>();
+  private openNotebooks: OpenNotebookEntry[] = [];
+  private readonly listeners = new Set<() => void>();
+  private snapshot: NotebookDataControllerSnapshot = { openNotebooks: [] };
+  private restored = false;
+
+  getSnapshot(): NotebookDataControllerSnapshot {
+    this.ensureRestored();
+    return this.snapshot;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.ensureRestored();
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  configureStores(options: { localNotebooks: LocalNotebooks | null }): void {
+    this.ensureRestored();
+    this.localNotebooks = options.localNotebooks;
+    for (const handle of this.notebooks.values()) {
+      handle.data.setNotebookStore(options.localNotebooks);
+    }
+    if (this.localNotebooks) {
+      void this.loadOpenNotebooks();
+    }
+  }
+
+  async openNotebook(
+    uri: string,
+    options?: { name?: string },
+  ): Promise<OpenNotebookResult> {
+    this.ensureRestored();
+    const requestedUri = uri.trim();
+    if (!requestedUri) {
+      throw new Error("openNotebook requires a non-empty URI");
+    }
+
+    const localUri = await this.resolveLocalUri(requestedUri, options?.name);
+    const name = await this.resolveNotebookName(localUri, options?.name);
+    let entry = this.upsertOpenEntry({
+      uri: localUri,
+      requestedUri,
+      name,
+      state: "loading",
+    });
+
+    const handle = this.ensureNotebookData({
+      uri: localUri,
+      name,
+      loaded: false,
+    });
+
+    if (this.localNotebooks) {
+      try {
+        const notebook = await this.localNotebooks.load(localUri);
+        handle.data.setNotebookStore(this.localNotebooks);
+        handle.data.loadNotebook(notebook, { persist: false });
+        handle.loaded = true;
+        entry = this.upsertOpenEntry({
+          ...entry,
+          name: await this.resolveNotebookName(localUri, name),
+          state: "loaded",
+          errorMessage: undefined,
+        });
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          entry = this.upsertOpenEntry({
+            ...entry,
+            state: "error",
+            errorMessage: String(error),
+          });
+        } else {
+          entry = this.upsertOpenEntry({
+            ...entry,
+            state: "error",
+            errorMessage: String(error),
+          });
+        }
+      }
+    }
+
+    return { localUri, entry };
+  }
+
+  closeNotebook(localUri: string): string | null {
+    this.ensureRestored();
+    const index = this.openNotebooks.findIndex((item) => item.uri === localUri);
+    const fallback =
+      index > 0
+        ? this.openNotebooks[index - 1]?.uri ?? null
+        : this.openNotebooks[index + 1]?.uri ?? null;
+    this.removeNotebook(localUri);
+    return fallback;
+  }
+
+  getNotebookData(localUri: string): NotebookData | undefined {
+    return this.notebooks.get(localUri)?.data;
+  }
+
+  getOpenNotebooks(): OpenNotebookEntry[] {
+    this.ensureRestored();
+    return this.openNotebooks;
+  }
+
+  getNotebookSnapshot(localUri: string): NotebookSnapshot | null {
+    return this.getNotebookData(localUri)?.getSnapshot() ?? null;
+  }
+
+  private async resolveLocalUri(uri: string, name?: string): Promise<string> {
+    if (isLocalFileUri(uri)) {
+      return uri;
+    }
+    if (!this.localNotebooks) {
+      throw new Error("Notebook store is not ready");
+    }
+    return this.localNotebooks.addFile(uri, name);
+  }
+
+  private async resolveNotebookName(uri: string, fallbackName?: string): Promise<string> {
+    if (fallbackName?.trim()) {
+      return fallbackName;
+    }
+    if (this.localNotebooks && uri.startsWith("local://")) {
+      try {
+        const metadata = await this.localNotebooks.getMetadata(uri);
+        if (metadata?.name) {
+          return metadata.name;
+        }
+      } catch {
+        // Fall back to URI-derived name.
+      }
+    }
+    return deriveDisplayName(uri);
+  }
+
+  private ensureNotebookData({
+    uri,
+    name,
+    notebook,
+    loaded = false,
+  }: {
+    uri: string;
+    name: string;
+    notebook?: parser_pb.Notebook;
+    loaded?: boolean;
+  }): NotebookDataHandle {
+    const existing = this.notebooks.get(uri);
+    if (existing) {
+      existing.data.setNotebookStore(this.localNotebooks);
+      return existing;
+    }
+
+    const data = new NotebookData({
+      uri,
+      name,
+      notebook: notebook ?? createEmptyNotebook(),
+      notebookStore: this.localNotebooks,
+      loaded,
+      resolveNotebookForAppKernel: (target?: unknown) => {
+        const targetUri = this.resolveTargetUri(target);
+        if (!targetUri) {
+          return this.notebooks.get(uri)?.data ?? null;
+        }
+        return this.notebooks.get(targetUri)?.data ?? null;
+      },
+      listNotebooksForAppKernel: () => this.listNotebookDataLike(uri),
+    });
+    const unsubscribe = data.subscribe(() => this.emit());
+    const handle = { data, unsubscribe, loaded };
+    this.notebooks.set(uri, handle);
+    this.emit();
+    return handle;
+  }
+
+  private resolveTargetUri(target?: unknown): string | null {
+    if (typeof target === "string" && target.trim() !== "") {
+      return target.trim();
+    }
+    if (
+      typeof target === "object" &&
+      target &&
+      "uri" in target &&
+      typeof (target as { uri?: unknown }).uri === "string" &&
+      (target as { uri: string }).uri.trim() !== ""
+    ) {
+      return (target as { uri: string }).uri.trim();
+    }
+    if (
+      typeof target === "object" &&
+      target &&
+      "handle" in target &&
+      typeof (target as { handle?: { uri?: unknown } }).handle?.uri ===
+        "string" &&
+      (target as { handle: { uri: string } }).handle.uri.trim() !== ""
+    ) {
+      return (target as { handle: { uri: string } }).handle.uri.trim();
+    }
+    return null;
+  }
+
+  private listNotebookDataLike(currentUri: string): NotebookDataLike[] {
+    const notebooksByUri = new Map<string, NotebookDataLike>();
+    for (const handle of this.notebooks.values()) {
+      notebooksByUri.set(handle.data.getUri(), handle.data);
+    }
+    for (const item of this.openNotebooks) {
+      if (!item.uri || notebooksByUri.has(item.uri)) {
+        continue;
+      }
+      const emptyNotebook = createEmptyNotebook();
+      notebooksByUri.set(item.uri, {
+        getUri: () => item.uri,
+        getName: () => item.name ?? item.uri,
+        getNotebook: () => emptyNotebook,
+        updateCell: () => {},
+        getCell: () => null,
+      });
+    }
+    const current = this.notebooks.get(currentUri)?.data;
+    if (current && !notebooksByUri.has(current.getUri())) {
+      notebooksByUri.set(current.getUri(), current);
+    }
+    return Array.from(notebooksByUri.values());
+  }
+
+  private upsertOpenEntry(entry: OpenNotebookEntry): OpenNotebookEntry {
+    let changed = false;
+    const next = this.openNotebooks.map((item) => {
+      if (item.uri !== entry.uri) {
+        return item;
+      }
+      changed = true;
+      return entry;
+    });
+    this.openNotebooks = changed ? next : [...this.openNotebooks, entry];
+    this.emit();
+    this.persist();
+    return entry;
+  }
+
+  private removeNotebook(uri: string): void {
+    const handle = this.notebooks.get(uri);
+    if (handle) {
+      handle.unsubscribe();
+    }
+    this.notebooks.delete(uri);
+    this.openNotebooks = this.openNotebooks.filter((item) => item.uri !== uri);
+    this.emit();
+    this.persist();
+  }
+
+  private async loadOpenNotebooks(): Promise<void> {
+    if (!this.localNotebooks) {
+      return;
+    }
+    for (const item of this.openNotebooks) {
+      const handle = this.ensureNotebookData({
+        uri: item.uri,
+        name: item.name,
+        loaded: false,
+      });
+      if (handle.loaded) {
+        continue;
+      }
+      try {
+        const notebook = await this.localNotebooks.load(item.uri);
+        handle.data.setNotebookStore(this.localNotebooks);
+        handle.data.loadNotebook(notebook, { persist: false });
+        handle.loaded = true;
+        this.upsertOpenEntry({
+          ...item,
+          name: await this.resolveNotebookName(item.uri, item.name),
+          state: "loaded",
+          errorMessage: undefined,
+        });
+      } catch (error) {
+        this.upsertOpenEntry({
+          ...item,
+          state: "error",
+          errorMessage: String(error),
+        });
+      }
+    }
+  }
+
+  private ensureRestored(): void {
+    if (this.restored) {
+      return;
+    }
+    this.restored = true;
+    this.openNotebooks = loadStoredOpenNotebooks();
+    for (const item of this.openNotebooks) {
+      this.ensureNotebookData({
+        uri: item.uri,
+        name: item.name,
+        loaded: false,
+      });
+    }
+    this.rebuildSnapshot();
+  }
+
+  private emit(): void {
+    this.rebuildSnapshot();
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch (error) {
+        console.error("NotebookDataController listener failed", error);
+      }
+    }
+  }
+
+  private persist(): void {
+    persistOpenNotebooks(this.openNotebooks);
+  }
+
+  private rebuildSnapshot(): void {
+    this.snapshot = {
+      openNotebooks: this.openNotebooks.map((item) => ({ ...item })),
+    };
+  }
+
+  private dispose(): void {
+    for (const handle of this.notebooks.values()) {
+      handle.unsubscribe();
+    }
+    this.notebooks.clear();
+    this.openNotebooks = [];
+    this.listeners.clear();
+    this.snapshot = { openNotebooks: [] };
+    this.restored = false;
+    this.localNotebooks = null;
+  }
+}
+
+export function getNotebookDataController(): NotebookDataController {
+  return NotebookDataController.getInstance();
+}
+
+export function __resetNotebookDataControllerForTests(): void {
+  NotebookDataController.resetForTests();
+}

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -236,6 +236,9 @@ export class NotebookDataController {
   closeNotebook(localUri: string): string | null {
     this.ensureRestored();
     const index = this.openNotebooks.findIndex((item) => item.uri === localUri);
+    if (index === -1) {
+      return null;
+    }
     const fallback =
       index > 0
         ? this.openNotebooks[index - 1]?.uri ?? null

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -138,13 +138,6 @@ function persistOpenNotebooks(list: OpenNotebookEntry[]): void {
   }
 }
 
-function isNotFoundError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return error.message.toLowerCase().includes("not found");
-}
-
 export class NotebookDataController {
   private static instance: NotebookDataController | null = null;
 
@@ -229,19 +222,11 @@ export class NotebookDataController {
           errorMessage: undefined,
         });
       } catch (error) {
-        if (isNotFoundError(error)) {
-          entry = this.upsertOpenEntry({
-            ...entry,
-            state: "error",
-            errorMessage: String(error),
-          });
-        } else {
-          entry = this.upsertOpenEntry({
-            ...entry,
-            state: "error",
-            errorMessage: String(error),
-          });
-        }
+        entry = this.upsertOpenEntry({
+          ...entry,
+          state: "error",
+          errorMessage: String(error),
+        });
       }
     }
 

--- a/app/src/lib/runtime/__fixtures__/codex-chatkit/manual-print-hello-world.output.json
+++ b/app/src/lib/runtime/__fixtures__/codex-chatkit/manual-print-hello-world.output.json
@@ -7,6 +7,238 @@
     {
       "type": "response.output_item.added",
       "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9b97888197b5f4517d4f08bffa"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9b97888197b5f4517d4f08bffa",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9b97888197b5f4517d4f08bffa",
+      "text": "**Following instructions to use ListCells**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9b97888197b5f4517d4f08bffa",
+      "text": "**Following instructions to use ListCells**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9b97888197b5f4517d4f08bffa",
+      "text": "**Following instructions to use ListCells**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ce4208197883787eb583c7792"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ce4208197883787eb583c7792",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ce4208197883787eb583c7792",
+      "text": "**Adding new Python code cell without execution**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ce4208197883787eb583c7792",
+      "text": "**Adding new Python code cell without execution**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ce4208197883787eb583c7792",
+      "text": "**Adding new Python code cell without execution**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ef71c8197b537fec196c4ee78"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ef71c8197b537fec196c4ee78",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ef71c8197b537fec196c4ee78",
+      "text": "**Investigating expected Cell kind format**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ef71c8197b537fec196c4ee78",
+      "text": "**Investigating expected Cell kind format**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5ac9ef71c8197b537fec196c4ee78",
+      "text": "**Investigating expected Cell kind format**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca49c0c81978854f5104d4e8656"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca49c0c81978854f5104d4e8656",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca49c0c81978854f5104d4e8656",
+      "text": "**Checking for resource template lists**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca49c0c81978854f5104d4e8656",
+      "text": "**Checking for resource template lists**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca49c0c81978854f5104d4e8656",
+      "text": "**Checking for resource template lists**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca8f8d881979bc076966b4d4ea7"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca8f8d881979bc076966b4d4ea7",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca8f8d881979bc076966b4d4ea7",
+      "text": "**Analyzing kind field serialization issue**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca8f8d881979bc076966b4d4ea7",
+      "text": "**Analyzing kind field serialization issue**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5aca8f8d881979bc076966b4d4ea7",
+      "text": "**Analyzing kind field serialization issue**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acaf66008197bdc123cff7c52cf3"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acaf66008197bdc123cff7c52cf3",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acaf66008197bdc123cff7c52cf3",
+      "text": "**Adjusting metadata structure**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acaf66008197bdc123cff7c52cf3",
+      "text": "**Adjusting metadata structure**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acaf66008197bdc123cff7c52cf3",
+      "text": "**Adjusting metadata structure**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb1b34881978daea10de1dda74b"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb1b34881978daea10de1dda74b",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb1b34881978daea10de1dda74b",
+      "text": "**Investigating cell kind mapping**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb1b34881978daea10de1dda74b",
+      "text": "**Investigating cell kind mapping**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb1b34881978daea10de1dda74b",
+      "text": "**Investigating cell kind mapping**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb56bec8197adaccc254125e3d5"
+    },
+    {
+      "type": "response.content_part.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb56bec8197adaccc254125e3d5",
+      "text": ""
+    },
+    {
+      "type": "response.output_text.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb56bec8197adaccc254125e3d5",
+      "text": "**Preparing final summary response**"
+    },
+    {
+      "type": "response.content_part.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb56bec8197adaccc254125e3d5",
+      "text": "**Preparing final summary response**"
+    },
+    {
+      "type": "response.output_item.done",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
+      "item_id": "rs_0d379186ae0045b40169a5acb56bec8197adaccc254125e3d5",
+      "text": "**Preparing final summary response**"
+    },
+    {
+      "type": "response.output_item.added",
+      "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
       "item_id": "msg_0d379186ae0045b40169a5acb7dcbc819789022aad5aeec56d"
     },
     {
@@ -386,11 +618,6 @@
       "response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff",
       "item_id": "msg_0d379186ae0045b40169a5acb7dcbc819789022aad5aeec56d",
       "text": "Inserted a new Runme Python code cell (`manual-cell-1`) containing exactly `print('Hello, world!')` and left it unexecuted, per instructions. The notebook still has the original markup intro cell and the existing `seed-code` cell untouched. No further changes made."
-    },
-    {
-      "type": "aisre.chatkit.state",
-      "thread_id": "019caf2a-2917-72c1-84dc-e3b3f57ce16b",
-      "previous_response_id": "019caf2a-2af1-7e40-928c-b56859ad21ff"
     },
     {
       "type": "response.completed",

--- a/docs-dev/CUJs/copy-current-notebook-to-drive.md
+++ b/docs-dev/CUJs/copy-current-notebook-to-drive.md
@@ -27,7 +27,9 @@ await app.openNotebook(copied.uri);
 ## Semantics
 
 - `app.getCurrentNotebook()` returns a stable notebook reference for the currently open notebook (at minimum, URI).
-- `app.openNotebook(uri)` opens a notebook and makes it current.
+- Publicly, `app.openNotebook(uri)` opens a notebook and makes it current.
+  Internally, it should call the notebook session open path and then select the
+  returned local URI.
 - `drive.resolvePath(path, options)` resolves a human-friendly Drive path to a concrete destination reference (ID-backed URI).
 - Path resolution is not the same as identity:
   - Drive names are not unique, so duplicates must be handled explicitly.

--- a/docs-dev/architecture/global-singletons.md
+++ b/docs-dev/architecture/global-singletons.md
@@ -1,0 +1,62 @@
+# Global Singletons
+
+Global singletons are acceptable when they own application logic that must be
+available outside React and when React can observe them through explicit
+subscriptions.
+
+They should not be hidden mutable state. A singleton that owns user-visible
+state should expose:
+
+- command methods for mutations
+- `getSnapshot()` for current state
+- `subscribe(listener)` for React adapters
+- an explicit test reset helper when module state would otherwise leak between
+  tests
+
+React contexts should adapt these objects for components. They should not
+duplicate the singleton's business state in parallel React state.
+
+## Notebook Session
+
+`NotebookDataController` is the singleton owner for notebook session state.
+
+It owns:
+
+- the open notebook list
+- the URI-keyed `NotebookData` registry
+- notebook open/close commands
+- loading notebook content through `LocalNotebooks`
+- persistence of the existing open-notebook restore key
+
+`NotebookContext` adapts `NotebookDataController` into React hooks:
+
+- `useNotebookList()`
+- `useNotebookSnapshot(uri)`
+- `getNotebookData(uri)`
+- `openNotebook(uri)`
+- `removeNotebook(uri)`
+
+`CurrentDocContext` is intentionally separate. It owns the selected visible
+notebook URI only. It should not create, mirror, or load notebooks.
+
+The expected caller flow is:
+
+```text
+await openNotebook(uri)
+setCurrentDoc(localUri)
+```
+
+Selection-only callers, such as the tab strip or open-notebooks sidebar, should
+call only `setCurrentDoc(localUri)` for notebooks that are already open.
+
+## Persistence
+
+The current notebook-session refactor keeps the existing shared `localStorage`
+keys:
+
+- `runme/currentDoc`
+- `runme/openNotebooks`
+
+Future multi-tab work will move current/open restore state to tab-local storage.
+Keep persistence code isolated enough that this storage swap does not require
+changing notebook loading or selection semantics.

--- a/docs-dev/design/20260224_saveas.md
+++ b/docs-dev/design/20260224_saveas.md
@@ -8,8 +8,9 @@ current web app architecture, with emphasis on Google Drive-backed notebooks.
 The goal is to define an implementation that works with the existing:
 
 - `NotebookData` in-memory model
-- `NotebookContext` tab registry
-- `CurrentDocContext` URL/document selection
+- `NotebookDataController` tab/model registry
+- `NotebookContext` React adapter
+- `CurrentDocContext` document selection
 - `LocalNotebooks` IndexedDB mirror for Drive files
 
 ## Summary
@@ -42,8 +43,8 @@ Important implications:
 
 - `CurrentDocContext` stores the active doc as a local URI and derives the URL
   `?doc=` from the local record's `remoteUri`
-- `NotebookContext` stores `NotebookData` instances in a map keyed by notebook
-  URI
+- `NotebookDataController` stores `NotebookData` instances in a map keyed by
+  notebook URI, and `NotebookContext` exposes that state to React
 - Tabs in `Actions.tsx` are keyed by the notebook URI
 
 Because of this, `Save As` is not just "rewrite remote target"; it changes the
@@ -54,7 +55,7 @@ document identity and should be modeled as opening a new notebook.
 ### Notebook Identity
 
 - `NotebookData` stores `uri` and persists using `notebookStore.save(this.uri, ...)`
-- `NotebookProvider` stores `NotebookData` instances in a map keyed by URI
+- `NotebookDataController` stores `NotebookData` instances in a map keyed by URI
 - Open tabs are tracked as `NotebookStoreItem[]` and keyed/rendered by URI
 
 Key files:
@@ -70,8 +71,9 @@ Drive files are mirrored to IndexedDB through `LocalNotebooks`:
 - local file record key: `local://file/<uuid>`
 - remote Drive target: `LocalFileRecord.remoteId`
 
-`CurrentDocContext` converts a remote Drive URI in the URL into a local mirror
-URI via `store.addFile(doc)`.
+Inbound Drive URLs are resolved by the Drive link coordinator and opened through
+the notebook session API. `CurrentDocContext` only stores the selected local
+notebook URI.
 
 Key files:
 
@@ -124,9 +126,11 @@ Illustrative flow for a "Save As to Google Drive" command:
    - `const newLocalUri = await localStore.addFile(remoteUri, fileName)`
 5. Persist notebook to the new local entry:
    - `await localStore.save(newLocalUri, notebook)`
-6. Switch current notebook in the UI:
+6. Open the new notebook session entry:
+   - `await openNotebook(newLocalUri)`
+7. Switch current notebook in the UI:
    - `setCurrentDoc(newLocalUri)`
-7. Optional:
+8. Optional:
    - close the old tab, or leave both tabs open
 
 ## IndexedDB Changes Required
@@ -158,8 +162,10 @@ To support `Save As` from AppConsole/AppKernel cells, expose an explicit helper:
 - `app.openNotebook(uri: string)` or
 - `app.setCurrentNotebook(uri: string)`
 
-This should call the same UI path used for normal notebook switching
-(`setCurrentDoc(...)`), not manually mutate URL state.
+The public App API may open and select for user convenience. Internally, it
+should call the same notebook session path used by Explorer and URL handling:
+`openNotebook(uri)` followed by `setCurrentDoc(localUri)`, not manual URL
+mutation.
 
 ## 2) Add a Higher-Level Save As Helper
 
@@ -190,14 +196,14 @@ existing `NotebookData` instance to point to a new URI.
 
 ## Recommended v1 Implementation Plan
 
-1. Add a UI-level helper to switch/open notebooks by local URI (`app.openNotebook`)
+1. Add a UI-level helper to open and select notebooks by local URI (`app.openNotebook`)
 2. Add a Drive `save as` helper that:
    - creates remote file
    - creates local mirror entry
    - saves notebook to local mirror
-   - switches current doc
+   - opens the new notebook session entry
+   - switches current doc to the returned local URI
 3. Add tests:
    - unit test for local mirror record creation + switch behavior
    - AppKernel CUJ notebook step verifying `Save As` switches the current doc
      and subsequent save writes to the new Drive target
-

--- a/docs-dev/design/20260311_appkernel_sandbox.md
+++ b/docs-dev/design/20260311_appkernel_sandbox.md
@@ -449,27 +449,31 @@ Reuse plan:
 - keep it as an internal autosave seam for `NotebookData`.
 - do not expose as sandbox-facing capability API.
 
-### `NotebookContextValue` + `NotebookData` registry (UI layer)
+### `NotebookDataController` + `NotebookContextValue` (open notebook registry)
 
 Location:
 
+- `app/src/lib/notebookDataController.ts`
 - `app/src/contexts/NotebookContext.tsx`
 
 What it provides:
 
-- URI-keyed map of open `NotebookData` instances.
-- `getNotebookData(uri)`, `useNotebookList()`, `useNotebookSnapshot(uri)`.
+- URI-keyed map of open `NotebookData` instances owned by
+  `NotebookDataController`.
+- `NotebookContext` React hooks over that controller:
+  `getNotebookData(uri)`, `useNotebookList()`, `useNotebookSnapshot(uri)`.
 
 Why not sufficient as sandbox API:
 
 - React/context/hook-oriented API, not transport-safe.
-- coupled to client render lifecycle, not a durable RPC contract.
+- the React adapter is coupled to client render lifecycle, not a durable RPC
+  contract.
 - does not provide revisioned handles.
 
 Reuse plan:
 
-- use this registry (or an extracted non-React service) on the host side to
-  implement `HostNotebooksApi.list/get`.
+- use `NotebookDataController` on the host side to implement
+  `HostNotebooksApi.list/get`.
 
 ### `NotebookData` / `NotebookDataLike` / `RunmeConsoleApi` (runtime helpers)
 
@@ -567,17 +571,19 @@ Planned:
 - `NotebookData` stays the source of truth for live open docs; `NotebookDbCore`
   is persistence + revision gate.
 
-### 3) `NotebookContext` supplies open notebook registry
+### 3) `NotebookDataController` supplies the open notebook registry
 
 Current:
 
-- `NotebookProvider` tracks open notebook list and URI->`NotebookData` map.
+- `NotebookDataController` tracks the open notebook list and
+  URI->`NotebookData` map.
+- `NotebookProvider`/`NotebookContext` adapt that state for React.
 
 Planned:
 
-- `HostNotebooksApi.list/get` target resolution uses `NotebookContext` data (or an
-  extracted registry service). `get()` without a target returns the active UI
-  notebook; all write/execute methods require an explicit target handle or URI.
+- `HostNotebooksApi.list/get` target resolution uses `NotebookDataController`.
+  `get()` without a target returns the active UI notebook; all write/execute
+  methods require an explicit target handle or URI.
 - This directly addresses wrong-notebook writes from implicit "current tab"
   behavior.
 

--- a/docs-dev/design/20260426_getAllRendersRefbug.md
+++ b/docs-dev/design/20260426_getAllRendersRefbug.md
@@ -70,9 +70,10 @@ The web app already documents `NotebookData` as the in-memory notebook model.
 - React views subscribe via `subscribe(...)` and `getSnapshot()`
 - mutations call `emit()` so views re-render
 
-`NotebookContext` is the owner of `NotebookData` instances. It keeps a URI-keyed
-registry of notebook models and exposes `useNotebookSnapshot(...)` so React can
-re-render from model snapshots.
+`NotebookDataController` is the owner of `NotebookData` instances. It keeps a
+URI-keyed registry of notebook models. `NotebookContext` adapts that registry
+for React and exposes `useNotebookSnapshot(...)` so React can re-render from
+model snapshots.
 
 That means the intended architecture is:
 

--- a/docs-dev/design/20260514_notebook_focus_persistence.md
+++ b/docs-dev/design/20260514_notebook_focus_persistence.md
@@ -92,7 +92,9 @@ When focus moves within a notebook cell:
 
 When the browser tab becomes focused and visible:
 
-- look at the visible notebook tab, not `currentDoc`
+- look at the visible notebook tab. After the notebook-session refactor,
+  `CurrentDocContext` may be used for this because it is selection-only; do not
+  use it as an open/load command.
 - read that notebook's stored active-cell state
 - if the stored cell still exists, restore focus to it
 - if the stored focus role is `editor` for a markdown cell, reopen that cell in

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -1,0 +1,535 @@
+# Multi-Tab Notebook Ownership
+
+Date: 2026-05-20
+
+Issue: https://github.com/runmedev/web/issues/215
+
+## Summary
+
+Support multiple browser tabs by making notebook ownership explicit.
+
+The product rule is intentionally narrow:
+
+1. A notebook can be open for editing in only one browser tab at a time.
+2. Different browser tabs can show different notebooks.
+3. A closed tab must not keep a notebook blocked.
+4. If a notebook is already open elsewhere, the current tab should show a clear
+   blocked state and offer a cooperative takeover path.
+
+This avoids cross-tab notebook synchronization. Each editable notebook has one
+writer, and other tabs must either open a different notebook or take ownership.
+
+## Browser Coordination Choice
+
+Use the Web Locks API as the correctness primitive.
+
+`navigator.locks` is designed for same-origin tabs and workers to coordinate
+exclusive access to shared resources. A lock is automatically released when the
+holding execution context goes away, which directly handles the "closed tab
+blocks forever" failure mode.
+
+Use `BroadcastChannel` for live cross-tab messages:
+
+- "please close this notebook" requests
+- "ownership released" notifications
+- best-effort "focus your tab" requests
+
+Use IndexedDB for best-effort ownership metadata that the UI can inspect. The
+lock is authoritative; metadata is descriptive and may be stale.
+
+Do not use a service worker as the ownership authority. A service worker is
+useful for fetch/cache orchestration, but its lifecycle is event-driven and not
+a reliable always-running single process for editor ownership. A `SharedWorker`
+is closer to the "one coordinator process" idea, but support is newer and it is
+still unnecessary if Web Locks owns exclusivity.
+
+References:
+
+- Web Locks API:
+  https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+- Broadcast Channel API:
+  https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API
+- SharedWorker:
+  https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker
+- Service worker lifecycle:
+  https://web.dev/articles/service-worker-lifecycle
+
+## Current State
+
+The current app has two pieces of global browser state that conflict with real
+multi-tab behavior:
+
+- `CurrentDocContext` persists `runme/currentDoc` in `localStorage`.
+- `NotebookContext` persists `runme/openNotebooks` in `localStorage`.
+
+Because `localStorage` is shared by same-origin tabs, all tabs converge on the
+same current document and same open notebook list. This is exactly what must
+change for "different tabs can show different open documents."
+
+Relevant current files:
+
+- `app/src/contexts/CurrentDocContext.tsx`
+- `app/src/contexts/NotebookContext.tsx`
+- `app/src/components/Actions/Actions.tsx`
+- `app/src/components/SidePanel/SidePanel.tsx`
+- `app/src/components/Workspace/WorkspaceExplorer.tsx`
+- `app/src/components/AppConsole/AppConsole.tsx`
+
+There is also an architectural coupling that should be fixed before adding tab
+ownership: the app does not cleanly separate "load a notebook into memory" from
+"show this notebook tab."
+
+Today notebook opening is mostly reactive:
+
+```text
+setCurrentDoc(uri)
+  -> NotebookContext effect observes current doc
+  -> loadNotebookIntoLocalMirror(uri)
+  -> ensureNotebook(...)
+  -> new NotebookData(...)
+  -> selected tab changes as a side effect
+```
+
+That makes `currentDoc` serve both as the visible selection and as the command
+channel for loading. Multi-tab ownership needs an imperative open path because
+ownership must be acquired before an editable notebook is considered open.
+
+Some of the stable-local-URI behavior already exists in `LocalNotebooks`:
+
+- `addFile(remoteUri, name)` creates or returns a stable `local://file/...`
+  record for a remote file before notebook content is necessarily loaded.
+- `load(localUri)` attempts best-effort sync and returns an empty notebook if
+  the local record has no `doc` yet.
+
+The missing piece is an explicit notebook session model that can represent:
+
+- a notebook tab that is selected/visible
+- a local mirror URI that is known and stable
+- a `NotebookData` model that may be loaded, loading, blocked, or failed
+- auth/loading errors that should be shown in the tab instead of collapsing the
+  selection
+
+## Proposed Model
+
+### Tab Identity
+
+Create one in-memory tab id at app startup:
+
+```ts
+const tabId = crypto.randomUUID();
+```
+
+Do not use `localStorage` for tab identity. Do not rely on persisted
+`sessionStorage` identity for correctness because duplicated browser tabs can
+clone session storage. A reload can receive a new tab id; ownership will be
+reacquired through Web Locks.
+
+Expose the tab id through a small `TabIdentityContext` or a module-level
+singleton.
+
+### Per-Tab Open State
+
+Move current/open editor state from shared `localStorage` to per-tab state:
+
+| State | Current storage | Proposed storage |
+| --- | --- | --- |
+| current document | `localStorage["runme/currentDoc"]` | `sessionStorage` plus React state |
+| open notebooks | `localStorage["runme/openNotebooks"]` | `sessionStorage` plus React state |
+| active cell | `localStorage["runme/notebook-active-cells"]` | keep shared; keyed by notebook URI and harmless |
+
+The URL `?doc=` should still be accepted as an initial open request, but after
+startup the selected document is tab-local.
+
+This does not mean keying `localStorage` by `tabId`. `localStorage` is shared by
+all same-origin tabs, so storing values like `runme/openNotebooks/<tabId>` would
+still create shared durable records that need garbage collection. It would also
+make duplicated-tab behavior harder to reason about.
+
+The intended split is:
+
+- use `sessionStorage` as the per-tab restore store for the current tab's open
+  notebook list and selected notebook
+- hydrate normal React state from `sessionStorage` on startup
+- use Web Locks plus the IndexedDB ownership table for cross-tab coordination
+
+If a browser duplicates a tab and clones `sessionStorage`, that cloned open list
+is only a restore hint. Each notebook still has to reacquire its Web Lock before
+it can become editable in the duplicated tab.
+
+### Reload vs New Tab
+
+There is no fully reliable browser API that says "this is the same physical tab"
+across every reload, restore, duplicated tab, and crash-recovery path.
+
+The practical signals are:
+
+- `sessionStorage` survives reloads and restores in the same top-level browsing
+  context, which makes it the right place to restore the open notebook list for
+  a refreshed tab.
+- `performance.getEntriesByType("navigation")[0].type` can distinguish
+  `"reload"`, `"navigate"`, and `"back_forward"` for the current page load.
+- `pageshow` / `pagehide` expose whether a page is moving through the
+  back/forward cache via `PageTransitionEvent.persisted`.
+
+Those signals should guide restore behavior, but they should not decide
+ownership. On startup, treat `sessionStorage` as a list of notebooks this tab
+wants to restore, then reacquire Web Locks one notebook at a time. If another
+tab still owns one of those notebooks, show the blocked state instead of opening
+it.
+
+If we need to keep using `localStorage` for compatibility, use it only as a
+legacy initial-open hint or as a shared ownership metadata store. Do not use
+shared `localStorage` as the source of truth for the tab's open editor list.
+
+### Notebook Session Model
+
+Move the business logic currently inside `NotebookProvider.ensureNotebook` and
+the `currentDoc` effects into a notebook session owner. This can start inside a
+refactored `NotebookProvider`, but it should have a controller-like API so it
+can later move out of React cleanly.
+
+The session model should own:
+
+- `openNotebooks`
+- `currentNotebookUri`
+- loaded `NotebookData` instances keyed by local URI
+- pending/blocked/error state per open notebook
+- restore/persist for the tab-local open list
+
+Suggested snapshot:
+
+```ts
+type NotebookTabState =
+  | "resolving"
+  | "blocked"
+  | "loading"
+  | "loaded"
+  | "error";
+
+interface OpenNotebookEntry {
+  uri: string;              // stable local://file/... when known
+  requestedUri: string;     // original URI from URL, Drive, fs, or local source
+  name: string;
+  state: NotebookTabState;
+  errorMessage?: string;
+  owner?: NotebookOwnershipRecord;
+}
+
+interface NotebookSessionSnapshot {
+  openNotebooks: OpenNotebookEntry[];
+  currentNotebookUri: string | null;
+}
+```
+
+The key split is:
+
+- `openNotebook(uri)`: resolves/creates the local mirror URI, acquires ownership,
+  creates or loads `NotebookData`, adds an open entry, and selects it.
+- `selectNotebook(localUri)`: changes the visible tab only. It must not load,
+  mirror, or acquire ownership.
+- `closeNotebook(localUri)`: removes the open entry, disposes the model, releases
+  ownership, and selects a same-tab fallback.
+
+Showing a notebook should be possible even before the notebook content is
+loaded. For example, a Drive URL with expired credentials should still become a
+visible tab with a stable local URI when possible, then render an auth/loading
+state in that tab until the load can complete.
+
+### Stable Local URI Resolution
+
+Before a notebook can be opened or owned, resolve it to the app-facing local
+URI:
+
+```text
+remote Drive URI / fs URI / local URI
+  -> local://file/<id>
+```
+
+Rules:
+
+- If the input is already `local://file/...`, use it directly.
+- If the input has an existing local mirror record by `remoteId`, return that
+  local URI without requiring fresh upstream credentials.
+- If the input is a Drive or filesystem URI and enough metadata is available,
+  create a local placeholder record and return its new local URI.
+- If creating the placeholder needs credentials that are unavailable, keep a
+  `resolving` or `error` tab entry keyed by the original request until the user
+  can authenticate and retry.
+
+`LocalNotebooks.addFile(remoteUri, name)` already implements the first part of
+this behavior for remote files. The session model should use that as the stable
+URI reservation primitive instead of waiting for full notebook content to load.
+
+### Ownership Record
+
+Add a small Dexie database, for example `runme-tab-coordination`, with a table
+keyed by canonical notebook URI.
+
+```ts
+interface NotebookOwnershipRecord {
+  notebookUri: string;
+  ownerTabId: string;
+  ownerLabel: string;
+  ownerUrl: string;
+  ownerStartedAt: string;
+  epoch: string;
+}
+```
+
+The `epoch` is a random UUID generated each time ownership is acquired. It lets
+late messages from an old owner be ignored after takeover.
+
+The canonical ownership key should be the editable local notebook URI:
+
+```text
+local://file/<id>
+```
+
+Drive and filesystem URLs should be normalized through the existing local
+mirror flow first, then ownership should be acquired for the resulting local
+URI.
+
+### Ownership Lease
+
+Add an ownership manager module, for example:
+
+```text
+app/src/lib/tabCoordination/notebookOwnership.ts
+```
+
+Suggested API:
+
+```ts
+type AcquireResult =
+  | { status: "acquired"; lease: NotebookLease }
+  | { status: "blocked"; owner: NotebookOwnershipRecord | null };
+
+interface NotebookLease {
+  notebookUri: string;
+  tabId: string;
+  epoch: string;
+  release(): void;
+  isCurrentOwner(): Promise<boolean>;
+}
+
+interface NotebookOwnershipManager {
+  acquire(notebookUri: string): Promise<AcquireResult>;
+  takeOver(notebookUri: string): Promise<AcquireResult>;
+  release(notebookUri: string): void;
+  getOwner(notebookUri: string): Promise<NotebookOwnershipRecord | null>;
+  subscribe(listener: () => void): () => void;
+}
+```
+
+`acquire` should call:
+
+```ts
+navigator.locks.request(lockName, { ifAvailable: true }, async (lock) => {
+  if (!lock) {
+    return blocked;
+  }
+  // Write ownership record and hold the callback open until release().
+});
+```
+
+The lock callback must return a promise that resolves only when the notebook is
+closed or ownership is otherwise released. That keeps the lock held for the
+whole edit session.
+
+### Metadata, Not Heartbeats
+
+Do not add a heartbeat protocol for initial multi-tab correctness.
+
+Web Locks already answer the important liveness question: if the owner tab is
+closed, reloaded, or crashes, the lock is released by the browser. A heartbeat
+would add timeout tuning and background-tab throttling issues without improving
+the exclusive-writer guarantee.
+
+Ownership metadata should be written when the lock is acquired and deleted on
+clean release. If metadata cleanup fails, the next opener should ignore stale
+metadata when the Web Lock is acquirable.
+
+The rules are:
+
+- if the Web Lock is unavailable, the notebook is owned elsewhere, even if the
+  metadata is missing or stale
+- if the Web Lock is available, the current tab may acquire ownership and
+  overwrite any stale metadata
+- metadata should never block opening by itself
+
+If later UX needs "last seen" or richer diagnostics, add a heartbeat as a
+separate enhancement. It should remain display-only.
+
+### Opening a Notebook
+
+All notebook-open paths must route through one async function:
+
+```ts
+openNotebook(uri, options)
+```
+
+The function should:
+
+1. Resolve or reserve a stable local mirror URI for the requested URI.
+2. Select or create an open tab entry for that URI.
+3. Acquire the ownership lock for the local URI once known.
+4. Create or retrieve the `NotebookData` model for the local URI.
+5. Load notebook content into `NotebookData` when storage/auth is available.
+6. If blocked or auth fails, keep the tab selected and render the blocked/error
+   state instead of dropping the current selection.
+
+Callers that currently call `setCurrentDoc` directly should be moved onto this
+path:
+
+- workspace explorer file clicks
+- Drive link coordinator
+- App Console `app.openNotebook(...)`
+- Runtime `appState.openNotebook(...)`
+- URL `?doc=` processing
+
+The tab strip and open-notebooks sidebar should call `selectNotebook` for
+notebooks already open in the same tab.
+
+### Closing a Notebook
+
+Closing an open notebook in this tab should:
+
+1. Stop rendering the notebook.
+2. Dispose the `NotebookData` entry if it exists.
+3. Release its Web Lock lease.
+4. Delete its ownership record if the epoch still matches.
+5. Broadcast `owner-released`.
+6. Select a same-tab fallback notebook, or clear `currentNotebookUri`.
+
+Use `pagehide` and `beforeunload` for best-effort release, but do not depend on
+those events for correctness. The Web Lock release on context shutdown is the
+important behavior.
+
+### Blocked Notebook UX
+
+When opening is blocked, `Actions` should render an explicit blocked state
+instead of the notebook editor:
+
+```text
+Notebook is already open in another browser tab
+
+<name>
+Owned by: Tab opened at 10:42 AM
+
+[Focus other tab] [Take over]
+```
+
+`Focus other tab` is best effort. It sends a BroadcastChannel message to the
+owner; the owner calls `window.focus()`. Browsers may ignore focus requests.
+
+`Take over` is cooperative:
+
+1. Broadcast `close-notebook-request` with notebook URI and requester tab id.
+2. Owner closes the notebook, releases the lease, and sends
+   `close-notebook-ack`.
+3. Requester retries `acquire`.
+
+If the owner does not respond, leave the notebook blocked for the initial
+implementation. A later explicit "Force take over" action could use Web Locks
+`steal: true`, but that should be a separate decision because it requires save
+and mutation paths to verify the ownership epoch before every write.
+
+Do not automatically steal locks.
+
+### AppKernel and Runtime Mutations
+
+The runtime APIs should only expose notebooks owned by the current tab.
+
+Change `runme.getCurrentNotebook()`, `runme.notebooks`, `app.openNotebook`, and
+AppKernel mutation helpers so they resolve only owned notebooks. Mutations
+against an unowned or blocked URI should throw a clear error:
+
+```text
+Notebook local://file/... is open in another browser tab.
+```
+
+`NotebookData` persistence should also guard writes by asking the ownership
+manager whether the current tab still owns the notebook URI and epoch.
+
+## Implementation Plan
+
+1. Refactor `NotebookProvider` around an explicit notebook session API:
+   `openNotebook`, `selectNotebook`, `closeNotebook`, `getNotebookData`, and a
+   subscription snapshot.
+2. Move `ensureNotebook`, `loadNotebookIntoLocalMirror`, and current-doc loading
+   effects behind that session API.
+3. Decouple selected tab state from loaded model state so auth/loading failures
+   can render in the selected tab.
+4. Convert `CurrentDocContext` and `NotebookContext` restore state from
+   shared `localStorage` to tab-local session restore.
+5. Update `WorkspaceExplorer`, `DriveLinkCoordinatorHost`, `AppConsole`, URL
+   handling, and `appState.openNotebook` to call `openNotebook`.
+6. Keep tab strip and open-notebooks sidebar selection on `selectNotebook`.
+7. Add `TabIdentityContext` and `NotebookOwnershipManager`.
+8. Add `runme-tab-coordination` Dexie schema and ownership record helpers.
+9. Add ownership acquisition/release to `openNotebook` and `closeNotebook`.
+10. Add blocked-notebook UI in `Actions` and sidebar indicators in
+   `SidePanel`.
+11. Guard AppKernel/runtime notebook mutation APIs with ownership checks.
+12. Add tests for ownership acquire/block/release/cooperative-takeover behavior.
+13. Add browser tests that open two same-origin pages and verify that the same
+   notebook cannot be edited in both.
+
+## Test Plan
+
+Unit tests:
+
+- stable local URI resolution returns an existing mirror without loading content
+- opening a notebook can create a selected tab before `NotebookData` is loaded
+- selecting a notebook does not load, mirror, or acquire ownership
+- acquire succeeds when no other tab holds the lock
+- acquire returns blocked when another tab holds the lock
+- release deletes the ownership record only for the matching epoch
+- stale metadata does not block when the Web Lock is available
+- runtime mutation rejects when ownership is missing
+
+Component tests:
+
+- blocked notebook state renders owner metadata and takeover controls
+- tab-local open notebook lists do not mirror across simulated tabs
+- closing a notebook releases its lease and selects the expected fallback
+
+Browser tests:
+
+- open notebook A in tab 1, attempt notebook A in tab 2, verify blocked UI
+- open notebook B in tab 2 while notebook A remains open in tab 1
+- close tab 1, then open notebook A in tab 2 without manual cleanup
+- click takeover in tab 2 and verify tab 1 closes notebook A
+- verify App Console mutation in a non-owner tab fails clearly
+
+## Migration
+
+No notebook content migration is required.
+
+The old shared keys should stop driving current/open editor state:
+
+- `runme/currentDoc`
+- `runme/openNotebooks`
+
+For one release, startup may read these keys as a legacy initial open request in
+the first loaded tab, then write only the new per-tab/session state. Do not keep
+writing the legacy keys after this change.
+
+## Risks
+
+- Web Locks requires a secure context. `localhost` is acceptable for local
+  development, and production is HTTPS.
+- Browser focus requests may be ignored. The UX should describe focus as best
+  effort.
+- `BroadcastChannel` messages are not durable. That is fine because ownership
+  correctness comes from Web Locks and IndexedDB state.
+- Force takeover is intentionally out of scope for the initial implementation.
+  It is only safe if save and mutation paths verify ownership epoch before
+  writing.
+
+## Recommendation
+
+Use Web Locks for exclusive notebook ownership, BroadcastChannel for live tab
+coordination, and IndexedDB records for owner metadata. Refactor current/open
+notebook UI state to be tab-local, then route every notebook-open operation
+through ownership acquisition.

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -166,13 +166,18 @@ singleton.
 
 ### Per-Tab Open State
 
-Move current/open editor state from shared `localStorage` to per-tab state:
+Move current/open editor restore state from shared `localStorage` to per-tab
+`sessionStorage`. The live state remains in the existing in-memory owners:
 
-| State | Current storage | Proposed storage |
-| --- | --- | --- |
-| current document | `localStorage["runme/currentDoc"]` | `sessionStorage` plus React state |
-| open notebooks | `localStorage["runme/openNotebooks"]` | `sessionStorage` plus React state |
-| active cell | `localStorage["runme/notebook-active-cells"]` | keep shared; keyed by notebook URI and harmless |
+| State | Live owner | Current restore storage | Proposed restore storage |
+| --- | --- | --- | --- |
+| current document | `CurrentDocContext` | `localStorage["runme/currentDoc"]` | `sessionStorage` |
+| open notebooks | `NotebookDataController` | `localStorage["runme/openNotebooks"]` | `sessionStorage` |
+| active cell | active-cell state helper | `localStorage["runme/notebook-active-cells"]` | keep shared; keyed by notebook URI and harmless |
+
+`sessionStorage` is only the per-tab restore backend. It is not the live source
+of truth. Runtime changes should update the live owner first, then persist the
+new snapshot to `sessionStorage`.
 
 The URL `?doc=` should still be accepted as an initial open request, but after
 startup the selected document is tab-local.
@@ -306,6 +311,11 @@ Showing a notebook should be possible even before the notebook content is
 loaded. For example, a Drive URL with expired credentials should still become a
 visible tab with a stable local URI when possible, then render an auth/loading
 state in that tab until the load can complete.
+
+Blocked entries are different. If another tab owns the notebook, the current tab
+should create or update only the `OpenNotebookEntry` with `state: "blocked"`.
+It should not create an editable `NotebookData` for that URI. The blocked view
+renders from `OpenNotebookEntry` metadata, not from notebook content.
 
 ### Stable Local URI Resolution
 
@@ -457,7 +467,8 @@ The function should:
 4. Create or retrieve the `NotebookData` model for the local URI.
 5. Load notebook content into `NotebookData` when storage/auth is available.
 6. If blocked, keep the open entry with `state: "blocked"` and return the local
-   URI so the caller can select it and render the blocked state.
+   URI so the caller can select it and render the blocked state. Do not create
+   editable `NotebookData` for blocked entries.
 7. If auth or load fails after a local URI exists, keep the open entry with
    `state: "error"` and return the local URI so the caller can select it and
    render retry/login affordances.
@@ -578,6 +589,7 @@ Unit tests:
   acquiring ownership
 - `openNotebook` returns blocked state when another tab owns the local URI
 - blocked open entries are selectable and renderable
+- blocked open entries do not create editable `NotebookData`
 - acquire succeeds when no other tab holds the lock
 - acquire returns blocked when another tab holds the lock
 - release deletes the ownership record only for the matching epoch

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -18,10 +18,11 @@ The product rule is intentionally narrow:
 2. Different browser tabs can show different notebooks.
 3. A closed tab must not keep a notebook blocked.
 4. If a notebook is already open elsewhere, the current tab should show a clear
-   blocked state and offer a cooperative takeover path.
+   blocked state and ask the user to close it in the other tab.
 
 This avoids cross-tab notebook synchronization. Each editable notebook has one
-writer, and other tabs must either open a different notebook or take ownership.
+writer, and other tabs must either open a different notebook or wait until the
+owner tab closes it.
 
 ## Browser Coordination Choice
 
@@ -34,7 +35,6 @@ blocks forever" failure mode.
 
 Use `BroadcastChannel` for live cross-tab messages:
 
-- "please close this notebook" requests
 - "ownership released" notifications
 - best-effort "focus your tab" requests
 
@@ -337,7 +337,8 @@ interface NotebookOwnershipRecord {
 ```
 
 The `epoch` is a random UUID generated each time ownership is acquired. It lets
-late messages from an old owner be ignored after takeover.
+late release/metadata messages from an old owner be ignored after a notebook is
+closed and reopened.
 
 The canonical ownership key should be the editable local notebook URI:
 
@@ -465,7 +466,8 @@ Closing an open notebook in this tab should:
 2. Dispose the `NotebookData` entry if it exists.
 3. Release its Web Lock lease.
 4. Delete its ownership record if the epoch still matches.
-5. Broadcast `owner-released`.
+5. Optionally broadcast `owner-released` so blocked tabs can retry or refresh
+   their displayed owner state.
 6. Return a same-tab fallback notebook URI, or `null`, so the caller can update
    `CurrentDocContext`.
 
@@ -487,22 +489,30 @@ Owned by: Tab opened at 10:42 AM
 [Focus other tab] [Take over]
 ```
 
-`Focus other tab` is best effort. It sends a BroadcastChannel message to the
-owner; the owner calls `window.focus()`. Browsers may ignore focus requests.
+Do not include `Take over` in the initial implementation.
 
-`Take over` is cooperative:
+The primary action should be guidance:
 
-1. Broadcast `close-notebook-request` with notebook URI and requester tab id.
-2. Owner closes the notebook, releases the lease, and sends
-   `close-notebook-ack`.
-3. Requester retries `acquire`.
+```text
+Close this notebook in the other tab, then retry here.
 
-If the owner does not respond, leave the notebook blocked for the initial
-implementation. A later explicit "Force take over" action could use Web Locks
-`steal: true`, but that should be a separate decision because it requires save
-and mutation paths to verify the ownership epoch before every write.
+[Focus other tab] [Retry]
+```
 
-Do not automatically steal locks.
+`Focus other tab` is best effort. It may send a BroadcastChannel message to the
+owner; the owner may call `window.focus()`. Browsers may ignore focus requests.
+The UI must still work if focus cannot be moved.
+
+`Retry` calls `openNotebook(localUri)` again. If the other tab has closed the
+notebook or gone away, the Web Lock should now be acquirable.
+
+A later explicit takeover action could use cooperative close or Web Locks
+`steal: true`, but that should be a separate design. It requires stronger save
+and mutation guards because the old owner may still be alive briefly or may
+attempt a late write.
+
+Do not automatically steal locks, and do not close notebooks in another tab in
+the initial implementation.
 
 ### AppKernel and Runtime Mutations
 
@@ -541,11 +551,13 @@ manager whether the current tab still owns the notebook URI and epoch.
 10. Keep all visible-tab selection on `CurrentDocContext.setCurrentDoc`.
 11. Add blocked-notebook UI in `Actions` and sidebar indicators in
     `SidePanel`.
-12. Add cooperative takeover over `BroadcastChannel`.
-13. Guard AppKernel/runtime notebook mutation APIs with ownership checks.
-14. Guard `NotebookData` autosave/persistence with ownership checks.
-15. Add tests for ownership acquire/block/release/cooperative-takeover behavior.
-16. Add browser tests that open two same-origin pages and verify that the same
+12. Add optional best-effort `Focus other tab` and `owner-released`
+    BroadcastChannel messages.
+13. Add a blocked-state `Retry` action that re-runs `openNotebook(localUri)`.
+14. Guard AppKernel/runtime notebook mutation APIs with ownership checks.
+15. Guard `NotebookData` autosave/persistence with ownership checks.
+16. Add tests for ownership acquire/block/release/retry behavior.
+17. Add browser tests that open two same-origin pages and verify that the same
     notebook cannot be edited in both.
 
 ## Test Plan
@@ -565,10 +577,13 @@ Unit tests:
 - runtime mutation rejects when ownership is missing
 - `CurrentDocContext` restore uses per-tab `sessionStorage`
 - `NotebookDataController` open-list restore uses per-tab `sessionStorage`
+- blocked-state retry acquires ownership after the original owner releases the
+  lock
 
 Component tests:
 
-- blocked notebook state renders owner metadata and takeover controls
+- blocked notebook state renders owner metadata, close-other-tab guidance, and
+  retry controls
 - tab-local open notebook lists do not mirror across simulated tabs
 - closing a notebook releases its lease and returns the expected fallback URI
 - tab strip and sidebar selection call `setCurrentDoc` without reacquiring
@@ -579,7 +594,7 @@ Browser tests:
 - open notebook A in tab 1, attempt notebook A in tab 2, verify blocked UI
 - open notebook B in tab 2 while notebook A remains open in tab 1
 - close tab 1, then open notebook A in tab 2 without manual cleanup
-- click takeover in tab 2 and verify tab 1 closes notebook A
+- click retry in tab 2 after tab 1 closes notebook A and verify tab 2 opens it
 - verify App Console mutation in a non-owner tab fails clearly
 
 ## Migration
@@ -600,16 +615,17 @@ writing the legacy keys after this change.
 - Web Locks requires a secure context. `localhost` is acceptable for local
   development, and production is HTTPS.
 - Browser focus requests may be ignored. The UX should describe focus as best
-  effort.
+  effort and rely on explicit user action plus retry.
 - `BroadcastChannel` messages are not durable. That is fine because ownership
   correctness comes from Web Locks and IndexedDB state.
-- Force takeover is intentionally out of scope for the initial implementation.
-  It is only safe if save and mutation paths verify ownership epoch before
-  writing.
+- Takeover is intentionally out of scope for the initial implementation. It is
+  only safe if save and mutation paths verify ownership epoch before writing,
+  and it needs a separate UX decision.
 
 ## Recommendation
 
-Use Web Locks for exclusive notebook ownership, BroadcastChannel for live tab
-coordination, and IndexedDB records for owner metadata. Refactor current/open
-notebook UI state to be tab-local, then route every notebook-open operation
-through ownership acquisition.
+Use Web Locks for exclusive notebook ownership and IndexedDB records for owner
+metadata. Use BroadcastChannel only for best-effort focus/release hints. Refactor
+current/open notebook UI state to be tab-local, then route every notebook-open
+operation through ownership acquisition. In the first implementation, blocked
+tabs ask the user to close the notebook in the other tab and retry.

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -375,7 +375,6 @@ interface NotebookLease {
 
 interface NotebookOwnershipManager {
   acquire(notebookUri: string): Promise<AcquireResult>;
-  takeOver(notebookUri: string): Promise<AcquireResult>;
   release(notebookUri: string): void;
   getOwner(notebookUri: string): Promise<NotebookOwnershipRecord | null>;
   subscribe(listener: () => void): () => void;
@@ -486,14 +485,6 @@ Notebook is already open in another browser tab
 <name>
 Owned by: Tab opened at 10:42 AM
 
-[Focus other tab] [Take over]
-```
-
-Do not include `Take over` in the initial implementation.
-
-The primary action should be guidance:
-
-```text
 Close this notebook in the other tab, then retry here.
 
 [Focus other tab] [Retry]
@@ -506,13 +497,7 @@ The UI must still work if focus cannot be moved.
 `Retry` calls `openNotebook(localUri)` again. If the other tab has closed the
 notebook or gone away, the Web Lock should now be acquirable.
 
-A later explicit takeover action could use cooperative close or Web Locks
-`steal: true`, but that should be a separate design. It requires stronger save
-and mutation guards because the old owner may still be alive briefly or may
-attempt a late write.
-
-Do not automatically steal locks, and do not close notebooks in another tab in
-the initial implementation.
+Do not close notebooks in another tab in the initial implementation.
 
 ### AppKernel and Runtime Mutations
 

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -4,6 +4,10 @@ Date: 2026-05-20
 
 Issue: https://github.com/runmedev/web/issues/215
 
+Builds on:
+
+- `docs-dev/design/20260520_notebook_session_refactor.md`
+
 ## Summary
 
 Support multiple browser tabs by making notebook ownership explicit.
@@ -56,11 +60,23 @@ References:
 
 ## Current State
 
-The current app has two pieces of global browser state that conflict with real
-multi-tab behavior:
+The session refactor is the baseline for this design. It moves open/load
+business logic out of React component refs and into `NotebookDataController`.
+After that refactor:
+
+- `NotebookDataController` owns `openNotebooks`.
+- `NotebookDataController` owns loaded `NotebookData` handles keyed by stable
+  local URI.
+- `NotebookContext` is a React adapter over the controller.
+- `CurrentDocContext` is selection-only: it tracks the visible notebook URI and
+  must not load, mirror, sync, or create `NotebookData`.
+- Open flows call `openNotebook(uri)` first, then call
+  `setCurrentDoc(localUri)` when they want to show the notebook.
+
+The remaining multi-tab problem is shared browser restore state:
 
 - `CurrentDocContext` persists `runme/currentDoc` in `localStorage`.
-- `NotebookContext` persists `runme/openNotebooks` in `localStorage`.
+- `NotebookDataController` persists `runme/openNotebooks` in `localStorage`.
 
 Because `localStorage` is shared by same-origin tabs, all tabs converge on the
 same current document and same open notebook list. This is exactly what must
@@ -74,12 +90,9 @@ Relevant current files:
 - `app/src/components/SidePanel/SidePanel.tsx`
 - `app/src/components/Workspace/WorkspaceExplorer.tsx`
 - `app/src/components/AppConsole/AppConsole.tsx`
+- `app/src/lib/notebookDataController.ts`
 
-There is also an architectural coupling that should be fixed before adding tab
-ownership: the app does not cleanly separate "load a notebook into memory" from
-"show this notebook tab."
-
-Today notebook opening is mostly reactive:
+The session refactor fixes the old reactive open path:
 
 ```text
 setCurrentDoc(uri)
@@ -94,6 +107,18 @@ That makes `currentDoc` serve both as the visible selection and as the command
 channel for loading. Multi-tab ownership needs an imperative open path because
 ownership must be acquired before an editable notebook is considered open.
 
+The target post-refactor path is:
+
+```text
+openNotebook(uri)
+  -> resolve or reserve stable local URI
+  -> create or update OpenNotebookEntry
+  -> create/load NotebookData when possible
+  -> return local URI plus state
+setCurrentDoc(localUri)
+  -> show the selected notebook tab
+```
+
 Some of the stable-local-URI behavior already exists in `LocalNotebooks`:
 
 - `addFile(remoteUri, name)` creates or returns a stable `local://file/...`
@@ -101,13 +126,12 @@ Some of the stable-local-URI behavior already exists in `LocalNotebooks`:
 - `load(localUri)` attempts best-effort sync and returns an empty notebook if
   the local record has no `doc` yet.
 
-The missing piece is an explicit notebook session model that can represent:
+The missing multi-tab pieces are:
 
-- a notebook tab that is selected/visible
-- a local mirror URI that is known and stable
-- a `NotebookData` model that may be loaded, loading, blocked, or failed
-- auth/loading errors that should be shown in the tab instead of collapsing the
-  selection
+- tab-local restore for selected/open notebook state
+- exclusive ownership for each editable local notebook URI
+- blocked-state rendering when ownership is held by another tab
+- runtime/save guards so only the owner tab can mutate a notebook
 
 ## Proposed Model
 
@@ -149,12 +173,30 @@ The intended split is:
 
 - use `sessionStorage` as the per-tab restore store for the current tab's open
   notebook list and selected notebook
-- hydrate normal React state from `sessionStorage` on startup
+- hydrate `NotebookDataController.openNotebooks` and `CurrentDocContext`
+  selection from `sessionStorage` on startup
 - use Web Locks plus the IndexedDB ownership table for cross-tab coordination
 
 If a browser duplicates a tab and clones `sessionStorage`, that cloned open list
 is only a restore hint. Each notebook still has to reacquire its Web Lock before
 it can become editable in the duplicated tab.
+
+The multi-tab implementation should introduce a small persistence adapter rather
+than hard-coding `sessionStorage` throughout the controller or
+`CurrentDocContext`:
+
+```ts
+interface NotebookSessionPersistence {
+  loadOpenNotebooks(): OpenNotebookEntry[];
+  saveOpenNotebooks(entries: OpenNotebookEntry[]): void;
+  loadCurrentDoc(): string | null;
+  saveCurrentDoc(uri: string | null): void;
+}
+```
+
+The first multi-tab PR can swap the existing `localStorage` implementation for a
+`sessionStorage` implementation and keep a one-time legacy import from
+`runme/currentDoc` and `runme/openNotebooks`.
 
 ### Reload vs New Tab
 
@@ -181,20 +223,26 @@ If we need to keep using `localStorage` for compatibility, use it only as a
 legacy initial-open hint or as a shared ownership metadata store. Do not use
 shared `localStorage` as the source of truth for the tab's open editor list.
 
-### Notebook Session Model
+### NotebookDataController Extensions
 
-Move the business logic currently inside `NotebookProvider.ensureNotebook` and
-the `currentDoc` effects into a notebook session owner. This can start inside a
-refactored `NotebookProvider`, but it should have a controller-like API so it
-can later move out of React cleanly.
+Extend `NotebookDataController`; do not add a separate notebook session owner.
+The refactor already gives us the correct place for open/load state.
 
-The session model should own:
+The controller should continue to own:
 
 - `openNotebooks`
-- `currentNotebookUri`
-- loaded `NotebookData` instances keyed by local URI
-- pending/blocked/error state per open notebook
-- restore/persist for the tab-local open list
+- loaded `NotebookData` instances keyed by stable local URI
+- pending/loading/error state per open notebook
+
+Multi-tab support adds:
+
+- tab-local restore/persist for `openNotebooks`
+- ownership lease tracking per open notebook
+- blocked state when another tab owns the notebook
+- ownership checks before load/save/mutation paths
+
+`CurrentDocContext` remains the selected visible notebook. It is not moved into
+`NotebookDataController` in this design.
 
 Suggested snapshot:
 
@@ -215,20 +263,31 @@ interface OpenNotebookEntry {
   owner?: NotebookOwnershipRecord;
 }
 
-interface NotebookSessionSnapshot {
+interface NotebookDataControllerSnapshot {
   openNotebooks: OpenNotebookEntry[];
-  currentNotebookUri: string | null;
 }
 ```
 
 The key split is:
 
 - `openNotebook(uri)`: resolves/creates the local mirror URI, acquires ownership,
-  creates or loads `NotebookData`, adds an open entry, and selects it.
-- `selectNotebook(localUri)`: changes the visible tab only. It must not load,
-  mirror, or acquire ownership.
+  creates or loads `NotebookData`, adds or updates an open entry, and returns
+  the local URI plus state.
+- `setCurrentDoc(localUri)`: changes the visible tab only. It must not load,
+  mirror, acquire ownership, or create `NotebookData`.
 - `closeNotebook(localUri)`: removes the open entry, disposes the model, releases
-  ownership, and selects a same-tab fallback.
+  ownership, and returns a same-tab fallback for `CurrentDocContext`.
+
+Most user-facing open flows still do both operations explicitly:
+
+```ts
+const result = await openNotebook(uri);
+setCurrentDoc(result.localUri);
+```
+
+Background preload or restore code may call `openNotebook(uri)` without selecting
+the notebook. Tab strip and sidebar selection should call only
+`setCurrentDoc(localUri)`.
 
 Showing a notebook should be possible even before the notebook content is
 loaded. For example, a Drive URL with expired credentials should still become a
@@ -252,13 +311,14 @@ Rules:
   local URI without requiring fresh upstream credentials.
 - If the input is a Drive or filesystem URI and enough metadata is available,
   create a local placeholder record and return its new local URI.
-- If creating the placeholder needs credentials that are unavailable, keep a
-  `resolving` or `error` tab entry keyed by the original request until the user
-  can authenticate and retry.
+- If creating the placeholder needs credentials that are unavailable, do not
+  create an `OpenNotebookEntry` without a local URI. Use the existing Drive
+  status-tab flow until the app can authenticate and retry.
 
 `LocalNotebooks.addFile(remoteUri, name)` already implements the first part of
-this behavior for remote files. The session model should use that as the stable
-URI reservation primitive instead of waiting for full notebook content to load.
+this behavior for remote files. `NotebookDataController` should use that as the
+stable URI reservation primitive instead of waiting for full notebook content to
+load.
 
 ### Ownership Record
 
@@ -371,12 +431,17 @@ openNotebook(uri, options)
 The function should:
 
 1. Resolve or reserve a stable local mirror URI for the requested URI.
-2. Select or create an open tab entry for that URI.
+2. Create or update an open tab entry for that local URI.
 3. Acquire the ownership lock for the local URI once known.
 4. Create or retrieve the `NotebookData` model for the local URI.
 5. Load notebook content into `NotebookData` when storage/auth is available.
-6. If blocked or auth fails, keep the tab selected and render the blocked/error
-   state instead of dropping the current selection.
+6. If blocked, keep the open entry with `state: "blocked"` and return the local
+   URI so the caller can select it and render the blocked state.
+7. If auth or load fails after a local URI exists, keep the open entry with
+   `state: "error"` and return the local URI so the caller can select it and
+   render retry/login affordances.
+8. If a local URI cannot be produced, fail without creating an open entry. Use
+   the existing Drive status-tab flow for auth-dependent shared links.
 
 Callers that currently call `setCurrentDoc` directly should be moved onto this
 path:
@@ -387,8 +452,10 @@ path:
 - Runtime `appState.openNotebook(...)`
 - URL `?doc=` processing
 
-The tab strip and open-notebooks sidebar should call `selectNotebook` for
-notebooks already open in the same tab.
+Those callers should call `setCurrentDoc(result.localUri)` only after
+`openNotebook` returns a local URI. The tab strip and open-notebooks sidebar
+should call only `setCurrentDoc(localUri)` for notebooks already open in the
+same tab.
 
 ### Closing a Notebook
 
@@ -399,7 +466,8 @@ Closing an open notebook in this tab should:
 3. Release its Web Lock lease.
 4. Delete its ownership record if the epoch still matches.
 5. Broadcast `owner-released`.
-6. Select a same-tab fallback notebook, or clear `currentNotebookUri`.
+6. Return a same-tab fallback notebook URI, or `null`, so the caller can update
+   `CurrentDocContext`.
 
 Use `pagehide` and `beforeunload` for best-effort release, but do not depend on
 those events for correctness. The Web Lock release on context shutdown is the
@@ -453,46 +521,58 @@ manager whether the current tab still owns the notebook URI and epoch.
 
 ## Implementation Plan
 
-1. Refactor `NotebookProvider` around an explicit notebook session API:
-   `openNotebook`, `selectNotebook`, `closeNotebook`, `getNotebookData`, and a
-   subscription snapshot.
-2. Move `ensureNotebook`, `loadNotebookIntoLocalMirror`, and current-doc loading
-   effects behind that session API.
-3. Decouple selected tab state from loaded model state so auth/loading failures
-   can render in the selected tab.
-4. Convert `CurrentDocContext` and `NotebookContext` restore state from
-   shared `localStorage` to tab-local session restore.
-5. Update `WorkspaceExplorer`, `DriveLinkCoordinatorHost`, `AppConsole`, URL
-   handling, and `appState.openNotebook` to call `openNotebook`.
-6. Keep tab strip and open-notebooks sidebar selection on `selectNotebook`.
-7. Add `TabIdentityContext` and `NotebookOwnershipManager`.
-8. Add `runme-tab-coordination` Dexie schema and ownership record helpers.
-9. Add ownership acquisition/release to `openNotebook` and `closeNotebook`.
-10. Add blocked-notebook UI in `Actions` and sidebar indicators in
-   `SidePanel`.
-11. Guard AppKernel/runtime notebook mutation APIs with ownership checks.
-12. Add tests for ownership acquire/block/release/cooperative-takeover behavior.
-13. Add browser tests that open two same-origin pages and verify that the same
-   notebook cannot be edited in both.
+1. Start from the session refactor:
+   - `NotebookDataController.openNotebook`
+   - `NotebookDataController.closeNotebook`
+   - `NotebookDataController.getNotebookData`
+   - `NotebookContext` as React adapter
+   - `CurrentDocContext` as selection-only state
+2. Add a `NotebookSessionPersistence` adapter and switch current/open restore
+   state from shared `localStorage` to tab-local `sessionStorage`.
+3. Add a one-time legacy import path from `runme/currentDoc` and
+   `runme/openNotebooks` into the current tab's `sessionStorage`.
+4. Add tab identity as an in-memory module singleton or `TabIdentityContext`.
+5. Add `NotebookOwnershipManager`.
+6. Add the `runme-tab-coordination` Dexie schema and ownership record helpers.
+7. Extend `OpenNotebookEntry` with ownership/blocked metadata.
+8. Add ownership acquisition to `NotebookDataController.openNotebook` after
+   stable local URI resolution and before editable load.
+9. Add ownership release to `NotebookDataController.closeNotebook`.
+10. Keep all visible-tab selection on `CurrentDocContext.setCurrentDoc`.
+11. Add blocked-notebook UI in `Actions` and sidebar indicators in
+    `SidePanel`.
+12. Add cooperative takeover over `BroadcastChannel`.
+13. Guard AppKernel/runtime notebook mutation APIs with ownership checks.
+14. Guard `NotebookData` autosave/persistence with ownership checks.
+15. Add tests for ownership acquire/block/release/cooperative-takeover behavior.
+16. Add browser tests that open two same-origin pages and verify that the same
+    notebook cannot be edited in both.
 
 ## Test Plan
 
 Unit tests:
 
 - stable local URI resolution returns an existing mirror without loading content
-- opening a notebook can create a selected tab before `NotebookData` is loaded
-- selecting a notebook does not load, mirror, or acquire ownership
+- `openNotebook` can create an open entry before `NotebookData` is loaded
+- `setCurrentDoc` can select that open entry without loading, mirroring, or
+  acquiring ownership
+- `openNotebook` returns blocked state when another tab owns the local URI
+- blocked open entries are selectable and renderable
 - acquire succeeds when no other tab holds the lock
 - acquire returns blocked when another tab holds the lock
 - release deletes the ownership record only for the matching epoch
 - stale metadata does not block when the Web Lock is available
 - runtime mutation rejects when ownership is missing
+- `CurrentDocContext` restore uses per-tab `sessionStorage`
+- `NotebookDataController` open-list restore uses per-tab `sessionStorage`
 
 Component tests:
 
 - blocked notebook state renders owner metadata and takeover controls
 - tab-local open notebook lists do not mirror across simulated tabs
-- closing a notebook releases its lease and selects the expected fallback
+- closing a notebook releases its lease and returns the expected fallback URI
+- tab strip and sidebar selection call `setCurrentDoc` without reacquiring
+  ownership
 
 Browser tests:
 

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -33,6 +33,19 @@ exclusive access to shared resources. A lock is automatically released when the
 holding execution context goes away, which directly handles the "closed tab
 blocks forever" failure mode.
 
+If `navigator.locks` is unavailable, do not silently fall back to metadata,
+heartbeats, or `localStorage` as an ownership authority. The app should show a
+clear unsupported-browser state for notebook editing:
+
+```text
+This browser does not support safe multi-tab notebook ownership.
+
+Use a browser with Web Locks support, or close other Runme tabs before editing.
+```
+
+The app may still render non-editing surfaces, but it must not claim exclusive
+notebook ownership without Web Locks.
+
 Use `BroadcastChannel` for live cross-tab messages:
 
 - "ownership released" notifications
@@ -363,7 +376,8 @@ Suggested API:
 ```ts
 type AcquireResult =
   | { status: "acquired"; lease: NotebookLease }
-  | { status: "blocked"; owner: NotebookOwnershipRecord | null };
+  | { status: "blocked"; owner: NotebookOwnershipRecord | null }
+  | { status: "unsupported"; reason: "web_locks_unavailable" };
 
 interface NotebookLease {
   notebookUri: string;
@@ -396,6 +410,11 @@ The lock callback must return a promise that resolves only when the notebook is
 closed or ownership is otherwise released. That keeps the lock held for the
 whole edit session.
 
+If `navigator.locks` is missing, `acquire` should return `unsupported` rather
+than `blocked`. `openNotebook` should map `unsupported` to an
+`OpenNotebookEntry` error state with a user-facing message. Do not create
+editable `NotebookData` for that entry.
+
 ### Metadata, Not Heartbeats
 
 Do not add a heartbeat protocol for initial multi-tab correctness.
@@ -416,6 +435,8 @@ The rules are:
 - if the Web Lock is available, the current tab may acquire ownership and
   overwrite any stale metadata
 - metadata should never block opening by itself
+- if the Web Locks API itself is unavailable, ownership is unsupported and the
+  app must not use metadata as a fallback lock
 
 If later UX needs "last seen" or richer diagnostics, add a heartbeat as a
 separate enhancement. It should remain display-only.
@@ -440,7 +461,9 @@ The function should:
 7. If auth or load fails after a local URI exists, keep the open entry with
    `state: "error"` and return the local URI so the caller can select it and
    render retry/login affordances.
-8. If a local URI cannot be produced, fail without creating an open entry. Use
+8. If Web Locks are unavailable, keep the open entry with `state: "error"` and a
+   clear unsupported-browser message. Do not create editable `NotebookData`.
+9. If a local URI cannot be produced, fail without creating an open entry. Use
    the existing Drive status-tab flow for auth-dependent shared links.
 
 Callers that currently call `setCurrentDoc` directly should be moved onto this
@@ -560,6 +583,9 @@ Unit tests:
 - release deletes the ownership record only for the matching epoch
 - stale metadata does not block when the Web Lock is available
 - runtime mutation rejects when ownership is missing
+- acquire returns unsupported when `navigator.locks` is missing
+- unsupported ownership renders an error entry and does not create editable
+  `NotebookData`
 - `CurrentDocContext` restore uses per-tab `sessionStorage`
 - `NotebookDataController` open-list restore uses per-tab `sessionStorage`
 - blocked-state retry acquires ownership after the original owner releases the
@@ -598,7 +624,9 @@ writing the legacy keys after this change.
 ## Risks
 
 - Web Locks requires a secure context. `localhost` is acceptable for local
-  development, and production is HTTPS.
+  development, and production is HTTPS. Browsers without `navigator.locks`
+  should show an unsupported editing state rather than falling back to weaker
+  coordination.
 - Browser focus requests may be ignored. The UX should describe focus as best
   effort and rely on explicit user action plus retry.
 - `BroadcastChannel` messages are not durable. That is fine because ownership

--- a/docs-dev/design/20260520_notebook_session_refactor.md
+++ b/docs-dev/design/20260520_notebook_session_refactor.md
@@ -1,0 +1,591 @@
+# Notebook Session Refactor
+
+Date: 2026-05-20
+
+Related:
+
+- https://github.com/runmedev/web/issues/215
+- `docs-dev/design/20260520_multi_tab_support.md`
+
+## Summary
+
+Refactor notebook tab/session state before adding multi-tab ownership.
+
+This document scopes a single PR. The PR should be deployable on its own and
+should avoid storage migrations or multi-tab behavior changes.
+
+The immediate problem is that the app does not cleanly distinguish:
+
+1. **Opening/loading a notebook**: resolving a requested URI, creating or finding
+   a stable local mirror URI, creating `NotebookData`, and loading content.
+2. **Showing a notebook**: selecting which already-open tab is currently visible.
+
+Today `CurrentDocContext` mixes those concerns. Setting current doc is both a
+selection update and the command that indirectly causes `NotebookContext` to
+load or create a `NotebookData` model.
+
+This refactor introduces a concrete global `NotebookDataController`:
+
+```ts
+const controller = getNotebookDataController();
+
+await controller.openNotebook(uri);
+controller.closeNotebook(localUri);
+controller.getNotebookData(localUri);
+```
+
+`CurrentDocContext` remains the selection API, but it is narrowed to only mean
+"which notebook is currently visible." It should no longer trigger notebook
+loading.
+
+`NotebookContext` becomes a React adapter over the controller.
+
+## PR Scope
+
+In scope for this PR:
+
+- add `NotebookDataController`
+- move the `NotebookData` registry out of React component refs
+- expose `openNotebook`, `closeNotebook`, `getNotebookData`, and controller
+  snapshots through `NotebookContext`
+- keep `CurrentDocContext` as the selection propagation mechanism
+- stop using current-doc changes as the way to load notebooks
+- keep existing `localStorage` keys and restore behavior
+
+Out of scope for this PR:
+
+- moving restore state from `localStorage` to `sessionStorage`
+- adding Web Locks or cross-tab ownership
+- making `LocalNotebooks` a singleton
+- changing `LocalNotebooks.load()` empty-doc behavior
+- removing `CurrentDocContext`
+
+## Motivation
+
+Multi-tab support will eventually need a single `openNotebook` path before Web
+Lock ownership can be added safely. This PR does not add locks; it creates the
+explicit open path that later lock acquisition can attach to.
+
+The current reactive path is backwards for that:
+
+```text
+setCurrentDoc(uri)
+  -> NotebookContext effect observes current doc
+  -> loadNotebookIntoLocalMirror(uri)
+  -> ensureNotebook(...)
+  -> new NotebookData(...)
+```
+
+That means any caller that wants to open a notebook smuggles the command through
+selection state. It also makes it difficult to show a notebook tab when content
+cannot be loaded yet, for example when a Drive URL is known but credentials have
+expired.
+
+The desired path is imperative:
+
+```text
+openNotebook(uri)
+  -> resolve or reserve stable local URI
+  -> create/load NotebookData when possible
+  -> return local URI plus load state
+```
+
+Showing the notebook remains the job of `CurrentDocContext`:
+
+```text
+setCurrentDoc(localUri)
+  -> propagate visible notebook selection to UI
+```
+
+Most user-facing open flows will call both:
+
+```text
+const result = await openNotebook(uri)
+setCurrentDoc(result.localUri)
+```
+
+That keeps document loading/model ownership separate from UI selection while
+still making Explorer, URL handling, and App Console flows straightforward.
+
+The full user-facing sequence is:
+
+```text
+openNotebook(uri)
+  -> resolve or reserve stable local URI
+  -> create/load NotebookData when possible
+setCurrentDoc(localUri)
+  -> render resolving/loading/error/loaded state in that tab
+```
+
+Selection becomes a simpler operation:
+
+```text
+setCurrentDoc(localUri)
+  -> update visible tab only
+```
+
+## Current State
+
+### In-Memory Notebook Model
+
+`NotebookData` is the in-memory model for one notebook.
+
+File:
+
+- `app/src/lib/notebookData.ts`
+
+It owns:
+
+- URI and display name
+- the `parser_pb.Notebook` proto
+- cell index/cache
+- subscriptions and snapshots
+- autosave scheduling
+- active streams and Jupyter sockets
+
+`NotebookData` is created in `NotebookProvider.ensureNotebook(...)`.
+
+### Loaded Notebook Registry
+
+`NotebookProvider` tracks loaded model instances in:
+
+```ts
+const storeRef = useRef<Map<string, StoreEntry>>(new Map());
+```
+
+where:
+
+```ts
+type StoreEntry = {
+  data: NotebookData;
+  unsubscribe: () => void;
+  loaded: boolean;
+};
+```
+
+The map is keyed by notebook URI.
+
+### Open Notebook List
+
+`NotebookProvider` separately tracks open tabs:
+
+```ts
+const [openNotebooks, setOpenNotebooks] = useState<NotebookStoreItem[]>([]);
+```
+
+This list is persisted to shared `localStorage["runme/openNotebooks"]`.
+
+### Current Selection
+
+`CurrentDocContext` tracks:
+
+```ts
+currentDoc: string | null
+```
+
+It restores from:
+
+- `?doc=...`
+- `localStorage["runme/currentDoc"]`
+
+It writes back to `localStorage["runme/currentDoc"]` and clears the URL query
+param.
+
+After this refactor, `CurrentDocContext` should keep tracking the visible
+selection, but it should stop owning open/load behavior. It may remain the
+shared propagation mechanism used by the tab strip, sidebar, App Console, and
+code mode.
+
+### Current Coupling
+
+Notebook loading is triggered by selection:
+
+- `WorkspaceExplorer` calls `setCurrentDoc(item.uri)`.
+- `DriveLinkCoordinatorHost` calls `setCurrentDoc(localUri)`.
+- App Console runtime `app.openNotebook(uri)` calls `setCurrentDoc(uri)`.
+- `NotebookContext` observes `getCurrentDoc()` and loads/mirrors/ensures a
+  notebook for that URI.
+
+This makes `currentDoc` both:
+
+- selected visible tab
+- open/load command
+
+## Existing Stable Local URI Behavior
+
+Some of the desired URI reservation behavior already exists.
+
+`LocalNotebooks.addFile(remoteUri, name)`:
+
+- looks up a file by `remoteId`
+- returns the existing `local://file/...` URI if found
+- otherwise creates a new local file record with empty `doc`
+- returns the new stable local URI
+
+`LocalNotebooks.load(localUri)`:
+
+- attempts best-effort sync
+- if the local record has no `doc`, returns an empty notebook
+
+This means we already have a way to represent "we know this file and have a
+stable local URI, but content may not be loaded yet." The notebook session
+should use that explicitly instead of treating content load as the same event
+as tab selection.
+
+## Target Model
+
+### NotebookDataController
+
+Add a vanilla TypeScript singleton:
+
+```text
+app/src/lib/notebookDataController.ts
+```
+
+Use a concrete class first. Do not add a separate interface until we have a
+second implementation or a real testability problem. TypeScript's structural
+typing is enough for tests that need small fakes.
+
+Suggested exports:
+
+```ts
+export class NotebookDataController {
+  static getInstance(): NotebookDataController;
+
+  getSnapshot(): NotebookDataControllerSnapshot;
+  subscribe(listener: () => void): () => void;
+
+  configureStores(options: {
+    localNotebooks: LocalNotebooks | null;
+  }): void;
+
+  openNotebook(
+    uri: string,
+    options?: { name?: string },
+  ): Promise<OpenNotebookResult>;
+  closeNotebook(localUri: string): string | null;
+
+  getNotebookData(localUri: string): NotebookData | undefined;
+  getOpenNotebooks(): OpenNotebookEntry[];
+}
+
+export function getNotebookDataController(): NotebookDataController;
+export function __resetNotebookDataControllerForTests(): void;
+```
+
+Make the singleton explicit rather than hiding state in React component refs.
+This matches the repo's existing manager pattern (`getRunnersManager`,
+`getJupyterManager`, `getHarnessManager`, `getCodexProjectManager`).
+
+`NotebookProvider` should configure the controller with the current
+`LocalNotebooks` instance and expose React hooks over the controller snapshot.
+
+### NotebookData Storage
+
+`NotebookDataController` owns the `NotebookData` registry. Move the current
+`NotebookProvider.storeRef` model map into the controller, while preserving the
+current placeholder behavior.
+
+```ts
+type NotebookDataHandle = {
+  data: NotebookData;
+  unsubscribe: () => void;
+};
+
+class NotebookDataController {
+  private readonly notebooks = new Map<string, NotebookDataHandle>();
+  private openNotebooks: OpenNotebookEntry[] = [];
+  private listeners = new Set<() => void>();
+}
+```
+
+The `notebooks` map is keyed by stable local notebook URI:
+
+```text
+local://file/<id>
+```
+
+Rules:
+
+- `getNotebookData(localUri)` returns `notebooks.get(localUri)?.data`.
+- `openNotebook(localUri)` may create a `NotebookDataHandle` with an empty
+  notebook and `loaded: false`, matching today's `ensureNotebook` behavior.
+- `openNotebook(remoteUri)` first resolves or reserves a local URI through
+  `LocalNotebooks`, then uses that local URI as the entry key.
+- `closeNotebook(localUri)` unsubscribes the handle, removes it from `notebooks`,
+  removes its open list entry, emits a snapshot update, and returns a fallback
+  local URI for `CurrentDocContext`.
+- `openNotebooks` is metadata for UI tabs; `notebooks` is the loaded model
+  registry. They are related but not the same thing.
+- loading, blocked, auth-required, and error state belongs on
+  `OpenNotebookEntry`, not inside `NotebookData`.
+
+This distinction matters because a notebook can be selected or visible before
+its content is loaded. For the first refactor, preserve the current behavior:
+`NotebookData` may exist before content is fully loaded, seeded with an empty
+notebook proto and later populated by `NotebookData.loadNotebook(...)`.
+
+The UI should not infer readiness from the existence of `NotebookData`. It
+should use `OpenNotebookEntry.state` for loading, auth-required, blocked, and
+error rendering. A later cleanup can decide whether to stop creating placeholder
+`NotebookData` instances.
+
+### Controller Snapshot
+
+```ts
+type NotebookTabState =
+  | "resolving"
+  | "loading"
+  | "loaded"
+  | "blocked"
+  | "error";
+
+interface OpenNotebookEntry {
+  uri: string;
+  requestedUri: string;
+  name: string;
+  state: NotebookTabState;
+  errorMessage?: string;
+}
+
+interface NotebookDataControllerSnapshot {
+  openNotebooks: OpenNotebookEntry[];
+}
+```
+
+`uri` is always the stable `local://file/...` URI for the open notebook. The
+controller should not create an `OpenNotebookEntry` until it has a local URI.
+
+For remote inputs, `openNotebook` must either:
+
+1. find an existing local mirror by `remoteId`, or
+2. reserve a new local record with `LocalNotebooks.addFile(remoteUri, name)`.
+
+If the controller cannot produce a local URI, the open command should fail
+without creating a notebook tab entry. Those failures belong in the existing
+status/error flow, not in `openNotebooks`.
+
+`requestedUri` preserves the original command target from URL, Drive, fs, or
+local source.
+
+`NotebookContext` should subscribe to this snapshot with `useSyncExternalStore`
+and expose hooks for React components. `CurrentDocContext` continues to expose
+the selected URI.
+
+### Command Semantics
+
+`openNotebook(uri)`:
+
+1. Normalize or reserve the stable local URI.
+2. Create or retrieve a `NotebookData` placeholder for the local URI.
+3. Start or perform content load when storage/auth is available.
+4. Return the stable local URI plus load state.
+5. Do not call `setCurrentDoc`.
+
+`setCurrentDoc(localUri)`:
+
+1. Updates the visible selected notebook URI.
+2. Propagates that selection to the tab strip, sidebar, App Console, code mode,
+   and other consumers.
+3. Persists selection through the existing `CurrentDocContext` behavior.
+4. Does not load, mirror, sync, acquire ownership, or create `NotebookData`.
+
+This means callers own intent:
+
+- Explorer file click: `const { localUri } = await openNotebook(uri); setCurrentDoc(localUri)`.
+- URL `?doc=` handling: `openNotebook(doc)` then `setCurrentDoc(localUri)` if
+  resolution succeeds far enough to produce a tab target.
+- Background preloading: call `openNotebook(uri)` without selecting it.
+- Tab strip/sidebar: call only `setCurrentDoc(localUri)`.
+
+`closeNotebook(localUri)`:
+
+1. Remove the open entry.
+2. Dispose/unsubscribe the `NotebookData` entry if present.
+3. Return a same-tab fallback URI so the caller can update `CurrentDocContext`.
+4. Persist the open list using the existing `runme/openNotebooks` behavior.
+
+Future multi-tab ownership hooks attach naturally, but are not part of this PR:
+
+- `openNotebook` acquires Web Lock ownership before editable load.
+- `closeNotebook` releases ownership.
+- blocked ownership becomes `state: "blocked"`.
+
+## Store Dependencies
+
+`NotebookDataController` should depend on `LocalNotebooks`, not directly on
+`FilesystemNotebookStore`.
+
+Reasoning:
+
+- `LocalNotebooks` is the app-facing notebook store for editable notebooks.
+- `LocalNotebooks.addFile(remoteUri, name)` can reserve a stable local URI for
+  Drive and filesystem-backed files.
+- `LocalNotebooks.load(localUri)` owns best-effort sync before hydrating
+  notebook content.
+- `LocalNotebooks` already has `setFilesystemStore(...)` so filesystem sync can
+  be wired there.
+
+Therefore controller configuration should be:
+
+```ts
+controller.configureStores({
+  localNotebooks,
+});
+```
+
+not:
+
+```ts
+controller.configureStores({
+  localNotebooks,
+  filesystemStore,
+});
+```
+
+For filesystem opens, the caller can pass the display name it already has from
+the explorer:
+
+```ts
+await controller.openNotebook(fsUri, { name: item.name });
+```
+
+The controller then calls `localNotebooks.addFile(fsUri, name)` and later
+`localNotebooks.load(localUri)`. If the filesystem store is not configured yet,
+`LocalNotebooks.load` may return cached/empty content or surface an error state;
+the controller should not bypass `LocalNotebooks` to talk to the filesystem
+store directly.
+
+`LocalNotebooks` is not currently a global singleton. `NotebookStoreInitializer`
+constructs it, configures its filesystem store, puts it in React context, and
+also stores it on `appState`. `NotebookDataController` could read
+`appState.localNotebooks`, but explicit configuration is clearer and easier to
+test:
+
+```ts
+getNotebookDataController().configureStores({ localNotebooks: localStore });
+```
+
+If we later make `LocalNotebooks` itself a singleton, this configuration method
+can become a thin no-op wrapper or be removed.
+
+## URL Handling
+
+`?doc=<uri>` should be treated as an open command, not current selection state.
+
+Startup flow:
+
+1. Read `doc` query param.
+2. Call `openNotebook(doc)`.
+3. If a local tab target is available, call `setCurrentDoc(localUri)`.
+4. Clear the query param.
+5. Render loading/error/loaded in the selected tab.
+
+Drive shared-link failures should not clear an existing selection. If the app can
+reserve or find a local URI, URL handling can select that tab and show
+retry/login affordances. If it cannot produce a local tab target yet, keep using
+the existing Drive status tab pattern until the user can authenticate and retry.
+
+## Persistence
+
+For this PR, keep the existing persistence behavior.
+
+Current shared keys:
+
+- `runme/currentDoc`
+- `runme/openNotebooks`
+
+The controller should read/write the same open-notebook state that
+`NotebookContext` uses today, only moving ownership of that logic out of React.
+`CurrentDocContext` should continue persisting current selection as it does
+today for this PR.
+
+Moving restore state to `sessionStorage` is deferred to a later multi-tab PR.
+
+## Implementation Plan
+
+### 1. Add NotebookDataController
+
+Create `app/src/lib/notebookDataController.ts` and move the loaded model
+registry out of React:
+
+- add `notebooks: Map<string, NotebookDataHandle>`
+- add `openNotebooks: OpenNotebookEntry[]`
+- add `subscribe` / `getSnapshot`
+- expose `openNotebook` and `closeNotebook`
+- expose `getNotebookData` and `getOpenNotebooks`
+- add `configureStores({ localNotebooks })`
+- add `__resetNotebookDataControllerForTests`
+
+`NotebookProvider` should become a thin React adapter:
+
+- configure the controller when `LocalNotebooks` changes
+- use `useSyncExternalStore` to expose `useNotebookList`
+- keep `useNotebookSnapshot` backed by `NotebookData.subscribe`
+- forward `openNotebook`, `closeNotebook`, and `getNotebookData`
+
+Keep `CurrentDocContext`, but document and enforce that it is selection-only.
+
+### 2. Move Opening Callers
+
+Change open-command callers to use `openNotebook`:
+
+- `WorkspaceExplorer` file open
+- `DriveLinkCoordinatorHost`
+- App Console `app.openNotebook(...)`
+- `appState.openNotebook(...)`
+- URL `?doc=` processing
+
+Keep selection callers on `CurrentDocContext.setCurrentDoc`, but make sure they
+only pass local URIs for already-open notebooks:
+
+- notebook tab strip
+- open-notebooks sidebar
+- close fallback selection
+- Explorer/Drive/URL/App Console flows after `openNotebook` returns a local URI
+
+### 3. Stop Loading From Current Selection
+
+Remove the `NotebookContext` effect that treats `getCurrentDoc()` as a load
+trigger.
+
+Loading should happen only through `openNotebook`.
+
+### 4. Narrow CurrentDocContext Within Existing Storage
+
+Remove non-selection responsibilities from `CurrentDocContext`:
+
+- stop processing URL `?doc=` inside the provider
+- stop registering `appState.openNotebook`
+- keep `getCurrentDoc` / `setCurrentDoc` for visible selection
+
+Runtime default notebook resolution can continue reading `getCurrentDoc()`, but
+that value should only ever represent a selected local notebook URI.
+
+## Testing
+
+Unit tests:
+
+- `openNotebook(localUri)` creates/loads one `NotebookData`
+- `openNotebook(remoteUri)` returns an existing local URI when a mirror exists
+- `openNotebook(remoteUri)` does not change current selection by itself
+- `setCurrentDoc(localUri)` changes selection without loading or creating a
+  model
+- `closeNotebook(localUri)` removes the model and returns fallback for
+  `CurrentDocContext`
+- URL `doc` processing calls `openNotebook` first, then `setCurrentDoc` with
+  the resolved local URI
+
+Component tests:
+
+- tab strip selection calls `setCurrentDoc`
+- explorer file click calls `openNotebook`
+- App Console `app.openNotebook` calls the session open path
+- loading/error state can be shown for selected entries without loaded content
+
+Browser tests:
+
+- open a local notebook and switch tabs without losing scroll state
+- refresh restores the open notebook session
+- Drive auth failure keeps a visible retry/error state instead of clearing the
+  selected notebook


### PR DESCRIPTION
## Summary
- add a singleton NotebookDataController that owns open notebook state and NotebookData handles outside React
- narrow CurrentDocContext to visible selection and move open flows to explicit openNotebook calls
- update multi-tab and architecture docs to match the new session boundary
- refresh the Codex ChatKit transcript fixture for reasoning-summary events

Fixes #215

## Tests
- pnpm -C app test --run
- runme run build test