### PR TITLE
[codex] Add multi-tab notebook ownership

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../runme/client";;
 import { CellData } from "../../lib/notebookData";
 import { useNotebookContext } from "../../contexts/NotebookContext";
+import type { OpenNotebookEntry } from "../../lib/notebookDataController";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { useOutput } from "../../contexts/OutputContext";
 import CellConsole, { fontSettings } from "./CellConsole";
@@ -1470,16 +1471,18 @@ export function Action({
 
 function NotebookTabContent({
   docUri,
+  entry,
   activeCell,
   isWindowFocused,
   onCellFocus,
 }: {
   docUri: string;
+  entry: OpenNotebookEntry;
   activeCell: NotebookActiveCellState | null;
   isWindowFocused: boolean;
   onCellFocus: (docUri: string, state: NotebookActiveCellState) => void;
 }) {
-  const { getNotebookData, useNotebookSnapshot } = useNotebookContext();
+  const { getNotebookData, openNotebook, useNotebookSnapshot } = useNotebookContext();
   const notebookSnapshot = useNotebookSnapshot(docUri);
   const cellDatas = useMemo(() => {
     if (!notebookSnapshot) {
@@ -1493,6 +1496,57 @@ function NotebookTabContent({
       .map((c) => (c?.refId ? data.getCell(c.refId) : null))
       .filter((c): c is CellData => Boolean(c));
   }, [getNotebookData, notebookSnapshot]);
+
+  if (entry.state === "blocked") {
+    const ownerText = entry.owner?.ownerStartedAt
+      ? `Tab opened at ${new Date(entry.owner.ownerStartedAt).toLocaleTimeString()}`
+      : "Another browser tab";
+    return (
+      <div
+        className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center text-sm text-nb-text-muted"
+        data-testid="notebook-blocked-state"
+      >
+        <div className="space-y-2">
+          <Text size="4" weight="bold" as="p" className="text-nb-text">
+            Notebook is already open in another browser tab
+          </Text>
+          <Text size="2" as="p">
+            {entry.name}
+          </Text>
+          <Text size="2" as="p">
+            Owned by: {ownerText}
+          </Text>
+          <Text size="2" as="p">
+            Close this notebook in the other tab, then retry here.
+          </Text>
+        </div>
+        <Button
+          variant="soft"
+          onClick={() => {
+            void openNotebook(docUri, { name: entry.name });
+          }}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (entry.state === "error") {
+    return (
+      <div
+        className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center text-sm text-nb-text-muted"
+        data-testid="notebook-error-state"
+      >
+        <Text size="4" weight="bold" as="p" className="text-nb-text">
+          Notebook could not be opened
+        </Text>
+        <Text size="2" as="p">
+          {entry.errorMessage ?? "An unknown error occurred."}
+        </Text>
+      </div>
+    );
+  }
 
   if (!notebookSnapshot || !notebookSnapshot.loaded) {
     return (
@@ -2150,6 +2204,7 @@ export default function Actions() {
               <TabPanel className="flex-1 min-h-0" data-document-id={doc.uri}>
                 <NotebookTabContent
                   docUri={doc.uri}
+                  entry={doc}
                   activeCell={activeCellsByDoc[doc.uri] ?? null}
                   isWindowFocused={
                     isWindowFocused && resolvedSelectedTabUri === doc.uri

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -9,7 +9,7 @@ let authData: {} | null = null;
 let isDriveSyncing = false;
 let activePanelState: PanelKey = "explorer";
 let currentDocUri: string | null = null;
-let openNotebooksState: { uri: string; name: string }[] = [];
+let openNotebooksState: { uri: string; name: string; state?: string }[] = [];
 let chatKitMountCount = 0;
 let chatKitUnmountCount = 0;
 const ensureAccessTokenMock = vi.fn(async () => "token");
@@ -198,5 +198,24 @@ describe("SidePanelContent ChatKit persistence", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close alpha.json" }));
     expect(removeNotebookMock).toHaveBeenCalledWith("local://file/alpha.json");
     expect(setCurrentDocMock).toHaveBeenCalledWith("fs://workspace/beta.json");
+  });
+
+  it("shows blocked notebook status from open entry metadata", () => {
+    activePanelState = "open-notebooks";
+    currentDocUri = "local://file/blocked";
+    openNotebooksState = [
+      {
+        uri: "local://file/blocked",
+        name: "blocked.json",
+        state: "blocked",
+      },
+    ];
+
+    render(<SidePanelContent />);
+
+    expect(screen.getByText("blocked.json")).toBeTruthy();
+    expect(screen.getByTestId("open-notebook-status-blocked").textContent).toBe(
+      "Blocked",
+    );
   });
 });

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -28,10 +28,25 @@ function getNotebookDisplayName(uri: string, name?: string): string {
   return name || uri.split("/").filter(Boolean).pop() || uri;
 }
 
+function getNotebookStatusLabel(state?: string): string | null {
+  if (state === "blocked") {
+    return "Blocked";
+  }
+  if (state === "error") {
+    return "Error";
+  }
+  if (state === "loading" || state === "resolving") {
+    return "Loading";
+  }
+  return null;
+}
+
 /**
  * OpenNotebooksPanel renders a lightweight "open editors" style list driven by
  * NotebookContext. It shares the same open-notebook state as the tab strip so
  * the sidebar remains a secondary view over the exact same source of truth.
+ * Status labels come from OpenNotebookEntry metadata; blocked entries do not
+ * have editable NotebookData models in this tab.
  */
 function OpenNotebooksPanel() {
   const { useNotebookList, removeNotebook } = useNotebookContext();
@@ -81,6 +96,7 @@ function OpenNotebooksPanel() {
             {openNotebooks.map((doc) => {
               const displayName = getNotebookDisplayName(doc.uri, doc.name);
               const isActive = doc.uri === currentDocUri;
+              const statusLabel = getNotebookStatusLabel(doc.state);
               return (
                 <li key={doc.uri}>
                   <div
@@ -96,8 +112,19 @@ function OpenNotebooksPanel() {
                       className="min-w-0 flex-1 text-left"
                       onClick={() => setCurrentDoc(doc.uri)}
                     >
-                      <div className="truncate text-sm font-medium">
-                        {displayName}
+                      <div className="flex min-w-0 items-center gap-2">
+                        <div className="truncate text-sm font-medium">
+                          {displayName}
+                        </div>
+                        {statusLabel ? (
+                          <span
+                            id={`open-notebook-status-${encodeURIComponent(doc.uri)}`}
+                            data-testid={`open-notebook-status-${doc.state}`}
+                            className="shrink-0 rounded-nb-xs border border-nb-border bg-white px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-nb-text-muted"
+                          >
+                            {statusLabel}
+                          </span>
+                        ) : null}
                       </div>
                       <div className="truncate text-xs text-nb-text-faint">
                         {doc.uri}

--- a/app/src/contexts/CurrentDocContext.test.tsx
+++ b/app/src/contexts/CurrentDocContext.test.tsx
@@ -1,9 +1,24 @@
 // @vitest-environment jsdom
 import { useEffect } from "react";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CurrentDocProvider, useCurrentDoc } from "./CurrentDocContext";
+
+function CurrentDocProbe() {
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
+  return (
+    <div>
+      <div data-testid="current-doc">{getCurrentDoc() ?? "none"}</div>
+      <button
+        type="button"
+        onClick={() => setCurrentDoc("local://file/selected")}
+      >
+        Select
+      </button>
+    </div>
+  );
+}
 
 function SetCurrentDocOnMount({ uri }: { uri: string }) {
   const { setCurrentDoc } = useCurrentDoc();
@@ -19,6 +34,7 @@ describe("CurrentDocProvider", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     window.localStorage.clear();
+    window.sessionStorage.clear();
     window.history.replaceState(
       null,
       "",
@@ -26,7 +42,45 @@ describe("CurrentDocProvider", () => {
     );
   });
 
-  it("does not clear pending URL doc intents when selecting a current doc", async () => {
+  it("restores current doc from per-tab sessionStorage", async () => {
+    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
+    window.sessionStorage.setItem("runme/currentDoc", "local://file/session");
+
+    render(
+      <CurrentDocProvider>
+        <CurrentDocProbe />
+      </CurrentDocProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-doc").textContent).toBe(
+        "local://file/session",
+      );
+    });
+  });
+
+  it("persists selection changes to sessionStorage without clearing URL doc intents", async () => {
+    render(
+      <CurrentDocProvider>
+        <CurrentDocProbe />
+      </CurrentDocProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select" }));
+
+    expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
+      "local://file/selected",
+    );
+    expect(window.localStorage.getItem("runme/currentDoc")).toBeNull();
+    expect(window.location.search).toContain("doc=");
+    await waitFor(() => {
+      expect(screen.getByTestId("current-doc").textContent).toBe(
+        "local://file/selected",
+      );
+    });
+  });
+
+  it("does not clear pending URL doc intents when selecting a current doc on mount", async () => {
     render(
       <CurrentDocProvider>
         <SetCurrentDocOnMount uri="local://file/restored" />
@@ -34,7 +88,7 @@ describe("CurrentDocProvider", () => {
     );
 
     await waitFor(() => {
-      expect(window.localStorage.getItem("runme/currentDoc")).toBe(
+      expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
         "local://file/restored",
       );
     });

--- a/app/src/contexts/CurrentDocContext.tsx
+++ b/app/src/contexts/CurrentDocContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-const CURRENT_DOC_STORAGE_KEY = "runme/currentDoc";
+import { getNotebookSessionPersistence } from "../lib/notebookSessionPersistence";
 
 interface CurrentDocContextValue {
   getCurrentDoc: () => string | null;
@@ -31,15 +31,7 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
   const [currentDoc, setCurrentDocState] = useState<string | null>(null);
 
   const loadStoredCurrentDoc = useCallback((): string | null => {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
-    }
-    try {
-      const stored = window.localStorage.getItem(CURRENT_DOC_STORAGE_KEY);
-      return stored?.trim() ? stored : null;
-    } catch {
-      return null;
-    }
+    return getNotebookSessionPersistence().loadCurrentDoc();
   }, []);
 
   useEffect(() => {
@@ -55,7 +47,7 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
       if (currentDoc === localUri) {
         return;
       }
-      // Avoid no-op updates that can trigger unnecessary renders/URL writes.
+      // Avoid no-op updates that can trigger unnecessary renders.
       setCurrentDocState((prev) => {
         if (prev === localUri) {
           return prev;
@@ -63,19 +55,7 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
         return localUri;
       });
 
-      const updateUrl = async () => {
-        try {
-          if (!localUri) {
-            window.localStorage.removeItem(CURRENT_DOC_STORAGE_KEY);
-          } else {
-            window.localStorage.setItem(CURRENT_DOC_STORAGE_KEY, localUri);
-          }
-        } catch {
-          // Ignore persistence failures for current-doc restore state.
-        }
-      };
-
-      void updateUrl();
+      getNotebookSessionPersistence().saveCurrentDoc(localUri);
     },
     [currentDoc],
   );

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -15,6 +15,7 @@ import {
   type OpenNotebookEntry,
   type OpenNotebookResult,
 } from "../lib/notebookDataController";
+import { appLogger } from "../lib/logging/runtime";
 import { appState } from "../lib/runtime/AppState";
 import { useCurrentDoc } from "./CurrentDocContext";
 import { useNotebookStore } from "./NotebookStoreContext";
@@ -128,7 +129,9 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
       }
       restoredCurrentDocRef.current = true;
       void controller.openNotebook(currentDoc).catch((error) => {
-        console.error("Failed to restore selected notebook", error);
+        appLogger.error("Failed to restore selected notebook", {
+          attrs: { scope: "notebook-session", error },
+        });
       });
     }
   }, [controller, getCurrentDoc, setCurrentDoc, store]);

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -672,9 +672,6 @@ export class NotebookData {
   }
 
   setNotebookStore(notebookStore: NotebookSaveStore | null): void {
-    if (!notebookStore || this.notebookStore) {
-      return;
-    }
     this.notebookStore = notebookStore;
   }
 

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { parser_pb } from "../contexts/CellContext";
 import type { LocalNotebooks } from "../storage/local";
+import type {
+  AcquireResult,
+  NotebookOwnershipManager,
+} from "./tabCoordination/notebookOwnership";
 import { NotebookStoreItemType } from "../storage/notebook";
 import {
   __resetNotebookDataControllerForTests,
@@ -87,10 +91,42 @@ function createFakeLocalNotebooks() {
   };
 }
 
+function createFakeOwnershipManager(
+  acquireResult?: AcquireResult,
+): NotebookOwnershipManager {
+  const fallbackLease = {
+    notebookUri: "local://file/demo",
+    tabId: "tab-test",
+    epoch: "epoch-test",
+    release: vi.fn(),
+    isCurrentOwner: vi.fn(async () => true),
+  };
+  return {
+    acquire: vi.fn(async (notebookUri: string) => {
+      if (acquireResult) {
+        return acquireResult;
+      }
+      return {
+        status: "acquired",
+        lease: {
+          ...fallbackLease,
+          notebookUri,
+        },
+      };
+    }),
+    release: vi.fn(),
+    getOwner: vi.fn(async () => null),
+    subscribe: vi.fn(() => () => {}),
+    isCurrentOwner: vi.fn(async () => true),
+    dispose: vi.fn(),
+  } as unknown as NotebookOwnershipManager;
+}
+
 describe("NotebookDataController", () => {
   beforeEach(() => {
     __resetNotebookDataControllerForTests();
     window.localStorage.clear();
+    window.sessionStorage.clear();
   });
 
   it("opens a local notebook and loads NotebookData", async () => {
@@ -103,6 +139,7 @@ describe("NotebookDataController", () => {
     });
 
     const controller = getNotebookDataController();
+    controller.configureOwnershipManager(createFakeOwnershipManager());
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
     });
@@ -136,6 +173,7 @@ describe("NotebookDataController", () => {
       notebook: createNotebook("console.log('existing')"),
     });
     const controller = getNotebookDataController();
+    controller.configureOwnershipManager(createFakeOwnershipManager());
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
     });
@@ -175,6 +213,7 @@ describe("NotebookDataController", () => {
       notebook: createNotebook("b"),
     });
     const controller = getNotebookDataController();
+    controller.configureOwnershipManager(createFakeOwnershipManager());
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
     });
@@ -235,6 +274,7 @@ describe("NotebookDataController", () => {
     );
 
     const controller = getNotebookDataController();
+    controller.configureOwnershipManager(createFakeOwnershipManager());
 
     expect(controller.getOpenNotebooks()).toEqual([
       expect.objectContaining({
@@ -244,13 +284,121 @@ describe("NotebookDataController", () => {
         state: "loading",
       }),
     ]);
-    expect(controller.getNotebookData("local://file/restored")).toBeDefined();
-    expect(JSON.parse(window.localStorage.getItem("runme/openNotebooks") ?? "[]")).toEqual([
+    expect(controller.getNotebookData("local://file/restored")).toBeUndefined();
+    controller.configureStores({
+      localNotebooks: createFakeLocalNotebooks() as unknown as LocalNotebooks,
+    });
+    expect(JSON.parse(window.sessionStorage.getItem("runme/openNotebooks") ?? "[]")).toEqual([
       expect.objectContaining({
         uri: "local://file/restored",
         name: "restored.json",
-        type: "file",
       }),
     ]);
+  });
+
+  it("keeps blocked entries metadata-only", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/blocked", {
+      id: "local://file/blocked",
+      name: "blocked.json",
+      remoteId: "local://file/blocked",
+      notebook: createNotebook("blocked"),
+    });
+    const owner = {
+      notebookUri: "local://file/blocked",
+      ownerTabId: "tab-other",
+      ownerLabel: "Other tab",
+      ownerUrl: "http://localhost/",
+      ownerStartedAt: "2026-05-22T12:00:00.000Z",
+      epoch: "epoch-other",
+    };
+    const controller = getNotebookDataController();
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: "blocked", owner }),
+    );
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+
+    const result = await controller.openNotebook("local://file/blocked");
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: "local://file/blocked",
+        state: "blocked",
+        owner,
+      }),
+    );
+    expect(controller.getNotebookData("local://file/blocked")).toBeUndefined();
+  });
+
+  it("returns unsupported state without creating editable NotebookData", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/unsupported", {
+      id: "local://file/unsupported",
+      name: "unsupported.json",
+      remoteId: "local://file/unsupported",
+      notebook: createNotebook("unsupported"),
+    });
+    const controller = getNotebookDataController();
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({
+        status: "unsupported",
+        reason: "web_locks_unavailable",
+      }),
+    );
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+
+    const result = await controller.openNotebook("local://file/unsupported");
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: "local://file/unsupported",
+        state: "error",
+      }),
+    );
+    expect(result.entry.errorMessage).toContain("does not support");
+    expect(result.entry.errorMessage).toContain("Web Locks");
+    expect(controller.getNotebookData("local://file/unsupported")).toBeUndefined();
+  });
+
+  it("releases notebook ownership when loading the local notebook fails", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/load-error", {
+      id: "local://file/load-error",
+      name: "load-error.json",
+      remoteId: "local://file/load-error",
+      notebook: createNotebook("load error"),
+    });
+    localStore.load.mockRejectedValueOnce(new Error("load failed"));
+    const release = vi.fn();
+    const controller = getNotebookDataController();
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({
+        status: "acquired",
+        lease: {
+          notebookUri: "local://file/load-error",
+          tabId: "tab-test",
+          epoch: "epoch-test",
+          release,
+          isCurrentOwner: vi.fn(async () => true),
+        },
+      }),
+    );
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+
+    const result = await controller.openNotebook("local://file/load-error");
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: "local://file/load-error",
+        state: "error",
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -401,4 +401,47 @@ describe("NotebookDataController", () => {
     );
     expect(release).toHaveBeenCalledTimes(1);
   });
+
+  it("does not release an existing loaded notebook when a duplicate open cannot reload", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/demo", {
+      id: "local://file/demo",
+      name: "demo.json",
+      remoteId: "local://file/demo",
+      notebook: createNotebook("loaded"),
+    });
+    const release = vi.fn();
+    const controller = getNotebookDataController();
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({
+        status: "acquired",
+        lease: {
+          notebookUri: "local://file/demo",
+          tabId: "tab-test",
+          epoch: "epoch-test",
+          release,
+          isCurrentOwner: vi.fn(async () => true),
+        },
+      }),
+    );
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+
+    await controller.openNotebook("local://file/demo");
+    localStore.load.mockRejectedValueOnce(new Error("load failed"));
+
+    const result = await controller.openNotebook("local://file/demo");
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: "local://file/demo",
+        state: "loaded",
+      }),
+    );
+    expect(
+      controller.getNotebookData("local://file/demo")?.getSnapshot().loaded,
+    ).toBe(true);
+    expect(release).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -2,15 +2,16 @@ import { create } from "@bufbuild/protobuf";
 
 import { parser_pb } from "../contexts/CellContext";
 import { NotebookData, type NotebookSnapshot } from "./notebookData";
+import { appLogger } from "./logging/runtime";
 import type { NotebookDataLike } from "./runtime/runmeConsole";
 import type { LocalNotebooks } from "../storage/local";
+import { getNotebookSessionPersistence } from "./notebookSessionPersistence";
 import {
-  NotebookStoreItem,
-  NotebookStoreItemType,
-} from "../storage/notebook";
-
-const OPEN_NOTEBOOKS_STORAGE_KEY = "runme/openNotebooks";
-const LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY = "aisre/openNotebooks";
+  getNotebookOwnershipManager,
+  type NotebookLease,
+  type NotebookOwnershipManager,
+  type NotebookOwnershipRecord,
+} from "./tabCoordination/notebookOwnership";
 
 export type NotebookTabState =
   | "resolving"
@@ -25,6 +26,7 @@ export interface OpenNotebookEntry {
   name: string;
   state: NotebookTabState;
   errorMessage?: string;
+  owner?: NotebookOwnershipRecord | null;
 }
 
 export interface OpenNotebookResult {
@@ -66,78 +68,6 @@ function deriveDisplayName(uri: string): string {
   return uri.split("/").filter(Boolean).pop() ?? uri;
 }
 
-function normalizeStoredOpenNotebook(item: unknown): OpenNotebookEntry | null {
-  if (!item || typeof item !== "object") {
-    return null;
-  }
-  const candidate = item as Partial<NotebookStoreItem & OpenNotebookEntry>;
-  if (typeof candidate.uri !== "string" || candidate.uri.trim() === "") {
-    return null;
-  }
-  if (
-    "type" in candidate &&
-    candidate.type !== undefined &&
-    candidate.type !== NotebookStoreItemType.File
-  ) {
-    return null;
-  }
-  return {
-    uri: candidate.uri,
-    requestedUri: candidate.requestedUri ?? candidate.uri,
-    name: candidate.name ?? candidate.uri,
-    state: candidate.state ?? "loading",
-    errorMessage: candidate.errorMessage,
-  };
-}
-
-function loadStoredOpenNotebooks(): OpenNotebookEntry[] {
-  if (typeof window === "undefined") {
-    return [];
-  }
-  try {
-    const raw =
-      window.localStorage.getItem(OPEN_NOTEBOOKS_STORAGE_KEY) ??
-      window.localStorage.getItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
-    if (!raw) {
-      return [];
-    }
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-    return parsed
-      .map(normalizeStoredOpenNotebook)
-      .filter((item): item is OpenNotebookEntry => Boolean(item));
-  } catch (error) {
-    console.error("Failed to load open notebooks from storage", error);
-    return [];
-  }
-}
-
-function persistOpenNotebooks(list: OpenNotebookEntry[]): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-  try {
-    const legacyShape: NotebookStoreItem[] = list
-      .filter((item) => item.uri.trim() !== "")
-      .map((item) => ({
-        uri: item.uri,
-        name: item.name,
-        type: NotebookStoreItemType.File,
-        children: [],
-        parents: [],
-      }));
-    window.localStorage.setItem(
-      OPEN_NOTEBOOKS_STORAGE_KEY,
-      JSON.stringify(legacyShape),
-    );
-    window.localStorage.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
-  } catch (error) {
-    console.error("Failed to persist open notebooks", error);
-  }
-}
-
 export class NotebookDataController {
   private static instance: NotebookDataController | null = null;
 
@@ -154,7 +84,9 @@ export class NotebookDataController {
   }
 
   private localNotebooks: LocalNotebooks | null = null;
+  private ownershipManager: NotebookOwnershipManager = getNotebookOwnershipManager();
   private readonly notebooks = new Map<string, NotebookDataHandle>();
+  private readonly leases = new Map<string, NotebookLease>();
   private openNotebooks: OpenNotebookEntry[] = [];
   private readonly listeners = new Set<() => void>();
   private snapshot: NotebookDataControllerSnapshot = { openNotebooks: [] };
@@ -177,11 +109,17 @@ export class NotebookDataController {
     this.ensureRestored();
     this.localNotebooks = options.localNotebooks;
     for (const handle of this.notebooks.values()) {
-      handle.data.setNotebookStore(options.localNotebooks);
+      handle.data.setNotebookStore(
+        this.createOwnedNotebookStore(handle.data.getUri()),
+      );
     }
     if (this.localNotebooks) {
       void this.loadOpenNotebooks();
     }
+  }
+
+  configureOwnershipManager(manager: NotebookOwnershipManager): void {
+    this.ownershipManager = manager;
   }
 
   async openNotebook(
@@ -201,7 +139,30 @@ export class NotebookDataController {
       requestedUri,
       name,
       state: "loading",
+      errorMessage: undefined,
+      owner: undefined,
     });
+
+    const acquireResult = await this.ownershipManager.acquire(localUri);
+    if (acquireResult.status === "unsupported") {
+      entry = this.upsertOpenEntry({
+        ...entry,
+        state: "error",
+        errorMessage:
+          "This browser does not support safe multi-tab notebook ownership. Use a browser with Web Locks support, or close other Runme tabs before editing.",
+      });
+      return { localUri, entry };
+    }
+    if (acquireResult.status === "blocked") {
+      entry = this.upsertOpenEntry({
+        ...entry,
+        state: "blocked",
+        owner: acquireResult.owner,
+        errorMessage: undefined,
+      });
+      return { localUri, entry };
+    }
+    this.leases.set(localUri, acquireResult.lease);
 
     const handle = this.ensureNotebookData({
       uri: localUri,
@@ -212,7 +173,7 @@ export class NotebookDataController {
     if (this.localNotebooks) {
       try {
         const notebook = await this.localNotebooks.load(localUri);
-        handle.data.setNotebookStore(this.localNotebooks);
+        handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri));
         handle.data.loadNotebook(notebook, { persist: false });
         handle.loaded = true;
         entry = this.upsertOpenEntry({
@@ -220,8 +181,10 @@ export class NotebookDataController {
           name: await this.resolveNotebookName(localUri, name),
           state: "loaded",
           errorMessage: undefined,
+          owner: undefined,
         });
       } catch (error) {
+        this.releaseLease(localUri);
         entry = this.upsertOpenEntry({
           ...entry,
           state: "error",
@@ -300,7 +263,7 @@ export class NotebookDataController {
   }): NotebookDataHandle {
     const existing = this.notebooks.get(uri);
     if (existing) {
-      existing.data.setNotebookStore(this.localNotebooks);
+      existing.data.setNotebookStore(this.createOwnedNotebookStore(uri));
       return existing;
     }
 
@@ -308,14 +271,14 @@ export class NotebookDataController {
       uri,
       name,
       notebook: notebook ?? createEmptyNotebook(),
-      notebookStore: this.localNotebooks,
+      notebookStore: this.createOwnedNotebookStore(uri),
       loaded,
       resolveNotebookForAppKernel: (target?: unknown) => {
         const targetUri = this.resolveTargetUri(target);
         if (!targetUri) {
-          return this.notebooks.get(uri)?.data ?? null;
+          return this.getOwnedNotebookData(uri);
         }
-        return this.notebooks.get(targetUri)?.data ?? null;
+        return this.getOwnedNotebookData(targetUri);
       },
       listNotebooksForAppKernel: () => this.listNotebookDataLike(uri),
     });
@@ -355,26 +318,23 @@ export class NotebookDataController {
   private listNotebookDataLike(currentUri: string): NotebookDataLike[] {
     const notebooksByUri = new Map<string, NotebookDataLike>();
     for (const handle of this.notebooks.values()) {
-      notebooksByUri.set(handle.data.getUri(), handle.data);
-    }
-    for (const item of this.openNotebooks) {
-      if (!item.uri || notebooksByUri.has(item.uri)) {
+      if (!this.leases.has(handle.data.getUri())) {
         continue;
       }
-      const emptyNotebook = createEmptyNotebook();
-      notebooksByUri.set(item.uri, {
-        getUri: () => item.uri,
-        getName: () => item.name ?? item.uri,
-        getNotebook: () => emptyNotebook,
-        updateCell: () => {},
-        getCell: () => null,
-      });
+      notebooksByUri.set(handle.data.getUri(), handle.data);
     }
-    const current = this.notebooks.get(currentUri)?.data;
+    const current = this.getOwnedNotebookData(currentUri);
     if (current && !notebooksByUri.has(current.getUri())) {
       notebooksByUri.set(current.getUri(), current);
     }
     return Array.from(notebooksByUri.values());
+  }
+
+  private getOwnedNotebookData(uri: string): NotebookData | null {
+    if (!this.leases.has(uri)) {
+      return null;
+    }
+    return this.notebooks.get(uri)?.data ?? null;
   }
 
   private upsertOpenEntry(entry: OpenNotebookEntry): OpenNotebookEntry {
@@ -393,6 +353,7 @@ export class NotebookDataController {
   }
 
   private removeNotebook(uri: string): void {
+    this.releaseLease(uri);
     const handle = this.notebooks.get(uri);
     if (handle) {
       handle.unsubscribe();
@@ -403,37 +364,23 @@ export class NotebookDataController {
     this.persist();
   }
 
+  private releaseLease(uri: string): void {
+    this.leases.get(uri)?.release();
+    this.leases.delete(uri);
+  }
+
   private async loadOpenNotebooks(): Promise<void> {
     if (!this.localNotebooks) {
       return;
     }
-    for (const item of this.openNotebooks) {
-      const handle = this.ensureNotebookData({
-        uri: item.uri,
-        name: item.name,
-        loaded: false,
-      });
-      if (handle.loaded) {
+    const restored = [...this.openNotebooks];
+    for (const item of restored) {
+      if (this.notebooks.get(item.uri)?.loaded) {
         continue;
       }
-      try {
-        const notebook = await this.localNotebooks.load(item.uri);
-        handle.data.setNotebookStore(this.localNotebooks);
-        handle.data.loadNotebook(notebook, { persist: false });
-        handle.loaded = true;
-        this.upsertOpenEntry({
-          ...item,
-          name: await this.resolveNotebookName(item.uri, item.name),
-          state: "loaded",
-          errorMessage: undefined,
-        });
-      } catch (error) {
-        this.upsertOpenEntry({
-          ...item,
-          state: "error",
-          errorMessage: String(error),
-        });
-      }
+      void this.openNotebook(item.requestedUri || item.uri, {
+        name: item.name,
+      });
     }
   }
 
@@ -442,14 +389,7 @@ export class NotebookDataController {
       return;
     }
     this.restored = true;
-    this.openNotebooks = loadStoredOpenNotebooks();
-    for (const item of this.openNotebooks) {
-      this.ensureNotebookData({
-        uri: item.uri,
-        name: item.name,
-        loaded: false,
-      });
-    }
+    this.openNotebooks = getNotebookSessionPersistence().loadOpenNotebooks();
     this.rebuildSnapshot();
   }
 
@@ -459,13 +399,15 @@ export class NotebookDataController {
       try {
         listener();
       } catch (error) {
-        console.error("NotebookDataController listener failed", error);
+        appLogger.error("NotebookDataController listener failed", {
+          attrs: { scope: "notebook-session", error },
+        });
       }
     }
   }
 
   private persist(): void {
-    persistOpenNotebooks(this.openNotebooks);
+    getNotebookSessionPersistence().saveOpenNotebooks(this.openNotebooks);
   }
 
   private rebuildSnapshot(): void {
@@ -475,6 +417,10 @@ export class NotebookDataController {
   }
 
   private dispose(): void {
+    for (const lease of this.leases.values()) {
+      lease.release();
+    }
+    this.leases.clear();
     for (const handle of this.notebooks.values()) {
       handle.unsubscribe();
     }
@@ -484,6 +430,21 @@ export class NotebookDataController {
     this.snapshot = { openNotebooks: [] };
     this.restored = false;
     this.localNotebooks = null;
+  }
+
+  private createOwnedNotebookStore(uri: string) {
+    if (!this.localNotebooks) {
+      return null;
+    }
+    return {
+      save: async (saveUri: string, notebook: parser_pb.Notebook) => {
+        const lease = this.leases.get(uri);
+        if (!lease || !(await lease.isCurrentOwner())) {
+          throw new Error(`Notebook ${uri} is not owned by this browser tab.`);
+        }
+        return this.localNotebooks?.save(saveUri, notebook);
+      },
+    };
   }
 }
 

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -170,6 +170,18 @@ export class NotebookDataController {
       loaded: false,
     });
 
+    if (handle.loaded) {
+      handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri));
+      entry = this.upsertOpenEntry({
+        ...entry,
+        name: handle.data.getName(),
+        state: "loaded",
+        errorMessage: undefined,
+        owner: undefined,
+      });
+      return { localUri, entry };
+    }
+
     if (this.localNotebooks) {
       try {
         const notebook = await this.localNotebooks.load(localUri);

--- a/app/src/lib/notebookSessionPersistence.test.ts
+++ b/app/src/lib/notebookSessionPersistence.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { NotebookStoreItemType } from "../storage/notebook";
+import { NotebookSessionPersistence } from "./notebookSessionPersistence";
+
+describe("NotebookSessionPersistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("uses sessionStorage for current doc before legacy localStorage", () => {
+    const persistence = new NotebookSessionPersistence();
+    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
+    window.sessionStorage.setItem("runme/currentDoc", "local://file/session");
+
+    expect(persistence.loadCurrentDoc()).toBe("local://file/session");
+  });
+
+  it("imports legacy current doc into sessionStorage", () => {
+    const persistence = new NotebookSessionPersistence();
+    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
+
+    expect(persistence.loadCurrentDoc()).toBe("local://file/legacy");
+    expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
+      "local://file/legacy",
+    );
+  });
+
+  it("writes only sessionStorage for current doc changes", () => {
+    const persistence = new NotebookSessionPersistence();
+
+    persistence.saveCurrentDoc("local://file/current");
+
+    expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
+      "local://file/current",
+    );
+    expect(window.localStorage.getItem("runme/currentDoc")).toBeNull();
+  });
+
+  it("does not fall back to legacy current doc after the session clears selection", () => {
+    const persistence = new NotebookSessionPersistence();
+    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
+
+    persistence.saveCurrentDoc(null);
+
+    expect(persistence.loadCurrentDoc()).toBeNull();
+  });
+
+  it("imports legacy open notebooks as OpenNotebookEntry records", () => {
+    const persistence = new NotebookSessionPersistence();
+    window.localStorage.setItem(
+      "runme/openNotebooks",
+      JSON.stringify([
+        {
+          uri: "local://file/legacy",
+          name: "legacy.json",
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [],
+        },
+      ]),
+    );
+
+    expect(persistence.loadOpenNotebooks()).toEqual([
+      {
+        uri: "local://file/legacy",
+        requestedUri: "local://file/legacy",
+        name: "legacy.json",
+        state: "loading",
+        errorMessage: undefined,
+        owner: undefined,
+      },
+    ]);
+    expect(
+      JSON.parse(window.sessionStorage.getItem("runme/openNotebooks") ?? "[]"),
+    ).toEqual([
+      expect.objectContaining({
+        uri: "local://file/legacy",
+        name: "legacy.json",
+      }),
+    ]);
+  });
+
+  it("does not fall back to legacy open notebooks when session list is empty", () => {
+    const persistence = new NotebookSessionPersistence();
+    window.localStorage.setItem(
+      "runme/openNotebooks",
+      JSON.stringify([
+        {
+          uri: "local://file/legacy",
+          name: "legacy.json",
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [],
+        },
+      ]),
+    );
+    window.sessionStorage.setItem("runme/openNotebooks", "[]");
+
+    expect(persistence.loadOpenNotebooks()).toEqual([]);
+  });
+});

--- a/app/src/lib/notebookSessionPersistence.test.ts
+++ b/app/src/lib/notebookSessionPersistence.test.ts
@@ -26,6 +26,7 @@ describe("NotebookSessionPersistence", () => {
     expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
       "local://file/legacy",
     );
+    expect(window.localStorage.getItem("runme/currentDoc")).toBeNull();
   });
 
   it("writes only sessionStorage for current doc changes", () => {
@@ -81,6 +82,33 @@ describe("NotebookSessionPersistence", () => {
         name: "legacy.json",
       }),
     ]);
+    expect(window.localStorage.getItem("runme/openNotebooks")).toBeNull();
+  });
+
+  it("clears older legacy open notebooks after importing them", () => {
+    const persistence = new NotebookSessionPersistence();
+    window.localStorage.setItem(
+      "aisre/openNotebooks",
+      JSON.stringify([
+        {
+          uri: "local://file/legacy",
+          name: "legacy.json",
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [],
+        },
+      ]),
+    );
+
+    expect(persistence.loadOpenNotebooks()).toEqual([
+      expect.objectContaining({
+        uri: "local://file/legacy",
+        requestedUri: "local://file/legacy",
+        name: "legacy.json",
+      }),
+    ]);
+    expect(window.sessionStorage.getItem("runme/openNotebooks")).toBeTruthy();
+    expect(window.localStorage.getItem("aisre/openNotebooks")).toBeNull();
   });
 
   it("does not fall back to legacy open notebooks when session list is empty", () => {

--- a/app/src/lib/notebookSessionPersistence.ts
+++ b/app/src/lib/notebookSessionPersistence.ts
@@ -87,10 +87,15 @@ export class NotebookSessionPersistence {
     if (fromSession !== undefined && fromSession !== null) {
       return fromSession.trim() || null;
     }
-    const fromLegacy =
-      getLocalStorage()?.getItem(CURRENT_DOC_STORAGE_KEY)?.trim() || null;
+    const local = getLocalStorage();
+    const fromLegacy = local?.getItem(CURRENT_DOC_STORAGE_KEY)?.trim() || null;
     if (fromLegacy) {
       this.saveCurrentDoc(fromLegacy);
+      try {
+        local?.removeItem(CURRENT_DOC_STORAGE_KEY);
+      } catch {
+        // Ignore legacy cleanup failures. The migrated session value is usable.
+      }
     }
     return fromLegacy;
   }
@@ -126,6 +131,12 @@ export class NotebookSessionPersistence {
     );
     if (fromLegacy.length > 0) {
       this.saveOpenNotebooks(fromLegacy);
+      try {
+        local?.removeItem(OPEN_NOTEBOOKS_STORAGE_KEY);
+        local?.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
+      } catch {
+        // Ignore legacy cleanup failures. The migrated session value is usable.
+      }
     }
     return fromLegacy;
   }

--- a/app/src/lib/notebookSessionPersistence.ts
+++ b/app/src/lib/notebookSessionPersistence.ts
@@ -1,0 +1,161 @@
+import {
+  NotebookStoreItem,
+  NotebookStoreItemType,
+} from "../storage/notebook";
+import type { OpenNotebookEntry } from "./notebookDataController";
+
+const CURRENT_DOC_STORAGE_KEY = "runme/currentDoc";
+const OPEN_NOTEBOOKS_STORAGE_KEY = "runme/openNotebooks";
+const LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY = "aisre/openNotebooks";
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeStoredOpenNotebook(item: unknown): OpenNotebookEntry | null {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const candidate = item as Partial<NotebookStoreItem & OpenNotebookEntry>;
+  if (typeof candidate.uri !== "string" || candidate.uri.trim() === "") {
+    return null;
+  }
+  if (
+    "type" in candidate &&
+    candidate.type !== undefined &&
+    candidate.type !== NotebookStoreItemType.File
+  ) {
+    return null;
+  }
+  return {
+    uri: candidate.uri,
+    requestedUri: candidate.requestedUri ?? candidate.uri,
+    name: candidate.name ?? candidate.uri,
+    state: candidate.state ?? "loading",
+    errorMessage: candidate.errorMessage,
+    owner: candidate.owner,
+  };
+}
+
+function parseOpenNotebooks(raw: string | null): OpenNotebookEntry[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map(normalizeStoredOpenNotebook)
+      .filter((item): item is OpenNotebookEntry => Boolean(item));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * NotebookSessionPersistence stores per-tab restore state.
+ *
+ * Runtime state still lives in `CurrentDocContext` and
+ * `NotebookDataController`; this class only hydrates them on startup and saves
+ * snapshots after changes. It reads legacy localStorage keys as an initial
+ * import path but only writes sessionStorage so same-origin tabs can diverge.
+ */
+export class NotebookSessionPersistence {
+  loadCurrentDoc(): string | null {
+    const session = getSessionStorage();
+    const fromSession = session?.getItem(CURRENT_DOC_STORAGE_KEY);
+    if (fromSession !== undefined && fromSession !== null) {
+      return fromSession.trim() || null;
+    }
+    const fromLegacy =
+      getLocalStorage()?.getItem(CURRENT_DOC_STORAGE_KEY)?.trim() || null;
+    if (fromLegacy) {
+      this.saveCurrentDoc(fromLegacy);
+    }
+    return fromLegacy;
+  }
+
+  saveCurrentDoc(uri: string | null): void {
+    const session = getSessionStorage();
+    if (!session) {
+      return;
+    }
+    try {
+      if (!uri) {
+        session.setItem(CURRENT_DOC_STORAGE_KEY, "");
+        return;
+      }
+      session.setItem(CURRENT_DOC_STORAGE_KEY, uri);
+    } catch {
+      // Ignore restore persistence failures. Live state has already changed.
+    }
+  }
+
+  loadOpenNotebooks(): OpenNotebookEntry[] {
+    const session = getSessionStorage();
+    const fromSession = session?.getItem(OPEN_NOTEBOOKS_STORAGE_KEY);
+    if (fromSession !== undefined && fromSession !== null) {
+      return parseOpenNotebooks(fromSession);
+    }
+
+    const local = getLocalStorage();
+    const fromLegacy = parseOpenNotebooks(
+      local?.getItem(OPEN_NOTEBOOKS_STORAGE_KEY) ??
+        local?.getItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY) ??
+        null,
+    );
+    if (fromLegacy.length > 0) {
+      this.saveOpenNotebooks(fromLegacy);
+    }
+    return fromLegacy;
+  }
+
+  saveOpenNotebooks(entries: OpenNotebookEntry[]): void {
+    const session = getSessionStorage();
+    if (!session) {
+      return;
+    }
+    try {
+      session.setItem(OPEN_NOTEBOOKS_STORAGE_KEY, JSON.stringify(entries));
+      session.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
+    } catch {
+      // Ignore restore persistence failures. Live state has already changed.
+    }
+  }
+}
+
+let persistence: NotebookSessionPersistence = new NotebookSessionPersistence();
+
+export function getNotebookSessionPersistence(): NotebookSessionPersistence {
+  return persistence;
+}
+
+export function __setNotebookSessionPersistenceForTests(
+  next: NotebookSessionPersistence,
+): void {
+  persistence = next;
+}
+
+export function __resetNotebookSessionPersistenceForTests(): void {
+  persistence = new NotebookSessionPersistence();
+}

--- a/app/src/lib/tabCoordination/notebookOwnership.test.ts
+++ b/app/src/lib/tabCoordination/notebookOwnership.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dexieState = vi.hoisted(() => ({
+  databases: new Map<string, Map<string, unknown>>(),
+}));
+
+vi.mock("dexie", () => {
+  class MockDexie {
+    private readonly databaseName: string;
+
+    constructor(databaseName: string) {
+      this.databaseName = databaseName;
+    }
+
+    version() {
+      return {
+        stores: () => this,
+      };
+    }
+
+    table() {
+      let records = dexieState.databases.get(this.databaseName);
+      if (!records) {
+        records = new Map<string, unknown>();
+        dexieState.databases.set(this.databaseName, records);
+      }
+      return {
+        put: async (record: { notebookUri: string }) => {
+          records.set(record.notebookUri, record);
+        },
+        get: async (notebookUri: string) => records.get(notebookUri),
+        delete: async (notebookUri: string) => {
+          records.delete(notebookUri);
+        },
+      };
+    }
+
+    close() {}
+  }
+
+  return { default: MockDexie };
+});
+
+import { NotebookOwnershipManager } from "./notebookOwnership";
+
+type LockCallback = (lock: { name: string } | null) => Promise<unknown> | unknown;
+
+const heldLocks = new Map<string, Promise<unknown>>();
+
+function installFakeWebLocks(): void {
+  Object.defineProperty(navigator, "locks", {
+    configurable: true,
+    value: {
+      request: vi.fn(
+        async (
+          name: string,
+          options: { ifAvailable?: boolean },
+          callback: LockCallback,
+        ) => {
+          if (heldLocks.has(name) && options.ifAvailable) {
+            return callback(null);
+          }
+          const result = Promise.resolve(callback({ name })).finally(() => {
+            heldLocks.delete(name);
+          });
+          heldLocks.set(name, result);
+          return result;
+        },
+      ),
+    },
+  });
+}
+
+async function flushReleasedLock(): Promise<void> {
+  await vi.waitFor(() => {
+    expect(heldLocks.size).toBe(0);
+  });
+}
+
+describe("NotebookOwnershipManager", () => {
+  beforeEach(() => {
+    dexieState.databases.clear();
+    heldLocks.clear();
+    installFakeWebLocks();
+    document.title = "Runme Test";
+    window.history.replaceState(null, "", "/notebooks");
+  });
+
+  it("returns unsupported when Web Locks are unavailable", async () => {
+    Object.defineProperty(navigator, "locks", {
+      configurable: true,
+      value: undefined,
+    });
+    const manager = new NotebookOwnershipManager({
+      dbName: "unsupported-test",
+      tabId: "tab-a",
+    });
+
+    await expect(manager.acquire("local://file/a")).resolves.toEqual({
+      status: "unsupported",
+      reason: "web_locks_unavailable",
+    });
+
+    manager.dispose();
+  });
+
+  it("blocks another tab while a notebook lock is held", async () => {
+    const first = new NotebookOwnershipManager({
+      dbName: "blocked-test",
+      tabId: "tab-a",
+    });
+    const second = new NotebookOwnershipManager({
+      dbName: "blocked-test",
+      tabId: "tab-b",
+    });
+
+    const acquired = await first.acquire("local://file/a");
+    expect(acquired.status).toBe("acquired");
+    const blocked = await second.acquire("local://file/a");
+
+    expect(blocked.status).toBe("blocked");
+    if (blocked.status === "blocked") {
+      expect(blocked.owner).toEqual(
+        expect.objectContaining({
+          notebookUri: "local://file/a",
+          ownerTabId: "tab-a",
+          ownerLabel: "Runme Test",
+        }),
+      );
+    }
+
+    if (acquired.status === "acquired") {
+      acquired.lease.release();
+    }
+    await flushReleasedLock();
+    first.dispose();
+    second.dispose();
+  });
+
+  it("releases ownership so another tab can acquire the notebook", async () => {
+    const first = new NotebookOwnershipManager({
+      dbName: "release-test",
+      tabId: "tab-a",
+    });
+    const second = new NotebookOwnershipManager({
+      dbName: "release-test",
+      tabId: "tab-b",
+    });
+
+    const acquired = await first.acquire("local://file/a");
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status === "acquired") {
+      acquired.lease.release();
+    }
+    await flushReleasedLock();
+
+    const reacquired = await second.acquire("local://file/a");
+
+    expect(reacquired.status).toBe("acquired");
+    if (reacquired.status === "acquired") {
+      reacquired.lease.release();
+    }
+    await flushReleasedLock();
+    first.dispose();
+    second.dispose();
+  });
+
+  it("does not report stale same-tab ownership after release starts", async () => {
+    const manager = new NotebookOwnershipManager({
+      dbName: "stale-release-test",
+      tabId: "tab-a",
+    });
+
+    const acquired = await manager.acquire("local://file/a");
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") {
+      return;
+    }
+
+    acquired.lease.release();
+
+    const ownerCheck = acquired.lease.isCurrentOwner();
+    const reacquire = manager.acquire("local://file/a");
+
+    await expect(ownerCheck).resolves.toBe(false);
+    await expect(reacquire).resolves.toEqual(
+      expect.objectContaining({ status: "blocked" }),
+    );
+
+    await flushReleasedLock();
+    manager.dispose();
+  });
+});

--- a/app/src/lib/tabCoordination/notebookOwnership.ts
+++ b/app/src/lib/tabCoordination/notebookOwnership.ts
@@ -1,0 +1,262 @@
+import Dexie, { type Table } from "dexie";
+
+import { getTabId } from "../tabIdentity";
+
+export interface NotebookOwnershipRecord {
+  notebookUri: string;
+  ownerTabId: string;
+  ownerLabel: string;
+  ownerUrl: string;
+  ownerStartedAt: string;
+  epoch: string;
+}
+
+export type AcquireResult =
+  | { status: "acquired"; lease: NotebookLease }
+  | { status: "blocked"; owner: NotebookOwnershipRecord | null }
+  | { status: "unsupported"; reason: "web_locks_unavailable" };
+
+export interface NotebookLease {
+  notebookUri: string;
+  tabId: string;
+  epoch: string;
+  release(): void;
+  isCurrentOwner(): Promise<boolean>;
+}
+
+class NotebookOwnershipDatabase extends Dexie {
+  ownership!: Table<NotebookOwnershipRecord, string>;
+
+  constructor(databaseName = "runme-tab-coordination") {
+    super(databaseName);
+    this.version(1).stores({
+      ownership: "&notebookUri, ownerTabId, epoch",
+    });
+    this.ownership = this.table("ownership");
+  }
+}
+
+type HeldLease = {
+  record: NotebookOwnershipRecord;
+  release: () => void;
+};
+
+function buildLockName(notebookUri: string): string {
+  return `runme:notebook:${notebookUri}`;
+}
+
+function getOwnerLabel(): string {
+  if (typeof document === "undefined") {
+    return "Runme tab";
+  }
+  return document.title || "Runme tab";
+}
+
+function getOwnerUrl(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return window.location.href;
+}
+
+function hasWebLocks(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    typeof navigator.locks?.request === "function"
+  );
+}
+
+/**
+ * NotebookOwnershipManager owns same-origin exclusive edit leases.
+ *
+ * Web Locks are the authority. IndexedDB records are diagnostic metadata for
+ * blocked UI and are deliberately allowed to be stale.
+ */
+export class NotebookOwnershipManager {
+  private readonly db: NotebookOwnershipDatabase;
+  private readonly tabId: string;
+  private readonly heldLeases = new Map<string, HeldLease>();
+  private readonly listeners = new Set<() => void>();
+  private readonly channel: BroadcastChannel | null;
+
+  constructor(options?: { dbName?: string; tabId?: string }) {
+    this.db = new NotebookOwnershipDatabase(options?.dbName);
+    this.tabId = options?.tabId ?? getTabId();
+    this.channel =
+      typeof BroadcastChannel === "function"
+        ? new BroadcastChannel("runme-notebook-ownership")
+        : null;
+    this.channel?.addEventListener("message", () => this.emit());
+  }
+
+  async acquire(notebookUri: string): Promise<AcquireResult> {
+    const existing = this.heldLeases.get(notebookUri);
+    if (existing) {
+      return {
+        status: "acquired",
+        lease: this.createLease(existing.record),
+      };
+    }
+    if (!hasWebLocks()) {
+      return { status: "unsupported", reason: "web_locks_unavailable" };
+    }
+
+    const lockName = buildLockName(notebookUri);
+    return new Promise<AcquireResult>((resolve) => {
+      let settled = false;
+      const settle = (result: AcquireResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(result);
+      };
+
+      void navigator.locks
+        .request(lockName, { ifAvailable: true }, async (lock) => {
+          if (!lock) {
+            settle({
+              status: "blocked",
+              owner: await this.getOwner(notebookUri),
+            });
+            return;
+          }
+
+          let releaseLock!: () => void;
+          const released = new Promise<void>((release) => {
+            releaseLock = release;
+          });
+          const record: NotebookOwnershipRecord = {
+            notebookUri,
+            ownerTabId: this.tabId,
+            ownerLabel: getOwnerLabel(),
+            ownerUrl: getOwnerUrl(),
+            ownerStartedAt: new Date().toISOString(),
+            epoch: crypto.randomUUID(),
+          };
+
+          await this.db.ownership.put(record);
+          this.heldLeases.set(notebookUri, {
+            record,
+            release: releaseLock,
+          });
+          this.broadcast("owner-acquired", record);
+          this.emit();
+          settle({
+            status: "acquired",
+            lease: this.createLease(record),
+          });
+
+          await released;
+          await this.deleteRecordIfCurrent(record);
+          this.heldLeases.delete(notebookUri);
+          this.broadcast("owner-released", record);
+          this.emit();
+        })
+        .catch(async () => {
+          settle({
+            status: "blocked",
+            owner: await this.getOwner(notebookUri),
+          });
+        });
+    });
+  }
+
+  release(notebookUri: string): void {
+    const held = this.heldLeases.get(notebookUri);
+    if (!held) {
+      return;
+    }
+    this.heldLeases.delete(notebookUri);
+    held.release();
+  }
+
+  async getOwner(notebookUri: string): Promise<NotebookOwnershipRecord | null> {
+    return (await this.db.ownership.get(notebookUri)) ?? null;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async isCurrentOwner(notebookUri: string, epoch?: string): Promise<boolean> {
+    const held = this.heldLeases.get(notebookUri);
+    if (!held) {
+      return false;
+    }
+    if (epoch && held.record.epoch !== epoch) {
+      return false;
+    }
+    return true;
+  }
+
+  dispose(): void {
+    for (const uri of Array.from(this.heldLeases.keys())) {
+      this.release(uri);
+    }
+    this.listeners.clear();
+    this.channel?.close();
+    void this.db.close();
+  }
+
+  private createLease(record: NotebookOwnershipRecord): NotebookLease {
+    return {
+      notebookUri: record.notebookUri,
+      tabId: record.ownerTabId,
+      epoch: record.epoch,
+      release: () => this.release(record.notebookUri),
+      isCurrentOwner: () =>
+        this.isCurrentOwner(record.notebookUri, record.epoch),
+    };
+  }
+
+  private async deleteRecordIfCurrent(
+    record: NotebookOwnershipRecord,
+  ): Promise<void> {
+    const current = await this.db.ownership.get(record.notebookUri);
+    if (
+      current?.ownerTabId === record.ownerTabId &&
+      current.epoch === record.epoch
+    ) {
+      await this.db.ownership.delete(record.notebookUri);
+    }
+  }
+
+  private broadcast(
+    type: "owner-acquired" | "owner-released",
+    record: NotebookOwnershipRecord,
+  ): void {
+    this.channel?.postMessage({ type, record });
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch {
+        // Ignore listener failures so ownership cleanup is not interrupted.
+      }
+    }
+  }
+}
+
+let manager: NotebookOwnershipManager = new NotebookOwnershipManager();
+
+export function getNotebookOwnershipManager(): NotebookOwnershipManager {
+  return manager;
+}
+
+export function __setNotebookOwnershipManagerForTests(
+  next: NotebookOwnershipManager,
+): void {
+  manager.dispose();
+  manager = next;
+}
+
+export function __resetNotebookOwnershipManagerForTests(): void {
+  manager.dispose();
+  manager = new NotebookOwnershipManager();
+}

--- a/app/src/lib/tabIdentity.ts
+++ b/app/src/lib/tabIdentity.ts
@@ -1,0 +1,20 @@
+let tabId: string | null = null;
+
+/**
+ * getTabId returns a per-page-load browser tab identifier.
+ *
+ * The id is intentionally in memory only. `sessionStorage` survives reloads and
+ * may be cloned when a browser tab is duplicated, so it is useful for restoring
+ * UI state but not for proving tab identity. Web Locks remain the ownership
+ * authority; this id is only metadata for diagnostics and blocked-state UI.
+ */
+export function getTabId(): string {
+  if (!tabId) {
+    tabId = crypto.randomUUID();
+  }
+  return tabId;
+}
+
+export function __resetTabIdForTests(): void {
+  tabId = null;
+}

--- a/app/test/browser/test-scenario-open-shared-drive-link.ts
+++ b/app/test/browser/test-scenario-open-shared-drive-link.ts
@@ -278,6 +278,7 @@ const seedRuntime = run(
     localStorage.setItem('${GOOGLE_CLIENT_STORAGE_KEY}', JSON.stringify({}));
     localStorage.removeItem('${GOOGLE_AUTH_STORAGE_KEY}');
     localStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
+    sessionStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     localStorage.setItem('${WORKSPACE_STORAGE_KEY}', JSON.stringify({ items: [] }));
     return 'ok';
   })()"`,
@@ -341,7 +342,7 @@ writeArtifact("scenario-open-shared-drive-link-03-after-reload.txt", snapshot);
 
 const currentDocRaw = run(
   `agent-browser eval "(async () => {
-    return localStorage.getItem('${CURRENT_DOC_STORAGE_KEY}') || '';
+    return sessionStorage.getItem('${CURRENT_DOC_STORAGE_KEY}') || '';
   })()"`,
 ).stdout.trim();
 writeArtifact("scenario-open-shared-drive-link-05-current-doc.txt", currentDocRaw);
@@ -438,6 +439,7 @@ run(
   `agent-browser eval "(async () => {
     localStorage.removeItem('${GOOGLE_AUTH_STORAGE_KEY}');
     localStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
+    sessionStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     localStorage.setItem('${WORKSPACE_STORAGE_KEY}', JSON.stringify({ items: [] }));
     return 'ok';
   })()"`,

--- a/docs-dev/design/20260520_multi_tab_support.md
+++ b/docs-dev/design/20260520_multi_tab_support.md
@@ -49,7 +49,6 @@ notebook ownership without Web Locks.
 Use `BroadcastChannel` for live cross-tab messages:
 
 - "ownership released" notifications
-- best-effort "focus your tab" requests
 
 Use IndexedDB for best-effort ownership metadata that the UI can inspect. The
 lock is authoritative; metadata is descriptive and may be stale.
@@ -521,12 +520,12 @@ Owned by: Tab opened at 10:42 AM
 
 Close this notebook in the other tab, then retry here.
 
-[Focus other tab] [Retry]
+[Retry]
 ```
 
-`Focus other tab` is best effort. It may send a BroadcastChannel message to the
-owner; the owner may call `window.focus()`. Browsers may ignore focus requests.
-The UI must still work if focus cannot be moved.
+The initial implementation does not include a focus request or takeover action.
+The blocked tab relies on the user closing the notebook in the owner tab and
+then clicking `Retry`.
 
 `Retry` calls `openNotebook(localUri)` again. If the other tab has closed the
 notebook or gone away, the Web Lock should now be acquirable.
@@ -570,8 +569,7 @@ manager whether the current tab still owns the notebook URI and epoch.
 10. Keep all visible-tab selection on `CurrentDocContext.setCurrentDoc`.
 11. Add blocked-notebook UI in `Actions` and sidebar indicators in
     `SidePanel`.
-12. Add optional best-effort `Focus other tab` and `owner-released`
-    BroadcastChannel messages.
+12. Add best-effort `owner-released` BroadcastChannel messages.
 13. Add a blocked-state `Retry` action that re-runs `openNotebook(localUri)`.
 14. Guard AppKernel/runtime notebook mutation APIs with ownership checks.
 15. Guard `NotebookData` autosave/persistence with ownership checks.
@@ -639,8 +637,6 @@ writing the legacy keys after this change.
   development, and production is HTTPS. Browsers without `navigator.locks`
   should show an unsupported editing state rather than falling back to weaker
   coordination.
-- Browser focus requests may be ignored. The UX should describe focus as best
-  effort and rely on explicit user action plus retry.
 - `BroadcastChannel` messages are not durable. That is fine because ownership
   correctness comes from Web Locks and IndexedDB state.
 - Takeover is intentionally out of scope for the initial implementation. It is
@@ -650,7 +646,7 @@ writing the legacy keys after this change.
 ## Recommendation
 
 Use Web Locks for exclusive notebook ownership and IndexedDB records for owner
-metadata. Use BroadcastChannel only for best-effort focus/release hints. Refactor
+metadata. Use BroadcastChannel only for best-effort release hints. Refactor
 current/open notebook UI state to be tab-local, then route every notebook-open
 operation through ownership acquisition. In the first implementation, blocked
 tabs ask the user to close the notebook in the other tab and retry.


### PR DESCRIPTION
## Summary
- add per-tab notebook restore state backed by sessionStorage with one-time legacy import
- add Web Locks based notebook ownership with blocked and unsupported states
- guard notebook load/save surfaces so only the owning tab mutates editable notebook data
- surface blocked/error/loading notebook states in the editor and sidebar

Fixes #215

## Validation
- pnpm -C app test --run src/contexts/CurrentDocContext.test.tsx src/lib/notebookSessionPersistence.test.ts src/lib/tabCoordination/notebookOwnership.test.ts src/lib/notebookDataController.test.ts
- pnpm -C app test --run
- runme run build test