### PR TITLE
Add notebook diff viewer

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import Callback from "./routes/callback";
 import RunRoute from "./routes/run";
 import RunsRoute from "./routes/runs";
+import NotebookDiffView from "./components/NotebookDiff/NotebookDiffView";
 import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 import AuthStatus from "./components/AuthStatus/AuthStatus";
@@ -83,6 +84,7 @@ function AppRouter() {
         <Route path="/runs" element={<RunsRoute />} />
         <Route path="/runs/:runName" element={<RunRoute />} />
         <Route path="/runs/:runName/edit" element={<MainPage />} />
+        <Route path="/diff/:diffId" element={<NotebookDiffView />} />
         <Route path="/auth/status" element={<BrowserAuthStatus />} />
         <Route path="/oidc/callback" element={<Callback />} />
         <Route
@@ -129,7 +131,7 @@ function App({ branding }: AppProps) {
     if (!hasLoggedStartup) {
       appLogger.info("Application startup complete", {
         attrs: {
-          routeCount: 8,
+          routeCount: 9,
         },
       });
       hasLoggedStartup = true;
@@ -289,6 +291,7 @@ const BrowserAuthStatus = () => {
       authData={authData}
       onLogin={() => browserAdapter.loginWithRedirect()}
       onLogout={() => browserAdapter.logout()}
+      description="Current browser authentication state for Runme Web."
     />
   );
 };

--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -76,4 +76,10 @@ describe("NotebookDiffView", () => {
 
     expect(screen.getByText("Diff no longer available")).toBeTruthy();
   });
+
+  it("does not double-decode encoded diff ids", () => {
+    renderRoute("/diff/%25");
+
+    expect(screen.getByText("Diff no longer available")).toBeTruthy();
+  });
 });

--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -1,0 +1,62 @@
+import { create } from "@bufbuild/protobuf";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { parser_pb } from "../../runme/client";
+import { computeNotebookDiff } from "../../lib/notebookDiff/diff";
+import { registerNotebookDiffDocument } from "../../lib/notebookDiff/registry";
+import NotebookDiffView from "./NotebookDiffView";
+
+function renderRoute(path: string) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/diff/:diffId" element={<NotebookDiffView />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function notebook(value: string) {
+  return create(parser_pb.NotebookSchema, {
+    cells: [
+      create(parser_pb.CellSchema, {
+        refId: "cell-1",
+        kind: parser_pb.CellKind.CODE,
+        languageId: "python",
+        value,
+      }),
+    ],
+    metadata: {},
+  });
+}
+
+describe("NotebookDiffView", () => {
+  it("renders a registered side-by-side diff document", () => {
+    const diff = computeNotebookDiff(
+      notebook("print('base')"),
+      notebook("print('compare')"),
+    );
+    const doc = registerNotebookDiffDocument({
+      base: { label: "Drive revision 1", revisionId: "1" },
+      compare: { label: "Local copy", revisionId: "local" },
+      diff,
+    });
+
+    renderRoute(`/diff/${encodeURIComponent(doc.id)}`);
+
+    expect(screen.getByText("Notebook Diff")).toBeTruthy();
+    expect(screen.getByText(/Drive revision 1 compared with Local copy/)).toBeTruthy();
+    expect(screen.getByText("Base: Drive revision 1")).toBeTruthy();
+    expect(screen.getByText("Compare: Local copy")).toBeTruthy();
+    expect(screen.getByText("print('base')")).toBeTruthy();
+    expect(screen.getByText("print('compare')")).toBeTruthy();
+  });
+
+  it("shows a recompute message for missing in-memory diff documents", () => {
+    renderRoute("/diff/missing");
+
+    expect(screen.getByText("Diff no longer available")).toBeTruthy();
+  });
+});

--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -54,6 +54,23 @@ describe("NotebookDiffView", () => {
     expect(screen.getByText("print('compare')")).toBeTruthy();
   });
 
+  it("renders unchanged cell contents inside the expandable row", () => {
+    const diff = computeNotebookDiff(
+      notebook("print('same')"),
+      notebook("print('same')"),
+    );
+    const doc = registerNotebookDiffDocument({
+      base: { label: "Drive revision 1", revisionId: "1" },
+      compare: { label: "Local copy", revisionId: "local" },
+      diff,
+    });
+
+    renderRoute(`/diff/${encodeURIComponent(doc.id)}`);
+
+    expect(screen.getByText("Unchanged cell cell-1")).toBeTruthy();
+    expect(screen.getAllByText("print('same')")).toHaveLength(2);
+  });
+
   it("shows a recompute message for missing in-memory diff documents", () => {
     renderRoute("/diff/missing");
 

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -268,7 +268,7 @@ function NotebookDiffContent({ document }: { document: NotebookDiffDocument }) {
 export default function NotebookDiffView() {
   const params = useParams<{ diffId: string }>();
   const document = params.diffId
-    ? getNotebookDiffDocument(decodeURIComponent(params.diffId))
+    ? getNotebookDiffDocument(params.diffId)
     : null;
 
   if (!document) {

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -191,10 +191,16 @@ function CellPanel({
 function DiffRow({ row }: { row: CellDiff }) {
   if (row.kind === "unchanged") {
     return (
-      <details className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2 text-sm text-nb-text-muted">
-        <summary className="cursor-pointer">
+      <details className="rounded border border-nb-border bg-nb-surface-2 text-sm text-nb-text-muted">
+        <summary className="cursor-pointer px-3 py-2">
           Unchanged cell {row.baseCell?.refId || row.compareCell?.refId || ""}
         </summary>
+        <div className="border-t border-nb-border bg-nb-bg p-3">
+          <div className="grid min-w-[920px] grid-cols-2 gap-3">
+            <CellPanel row={row} side="base" />
+            <CellPanel row={row} side="compare" />
+          </div>
+        </div>
       </details>
     );
   }

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -1,0 +1,286 @@
+import { Badge, Button, ScrollArea, Text } from "@radix-ui/themes";
+import { Link, useParams } from "react-router-dom";
+
+import { parser_pb } from "../../runme/client";
+import { getNotebookDiffDocument } from "../../lib/notebookDiff/registry";
+import type {
+  CellDiff,
+  NotebookDiffDocument,
+  OutputItemSummary,
+  TextDiff,
+  TextDiffLine,
+} from "../../lib/notebookDiff/model";
+
+function cellKindLabel(cell?: parser_pb.Cell): string {
+  if (!cell) {
+    return "";
+  }
+  if (cell.kind === parser_pb.CellKind.MARKUP) {
+    return "Markdown";
+  }
+  if (cell.kind === parser_pb.CellKind.CODE) {
+    return cell.languageId || "Code";
+  }
+  return cell.languageId || "Cell";
+}
+
+function changeBadgeColor(kind: CellDiff["kind"]): "gray" | "green" | "red" | "amber" {
+  switch (kind) {
+    case "inserted":
+      return "green";
+    case "deleted":
+      return "red";
+    case "modified":
+      return "amber";
+    default:
+      return "gray";
+  }
+}
+
+function statusText(row: CellDiff): string {
+  if (row.kind === "inserted") {
+    return "Inserted";
+  }
+  if (row.kind === "deleted") {
+    return "Deleted";
+  }
+  if (row.kind === "unchanged") {
+    return row.moved ? "Moved" : "Unchanged";
+  }
+  return row.changedFields
+    .map((field) => (field === "move" ? "moved" : field))
+    .join(", ");
+}
+
+function lineClass(line: TextDiffLine, side: "base" | "compare"): string {
+  if (line.kind === "equal") {
+    return "text-nb-text";
+  }
+  if (side === "base" && line.kind === "removed") {
+    return "bg-red-50 text-red-900";
+  }
+  if (side === "compare" && line.kind === "added") {
+    return "bg-emerald-50 text-emerald-900";
+  }
+  return "text-nb-text-faint";
+}
+
+function lineText(line: TextDiffLine, side: "base" | "compare"): string {
+  if (side === "base") {
+    return line.baseLine ?? "";
+  }
+  return line.compareLine ?? "";
+}
+
+function SourceDiff({
+  diff,
+  side,
+  fallback,
+}: {
+  diff?: TextDiff;
+  side: "base" | "compare";
+  fallback: string;
+}) {
+  const lines =
+    diff?.lines.length ? diff.lines : fallback ? fallback.split(/\r?\n/) : [];
+  return (
+    <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words p-3 font-mono text-xs leading-5">
+      {lines.length === 0 ? (
+        <span className="text-nb-text-faint">No source</span>
+      ) : (
+        lines.map((line, index) => {
+          const normalizedLine =
+            typeof line === "string"
+              ? ({ kind: "equal", baseLine: line, compareLine: line } as TextDiffLine)
+              : line;
+          return (
+            <div
+              key={`${side}-line-${index}`}
+              className={`min-h-5 rounded px-1 ${lineClass(normalizedLine, side)}`}
+            >
+              {lineText(normalizedLine, side) || " "}
+            </div>
+          );
+        })
+      )}
+    </pre>
+  );
+}
+
+function OutputSummary({
+  items,
+  side,
+}: {
+  items: OutputItemSummary[];
+  side: "base" | "compare";
+}) {
+  if (items.length === 0) {
+    return <div className="text-xs text-nb-text-faint">No outputs</div>;
+  }
+  return (
+    <details className="rounded border border-nb-border bg-nb-surface-2 p-2 text-xs" open={false}>
+      <summary className="cursor-pointer text-nb-text-muted">
+        {items.length} output item{items.length === 1 ? "" : "s"} on {side}
+      </summary>
+      <div className="mt-2 space-y-2">
+        {items.map((item, index) => (
+          <div key={`${side}-output-${index}`} className="rounded bg-white p-2">
+            <div className="font-mono text-[11px] text-nb-text-muted">
+              {item.mime} · {item.kind} · {item.sizeBytes} bytes
+            </div>
+            {item.text && (
+              <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] text-nb-text">
+                {item.text}
+              </pre>
+            )}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function CellPanel({
+  row,
+  side,
+}: {
+  row: CellDiff;
+  side: "base" | "compare";
+}) {
+  const cell = side === "base" ? row.baseCell : row.compareCell;
+  const empty =
+    (side === "base" && row.kind === "inserted") ||
+    (side === "compare" && row.kind === "deleted");
+  const outputItems =
+    side === "base"
+      ? row.outputDiff?.baseItems ?? []
+      : row.outputDiff?.compareItems ?? [];
+
+  if (empty) {
+    return (
+      <div className="flex min-h-28 items-center justify-center rounded border border-dashed border-nb-border bg-nb-surface-2 text-sm text-nb-text-faint">
+        No cell on this side
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0 rounded border border-nb-border bg-white">
+      <div className="flex items-center justify-between border-b border-nb-border bg-nb-surface-2 px-3 py-2">
+        <span className="text-xs font-medium text-nb-text-muted">
+          {cellKindLabel(cell)}
+        </span>
+        <span className="font-mono text-[11px] text-nb-text-faint">
+          {cell?.refId || "no-ref"}
+        </span>
+      </div>
+      <SourceDiff
+        diff={row.sourceDiff}
+        side={side}
+        fallback={cell?.value ?? ""}
+      />
+      {row.outputDiff?.changed && (
+        <div className="border-t border-nb-border p-3">
+          <OutputSummary items={outputItems} side={side} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffRow({ row }: { row: CellDiff }) {
+  if (row.kind === "unchanged") {
+    return (
+      <details className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2 text-sm text-nb-text-muted">
+        <summary className="cursor-pointer">
+          Unchanged cell {row.baseCell?.refId || row.compareCell?.refId || ""}
+        </summary>
+      </details>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-nb-border bg-nb-bg p-3 shadow-sm">
+      <div className="mb-3 flex items-center gap-2">
+        <Badge color={changeBadgeColor(row.kind)}>{statusText(row)}</Badge>
+        {row.outputDiff?.changed && <Badge color="blue">outputs changed</Badge>}
+        {row.metadataDiff?.changed && <Badge color="purple">metadata changed</Badge>}
+      </div>
+      <div className="grid min-w-[920px] grid-cols-2 gap-3">
+        <CellPanel row={row} side="base" />
+        <CellPanel row={row} side="compare" />
+      </div>
+    </section>
+  );
+}
+
+function NotebookDiffContent({ document }: { document: NotebookDiffDocument }) {
+  const { diff } = document;
+  return (
+    <div className="flex h-screen w-screen flex-col bg-nb-surface">
+      <header className="border-b border-nb-border bg-white px-5 py-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <Text as="p" size="5" weight="bold" className="text-nb-text">
+              Notebook Diff
+            </Text>
+            <Text as="p" size="2" className="text-nb-text-muted">
+              {document.base.label} compared with {document.compare.label}
+            </Text>
+          </div>
+          <Button asChild variant="soft">
+            <Link to="/">Back to notebooks</Link>
+          </Button>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2 text-sm text-nb-text-muted">
+          <Badge color="green">{diff.summary.insertedCells} inserted</Badge>
+          <Badge color="red">{diff.summary.deletedCells} deleted</Badge>
+          <Badge color="amber">{diff.summary.modifiedCells} modified</Badge>
+          <Badge color="blue">{diff.summary.outputChanges} output changes</Badge>
+          <Badge color="gray">{diff.summary.unchangedCells} unchanged</Badge>
+        </div>
+        <div className="mt-4 grid min-w-[920px] grid-cols-2 gap-3 overflow-x-auto text-xs font-medium uppercase tracking-wide text-nb-text-muted">
+          <div className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2">
+            Base: {document.base.label}
+          </div>
+          <div className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2">
+            Compare: {document.compare.label}
+          </div>
+        </div>
+      </header>
+      <ScrollArea type="auto" scrollbars="both" className="min-h-0 flex-1">
+        <div className="space-y-3 p-5">
+          {diff.cells.map((row) => (
+            <DiffRow key={row.id} row={row} />
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+export default function NotebookDiffView() {
+  const params = useParams<{ diffId: string }>();
+  const document = params.diffId
+    ? getNotebookDiffDocument(decodeURIComponent(params.diffId))
+    : null;
+
+  if (!document) {
+    return (
+      <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-nb-surface text-center">
+        <Text as="p" size="4" weight="bold">
+          Diff no longer available
+        </Text>
+        <Text as="p" size="2" className="max-w-md text-nb-text-muted">
+          Recompute the notebook diff from a browser JavaScript cell, then call
+          notebookDiff.openDiffTab(diff) again.
+        </Text>
+        <Button asChild variant="soft">
+          <Link to="/">Back to notebooks</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return <NotebookDiffContent document={document} />;
+}

--- a/app/src/lib/notebookDiff/diff.test.ts
+++ b/app/src/lib/notebookDiff/diff.test.ts
@@ -1,0 +1,124 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { MimeType, RunmeMetadataKey, parser_pb } from "../../runme/client";
+import { computeNotebookDiff } from "./diff";
+
+const encoder = new TextEncoder();
+
+function cell(args: {
+  refId: string;
+  value: string;
+  kind?: parser_pb.CellKind;
+  languageId?: string;
+  metadata?: Record<string, string>;
+  stdout?: string;
+}) {
+  return create(parser_pb.CellSchema, {
+    refId: args.refId,
+    kind: args.kind ?? parser_pb.CellKind.CODE,
+    languageId: args.languageId ?? "python",
+    value: args.value,
+    metadata: args.metadata ?? {},
+    outputs:
+      args.stdout === undefined
+        ? []
+        : [
+            create(parser_pb.CellOutputSchema, {
+              items: [
+                create(parser_pb.CellOutputItemSchema, {
+                  mime: MimeType.VSCodeNotebookStdOut,
+                  data: encoder.encode(args.stdout),
+                }),
+              ],
+            }),
+          ],
+  });
+}
+
+function notebook(cells: parser_pb.Cell[]) {
+  return create(parser_pb.NotebookSchema, {
+    cells,
+    metadata: {},
+  });
+}
+
+describe("computeNotebookDiff", () => {
+  it("matches cells by refId and reports source changes", () => {
+    const diff = computeNotebookDiff(
+      notebook([cell({ refId: "a", value: "x = 1\nprint(x)" })]),
+      notebook([cell({ refId: "a", value: "x = 2\nprint(x)" })]),
+    );
+
+    expect(diff.summary.modifiedCells).toBe(1);
+    expect(diff.summary.sourceChanges).toBe(1);
+    expect(diff.cells[0].kind).toBe("modified");
+    expect(diff.cells[0].sourceDiff?.changed).toBe(true);
+  });
+
+  it("reports inserted and deleted cells in compare order", () => {
+    const diff = computeNotebookDiff(
+      notebook([
+        cell({ refId: "a", value: "base a" }),
+        cell({ refId: "b", value: "base b" }),
+      ]),
+      notebook([
+        cell({ refId: "a", value: "base a" }),
+        cell({ refId: "c", value: "compare c" }),
+      ]),
+    );
+
+    expect(diff.cells.map((row) => row.kind)).toEqual([
+      "unchanged",
+      "inserted",
+      "deleted",
+    ]);
+    expect(diff.summary.insertedCells).toBe(1);
+    expect(diff.summary.deletedCells).toBe(1);
+  });
+
+  it("ignores transient execution metadata but reports authored metadata", () => {
+    const diff = computeNotebookDiff(
+      notebook([
+        cell({
+          refId: "a",
+          value: "print(1)",
+          metadata: {
+            [RunmeMetadataKey.Sequence]: "1",
+            [RunmeMetadataKey.RunnerName]: "local",
+          },
+        }),
+      ]),
+      notebook([
+        cell({
+          refId: "a",
+          value: "print(1)",
+          metadata: {
+            [RunmeMetadataKey.Sequence]: "2",
+            [RunmeMetadataKey.RunnerName]: "remote",
+          },
+        }),
+      ]),
+    );
+
+    expect(diff.summary.metadataChanges).toBe(1);
+    expect(diff.cells[0].metadataDiff?.base).toEqual({
+      [RunmeMetadataKey.RunnerName]: "local",
+    });
+    expect(diff.cells[0].metadataDiff?.compare).toEqual({
+      [RunmeMetadataKey.RunnerName]: "remote",
+    });
+  });
+
+  it("reports output-only changes as modified cells", () => {
+    const diff = computeNotebookDiff(
+      notebook([cell({ refId: "a", value: "print(value)", stdout: "old\n" })]),
+      notebook([cell({ refId: "a", value: "print(value)", stdout: "new\n" })]),
+    );
+
+    expect(diff.summary.modifiedCells).toBe(1);
+    expect(diff.summary.outputChanges).toBe(1);
+    expect(diff.cells[0].changedFields).toContain("outputs");
+  });
+});
+

--- a/app/src/lib/notebookDiff/diff.test.ts
+++ b/app/src/lib/notebookDiff/diff.test.ts
@@ -120,5 +120,25 @@ describe("computeNotebookDiff", () => {
     expect(diff.summary.outputChanges).toBe(1);
     expect(diff.cells[0].changedFields).toContain("outputs");
   });
-});
 
+  it("does not compute text output diffs for large outputs", () => {
+    const baseOutput = Array.from(
+      { length: 501 },
+      (_value, index) => `old ${index}`,
+    ).join("\n");
+    const compareOutput = Array.from(
+      { length: 501 },
+      (_value, index) => `new ${index}`,
+    ).join("\n");
+
+    const diff = computeNotebookDiff(
+      notebook([cell({ refId: "a", value: "print(value)", stdout: baseOutput })]),
+      notebook([
+        cell({ refId: "a", value: "print(value)", stdout: compareOutput }),
+      ]),
+    );
+
+    expect(diff.summary.outputChanges).toBe(1);
+    expect(diff.cells[0].outputDiff?.textDiff).toBeUndefined();
+  });
+});

--- a/app/src/lib/notebookDiff/diff.ts
+++ b/app/src/lib/notebookDiff/diff.ts
@@ -24,6 +24,8 @@ const INTERNAL_OUTPUT_MIMES = new Set<string>([
 ]);
 
 const TEXT_DECODER = new TextDecoder();
+const MAX_OUTPUT_TEXT_DIFF_BYTES = 100_000;
+const MAX_OUTPUT_TEXT_DIFF_LINES = 500;
 
 const TRANSIENT_METADATA_KEYS = new Set<string>([
   RunmeMetadataKey.Sequence,
@@ -349,8 +351,36 @@ function diffOutputs(baseCell: parser_pb.Cell, compareCell: parser_pb.Cell): Out
     changed,
     baseItems,
     compareItems,
-    textDiff: baseText || compareText ? diffText(baseText, compareText) : undefined,
+    textDiff: maybeDiffOutputText(baseText, compareText),
   };
+}
+
+function maybeDiffOutputText(
+  baseText: string,
+  compareText: string,
+): TextDiff | undefined {
+  if (!baseText && !compareText) {
+    return undefined;
+  }
+  if (baseText.length + compareText.length > MAX_OUTPUT_TEXT_DIFF_BYTES) {
+    return undefined;
+  }
+  const baseLineCount = countLines(baseText);
+  const compareLineCount = countLines(compareText);
+  if (
+    baseLineCount > MAX_OUTPUT_TEXT_DIFF_LINES ||
+    compareLineCount > MAX_OUTPUT_TEXT_DIFF_LINES
+  ) {
+    return undefined;
+  }
+  return diffText(baseText, compareText);
+}
+
+function countLines(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  return text.replace(/\r\n/g, "\n").split("\n").length;
 }
 
 function summarizeOutputs(outputs: parser_pb.CellOutput[]): OutputItemSummary[] {
@@ -490,4 +520,3 @@ function summarize(rows: CellDiff[]): NotebookDiff["summary"] {
     },
   );
 }
-

--- a/app/src/lib/notebookDiff/diff.ts
+++ b/app/src/lib/notebookDiff/diff.ts
@@ -397,7 +397,7 @@ function summarizeOutputs(outputs: parser_pb.CellOutput[]): OutputItemSummary[] 
 function summarizeOutputItem(item: parser_pb.CellOutputItem): OutputItemSummary {
   const mime = (item.mime ?? "").trim();
   const bytes = normalizeBytes(item.data);
-  const checksum = md5(Array.from(bytes).join(","));
+  const checksum = md5(bytes);
   if (isTextLikeMime(mime)) {
     return {
       mime,

--- a/app/src/lib/notebookDiff/diff.ts
+++ b/app/src/lib/notebookDiff/diff.ts
@@ -1,0 +1,493 @@
+import md5 from "md5";
+
+import { MimeType, RunmeMetadataKey, parser_pb } from "../../runme/client";
+import {
+  type CellDiff,
+  type MetadataDiff,
+  type NotebookDiff,
+  type NotebookDiffOptions,
+  type OutputDiff,
+  type OutputItemSummary,
+  type TextDiff,
+  type TextDiffLine,
+} from "./model";
+
+const DEFAULT_OPTIONS: Required<NotebookDiffOptions> = {
+  includeOutputs: true,
+  includeMetadata: true,
+  ignoreTransientMetadata: true,
+};
+
+const INTERNAL_OUTPUT_MIMES = new Set<string>([
+  MimeType.StatefulRunmeOutputItems,
+  MimeType.StatefulRunmeTerminal,
+]);
+
+const TEXT_DECODER = new TextDecoder();
+
+const TRANSIENT_METADATA_KEYS = new Set<string>([
+  RunmeMetadataKey.Sequence,
+  RunmeMetadataKey.LastRunID,
+  RunmeMetadataKey.Pid,
+  RunmeMetadataKey.ExitCode,
+]);
+
+type IndexedCell = {
+  cell: parser_pb.Cell;
+  index: number;
+};
+
+type CellMatch = {
+  base: IndexedCell;
+  compare: IndexedCell;
+};
+
+export function computeNotebookDiff(
+  baseNotebook: parser_pb.Notebook,
+  compareNotebook: parser_pb.Notebook,
+  options: NotebookDiffOptions = {},
+): NotebookDiff {
+  const resolvedOptions = { ...DEFAULT_OPTIONS, ...options };
+  const baseCells = (baseNotebook.cells ?? []).map((cell, index) => ({
+    cell,
+    index,
+  }));
+  const compareCells = (compareNotebook.cells ?? []).map((cell, index) => ({
+    cell,
+    index,
+  }));
+  const matches = matchCells(baseCells, compareCells);
+  const compareRefToMatch = new Map<string, CellMatch>();
+  const baseRefToMatch = new Map<string, CellMatch>();
+  for (const match of matches) {
+    compareRefToMatch.set(cellKey(match.compare.cell, match.compare.index), match);
+    baseRefToMatch.set(cellKey(match.base.cell, match.base.index), match);
+  }
+
+  const rows: CellDiff[] = [];
+  let baseCursor = 0;
+  for (const compare of compareCells) {
+    const match = compareRefToMatch.get(cellKey(compare.cell, compare.index));
+    if (!match) {
+      rows.push(createInsertedCellDiff(compare));
+      continue;
+    }
+
+    while (baseCursor < match.base.index) {
+      const base = baseCells[baseCursor];
+      if (!baseRefToMatch.has(cellKey(base.cell, base.index))) {
+        rows.push(createDeletedCellDiff(base));
+      }
+      baseCursor += 1;
+    }
+
+    rows.push(createMatchedCellDiff(match, resolvedOptions));
+    baseCursor = Math.max(baseCursor, match.base.index + 1);
+  }
+
+  while (baseCursor < baseCells.length) {
+    const base = baseCells[baseCursor];
+    if (!baseRefToMatch.has(cellKey(base.cell, base.index))) {
+      rows.push(createDeletedCellDiff(base));
+    }
+    baseCursor += 1;
+  }
+
+  return {
+    cells: rows,
+    summary: summarize(rows),
+  };
+}
+
+function matchCells(
+  baseCells: IndexedCell[],
+  compareCells: IndexedCell[],
+): CellMatch[] {
+  const matches: CellMatch[] = [];
+  const usedBaseIndexes = new Set<number>();
+  const usedCompareIndexes = new Set<number>();
+
+  const baseByRef = uniqueRefMap(baseCells);
+  const compareByRef = uniqueRefMap(compareCells);
+  for (const [refId, base] of baseByRef.entries()) {
+    const compare = compareByRef.get(refId);
+    if (!compare) {
+      continue;
+    }
+    matches.push({ base, compare });
+    usedBaseIndexes.add(base.index);
+    usedCompareIndexes.add(compare.index);
+  }
+
+  const exactBase = new Map<string, IndexedCell[]>();
+  for (const base of baseCells) {
+    if (usedBaseIndexes.has(base.index)) {
+      continue;
+    }
+    const key = authoredCellKey(base.cell);
+    exactBase.set(key, [...(exactBase.get(key) ?? []), base]);
+  }
+
+  for (const compare of compareCells) {
+    if (usedCompareIndexes.has(compare.index)) {
+      continue;
+    }
+    const key = authoredCellKey(compare.cell);
+    const candidates = exactBase.get(key) ?? [];
+    const base = candidates.find((candidate) => !usedBaseIndexes.has(candidate.index));
+    if (!base) {
+      continue;
+    }
+    matches.push({ base, compare });
+    usedBaseIndexes.add(base.index);
+    usedCompareIndexes.add(compare.index);
+  }
+
+  matches.sort((a, b) => a.compare.index - b.compare.index);
+  return matches;
+}
+
+function uniqueRefMap(cells: IndexedCell[]): Map<string, IndexedCell> {
+  const counts = new Map<string, number>();
+  for (const { cell } of cells) {
+    if (!cell.refId) {
+      continue;
+    }
+    counts.set(cell.refId, (counts.get(cell.refId) ?? 0) + 1);
+  }
+
+  const result = new Map<string, IndexedCell>();
+  for (const item of cells) {
+    if (item.cell.refId && counts.get(item.cell.refId) === 1) {
+      result.set(item.cell.refId, item);
+    }
+  }
+  return result;
+}
+
+function createInsertedCellDiff(compare: IndexedCell): CellDiff {
+  return {
+    id: `inserted:${compare.cell.refId || compare.index}`,
+    kind: "inserted",
+    compareIndex: compare.index,
+    compareCell: compare.cell,
+    moved: false,
+    changedFields: ["source"],
+  };
+}
+
+function createDeletedCellDiff(base: IndexedCell): CellDiff {
+  return {
+    id: `deleted:${base.cell.refId || base.index}`,
+    kind: "deleted",
+    baseIndex: base.index,
+    baseCell: base.cell,
+    moved: false,
+    changedFields: ["source"],
+  };
+}
+
+function createMatchedCellDiff(
+  match: CellMatch,
+  options: Required<NotebookDiffOptions>,
+): CellDiff {
+  const sourceDiff = diffText(match.base.cell.value ?? "", match.compare.cell.value ?? "");
+  const metadataDiff = options.includeMetadata
+    ? diffMetadata(match.base.cell, match.compare.cell, options)
+    : undefined;
+  const outputDiff = options.includeOutputs
+    ? diffOutputs(match.base.cell, match.compare.cell)
+    : undefined;
+  const moved = match.base.index !== match.compare.index;
+  const changedFields: CellDiff["changedFields"] = [];
+
+  if (sourceDiff.changed) {
+    changedFields.push("source");
+  }
+  if (metadataDiff?.changed) {
+    changedFields.push("metadata");
+  }
+  if (outputDiff?.changed) {
+    changedFields.push("outputs");
+  }
+  if (match.base.cell.kind !== match.compare.cell.kind) {
+    changedFields.push("kind");
+  }
+  if ((match.base.cell.languageId ?? "") !== (match.compare.cell.languageId ?? "")) {
+    changedFields.push("language");
+  }
+  if (moved) {
+    changedFields.push("move");
+  }
+
+  return {
+    id: match.base.cell.refId || match.compare.cell.refId || `matched:${match.base.index}:${match.compare.index}`,
+    kind: changedFields.length > 0 ? "modified" : "unchanged",
+    baseIndex: match.base.index,
+    compareIndex: match.compare.index,
+    baseCell: match.base.cell,
+    compareCell: match.compare.cell,
+    moved,
+    sourceDiff,
+    metadataDiff,
+    outputDiff,
+    changedFields,
+  };
+}
+
+export function diffText(baseText: string, compareText: string): TextDiff {
+  if (baseText === compareText) {
+    return {
+      changed: false,
+      lines: splitLines(baseText).map((line) => ({
+        kind: "equal",
+        baseLine: line,
+        compareLine: line,
+      })),
+    };
+  }
+
+  const baseLines = splitLines(baseText);
+  const compareLines = splitLines(compareText);
+  const table = buildLcsTable(baseLines, compareLines);
+  const lines: TextDiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < baseLines.length && j < compareLines.length) {
+    if (baseLines[i] === compareLines[j]) {
+      lines.push({
+        kind: "equal",
+        baseLine: baseLines[i],
+        compareLine: compareLines[j],
+      });
+      i += 1;
+      j += 1;
+    } else if (table[i + 1]?.[j] >= table[i]?.[j + 1]) {
+      lines.push({ kind: "removed", baseLine: baseLines[i] });
+      i += 1;
+    } else {
+      lines.push({ kind: "added", compareLine: compareLines[j] });
+      j += 1;
+    }
+  }
+  while (i < baseLines.length) {
+    lines.push({ kind: "removed", baseLine: baseLines[i] });
+    i += 1;
+  }
+  while (j < compareLines.length) {
+    lines.push({ kind: "added", compareLine: compareLines[j] });
+    j += 1;
+  }
+  return { changed: true, lines };
+}
+
+function splitLines(text: string): string[] {
+  if (!text) {
+    return [];
+  }
+  return text.replace(/\r\n/g, "\n").split("\n");
+}
+
+function buildLcsTable(baseLines: string[], compareLines: string[]): number[][] {
+  const table = Array.from({ length: baseLines.length + 1 }, () =>
+    Array.from({ length: compareLines.length + 1 }, () => 0),
+  );
+  for (let i = baseLines.length - 1; i >= 0; i -= 1) {
+    for (let j = compareLines.length - 1; j >= 0; j -= 1) {
+      table[i][j] =
+        baseLines[i] === compareLines[j]
+          ? table[i + 1][j + 1] + 1
+          : Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+  return table;
+}
+
+function diffMetadata(
+  baseCell: parser_pb.Cell,
+  compareCell: parser_pb.Cell,
+  options: Required<NotebookDiffOptions>,
+): MetadataDiff {
+  const base = normalizeMetadata(baseCell.metadata ?? {}, options);
+  const compare = normalizeMetadata(compareCell.metadata ?? {}, options);
+  return {
+    changed: stableStringify(base) !== stableStringify(compare),
+    base,
+    compare,
+  };
+}
+
+function normalizeMetadata(
+  metadata: Record<string, string>,
+  options: Required<NotebookDiffOptions>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata ?? {})) {
+    if (options.ignoreTransientMetadata && TRANSIENT_METADATA_KEYS.has(key)) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function diffOutputs(baseCell: parser_pb.Cell, compareCell: parser_pb.Cell): OutputDiff {
+  const baseItems = summarizeOutputs(baseCell.outputs ?? []);
+  const compareItems = summarizeOutputs(compareCell.outputs ?? []);
+  const baseSerialized = stableStringify(baseItems);
+  const compareSerialized = stableStringify(compareItems);
+  const changed = baseSerialized !== compareSerialized;
+  const baseText = baseItems
+    .filter((item) => item.kind === "text")
+    .map((item) => `[${item.mime}]\n${item.text ?? ""}`)
+    .join("\n\n");
+  const compareText = compareItems
+    .filter((item) => item.kind === "text")
+    .map((item) => `[${item.mime}]\n${item.text ?? ""}`)
+    .join("\n\n");
+  return {
+    changed,
+    baseItems,
+    compareItems,
+    textDiff: baseText || compareText ? diffText(baseText, compareText) : undefined,
+  };
+}
+
+function summarizeOutputs(outputs: parser_pb.CellOutput[]): OutputItemSummary[] {
+  return outputs.flatMap((output) =>
+    (output.items ?? [])
+      .filter((item) => {
+        const mime = (item.mime ?? "").trim();
+        return mime && !INTERNAL_OUTPUT_MIMES.has(mime);
+      })
+      .map((item) => summarizeOutputItem(item)),
+  );
+}
+
+function summarizeOutputItem(item: parser_pb.CellOutputItem): OutputItemSummary {
+  const mime = (item.mime ?? "").trim();
+  const bytes = normalizeBytes(item.data);
+  const checksum = md5(Array.from(bytes).join(","));
+  if (isTextLikeMime(mime)) {
+    return {
+      mime,
+      kind: "text",
+      text: decodeText(bytes),
+      sizeBytes: bytes.byteLength,
+      checksum,
+    };
+  }
+  return {
+    mime,
+    kind: "binary",
+    sizeBytes: bytes.byteLength,
+    checksum,
+  };
+}
+
+function normalizeBytes(data?: Uint8Array | ArrayLike<number> | null): Uint8Array {
+  if (!data) {
+    return new Uint8Array();
+  }
+  return data instanceof Uint8Array ? data : Uint8Array.from(data);
+}
+
+function decodeText(bytes: Uint8Array): string {
+  if (bytes.byteLength === 0) {
+    return "";
+  }
+  try {
+    return TEXT_DECODER.decode(bytes);
+  } catch {
+    return "";
+  }
+}
+
+function isTextLikeMime(mime: string): boolean {
+  return (
+    mime === MimeType.VSCodeNotebookStdOut ||
+    mime === MimeType.VSCodeNotebookStdErr ||
+    mime.startsWith("text/") ||
+    mime === "application/json" ||
+    mime.endsWith("+json") ||
+    mime === "application/javascript" ||
+    mime === "application/xml" ||
+    mime.endsWith("+xml") ||
+    mime === "application/sql" ||
+    mime === "application/yaml" ||
+    mime === "application/x-yaml"
+  );
+}
+
+function authoredCellKey(cell: parser_pb.Cell): string {
+  return stableStringify({
+    kind: cell.kind,
+    languageId: cell.languageId ?? "",
+    value: cell.value ?? "",
+  });
+}
+
+function cellKey(cell: parser_pb.Cell, index: number): string {
+  return cell.refId || `index:${index}`;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => [key, sortValue(item)]),
+  );
+}
+
+function summarize(rows: CellDiff[]): NotebookDiff["summary"] {
+  return rows.reduce<NotebookDiff["summary"]>(
+    (summary, row) => {
+      if (row.kind === "unchanged") {
+        summary.unchangedCells += 1;
+      }
+      if (row.kind === "inserted") {
+        summary.insertedCells += 1;
+      }
+      if (row.kind === "deleted") {
+        summary.deletedCells += 1;
+      }
+      if (row.kind === "modified") {
+        summary.modifiedCells += 1;
+      }
+      if (row.moved) {
+        summary.movedCells += 1;
+      }
+      if (row.changedFields.includes("source")) {
+        summary.sourceChanges += 1;
+      }
+      if (row.changedFields.includes("metadata")) {
+        summary.metadataChanges += 1;
+      }
+      if (row.changedFields.includes("outputs")) {
+        summary.outputChanges += 1;
+      }
+      return summary;
+    },
+    {
+      unchangedCells: 0,
+      insertedCells: 0,
+      deletedCells: 0,
+      modifiedCells: 0,
+      movedCells: 0,
+      sourceChanges: 0,
+      metadataChanges: 0,
+      outputChanges: 0,
+    },
+  );
+}
+

--- a/app/src/lib/notebookDiff/model.ts
+++ b/app/src/lib/notebookDiff/model.ts
@@ -1,0 +1,89 @@
+import type { parser_pb } from "../../runme/client";
+
+export type TextDiffLineKind = "equal" | "removed" | "added";
+
+export interface TextDiffLine {
+  kind: TextDiffLineKind;
+  baseLine?: string;
+  compareLine?: string;
+}
+
+export interface TextDiff {
+  changed: boolean;
+  lines: TextDiffLine[];
+}
+
+export interface MetadataDiff {
+  changed: boolean;
+  base: Record<string, string>;
+  compare: Record<string, string>;
+}
+
+export interface OutputItemSummary {
+  mime: string;
+  kind: "text" | "binary";
+  text?: string;
+  sizeBytes: number;
+  checksum: string;
+}
+
+export interface OutputDiff {
+  changed: boolean;
+  baseItems: OutputItemSummary[];
+  compareItems: OutputItemSummary[];
+  textDiff?: TextDiff;
+}
+
+export type CellDiffKind = "unchanged" | "inserted" | "deleted" | "modified";
+
+export interface CellDiff {
+  id: string;
+  kind: CellDiffKind;
+  baseIndex?: number;
+  compareIndex?: number;
+  moved: boolean;
+  baseCell?: parser_pb.Cell;
+  compareCell?: parser_pb.Cell;
+  sourceDiff?: TextDiff;
+  metadataDiff?: MetadataDiff;
+  outputDiff?: OutputDiff;
+  changedFields: Array<"source" | "metadata" | "outputs" | "kind" | "language" | "move">;
+}
+
+export interface NotebookDiffSummary {
+  unchangedCells: number;
+  insertedCells: number;
+  deletedCells: number;
+  modifiedCells: number;
+  movedCells: number;
+  sourceChanges: number;
+  metadataChanges: number;
+  outputChanges: number;
+}
+
+export interface NotebookDiff {
+  baseLabel?: string;
+  compareLabel?: string;
+  cells: CellDiff[];
+  summary: NotebookDiffSummary;
+}
+
+export interface NotebookDiffOptions {
+  includeOutputs?: boolean;
+  includeMetadata?: boolean;
+  ignoreTransientMetadata?: boolean;
+}
+
+export interface NotebookDiffDocument {
+  id: string;
+  base: {
+    label: string;
+    revisionId?: string;
+  };
+  compare: {
+    label: string;
+    revisionId?: string;
+  };
+  diff: NotebookDiff;
+}
+

--- a/app/src/lib/notebookDiff/registry.ts
+++ b/app/src/lib/notebookDiff/registry.ts
@@ -1,0 +1,32 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { getAppPath } from "../appBase";
+import type { NotebookDiffDocument } from "./model";
+
+const documents = new Map<string, NotebookDiffDocument>();
+
+export function registerNotebookDiffDocument(
+  document: Omit<NotebookDiffDocument, "id"> & { id?: string },
+): NotebookDiffDocument {
+  const id = document.id?.trim() || `notebook-diff-${uuidv4()}`;
+  const stored = { ...document, id };
+  documents.set(id, stored);
+  return stored;
+}
+
+export function getNotebookDiffDocument(id: string): NotebookDiffDocument | null {
+  return documents.get(id) ?? null;
+}
+
+export function openNotebookDiffDocument(
+  document: NotebookDiffDocument | { id: string },
+): void {
+  const id = document.id.trim();
+  if (!id) {
+    throw new Error("openDiffTab requires a diff document id");
+  }
+  const path = getAppPath(`/diff/${encodeURIComponent(id)}`);
+  window.history.pushState(null, "", path);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+

--- a/app/src/lib/notebookDiff/runtime.test.ts
+++ b/app/src/lib/notebookDiff/runtime.test.ts
@@ -23,6 +23,124 @@ function notebook(value: string) {
 }
 
 describe("createNotebookDiffRuntimeApi", () => {
+  it("lists plain Drive revisions for the current local notebook", async () => {
+    const notebooksApi = {
+      get: vi.fn().mockResolvedValue({
+        summary: {
+          uri: "local://file/one",
+          name: "Notebook",
+          isOpen: true,
+          source: "local",
+        },
+        handle: {
+          uri: "local://file/one",
+          revision: "local-revision",
+        },
+        notebook: notebook("print('local')"),
+      }),
+    } as unknown as NotebooksApi;
+    const localNotebooks = {
+      getMetadata: vi.fn().mockResolvedValue({
+        uri: "local://file/one",
+        name: "Notebook",
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri: "https://drive.google.com/file/d/drive-file/view",
+        parents: [],
+      }),
+    } as unknown as LocalNotebooks;
+    const driveStore = {
+      listRevisions: vi.fn().mockResolvedValue([
+        {
+          id: "revision-1",
+          modifiedTime: "2026-05-25T00:00:00.000Z",
+          size: "123",
+          keepForever: true,
+          lastModifyingUser: {
+            displayName: "User One",
+            emailAddress: "user@example.com",
+          },
+          ignoredField: "not returned",
+        },
+        {
+          modifiedTime: "missing id",
+        },
+      ]),
+    } as unknown as DriveNotebookStore;
+
+    const api = createNotebookDiffRuntimeApi({
+      notebooksApi,
+      resolveLocalNotebooks: () => localNotebooks,
+      resolveDriveNotebookStore: () => driveStore,
+    });
+
+    const revisions = await api.listDriveRevisions();
+
+    expect(revisions).toEqual([
+      {
+        id: "revision-1",
+        mimeType: undefined,
+        modifiedTime: "2026-05-25T00:00:00.000Z",
+        md5Checksum: undefined,
+        size: "123",
+        keepForever: true,
+        lastModifyingUser: {
+          displayName: "User One",
+          emailAddress: "user@example.com",
+        },
+      },
+    ]);
+  });
+
+  it("accepts the internal current notebook object as a revision target", async () => {
+    const notebooksApi = {
+      get: vi.fn().mockResolvedValue({
+        summary: {
+          uri: "local://file/one",
+          name: "Notebook",
+          isOpen: true,
+          source: "local",
+        },
+        handle: {
+          uri: "local://file/one",
+          revision: "local-revision",
+        },
+        notebook: notebook("print('local')"),
+      }),
+    } as unknown as NotebooksApi;
+    const localNotebooks = {
+      getMetadata: vi.fn().mockResolvedValue({
+        uri: "local://file/one",
+        name: "Notebook",
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri: "https://drive.google.com/file/d/drive-file/view",
+        parents: [],
+      }),
+    } as unknown as LocalNotebooks;
+    const driveStore = {
+      listRevisions: vi.fn().mockResolvedValue([
+        {
+          id: "revision-1",
+        },
+      ]),
+    } as unknown as DriveNotebookStore;
+
+    const api = createNotebookDiffRuntimeApi({
+      notebooksApi,
+      resolveLocalNotebooks: () => localNotebooks,
+      resolveDriveNotebookStore: () => driveStore,
+    });
+
+    await api.listDriveRevisions({
+      getUri: () => "local://file/one",
+    });
+
+    expect(notebooksApi.get).toHaveBeenCalledWith({
+      uri: "local://file/one",
+    });
+  });
+
   it("computes a diff against a Drive revision for the current local notebook", async () => {
     const notebooksApi = {
       get: vi.fn().mockResolvedValue({
@@ -72,4 +190,3 @@ describe("createNotebookDiffRuntimeApi", () => {
     expect(doc.diff.summary.sourceChanges).toBe(1);
   });
 });
-

--- a/app/src/lib/notebookDiff/runtime.test.ts
+++ b/app/src/lib/notebookDiff/runtime.test.ts
@@ -1,0 +1,75 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it, vi } from "vitest";
+
+import { parser_pb } from "../../runme/client";
+import { NotebookStoreItemType } from "../../storage/notebook";
+import type { DriveNotebookStore } from "../../storage/drive";
+import type LocalNotebooks from "../../storage/local";
+import type { NotebooksApi } from "../runtime/runmeConsole";
+import { createNotebookDiffRuntimeApi } from "./runtime";
+
+function notebook(value: string) {
+  return create(parser_pb.NotebookSchema, {
+    cells: [
+      create(parser_pb.CellSchema, {
+        refId: "cell-1",
+        kind: parser_pb.CellKind.CODE,
+        languageId: "python",
+        value,
+      }),
+    ],
+    metadata: {},
+  });
+}
+
+describe("createNotebookDiffRuntimeApi", () => {
+  it("computes a diff against a Drive revision for the current local notebook", async () => {
+    const notebooksApi = {
+      get: vi.fn().mockResolvedValue({
+        summary: {
+          uri: "local://file/one",
+          name: "Notebook",
+          isOpen: true,
+          source: "local",
+        },
+        handle: {
+          uri: "local://file/one",
+          revision: "local-revision",
+        },
+        notebook: notebook("print('local')"),
+      }),
+    } as unknown as NotebooksApi;
+    const localNotebooks = {
+      getMetadata: vi.fn().mockResolvedValue({
+        uri: "local://file/one",
+        name: "Notebook",
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri: "https://drive.google.com/file/d/drive-file/view",
+        parents: [],
+      }),
+    } as unknown as LocalNotebooks;
+    const driveStore = {
+      loadRevision: vi.fn().mockResolvedValue(notebook("print('base')")),
+    } as unknown as DriveNotebookStore;
+
+    const api = createNotebookDiffRuntimeApi({
+      notebooksApi,
+      resolveLocalNotebooks: () => localNotebooks,
+      resolveDriveNotebookStore: () => driveStore,
+    });
+
+    const doc = await api.diffDriveRevision({
+      revisionId: "revision-1",
+    });
+
+    expect(driveStore.loadRevision).toHaveBeenCalledWith(
+      "https://drive.google.com/file/d/drive-file/view",
+      "revision-1",
+    );
+    expect(doc.base.revisionId).toBe("revision-1");
+    expect(doc.compare.revisionId).toBe("local-revision");
+    expect(doc.diff.summary.sourceChanges).toBe(1);
+  });
+});
+

--- a/app/src/lib/notebookDiff/runtime.ts
+++ b/app/src/lib/notebookDiff/runtime.ts
@@ -1,0 +1,110 @@
+import type { NotebookTarget, NotebooksApi } from "../runtime/runmeConsole";
+import type { DriveNotebookStore, DriveRevision } from "../../storage/drive";
+import type LocalNotebooks from "../../storage/local";
+import { isDriveItemUri } from "../../storage/drive";
+import { computeNotebookDiff } from "./diff";
+import {
+  openNotebookDiffDocument,
+  registerNotebookDiffDocument,
+} from "./registry";
+import type { NotebookDiffDocument } from "./model";
+
+export type DriveNotebookRevision = DriveRevision & { id: string };
+
+export type NotebookDiffRuntimeApi = {
+  listDriveRevisions: (target?: NotebookTarget) => Promise<DriveNotebookRevision[]>;
+  diffDriveRevision: (args: {
+    target?: NotebookTarget;
+    revisionId: string;
+    includeOutputs?: boolean;
+    includeMetadata?: boolean;
+  }) => Promise<NotebookDiffDocument>;
+  openDiffTab: (diff: NotebookDiffDocument | { id: string }) => Promise<void>;
+  help: () => string;
+};
+
+export function createNotebookDiffRuntimeApi({
+  notebooksApi,
+  resolveLocalNotebooks,
+  resolveDriveNotebookStore,
+}: {
+  notebooksApi: NotebooksApi;
+  resolveLocalNotebooks: () => LocalNotebooks | null;
+  resolveDriveNotebookStore: () => DriveNotebookStore | null;
+}): NotebookDiffRuntimeApi {
+  const resolveDriveRemoteUri = async (target?: NotebookTarget) => {
+    const doc = await notebooksApi.get(target);
+    const localStore = resolveLocalNotebooks();
+    if (!localStore) {
+      throw new Error("Local notebook mirror store is not initialized yet.");
+    }
+    const metadata = await localStore.getMetadata(doc.handle.uri);
+    const remoteUri = metadata?.remoteUri;
+    if (!remoteUri || !isDriveItemUri(remoteUri)) {
+      throw new Error(
+        `Notebook ${doc.handle.uri} is not backed by a Google Drive file.`,
+      );
+    }
+    return { doc, remoteUri };
+  };
+
+  const requireDriveStore = () => {
+    const driveStore = resolveDriveNotebookStore();
+    if (!driveStore) {
+      throw new Error("Google Drive notebook store is not initialized yet.");
+    }
+    return driveStore;
+  };
+
+  return {
+    listDriveRevisions: async (target?: NotebookTarget) => {
+      const { remoteUri } = await resolveDriveRemoteUri(target);
+      const revisions = await requireDriveStore().listRevisions(remoteUri);
+      return revisions.filter((revision): revision is DriveNotebookRevision =>
+        Boolean(revision.id),
+      );
+    },
+    diffDriveRevision: async (args) => {
+      if (!args?.revisionId?.trim()) {
+        throw new Error("notebookDiff.diffDriveRevision requires revisionId.");
+      }
+      const { doc, remoteUri } = await resolveDriveRemoteUri(args.target);
+      const driveStore = requireDriveStore();
+      const baseNotebook = await driveStore.loadRevision(
+        remoteUri,
+        args.revisionId,
+      );
+      const diff = computeNotebookDiff(baseNotebook, doc.notebook, {
+        includeOutputs: args.includeOutputs ?? true,
+        includeMetadata: args.includeMetadata ?? true,
+      });
+      diff.baseLabel = `Drive revision ${args.revisionId}`;
+      diff.compareLabel = "Local copy";
+      return registerNotebookDiffDocument({
+        base: {
+          label: diff.baseLabel,
+          revisionId: args.revisionId,
+        },
+        compare: {
+          label: diff.compareLabel,
+          revisionId: doc.handle.revision,
+        },
+        diff,
+      });
+    },
+    openDiffTab: async (diff) => {
+      openNotebookDiffDocument(diff);
+    },
+    help: () =>
+      [
+        "notebookDiff.listDriveRevisions(target?)",
+        "notebookDiff.diffDriveRevision({ target?, revisionId, includeOutputs?, includeMetadata? })",
+        "notebookDiff.openDiffTab(diffOrId)",
+        "Example:",
+        "  const revisions = await notebookDiff.listDriveRevisions();",
+        "  const diff = await notebookDiff.diffDriveRevision({ revisionId: revisions.at(-2).id });",
+        "  await notebookDiff.openDiffTab(diff);",
+      ].join("\n"),
+  };
+}
+

--- a/app/src/lib/notebookDiff/runtime.ts
+++ b/app/src/lib/notebookDiff/runtime.ts
@@ -67,10 +67,19 @@ function normalizeTarget(target?: NotebookDiffTarget): NotebookTarget | undefine
   if (!target) {
     return undefined;
   }
-  if (typeof target.getUri === "function") {
+  if (hasGetUri(target)) {
     return { uri: target.getUri() };
   }
   return target;
+}
+
+function hasGetUri(
+  target: NotebookDiffTarget,
+): target is { getUri: () => string } {
+  return (
+    !!target &&
+    typeof (target as { getUri?: unknown }).getUri === "function"
+  );
 }
 
 export function createNotebookDiffRuntimeApi({

--- a/app/src/lib/notebookDiff/runtime.ts
+++ b/app/src/lib/notebookDiff/runtime.ts
@@ -10,11 +10,18 @@ import {
 import type { NotebookDiffDocument } from "./model";
 
 export type DriveNotebookRevision = DriveRevision & { id: string };
+type NotebookDiffTarget =
+  | NotebookTarget
+  | { getUri: () => string }
+  | null
+  | undefined;
 
 export type NotebookDiffRuntimeApi = {
-  listDriveRevisions: (target?: NotebookTarget) => Promise<DriveNotebookRevision[]>;
+  listDriveRevisions: (
+    target?: NotebookDiffTarget,
+  ) => Promise<DriveNotebookRevision[]>;
   diffDriveRevision: (args: {
-    target?: NotebookTarget;
+    target?: NotebookDiffTarget;
     revisionId: string;
     includeOutputs?: boolean;
     includeMetadata?: boolean;
@@ -22,6 +29,49 @@ export type NotebookDiffRuntimeApi = {
   openDiffTab: (diff: NotebookDiffDocument | { id: string }) => Promise<void>;
   help: () => string;
 };
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function toDriveNotebookRevision(
+  revision: DriveRevision,
+): DriveNotebookRevision | null {
+  const id = optionalString(revision.id);
+  if (!id) {
+    return null;
+  }
+  const lastModifyingUser =
+    revision.lastModifyingUser && typeof revision.lastModifyingUser === "object"
+      ? {
+          displayName: optionalString(revision.lastModifyingUser.displayName),
+          emailAddress: optionalString(revision.lastModifyingUser.emailAddress),
+        }
+      : undefined;
+
+  return {
+    id,
+    mimeType: optionalString(revision.mimeType),
+    modifiedTime: optionalString(revision.modifiedTime),
+    md5Checksum: optionalString(revision.md5Checksum),
+    size: optionalString(revision.size),
+    keepForever:
+      typeof revision.keepForever === "boolean"
+        ? revision.keepForever
+        : undefined,
+    lastModifyingUser,
+  };
+}
+
+function normalizeTarget(target?: NotebookDiffTarget): NotebookTarget | undefined {
+  if (!target) {
+    return undefined;
+  }
+  if (typeof target.getUri === "function") {
+    return { uri: target.getUri() };
+  }
+  return target;
+}
 
 export function createNotebookDiffRuntimeApi({
   notebooksApi,
@@ -32,8 +82,8 @@ export function createNotebookDiffRuntimeApi({
   resolveLocalNotebooks: () => LocalNotebooks | null;
   resolveDriveNotebookStore: () => DriveNotebookStore | null;
 }): NotebookDiffRuntimeApi {
-  const resolveDriveRemoteUri = async (target?: NotebookTarget) => {
-    const doc = await notebooksApi.get(target);
+  const resolveDriveRemoteUri = async (target?: NotebookDiffTarget) => {
+    const doc = await notebooksApi.get(normalizeTarget(target));
     const localStore = resolveLocalNotebooks();
     if (!localStore) {
       throw new Error("Local notebook mirror store is not initialized yet.");
@@ -57,12 +107,13 @@ export function createNotebookDiffRuntimeApi({
   };
 
   return {
-    listDriveRevisions: async (target?: NotebookTarget) => {
+    listDriveRevisions: async (target?: NotebookDiffTarget) => {
       const { remoteUri } = await resolveDriveRemoteUri(target);
       const revisions = await requireDriveStore().listRevisions(remoteUri);
-      return revisions.filter((revision): revision is DriveNotebookRevision =>
-        Boolean(revision.id),
-      );
+      return revisions.flatMap((revision) => {
+        const normalized = toDriveNotebookRevision(revision);
+        return normalized ? [normalized] : [];
+      });
     },
     diffDriveRevision: async (args) => {
       if (!args?.revisionId?.trim()) {
@@ -101,10 +152,10 @@ export function createNotebookDiffRuntimeApi({
         "notebookDiff.diffDriveRevision({ target?, revisionId, includeOutputs?, includeMetadata? })",
         "notebookDiff.openDiffTab(diffOrId)",
         "Example:",
-        "  const revisions = await notebookDiff.listDriveRevisions();",
-        "  const diff = await notebookDiff.diffDriveRevision({ revisionId: revisions.at(-2).id });",
+        "  const doc = await notebooks.get();",
+        "  const revisions = await notebookDiff.listDriveRevisions({ handle: doc.handle });",
+        "  const diff = await notebookDiff.diffDriveRevision({ target: { handle: doc.handle }, revisionId: revisions.at(-2).id });",
         "  await notebookDiff.openDiffTab(diff);",
       ].join("\n"),
   };
 }
-

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -37,6 +37,7 @@ import {
   registerImportedMarkdownForUri,
   toImportedNotebookName,
 } from '../markdownImport'
+import { createNotebookDiffRuntimeApi } from '../notebookDiff/runtime'
 import type { Runner } from '../runner'
 import { appState } from './AppState'
 import type {
@@ -192,6 +193,11 @@ export function createAppJsGlobals({
   const notebooksApi = createNotebooksApi({
     resolveNotebook: resolveNotebook ?? (() => runme.getCurrentNotebook()),
     listNotebooks,
+  })
+  const notebookDiffApi = createNotebookDiffRuntimeApi({
+    notebooksApi,
+    resolveLocalNotebooks: () => appState.localNotebooks,
+    resolveDriveNotebookStore: () => appState.driveNotebookStore,
   })
   const jupyterManager = getJupyterManager()
   const harnessManager = getHarnessManager()
@@ -594,6 +600,7 @@ export function createAppJsGlobals({
   return {
     runme: runmeApi,
     notebooks: notebooksHelpers,
+    notebookDiff: notebookDiffApi,
     codex: codexApi,
     opfs: {
       exists: (path: string) => {
@@ -1189,6 +1196,7 @@ export function createAppJsGlobals({
         'Available namespaces:',
         '  runme           - Notebook helpers (run all, clear outputs)',
         '  notebooks       - Notebook document API plus create/append helpers',
+        '  notebookDiff    - Compare Drive-backed notebook revisions',
         '  opfs            - Origin-private browser file storage helpers',
         '  net             - Browser network helpers',
         '  codex           - Codex project and turn-journal helpers',
@@ -1206,6 +1214,7 @@ export function createAppJsGlobals({
         'High-value commands:',
         '  await notebooks.createLocal("hello")',
         '  await notebooks.appendCodeCell({ value: "print(1)", languageId: "python" })',
+        '  const diff = await notebookDiff.diffDriveRevision({ revisionId })',
         '  runmeRunners.ensure("openai-local", "ws://localhost:9988/ws", { setDefault: true })',
         '',
         'Type <namespace>.help() for detailed commands, e.g. explorer.help()',

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -5,6 +5,7 @@ import {
   createAppKernelOpfsApi,
 } from './appKernelLowLevelApis'
 import { getCodexTurnEvents, listCodexTurns } from './codexTurns'
+import { createNotebookDiffRuntimeApi } from '../notebookDiff/runtime'
 import { JSKernel } from './jsKernel'
 import {
   type NotebooksApiBridgeServer,
@@ -12,6 +13,7 @@ import {
   createNotebooksApiBridgeServer,
 } from './notebooksApiBridge'
 import { type NotebookDataLike, createRunmeConsoleApi } from './runmeConsole'
+import { appState } from './AppState'
 import {
   CODE_MODE_SANDBOX_ALLOWED_METHODS,
   SandboxJSKernel,
@@ -107,11 +109,17 @@ export function createCodeModeExecutor(options: {
       })
       const opfsApi = createAppKernelOpfsApi()
       const networkApi = createAppKernelNetworkApi()
+      const hostNotebooksApi = createHostNotebooksApi({
+        resolveNotebook,
+        listNotebooks,
+      })
       const notebooksApiBridgeServer = createNotebooksApiBridgeServer({
-        notebooksApi: createHostNotebooksApi({
-          resolveNotebook,
-          listNotebooks,
-        }),
+        notebooksApi: hostNotebooksApi,
+      })
+      const notebookDiffApi = createNotebookDiffRuntimeApi({
+        notebooksApi: hostNotebooksApi,
+        resolveLocalNotebooks: () => appState.localNotebooks,
+        resolveDriveNotebookStore: () => appState.driveNotebookStore,
       })
 
       const chunks: string[] = []
@@ -178,6 +186,7 @@ export function createCodeModeExecutor(options: {
                     opfsApi,
                     networkApi,
                     notebooksApiBridgeServer,
+                    notebookDiffApi,
                   }),
               },
             }).run(normalizedCode, { signal: abortController.signal })
@@ -258,6 +267,7 @@ async function handleSandboxAppKernelBridgeCall({
   opfsApi,
   networkApi,
   notebooksApiBridgeServer,
+  notebookDiffApi,
 }: {
   method: string
   args: unknown[]
@@ -265,6 +275,7 @@ async function handleSandboxAppKernelBridgeCall({
   opfsApi: ReturnType<typeof createAppKernelOpfsApi>
   networkApi: ReturnType<typeof createAppKernelNetworkApi>
   notebooksApiBridgeServer: NotebooksApiBridgeServer
+  notebookDiffApi: ReturnType<typeof createNotebookDiffRuntimeApi>
 }): Promise<unknown> {
   const target = args[0]
   switch (method) {
@@ -340,6 +351,14 @@ async function handleSandboxAppKernelBridgeCall({
         String(args[0] ?? ''),
         (args[1] as { sessionId?: string }) ?? undefined
       )
+    case 'notebookDiff.listDriveRevisions':
+      return notebookDiffApi.listDriveRevisions(args[0] as any)
+    case 'notebookDiff.diffDriveRevision':
+      return notebookDiffApi.diffDriveRevision(args[0] as any)
+    case 'notebookDiff.openDiffTab':
+      return notebookDiffApi.openDiffTab(args[0] as any)
+    case 'notebookDiff.help':
+      return notebookDiffApi.help()
     default:
       if (method.startsWith('notebooks.')) {
         return notebooksApiBridgeServer.handleMessage({

--- a/app/src/lib/runtime/jsKernel.test.ts
+++ b/app/src/lib/runtime/jsKernel.test.ts
@@ -76,6 +76,23 @@ describe("JSKernel", () => {
 
     expect(stdout).toHaveBeenCalledWith('{"count":"1","nested":{"id":"2"}}\n');
   });
+
+  it("supports console.table for arrays of objects", async () => {
+    const stdout = vi.fn();
+    const kernel = new JSKernel({
+      hooks: {
+        onStdout: stdout,
+      },
+    });
+
+    await kernel.run(
+      'console.table([{ id: "1", size: 10 }, { id: "2", modifiedTime: "today" }]);',
+    );
+
+    expect(stdout).toHaveBeenCalledWith(
+      "(index)\tid\tsize\tmodifiedTime\n0\t1\t10\t\n1\t2\t\ttoday\n",
+    );
+  });
 });
 
 describe("JSKernel app globals", () => {

--- a/app/src/lib/runtime/jsKernel.ts
+++ b/app/src/lib/runtime/jsKernel.ts
@@ -115,7 +115,7 @@ export class JSKernel {
               "- d3: D3.js",
               "- app.clear(): clear the render container",
               "- app.render(fn): render into the container with a D3 selection",
-              "- console.log/info/warn/error: write to this console",
+              "- console.log/info/table/warn/error: write to this console",
               "- app.runners.get(): list configured runners",
               "- app.runners.update(name, endpoint): add/update a runner",
               "- app.runners.delete(name): remove a runner",
@@ -174,6 +174,8 @@ export class JSKernel {
     return {
       log: (...args: unknown[]) => stdout(this.formatArgs(args)),
       info: (...args: unknown[]) => stdout(this.formatArgs(args)),
+      table: (data: unknown, columns?: string[]) =>
+        stdout(this.formatTable(data, columns)),
       warn: (...args: unknown[]) => stderr(this.formatArgs(args)),
       error: (...args: unknown[]) => stderr(this.formatArgs(args)),
     };
@@ -196,6 +198,60 @@ export class JSKernel {
         })
         .join(" ") + "\n"
     );
+  }
+
+  private formatTable(data: unknown, columns?: string[]): string {
+    if (!Array.isArray(data)) {
+      return this.formatArgs([data]);
+    }
+
+    const normalizedRows = data.map((row, index) => {
+      if (row && typeof row === "object" && !Array.isArray(row)) {
+        return { index, values: row as Record<string, unknown> };
+      }
+      return { index, values: { value: row } };
+    });
+
+    const selectedColumns =
+      columns && columns.length > 0
+        ? columns
+        : Array.from(
+            normalizedRows.reduce((seen, row) => {
+              Object.keys(row.values).forEach((key) => seen.add(key));
+              return seen;
+            }, new Set<string>()),
+          );
+    const headers = ["(index)", ...selectedColumns];
+    const lines = [
+      headers.join("\t"),
+      ...normalizedRows.map((row) =>
+        [row.index, ...selectedColumns.map((key) => row.values[key])]
+          .map((value) =>
+            typeof value === "string" ? value : this.formatTableCell(value),
+          )
+          .join("\t"),
+      ),
+    ];
+    return `${lines.join("\n")}\n`;
+  }
+
+  private formatTableCell(value: unknown): string {
+    if (value === undefined) {
+      return "";
+    }
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    if (value && typeof value === "object") {
+      try {
+        return JSON.stringify(value, (_key, item) =>
+          typeof item === "bigint" ? item.toString() : item,
+        );
+      } catch {
+        return String(value);
+      }
+    }
+    return String(value);
   }
 
   private createAppHelpers(

--- a/app/src/lib/runtime/jsKernel.ts
+++ b/app/src/lib/runtime/jsKernel.ts
@@ -205,7 +205,10 @@ export class JSKernel {
       return this.formatArgs([data]);
     }
 
-    const normalizedRows = data.map((row, index) => {
+    const normalizedRows: Array<{
+      index: number;
+      values: Record<string, unknown>;
+    }> = data.map((row, index) => {
       if (row && typeof row === "object" && !Array.isArray(row)) {
         return { index, values: row as Record<string, unknown> };
       }

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -159,6 +159,56 @@ function buildSandboxSrcDoc(options: {
             })
             .join(" ") + "\\n";
 
+        const formatTableCell = (value) => {
+          if (value === undefined) {
+            return "";
+          }
+          if (typeof value === "bigint") {
+            return value.toString();
+          }
+          if (value && typeof value === "object") {
+            try {
+              return JSON.stringify(
+                value,
+                (_key, item) => (typeof item === "bigint" ? item.toString() : item),
+              );
+            } catch {
+              return String(value);
+            }
+          }
+          return String(value);
+        };
+
+        const formatTable = (data, columns) => {
+          if (!Array.isArray(data)) {
+            return formatArgs([data]);
+          }
+          const normalizedRows = data.map((row, index) => {
+            if (row && typeof row === "object" && !Array.isArray(row)) {
+              return { index, values: row };
+            }
+            return { index, values: { value: row } };
+          });
+          const selectedColumns = Array.isArray(columns) && columns.length > 0
+            ? columns
+            : Array.from(
+                normalizedRows.reduce((seen, row) => {
+                  Object.keys(row.values).forEach((key) => seen.add(key));
+                  return seen;
+                }, new Set()),
+              );
+          const headers = ["(index)", ...selectedColumns];
+          const lines = [
+            headers.join("\\t"),
+            ...normalizedRows.map((row) =>
+              [row.index, ...selectedColumns.map((key) => row.values[key])]
+                .map(formatTableCell)
+                .join("\\t"),
+            ),
+          ];
+          return lines.join("\\n") + "\\n";
+        };
+
         const post = (payload) => {
           if (!port) {
             return;
@@ -181,6 +231,7 @@ function buildSandboxSrcDoc(options: {
         const consoleProxy = {
           log: (...args) => post({ type: "stdout", data: formatArgs(args) }),
           info: (...args) => post({ type: "stdout", data: formatArgs(args) }),
+          table: (data, columns) => post({ type: "stdout", data: formatTable(data, columns) }),
           warn: (...args) => post({ type: "stderr", data: formatArgs(args) }),
           error: (...args) => post({ type: "stderr", data: formatArgs(args) }),
         };

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -41,6 +41,10 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'runme.help',
   'codex.turns.list',
   'codex.turns.getEvents',
+  'notebookDiff.listDriveRevisions',
+  'notebookDiff.diffDriveRevision',
+  'notebookDiff.openDiffTab',
+  'notebookDiff.help',
   ...SANDBOX_NOTEBOOKS_API_METHODS,
 ]
 
@@ -204,6 +208,12 @@ function buildSandboxSrcDoc(options: {
         });
 
         const notebooks = createSandboxNotebooksApiClient(hostCall);
+        const notebookDiff = {
+          listDriveRevisions: (target) => hostCall("notebookDiff.listDriveRevisions", [target]),
+          diffDriveRevision: (args) => hostCall("notebookDiff.diffDriveRevision", [args]),
+          openDiffTab: (diff) => hostCall("notebookDiff.openDiffTab", [diff]),
+          help: () => hostCall("notebookDiff.help", []),
+        };
         const codex = {
           turns: {
             list: () => hostCall("codex.turns.list", []),
@@ -239,6 +249,9 @@ function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.get([target]) # omitted target = current UI notebook");
           consoleProxy.log("- notebooks.update({ target, expectedRevision?, operations })");
           consoleProxy.log("- notebooks.execute({ target, refIds })");
+          consoleProxy.log("- notebookDiff.listDriveRevisions([target])");
+          consoleProxy.log("- notebookDiff.diffDriveRevision({ target?, revisionId, includeOutputs?, includeMetadata? })");
+          consoleProxy.log("- notebookDiff.openDiffTab(diff)");
           consoleProxy.log("- codex.turns.list()");
           consoleProxy.log("- codex.turns.getEvents(turnId, { sessionId? })");
           consoleProxy.log("- const [latest] = await codex.turns.list(); consoleProxy.log(await codex.turns.getEvents(latest.turnId));");
@@ -254,11 +267,12 @@ function buildSandboxSrcDoc(options: {
               "opfs",
               "net",
               "notebooks",
+              "notebookDiff",
               "codex",
               "help",
               '"use strict"; return (async () => {\\n' + code + '\\n})();',
             );
-            await runner(consoleProxy, runme, opfs, net, notebooks, codex, help);
+            await runner(consoleProxy, runme, opfs, net, notebooks, notebookDiff, codex, help);
           } catch (error) {
             exitCode = 1;
             post({ type: "stderr", data: String(error) + "\\n" });
@@ -534,7 +548,12 @@ export class SandboxJSKernel {
         resolve()
       }
       hostPort.addEventListener('message', onReady as EventListener)
-      iframe.contentWindow.postMessage({ type: SANDBOX_INIT_MESSAGE }, '*', [
+      const contentWindow = iframe.contentWindow
+      if (!contentWindow) {
+        reject(new Error('Sandbox iframe content window is unavailable.'))
+        return
+      }
+      contentWindow.postMessage({ type: SANDBOX_INIT_MESSAGE }, '*', [
         channel.port2,
       ])
     })

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -1,9 +1,18 @@
 /// <reference types="vitest" />
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import {
+  clearGoogleDriveRuntime,
+  setGoogleDriveBaseUrl,
+} from "../lib/googleDriveRuntime";
 import { NotebookStoreItemType } from "./notebook";
-import { isDriveItemUri, parseDriveItem } from "./drive";
+import { DriveNotebookStore, isDriveItemUri, parseDriveItem } from "./drive";
+
+afterEach(() => {
+  clearGoogleDriveRuntime();
+  vi.restoreAllMocks();
+});
 
 describe("parseDriveItem", () => {
   it("extracts id from file share URL", () => {
@@ -71,5 +80,41 @@ describe("isDriveItemUri", () => {
     expect(isDriveItemUri("0BwwA4oUTeiV1UVNwOHItT0xfa2M")).toBe(false);
     expect(isDriveItemUri("https://example.com/not-drive")).toBe(false);
     expect(isDriveItemUri("https://drive.google.com/not-a-drive-item")).toBe(false);
+  });
+});
+
+describe("DriveNotebookStore", () => {
+  it("paginates Drive revisions", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        const pageToken = url.searchParams.get("pageToken");
+        const body = pageToken
+          ? { revisions: [{ id: "revision-2", size: "20" }] }
+          : {
+              revisions: [{ id: "revision-1", size: "10" }],
+              nextPageToken: "next-page",
+            };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const revisions = await store.listRevisions(
+      "https://drive.google.com/file/d/file123/view",
+    );
+
+    expect(revisions.map((revision) => revision.id)).toEqual([
+      "revision-1",
+      "revision-2",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      new URL(String(fetchMock.mock.calls[1][0])).searchParams.get("pageToken"),
+    ).toBe("next-page");
   });
 });

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -607,6 +607,33 @@ export interface DriveRevision {
   };
 }
 
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeDriveRevision(revision: DriveRevision): DriveRevision {
+  const lastModifyingUser =
+    revision.lastModifyingUser && typeof revision.lastModifyingUser === "object"
+      ? {
+          displayName: optionalString(revision.lastModifyingUser.displayName),
+          emailAddress: optionalString(revision.lastModifyingUser.emailAddress),
+        }
+      : undefined;
+
+  return {
+    id: optionalString(revision.id),
+    mimeType: optionalString(revision.mimeType),
+    modifiedTime: optionalString(revision.modifiedTime),
+    md5Checksum: optionalString(revision.md5Checksum),
+    size: optionalString(revision.size),
+    keepForever:
+      typeof revision.keepForever === "boolean"
+        ? revision.keepForever
+        : undefined,
+    lastModifyingUser,
+  };
+}
+
 export function parseDriveItem(uri: string): DriveItem {
   if (!uri) {
     throw new Error("Google Drive URI must be provided");
@@ -921,7 +948,7 @@ export class DriveNotebookStore {
       fields:
         "revisions(id,mimeType,modifiedTime,md5Checksum,size,keepForever,lastModifyingUser(displayName,emailAddress))",
     });
-    return response.result?.revisions ?? [];
+    return (response.result?.revisions ?? []).map(normalizeDriveRevision);
   }
 
   async loadRevision(

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -13,9 +13,12 @@ const GAPI_SCRIPT_SRC = "https://apis.google.com/js/api.js";
 // VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file content version.
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
 const VERSION_FIELDS = "md5Checksum,headRevisionId";
+const NOTEBOOK_JSON_WRITE_OPTIONS = {
+  emitDefaultValues: true,
+} as unknown as Parameters<typeof toJsonString>[2];
 
 let gapiScriptPromise: Promise<void> | null = null;
-let clientPromise: Promise<GapiDriveFilesClient> | null = null;
+let clientPromise: Promise<DriveFilesClient> | null = null;
 
 // Minimal type definitions that describe just the specific pieces of the global
 // gapi client that this module relies on. This keeps the usage of window.gapi
@@ -40,6 +43,11 @@ type GapiDriveFileMethods = {
   list: (request: Record<string, unknown>) => Promise<unknown>;
 };
 
+type GapiDriveRevisionMethods = {
+  get: (request: Record<string, unknown>) => Promise<unknown>;
+  list: (request: Record<string, unknown>) => Promise<unknown>;
+};
+
 type GapiRequestArgs = {
   path: string;
   method?: string;
@@ -53,8 +61,10 @@ interface GapiGlobal {
   client: {
     load: (name: string, version: string) => Promise<void>;
     setToken: (token: { access_token: string }) => void;
+    getToken?: () => { access_token?: string } | null;
     drive: {
       files: GapiDriveFileMethods;
+      revisions: GapiDriveRevisionMethods;
     };
     request: (args: GapiRequestArgs) => Promise<unknown>;
   };
@@ -63,6 +73,7 @@ interface GapiGlobal {
 type DriveCreateResponse = { result?: DriveDoc };
 type DriveUpdateResponse = { result?: DriveDoc };
 type DriveListResponse = { result?: { files?: DriveDoc[] } };
+type DriveRevisionListResponse = { result?: { revisions?: DriveRevision[] } };
 
 interface DriveFilesClient {
   create(doc: DriveDoc): Promise<DriveDoc>;
@@ -71,14 +82,20 @@ interface DriveFilesClient {
     request: Record<string, unknown>,
   ): Promise<{ body?: string; result?: unknown }>;
   list(request: Record<string, unknown>): Promise<DriveListResponse>;
+  listRevisions(request: Record<string, unknown>): Promise<DriveRevisionListResponse>;
+  getRevision(
+    request: Record<string, unknown>,
+  ): Promise<{ body?: string; result?: unknown }>;
   ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc>;
 }
 
 class GapiDriveFilesClient implements DriveFilesClient {
   private readonly files: GapiDriveFileMethods;
+  private readonly revisions: GapiDriveRevisionMethods;
 
   constructor(private readonly gapi: GapiGlobal) {
     this.files = this.gapi.client.drive.files;
+    this.revisions = this.gapi.client.drive.revisions;
   }
 
   // setContent uploads content to a Google Drive file using a media upload.
@@ -105,7 +122,7 @@ class GapiDriveFilesClient implements DriveFilesClient {
         supportsAllDrives: "true",
       },
       headers: {
-        Authorization: `Bearer ${this.gapi.client["getToken"]()?.access_token}`,
+        Authorization: `Bearer ${this.gapi.client.getToken?.()?.access_token ?? ""}`,
         "Content-Type": mimeType ?? "application/octet-stream",
         "Content-Length": String(byteLength),
       },
@@ -183,6 +200,19 @@ class GapiDriveFilesClient implements DriveFilesClient {
 
   list(request: Record<string, unknown>): Promise<DriveListResponse> {
     return this.files.list(request as any) as Promise<DriveListResponse>;
+  }
+
+  listRevisions(request: Record<string, unknown>): Promise<DriveRevisionListResponse> {
+    return this.revisions.list(request as any) as Promise<DriveRevisionListResponse>;
+  }
+
+  getRevision(
+    request: Record<string, unknown>,
+  ): Promise<{ body?: string; result?: unknown }> {
+    return this.revisions.get(request as any) as Promise<{
+      body?: string;
+      result?: unknown;
+    }>;
   }
 
   async ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc> {
@@ -359,6 +389,30 @@ class FetchDriveFilesClient implements DriveFilesClient {
     }) as Promise<DriveListResponse>;
   }
 
+  listRevisions(request: Record<string, unknown>): Promise<DriveRevisionListResponse> {
+    const fileId = String(request.fileId ?? "");
+    return this.request(
+      "GET",
+      `/drive/v3/files/${encodeURIComponent(fileId)}/revisions`,
+      { params: request },
+    ) as Promise<DriveRevisionListResponse>;
+  }
+
+  getRevision(
+    request: Record<string, unknown>,
+  ): Promise<{ body?: string; result?: unknown }> {
+    const fileId = String(request.fileId ?? "");
+    const revisionId = String(request.revisionId ?? "");
+    return this.request(
+      "GET",
+      `/drive/v3/files/${encodeURIComponent(fileId)}/revisions/${encodeURIComponent(revisionId)}`,
+      {
+        params: request,
+        expectText: request.alt === "media",
+      },
+    );
+  }
+
   async ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc> {
     if (!file.id || !parentId) {
       return file;
@@ -470,9 +524,12 @@ async function ensureDriveFilesClient(
   }
 
   const gapi = await ensureGapi();
+  if (!gapi) {
+    throw new Error("Google API client is unavailable");
+  }
 
   if (!clientPromise) {
-    clientPromise = new Promise((resolve, reject) => {
+    clientPromise = new Promise<DriveFilesClient>((resolve, reject) => {
       gapi.load("client", {
         callback: async () => {
           try {
@@ -490,7 +547,11 @@ async function ensureDriveFilesClient(
     });
   }
 
-  const client = await clientPromise;
+  const pendingClient = clientPromise;
+  if (!pendingClient) {
+    throw new Error("Google Drive client initialization failed");
+  }
+  const client = await pendingClient;
   gapi.client.setToken({ access_token: accessToken });
   return client;
 }
@@ -531,6 +592,19 @@ type DriveFileMetadata = {
 export interface DriveVersionMetadata {
   md5Checksum?: string;
   headRevisionId?: string;
+}
+
+export interface DriveRevision {
+  id?: string;
+  mimeType?: string;
+  modifiedTime?: string;
+  md5Checksum?: string;
+  size?: string;
+  keepForever?: boolean;
+  lastModifyingUser?: {
+    displayName?: string;
+    emailAddress?: string;
+  };
 }
 
 export function parseDriveItem(uri: string): DriveItem {
@@ -633,9 +707,7 @@ function createInitialNotebookJson(): string {
   const notebook = create(parser_pb.NotebookSchema, {
     cells: [],
   });
-  return toJsonString(parser_pb.NotebookSchema, notebook, {
-    emitDefaultValues: true,
-  });
+  return toJsonString(parser_pb.NotebookSchema, notebook, NOTEBOOK_JSON_WRITE_OPTIONS);
 }
 
 function extractBody(response: { body?: string; result?: unknown }): string {
@@ -657,7 +729,7 @@ export class DriveNotebookStore {
 
   private readonly lastReadVersion = new Map<string, string>();
 
-  private async getFilesClient(): Promise<GapiDriveFilesClient> {
+  private async getFilesClient(): Promise<DriveFilesClient> {
     const token = await this.ensureAccessToken();
     return ensureDriveFilesClient(token);
   }
@@ -678,16 +750,17 @@ export class DriveNotebookStore {
     if (!file.id) {
       throw new Error("Failed to create Google Drive notebook file");
     }
+    const fileId = file.id;
     file = await client.ensureParent(file, id);
     const isFolder = file.mimeType === "application/vnd.google-apps.folder";
     return {
-      uri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
+      uri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       name: file.name ?? name,
       type: isFolder
         ? NotebookStoreItemType.Folder
         : NotebookStoreItemType.File,
       children: [],
-      remoteUri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
+      remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       parents: [parentUri],
     };
   }
@@ -719,9 +792,11 @@ export class DriveNotebookStore {
       );
       return { conflicted: true };
     }
-    const json = toJsonString(parser_pb.NotebookSchema, notebook, {
-      emitDefaultValues: true,
-    });
+    const json = toJsonString(
+      parser_pb.NotebookSchema,
+      notebook,
+      NOTEBOOK_JSON_WRITE_OPTIONS,
+    );
 
     await client.update({
       id,
@@ -832,6 +907,45 @@ export class DriveNotebookStore {
     });
     const result = metadataResponse.result as DriveVersionMetadata | undefined;
     return result ?? null;
+  }
+
+  async listRevisions(uri: string): Promise<DriveRevision[]> {
+    const { id, type } = parseDriveItem(uri);
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error("DriveNotebookStore.listRevisions expects a file URI");
+    }
+    const client = await this.getFilesClient();
+    const response = await client.listRevisions({
+      fileId: id,
+      supportsAllDrives: true,
+      fields:
+        "revisions(id,mimeType,modifiedTime,md5Checksum,size,keepForever,lastModifyingUser(displayName,emailAddress))",
+    });
+    return response.result?.revisions ?? [];
+  }
+
+  async loadRevision(
+    uri: string,
+    revisionId: string,
+  ): Promise<parser_pb.Notebook> {
+    const { id, type } = parseDriveItem(uri);
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error("DriveNotebookStore.loadRevision expects a file URI");
+    }
+    if (!revisionId?.trim()) {
+      throw new Error("DriveNotebookStore.loadRevision requires a revision id");
+    }
+    const client = await this.getFilesClient();
+    const response = await client.getRevision({
+      fileId: id,
+      revisionId: revisionId.trim(),
+      supportsAllDrives: true,
+      alt: "media",
+    });
+    const body = extractBody(response);
+    return fromJsonString(parser_pb.NotebookSchema, body, {
+      ignoreUnknownFields: true,
+    });
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -73,7 +73,9 @@ interface GapiGlobal {
 type DriveCreateResponse = { result?: DriveDoc };
 type DriveUpdateResponse = { result?: DriveDoc };
 type DriveListResponse = { result?: { files?: DriveDoc[] } };
-type DriveRevisionListResponse = { result?: { revisions?: DriveRevision[] } };
+type DriveRevisionListResponse = {
+  result?: { revisions?: DriveRevision[]; nextPageToken?: string };
+};
 
 interface DriveFilesClient {
   create(doc: DriveDoc): Promise<DriveDoc>;
@@ -942,13 +944,22 @@ export class DriveNotebookStore {
       throw new Error("DriveNotebookStore.listRevisions expects a file URI");
     }
     const client = await this.getFilesClient();
-    const response = await client.listRevisions({
-      fileId: id,
-      supportsAllDrives: true,
-      fields:
-        "revisions(id,mimeType,modifiedTime,md5Checksum,size,keepForever,lastModifyingUser(displayName,emailAddress))",
-    });
-    return (response.result?.revisions ?? []).map(normalizeDriveRevision);
+    const revisions: DriveRevision[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const response = await client.listRevisions({
+        fileId: id,
+        supportsAllDrives: true,
+        fields:
+          "nextPageToken,revisions(id,mimeType,modifiedTime,md5Checksum,size,keepForever,lastModifyingUser(displayName,emailAddress))",
+        ...(pageToken ? { pageToken } : {}),
+      });
+      revisions.push(...(response.result?.revisions ?? []));
+      pageToken = optionalString(response.result?.nextPageToken);
+    } while (pageToken);
+
+    return revisions.map(normalizeDriveRevision);
   }
 
   async loadRevision(

--- a/docs-dev/design/20260522_notebook_diffs.md
+++ b/docs-dev/design/20260522_notebook_diffs.md
@@ -1,0 +1,789 @@
+# Notebook Diffs
+
+Date: 2026-05-22
+
+Builds on:
+
+- `docs-dev/design/20260409_refactor_notebooks.md`
+- `docs-dev/design/20260409_track_drive_versions.md`
+- `docs-dev/design/20260511_markdown_serialization.md`
+
+## Summary
+
+Render differences between two versions of the same notebook so users can
+understand and resolve changes.
+
+The UI should feel closer to Google Colab's notebook-aware diff than to a raw
+JSON diff. Users should see cells as the primary unit, with inline source
+changes, output changes, inserted/deleted cells, moved cells when we can detect
+them, and metadata changes only when they matter.
+
+Recommended first step:
+
+1. Build a browser-side two-way diff model for Runme notebooks.
+2. Render that model with existing cell rendering components in a read-only diff
+   view.
+3. Defer automatic merge/conflict resolution until the two-way diff UI is
+   usable.
+4. Use `nbdime` as the main prior-art reference, not as a dependency for v0.
+
+## Problem
+
+Runme stores editable notebooks as structured protobuf JSON in the local mirror.
+Generic line-based diffs do a poor job on that representation because they
+highlight storage shape instead of authored content.
+
+The user needs to answer questions such as:
+
+- Which cells were added, removed, or edited?
+- Did source code change, or only outputs?
+- Did generated execution metadata change?
+- Can I accept the local version, the remote version, or a specific cell-level
+  change?
+
+These questions come up naturally in sync and version workflows:
+
+- Google Drive revision comparison.
+- Local mirror versus upstream conflict resolution.
+- Future restore/version history UI.
+- Potential git-backed file workflows.
+
+## Goals
+
+- Compare two notebook versions in the browser.
+- Show a notebook-aware diff organized by cells.
+- Highlight source changes inline for markdown, HTML, and code cells.
+- Show output changes without making generated output noise dominate the view.
+- Keep the diff computation independent from the React rendering layer.
+- Make the diff model reusable for future conflict resolution.
+- Treat execution counters, transient run state, and volatile metadata as
+  ignorable by default.
+- Support Runme notebooks in V0.
+
+## Non-Goals
+
+- Full three-way merge in the first milestone.
+- Exact parity with Google Colab.
+- Exact compatibility with `nbdime`'s internal diff format.
+- Rendering every rich output type in v0.
+- Git integration in the first milestone.
+- Converting Runme notebooks to `.ipynb` solely to diff them.
+- Direct `.ipynb` diff support in V0.
+
+## Current Implementation Context
+
+The app-facing persistence path is:
+
+```text
+NotebookData / editor tabs
+  -> local://file/<id>
+  -> LocalNotebooks / IndexedDB
+  -> optional upstream from LocalFileRecord.remoteId
+```
+
+`LocalFileRecord` persists:
+
+- stable local URI,
+- upstream URI,
+- serialized notebook JSON,
+- local checksum,
+- last observed upstream checksum/revision metadata,
+- sync status/error metadata.
+
+`NotebookData` owns one in-memory `parser_pb.Notebook` and exposes immutable
+snapshots for React rendering. Cells have stable `refId` values and include:
+
+- `kind`,
+- `languageId`,
+- `value`,
+- `metadata`,
+- `outputs`.
+
+The web app already has browser-side notebook serialization for search sidecars:
+
+- `app/src/lib/markdown/serializeNotebookToMarkdown.ts`
+
+That serializer is useful as a reference for text extraction, but it is not the
+right diff representation. A diff needs to preserve cell identity and structure
+instead of flattening the notebook to Markdown.
+
+## Prior Art
+
+### Jupyter Notebook Format
+
+Jupyter notebooks are structured JSON documents with top-level `metadata`,
+`nbformat`, `nbformat_minor`, and `cells`. Code cells contain source and
+outputs. Outputs can be stream text, rich mime bundles, execution results, or
+errors. Newer Jupyter notebooks also have stable cell ids.
+
+Source:
+
+- <https://nbformat.readthedocs.io/en/latest/format_description.html>
+
+Design implication:
+
+- Notebook diffing should operate on notebook structure first, not on serialized
+  JSON lines.
+- Stable cell ids are the best matching key when present. Runme's `refId` can
+  play the same role for Runme-native notebooks.
+
+### nbdime
+
+`nbdime` is Project Jupyter's purpose-built tool for diffing and merging
+Jupyter notebooks. It provides:
+
+- terminal notebook diffs,
+- web-rendered notebook diffs,
+- two-way diff,
+- three-way merge,
+- git and Mercurial integration,
+- notebook extensions,
+- a REST API,
+- a structured JSON-compatible diff format.
+
+Sources:
+
+- <https://nbdime.readthedocs.io/en/latest/>
+- <https://github.com/jupyter/nbdime>
+- <https://nbdime.readthedocs.io/en/latest/diffing.html>
+- <https://nbdime.readthedocs.io/en/latest/merging.html>
+- <https://nbdime.readthedocs.io/en/latest/restapi.html>
+
+Important ideas to borrow:
+
+- Diff the logical notebook tree, not the raw file.
+- Represent changes as operations over mappings, sequences, and strings.
+- Treat generated fields specially. `nbdime` can auto-resolve generated values
+  such as execution counters.
+- Render image/rich-output diffs differently from text diffs.
+- Use three-way merge decisions when resolving conflicts.
+
+Important ideas not to copy directly in v0:
+
+- Do not introduce a Python server dependency only to compute diffs.
+- Do not make Runme's diff model depend on `.ipynb` field names.
+- Do not adopt the full `nbdime` merge format before we know our conflict UI.
+
+### JupyterLab Git
+
+`jupyterlab-git` is a JupyterLab extension for Git workflows. It exposes file
+diffs from the JupyterLab Git panel and supports click-to-diff behavior. It is
+useful prior art for where a notebook diff appears in a larger app workflow,
+not necessarily for Runme's diff computation.
+
+Source:
+
+- <https://github.com/jupyterlab/jupyterlab-git>
+
+Design implication:
+
+- Diff UI should be reachable from version/sync surfaces, not only from a
+  standalone compare page.
+- The app should support a read-only review path before it supports write-back
+  resolution.
+
+### Google Colab
+
+Colab is the product reference for the target interaction: users compare
+notebook versions as notebook cells, not as raw JSON.
+
+Current gaps:
+
+- We should capture screenshots or a short behavior inventory from Colab before
+  committing to detailed visual parity.
+- Public Colab docs do not appear to define a reusable diff algorithm or API.
+
+Design implication:
+
+- Treat Colab as UX inspiration, not as implementation prior art.
+
+## Proposed Architecture
+
+Separate diff computation from rendering.
+
+```text
+base notebook + compare notebook
+  -> normalize notebook trees
+  -> match cells
+  -> compute structured cell diffs
+  -> NotebookDiff model
+  -> read-only React diff view
+  -> later: resolution actions
+```
+
+## Code-Centric V0
+
+V0 should expose notebook diffing as browser-kernel functions before we build a
+polished product workflow.
+
+Users should be able to write JavaScript in an AppKernel browser cell to:
+
+1. list earlier versions of the current Drive-backed notebook,
+2. compute a diff between the local mirror and a selected earlier version,
+3. open the rendered diff in an app tab.
+
+This fits the current Runme workflow:
+
+- AppKernel already exposes browser-local helpers such as `notebooks` and
+  `drive`.
+- Code cells are a natural testing surface for early functionality.
+- We can dogfood the diff model without deciding the final sync-conflict UI.
+- We can keep the first implementation browser-only.
+
+### Google Drive Version Concept
+
+Use Google Drive `Revision` as the backing concept for earlier Drive versions.
+
+Relevant Drive API facts:
+
+- A file has `revisions`.
+- `revisions.list` lists available revisions for a file.
+- `revisions.get` fetches revision metadata or content by `fileId` and
+  `revisionId`.
+- Passing `alt=media` to `revisions.get` returns the revision contents in the
+  response body.
+- Drive blob revisions can be purged. Non-head blob revisions are typically
+  purgeable unless marked `keepForever`.
+- `Revision` metadata includes fields such as `id`, `mimeType`, `md5Checksum`,
+  `modifiedTime`, `size`, and `lastModifyingUser`.
+
+Sources:
+
+- <https://developers.google.com/workspace/drive/api/reference/rest/v3/revisions>
+- <https://developers.google.com/workspace/drive/api/reference/rest/v3/revisions/list>
+- <https://developers.google.com/workspace/drive/api/reference/rest/v3/revisions/get>
+- <https://developers.google.com/workspace/drive/api/guides/manage-revisions>
+
+Design implication:
+
+- The API should say "available Drive revisions", not "complete notebook
+  history".
+- V0 should compare the local mirror against a selected available revision.
+- If an older revision is missing from Drive's API response, the app should
+  report that limitation instead of trying to synthesize history.
+
+### Runtime Helper API
+
+Expose a new helper namespace in the browser kernel:
+
+```ts
+type DriveNotebookRevision = {
+  id: string;
+  modifiedTime?: string;
+  md5Checksum?: string;
+  size?: string;
+  lastModifyingUser?: {
+    displayName?: string;
+    emailAddress?: string;
+  };
+};
+
+type NotebookDiffDocument = {
+  id: string;
+  base: {
+    label: string;
+    notebook: parser_pb.Notebook;
+    revisionId?: string;
+  };
+  compare: {
+    label: string;
+    notebook: parser_pb.Notebook;
+    revisionId?: string;
+  };
+  diff: NotebookDiff;
+};
+
+type NotebookDiffRuntimeApi = {
+  listDriveRevisions(
+    target?: { uri: string } | { handle: { uri: string; revision: string } }
+  ): Promise<DriveNotebookRevision[]>;
+
+  diffDriveRevision(args: {
+    target?: { uri: string } | { handle: { uri: string; revision: string } };
+    revisionId: string;
+    includeOutputs?: boolean;
+    includeMetadata?: boolean;
+  }): Promise<NotebookDiffDocument>;
+
+  openDiffTab(diff: NotebookDiffDocument | { id: string }): Promise<void>;
+
+  help(): string;
+};
+```
+
+Example usage:
+
+```js
+const revisions = await notebookDiff.listDriveRevisions();
+console.table(revisions.map((r) => ({
+  id: r.id,
+  modifiedTime: r.modifiedTime,
+  md5Checksum: r.md5Checksum,
+})));
+
+const diff = await notebookDiff.diffDriveRevision({
+  revisionId: revisions.at(-2).id,
+  includeOutputs: false,
+});
+
+await notebookDiff.openDiffTab(diff);
+```
+
+Naming note:
+
+- `base` should be the earlier Drive revision.
+- `compare` should be the current local mirror.
+- The rendered tab can label them as "Drive revision <id>" and "Local copy".
+
+### Fetching the Earlier Notebook
+
+`diffDriveRevision` should:
+
+1. Resolve the target notebook. If omitted, use the current notebook selected in
+   the UI.
+2. Look up the local mirror record and require a Drive-backed `remoteId`.
+3. Parse the Drive file id from `remoteId`.
+4. Call `revisions.get(fileId, revisionId, alt=media)` to fetch the earlier
+   blob content.
+5. Deserialize the returned JSON into `parser_pb.Notebook`.
+6. Compare it with the current local notebook from `notebooks.get`.
+7. Return a `NotebookDiffDocument`.
+
+Do not fetch the current version back from Drive for this V0 path. The point of
+the flow is to compare "what I have locally right now" against "an earlier
+Drive revision".
+
+Open question:
+
+- Existing Drive code tracks `files.headRevisionId` as
+  `LocalFileRecord.lastUpstreamVersion.revisionId`. We should confirm whether
+  that id can always be passed to `revisions.get` for blob notebook files in our
+  current auth/scopes.
+
+### Opening a Diff Tab
+
+`openDiffTab` should register an in-memory diff document and open a local app
+route, for example:
+
+```text
+/diff/<diffDocumentId>
+```
+
+The route should read the diff document from an app-local registry.
+
+This avoids encoding large notebook payloads into the URL and avoids persisting
+experimental diff state in IndexedDB. If the user refreshes the page, the app
+can show "Diff no longer available; recompute it from the browser kernel."
+
+Future versions can persist diff documents when a stable product workflow needs
+shareable or reloadable diff URLs.
+
+### Why Start With Runtime Helpers
+
+This is intentionally developer-oriented.
+
+Benefits:
+
+- We can test Drive revision fetch, notebook diffing, and rendering separately.
+- We can write reproducible notebook cells that exercise real Drive-backed
+  notebooks.
+- We do not need to design the final review button, conflict modal, or version
+  picker before validating the diff model.
+- The same helper API can later power UI actions.
+
+Tradeoff:
+
+- V0 will not be discoverable for normal users. That is acceptable because the
+  main risk is correctness and rendering quality, not entry-point placement.
+
+### Diff Computation
+
+Add a pure TypeScript module:
+
+- `app/src/lib/notebookDiff/`
+
+Suggested first API:
+
+```ts
+export type NotebookDiffOptions = {
+  includeOutputs?: boolean;
+  includeMetadata?: boolean;
+  ignoreTransientMetadata?: boolean;
+};
+
+export type NotebookDiff = {
+  baseLabel?: string;
+  compareLabel?: string;
+  cells: CellDiff[];
+  notebookMetadata?: JsonDiff;
+  summary: NotebookDiffSummary;
+};
+
+export type CellDiff =
+  | UnchangedCellDiff
+  | InsertedCellDiff
+  | DeletedCellDiff
+  | ModifiedCellDiff
+  | MovedCellDiff;
+```
+
+The implementation should not expose raw JSON patch operations as the primary
+UI contract. The UI needs cell-level concepts:
+
+- inserted,
+- deleted,
+- modified,
+- moved,
+- unchanged with optional folding,
+- source changed,
+- outputs changed,
+- metadata changed.
+
+Use lower-level text/json diff libraries internally if needed.
+
+V0 should target Runme notebooks only. The diff engine may use a small
+normalized internal shape if it keeps the implementation clean, but it does not
+need to support imported `.ipynb` notebooks. A Jupyter adapter can be added
+later if direct `.ipynb` comparison becomes a product requirement.
+
+### Notebook Normalization
+
+Normalize before diffing:
+
+- clone the proto objects into plain JSON-like structures,
+- drop volatile metadata by default,
+- normalize missing arrays/maps,
+- normalize trailing whitespace according to a documented option,
+- decode text-like output payloads where practical,
+- replace binary output payloads with stable summaries.
+
+Default ignored metadata should include:
+
+- active process ids,
+- last run ids,
+- transient execution status,
+- fields that only reflect in-progress execution.
+
+Do not ignore authored metadata such as runner selection, language selection, or
+cell visibility until we decide whether the user needs to see those changes.
+
+### Cell Matching
+
+Use a tiered matching strategy:
+
+1. Match by `refId` when both notebooks have unique stable refs.
+2. Match by exact authored content when `refId` is missing or duplicated.
+3. Match by similarity over `kind`, `languageId`, and `value`.
+4. Treat remaining cells as insertions/deletions.
+
+Move detection should be best-effort. A cell with the same `refId` but different
+index is a move. A moved and edited cell should be represented as both moved and
+modified.
+
+Resolved:
+
+- Runme notebook cell `refId` values are durable across save and load.
+- Runme should keep `refId` values as stable as possible across import, export,
+  copy, and duplicate operations because diff quality depends on stable cell
+  identity.
+- If an operation would create duplicate `refId` values within one notebook, it
+  should regenerate only the copied/inserted cell refs needed to preserve
+  per-notebook uniqueness.
+
+### Source Diff
+
+For `value` changes, compute an inline text diff.
+
+Requirements:
+
+- line-level hunks for multi-line code and markdown,
+- word-level highlighting within modified lines when cheap enough,
+- stable behavior for long cells,
+- syntax highlighting for code cells if the renderer already supports it.
+
+Potential implementation choices:
+
+- Use an existing JavaScript diff package for line/word chunks.
+- Use Monaco diff editor in read-only mode for expanded source diffs.
+- Start with a lightweight line/word diff and revisit Monaco only if needed.
+
+Recommendation for v0:
+
+- Use a lightweight pure TypeScript diff package for the model.
+- Render the result with app-owned components.
+
+Reason:
+
+- Monaco is strong for source diff, but notebook diff also needs cell
+  insertion, deletion, output, and metadata structure. Putting Monaco at the
+  center can make the non-source parts harder to model.
+
+### Output Diff
+
+Output diffs should be enabled by default.
+
+Recommended v0 behavior:
+
+- Always indicate when outputs differ.
+- Text outputs: show inline line diffs.
+- JSON outputs: pretty-print and diff as text.
+- HTML outputs: show source diff first; rendered preview can come later.
+- Images and binary outputs: show added/removed/changed summaries based on mime
+  type, size, and checksum.
+- Stateful Runme terminal/output internals: hide by default.
+- Fold large or noisy output bodies by default so output changes do not dominate
+  the cell source diff.
+
+Future behavior:
+
+- Render image diffs for matching image mime types.
+- Render rich output previews side by side in sandboxed containers.
+- Let users toggle "source only", "source + text outputs", and "all outputs".
+
+Resolution behavior:
+
+- Do not merge outputs in V0.
+- If a conflict resolution or merge path creates a resolved notebook, clear
+  outputs for affected cells.
+- Users can rerun cells after resolving authored source and metadata.
+- Output-only divergence still counts as a sync conflict. The app should let
+  the user decide which notebook state to preserve, even when authored source
+  and metadata are unchanged.
+
+Reason:
+
+- Output merge semantics are ill-defined. Outputs are generated artifacts, can
+  depend on external state, and may not be reproducible from either side of the
+  diff. Clearing outputs is simpler and avoids creating misleading combined
+  results.
+
+### Metadata Diff
+
+Metadata should be summarized, not shown as a raw JSON tree by default.
+
+Recommended v0 behavior:
+
+- Hide transient metadata.
+- Show user-visible metadata changes as compact badges or an expandable JSON
+  section.
+- Include metadata changes in the summary count so hidden changes are not
+  invisible.
+
+Examples:
+
+- runner changed,
+- language changed,
+- Jupyter server/kernel selection changed,
+- hidden/collapsed state changed.
+
+Design question:
+
+- Which metadata keys should affect notebook diffs, and which should be ignored
+  as execution noise?
+
+This matters because notebook metadata mixes two kinds of state:
+
+- Authored user state: configuration that changes notebook behavior or user
+  intent, such as runner selection, language/runtime selection, visibility, or
+  cell presentation settings.
+- Transient execution state: values created while running cells, such as process
+  ids, active run ids, exit status, execution sequence, streaming/incomplete
+  output markers, and timestamps.
+
+The diff should show authored state because users may need to review or resolve
+it. The diff should hide transient execution state by default because it changes
+frequently and can make two notebooks look different even when the authored
+content is the same.
+
+The decision we need is a concrete allowlist or blocklist:
+
+- Show by default: metadata that affects how the notebook runs or renders.
+- Hide by default: metadata that only records a past or in-progress execution.
+- Put behind an "advanced metadata" toggle: diagnostic metadata that can be
+  useful for debugging but is not normally part of user-authored notebook
+  content.
+
+Decision for V0:
+
+- Start with this show/hide/advanced split.
+- Treat the exact metadata key lists as implementation details that we can
+  refine as we inspect real notebooks.
+- Prefer hiding execution noise over showing every possible metadata change.
+
+## Rendering Design
+
+Add a read-only diff route or panel that takes two notebook versions and a
+comparison label.
+
+The V0 UI should use a side-by-side notebook diff as the single canonical view:
+
+- diff rows appear in notebook order,
+- the base version appears in the left column,
+- the compare version appears in the right column,
+- inserted cells render with an empty left column and an added right column,
+- deleted cells render with a deleted left column and an empty right column,
+- modified cells render both versions side by side,
+- unchanged cells are collapsed by default across both columns,
+- outputs appear below the source for each side when enabled.
+
+Markdown cells should render as source diffs in V0. Do not add a separate
+rendered Markdown preview path in the first implementation. Source diff is the
+authored state users resolve, and keeping one representation avoids a second
+view mode.
+
+Use one viewing mode in V0. Do not build both vertical and side-by-side
+renderers.
+
+Reasons:
+
+- It is closer to Colab's comparison model.
+- It makes before/after review more direct.
+- It avoids spending V0 effort on maintaining two render paths.
+- A single canonical view makes testing and user feedback easier.
+
+Simplifications for V0:
+
+- Do not try to perfectly synchronize line heights inside source diffs.
+- Use row-level alignment for cells, not pixel-perfect alignment for every
+  line.
+- Collapse unchanged cells by default.
+- Fold outputs by default if they make a row too tall.
+- On narrow screens, allow horizontal scrolling instead of introducing a
+  separate vertical renderer.
+- Do not virtualize diff rows in V0. If very large notebooks are slow, add a
+  temporary warning or cap before building virtualization.
+
+Virtualization can become necessary when the diff view tries to mount too many
+expensive rows at once:
+
+- notebooks with hundreds or thousands of cells,
+- cells with very large source blocks,
+- cells with large outputs,
+- syntax-highlighted code on both sides,
+- markdown preview rendering for many changed cells,
+- side-by-side layout measurement across many rows.
+
+Punt on this for V0. The first implementation should optimize for correctness
+and simpler rendering. If real notebooks expose performance problems, add
+virtualization after the row model stabilizes.
+
+Resolution actions should be out of scope for the first render-only milestone.
+When we add them, use whole-cell resolution for V0:
+
+- accept base cell,
+- accept compare cell,
+- delete cell,
+- keep both cells.
+
+Do not offer output merge actions in V0. Resolution should produce authored
+notebook state, then clear outputs for the cells touched by resolution.
+
+Do not support source-hunk, metadata-only, or output-subpart resolution in V0.
+Those can be added later if whole-cell resolution is too coarse.
+
+## Version and Sync Integration
+
+The initial diff entry points should come from version-aware workflows:
+
+1. Browser-kernel helper: compare current local notebook with an available
+   Drive revision.
+2. Compare local mirror with upstream version during a sync conflict.
+3. Compare current local notebook with an older Drive revision from a UI picker.
+4. Compare two saved local snapshots once snapshot history exists.
+
+Google Drive-backed notebooks already track upstream version metadata in
+`LocalFileRecord.lastUpstreamVersion`. That metadata can label the two sides of
+the diff, but the diff should compare notebook payloads, not revision ids.
+
+Output-only changes should count as sync conflicts. Outputs are part of the
+persisted notebook state, so the app should not silently choose local or
+upstream output state when they diverge. V0 resolution can still clear outputs
+for affected cells rather than trying to merge them.
+
+Open implementation question:
+
+- How do we fetch older Drive revisions in the browser without broadening Drive
+  scopes or introducing a backend helper?
+
+Initial answer:
+
+- Use Drive `revisions.list` and `revisions.get(..., alt=media)` for
+  Drive-backed blob notebook files.
+- Require the browser OAuth credential to include scopes that can read the
+  Drive file and its revision history.
+- Accept that Drive's revision list can be incomplete and that older blob
+  revisions can be purged.
+
+Decision for V0:
+
+- Drive revision fetch should happen in the browser.
+- The implementation can assume the active OAuth credential has the required
+  Drive scopes to fetch notebook documents and revision contents.
+- If the credential lacks scope, the helper should fail with an auth/scope error
+  instead of falling back to a backend.
+
+## Proposed Milestones
+
+### Milestone 1: Code-Centric V0
+
+- Add `app/src/lib/notebookDiff/`.
+- Add a runtime `notebookDiff` helper namespace.
+- Implement `notebookDiff.listDriveRevisions`.
+- Implement `notebookDiff.diffDriveRevision`.
+- Implement `notebookDiff.openDiffTab`.
+- Add a minimal read-only diff route backed by an in-memory diff registry.
+- Add one browser-kernel example cell that lists revisions, computes a diff,
+  and opens the diff tab.
+
+### Milestone 2: Research and Fixtures
+
+- Capture Colab screenshot examples for added, deleted, edited, moved cells,
+  output-only changes, and metadata-only changes.
+- Add notebook fixture pairs under `app/test/fixtures/notebooks/diffs/`.
+- Add expected `NotebookDiff` JSON snapshots.
+
+### Milestone 3: Pure Diff Model
+
+- Implement normalization.
+- Implement cell matching.
+- Implement source and text-output diffs.
+- Add unit tests for each fixture pair.
+
+### Milestone 4: Read-Only Renderer
+
+- Improve the read-only React diff view.
+- Render inserted/deleted/modified cells.
+- Fold unchanged cells.
+- Add output diff toggles.
+- Add browser tests with representative fixtures.
+
+### Milestone 5: Sync Conflict Entry Point
+
+- When sync detects a local/upstream conflict, expose a "Review changes" action.
+- Load both versions.
+- Open the diff view with local and upstream labels.
+- Keep resolution manual in this milestone.
+
+### Milestone 6: Resolution
+
+- Extend the diff model toward three-way decisions.
+- Use base/local/remote versions when available.
+- Add cell-level accept actions.
+- Persist the resolved notebook through `LocalNotebooks`.
+
+## Open Questions
+
+None for V0.
+
+## Recommendation
+
+Build a Runme-native diff model in TypeScript and use `nbdime` as the design
+reference.
+
+Do not shell out to `nbdime` or require a Python/Jupyter server in v0. That
+would make notebook review depend on an optional runtime and would not fit the
+browser-first local mirror architecture.
+
+The model should be intentionally close to notebook concepts rather than a
+generic JSON patch. We can add JSON-patch export or `nbdime` compatibility
+later if integrations need it.

--- a/docs/16-notebook-diffs.md
+++ b/docs/16-notebook-diffs.md
@@ -19,20 +19,45 @@ inspect revisions, compute the diff, and open the rendered diff view.
 Run this in a JavaScript cell using the AppKernel browser runner:
 
 ```js
-const revisions = await notebookDiff.listDriveRevisions();
+const target = {
+  uri: "local://file/a2d06400-8b02-4965-b26c-5e977945267f",
+};
 
-console.table(
-  revisions.map((revision) => ({
-    id: revision.id,
-    modifiedTime: revision.modifiedTime,
-    md5Checksum: revision.md5Checksum,
-    size: revision.size,
-    lastModifyingUser: revision.lastModifyingUser?.emailAddress,
-  })),
+const revisions = await notebookDiff.listDriveRevisions(target);
+
+const rows = revisions.map((revision) => ({
+  id: revision.id,
+  modifiedTime: revision.modifiedTime ?? "",
+  size: revision.size ?? "",
+  md5Checksum: revision.md5Checksum ?? "",
+  user: revision.lastModifyingUser?.emailAddress ?? "",
+}));
+
+const columns = ["id", "modifiedTime", "size", "md5Checksum", "user"];
+const widths = columns.map((column) =>
+  Math.max(column.length, ...rows.map((row) => String(row[column] ?? "").length)),
+);
+
+const formatRow = (row) =>
+  columns
+    .map((column, index) => String(row[column] ?? "").padEnd(widths[index]))
+    .join("  ");
+
+const header = Object.fromEntries(columns.map((column) => [column, column]));
+const separator = Object.fromEntries(
+  columns.map((column, index) => [column, "-".repeat(widths[index])]),
+);
+
+console.log(
+  "Found " + rows.length + " revision(s)\n" +
+    [formatRow(header), formatRow(separator), ...rows.map(formatRow)].join("\n"),
 );
 ```
 
 The returned revision ids are Google Drive `Revision` ids for the notebook file.
+Replace `target.uri` with the local URI for the notebook you want to inspect.
+Use `console.log` for the table because App Console runtimes do not all expose
+`console.table`.
 
 ## Compute and Open a Diff
 
@@ -46,6 +71,7 @@ if (!revisionId) {
 }
 
 const diff = await notebookDiff.diffDriveRevision({
+  target,
   revisionId,
   includeOutputs: true,
   includeMetadata: true,
@@ -88,4 +114,3 @@ await notebookDiff.openDiffTab(diff);
 - Output-only changes count as real differences.
 - V0 does not merge outputs. Conflict-resolution flows should clear outputs for
   cells touched by resolution and let users rerun cells.
-

--- a/docs/16-notebook-diffs.md
+++ b/docs/16-notebook-diffs.md
@@ -19,9 +19,8 @@ inspect revisions, compute the diff, and open the rendered diff view.
 Run this in a JavaScript cell using the AppKernel browser runner:
 
 ```js
-const target = {
-  uri: "local://file/a2d06400-8b02-4965-b26c-5e977945267f",
-};
+const doc = await notebooks.get();
+const target = { handle: doc.handle };
 
 const revisions = await notebookDiff.listDriveRevisions(target);
 
@@ -33,6 +32,17 @@ const rows = revisions.map((revision) => ({
   user: revision.lastModifyingUser?.emailAddress ?? "",
 }));
 
+console.table(rows);
+```
+
+The returned revision ids are Google Drive `Revision` ids for the notebook file.
+The snippet above targets the current notebook tab. To target a specific local
+notebook, use `const target = { uri: "local://file/..." }` instead.
+
+If you are running against an older app session where `console.table` is not
+available, use this fallback formatter:
+
+```js
 const columns = ["id", "modifiedTime", "size", "md5Checksum", "user"];
 const widths = columns.map((column) =>
   Math.max(column.length, ...rows.map((row) => String(row[column] ?? "").length)),
@@ -54,16 +64,14 @@ console.log(
 );
 ```
 
-The returned revision ids are Google Drive `Revision` ids for the notebook file.
-Replace `target.uri` with the local URI for the notebook you want to inspect.
-Use `console.log` for the table because App Console runtimes do not all expose
-`console.table`.
-
 ## Compute and Open a Diff
 
 Choose one of the returned revision ids, then run:
 
 ```js
+const doc = await notebooks.get();
+const target = { handle: doc.handle };
+const revisions = await notebookDiff.listDriveRevisions(target);
 const revisionId = revisions.at(-2)?.id;
 
 if (!revisionId) {

--- a/docs/16-notebook-diffs.md
+++ b/docs/16-notebook-diffs.md
@@ -1,0 +1,91 @@
+# Notebook Diffs
+
+Runme can compute and render a notebook-aware diff between the local copy of a
+Google Drive-backed notebook and an available Google Drive revision.
+
+This is a code-centric V0. Use a browser JavaScript cell in the notebook to
+inspect revisions, compute the diff, and open the rendered diff view.
+
+## Requirements
+
+- The current notebook must be backed by a Google Drive file.
+- The browser OAuth credential must have access to read the Drive file and its
+  revision contents.
+- The revision must still be available from Google Drive. Drive does not
+  guarantee complete history for every blob revision.
+
+## List Available Drive Revisions
+
+Run this in a JavaScript cell using the AppKernel browser runner:
+
+```js
+const revisions = await notebookDiff.listDriveRevisions();
+
+console.table(
+  revisions.map((revision) => ({
+    id: revision.id,
+    modifiedTime: revision.modifiedTime,
+    md5Checksum: revision.md5Checksum,
+    size: revision.size,
+    lastModifyingUser: revision.lastModifyingUser?.emailAddress,
+  })),
+);
+```
+
+The returned revision ids are Google Drive `Revision` ids for the notebook file.
+
+## Compute and Open a Diff
+
+Choose one of the returned revision ids, then run:
+
+```js
+const revisionId = revisions.at(-2)?.id;
+
+if (!revisionId) {
+  throw new Error("No earlier Drive revision is available.");
+}
+
+const diff = await notebookDiff.diffDriveRevision({
+  revisionId,
+  includeOutputs: true,
+  includeMetadata: true,
+});
+
+await notebookDiff.openDiffTab(diff);
+```
+
+The diff view compares:
+
+- left column: the selected Drive revision,
+- right column: the current local notebook copy.
+
+The renderer shows inserted, deleted, modified, moved, and unchanged cells.
+Unchanged cells are collapsed by default. Output changes are indicated by
+default, with large output bodies folded so source changes remain readable.
+
+## Target A Specific Open Notebook
+
+When multiple notebooks are open, pass a notebook target explicitly:
+
+```js
+const doc = await notebooks.get();
+const revisions = await notebookDiff.listDriveRevisions({
+  handle: doc.handle,
+});
+
+const diff = await notebookDiff.diffDriveRevision({
+  target: { handle: doc.handle },
+  revisionId: revisions.at(-2).id,
+});
+
+await notebookDiff.openDiffTab(diff);
+```
+
+## Notes
+
+- V0 supports Runme notebooks only.
+- Markdown cells are rendered as source diffs.
+- Output-only changes count as real differences.
+- V0 does not merge outputs. Conflict-resolution flows should clear outputs for
+  cells touched by resolution and let users rerun cells.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Current numbered docs:
 - [13-app-console-reference.md](13-app-console-reference.md)
 - [14-authentication-and-app-configuration.md](14-authentication-and-app-configuration.md)
 - [15-logs-diagnostics-and-troubleshooting.md](15-logs-diagnostics-and-troubleshooting.md)
+- [16-notebook-diffs.md](16-notebook-diffs.md)
 
 Additional topical docs:
 


### PR DESCRIPTION
## Summary
- add a Runme-native notebook diff model and side-by-side diff viewer route
- expose browser-kernel notebookDiff helpers for listing Drive revisions, computing local-vs-revision diffs, and opening the diff view
- document how to compare the local copy of a Drive-backed notebook against available Drive revisions

## Verification
- pnpm -C app test --run src/lib/notebookDiff/diff.test.ts src/lib/notebookDiff/runtime.test.ts src/components/NotebookDiff/NotebookDiffView.test.tsx
- runme run build test

## Notes
- Drive revision diffing assumes the browser OAuth credential has scopes to read the Drive file and revision contents.
- I did not verify against a live Drive file locally; covered the Drive-backed runtime path with mocks and verified the build/test gate.