### PR TITLE
[codex] Implement workspace document tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+app/.vite/
 
 # pnpm
 .pnpm-store/

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,6 +32,7 @@ import { FilesystemNotebookStore } from "./storage/fs";
 import { isFileSystemAccessSupported } from "./storage/fs";
 import LocalNotebooks from "./storage/local";
 import { CurrentDocProvider } from "./contexts/CurrentDocContext";
+import { WorkspaceDocumentProvider } from "./contexts/WorkspaceDocumentContext";
 import {
   FilesystemStoreProvider,
   useFilesystemStore,
@@ -169,11 +170,13 @@ function App({ branding }: AppProps) {
                     >
                       <OutputProvider>
                         <NotebookProvider>
-                          <WebMcpToolRegistrationHost />
-                          <SidePanelProvider>
-                            <GlobalToast />
-                            <AppRouter />
-                          </SidePanelProvider>
+                          <WorkspaceDocumentProvider>
+                            <WebMcpToolRegistrationHost />
+                            <SidePanelProvider>
+                              <GlobalToast />
+                              <AppRouter />
+                            </SidePanelProvider>
+                          </WorkspaceDocumentProvider>
                         </NotebookProvider>
                       </OutputProvider>
                     </RunnersProvider>

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 import { clone, create } from "@bufbuild/protobuf";
 import {
   APPKERNEL_RUNNER_NAME,
@@ -9,7 +9,15 @@ import {
 
 import { parser_pb, RunmeMetadataKey } from "../../runme/client";
 import type { CellData } from "../../lib/notebookData";
-import { Action } from "./Actions";
+import Actions, { Action } from "./Actions";
+
+const contextMocks = vi.hoisted(() => ({
+  workspaceDocuments: [] as Array<{ uri: string; title: string }>,
+  currentDoc: null as string | null,
+  setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
+  closeWorkspaceDocument: vi.fn(),
+}));
 
 // Minimal mocks for contexts Action consumes
 vi.mock("../../contexts/OutputContext", () => ({
@@ -46,9 +54,9 @@ vi.mock("../../contexts/NotebookContext", () => ({
 
 vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
   useWorkspaceDocumentContext: () => ({
-    useWorkspaceDocuments: () => [],
-    showDocument: () => {},
-    closeWorkspaceDocument: () => null,
+    useWorkspaceDocuments: () => contextMocks.workspaceDocuments,
+    showDocument: contextMocks.showDocument,
+    closeWorkspaceDocument: contextMocks.closeWorkspaceDocument,
   }),
 }));
 
@@ -67,8 +75,8 @@ vi.mock("../../contexts/FilesystemStoreContext", () => ({
 
 vi.mock("../../contexts/CurrentDocContext", () => ({
   useCurrentDoc: () => ({
-    getCurrentDoc: () => null,
-    setCurrentDoc: () => {},
+    getCurrentDoc: () => contextMocks.currentDoc,
+    setCurrentDoc: contextMocks.setCurrentDoc,
   }),
 }));
 
@@ -181,6 +189,35 @@ class StubCellData {
   remove() {}
   run() {}
 }
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  contextMocks.workspaceDocuments = [];
+  contextMocks.currentDoc = null;
+  contextMocks.setCurrentDoc.mockReset();
+  contextMocks.setCurrentDoc.mockImplementation((uri: string | null) => {
+    contextMocks.currentDoc = uri;
+  });
+  contextMocks.showDocument.mockReset();
+  contextMocks.closeWorkspaceDocument.mockReset();
+});
+
+describe("Actions tabs", () => {
+  it("falls back from a stale current URI to an open workspace document", async () => {
+    contextMocks.currentDoc = "diff://notebook/not-restored";
+    contextMocks.workspaceDocuments = [
+      { uri: "local://file/restored", title: "restored.json" },
+    ];
+
+    render(<Actions />);
+
+    await waitFor(() => {
+      expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(
+        "local://file/restored",
+      );
+    });
+  });
+});
 
 describe("Action component", () => {
   it("updates CellConsole key when runID changes", async () => {

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -2,7 +2,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { clone, create } from "@bufbuild/protobuf";
-import React from "react";
 import {
   APPKERNEL_RUNNER_NAME,
   APPKERNEL_SANDBOX_RUNNER_NAME,
@@ -42,8 +41,14 @@ vi.mock("../../contexts/NotebookContext", () => ({
   useNotebookContext: () => ({
     getNotebookData: () => null,
     useNotebookSnapshot: () => null,
-    useNotebookList: () => [],
-    removeNotebook: () => {},
+  }),
+}));
+
+vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
+  useWorkspaceDocumentContext: () => ({
+    useWorkspaceDocuments: () => [],
+    showDocument: () => {},
+    closeWorkspaceDocument: () => null,
   }),
 }));
 
@@ -133,7 +138,7 @@ class StubCellData {
     return this.subscribe(listener);
   }
 
-  subscribeToRunIDChange(listener: (id: string) => void) {
+  subscribeToRunIDChange(_listener: (id: string) => void) {
     return () => {};
   }
 
@@ -189,9 +194,9 @@ describe("Action component", () => {
       },
       value: "echo hi",
     });
-    const stub = new StubCellData(cell) as unknown as CellData;
+    const stub = new StubCellData(cell);
 
-    render(<Action cellData={stub} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
 
     const first = screen.getByTestId("cell-console") as HTMLElement;
     const firstKey = first.dataset.runkey;
@@ -218,9 +223,9 @@ describe("Action component", () => {
       },
       value: "echo hi",
     });
-    const stub = new StubCellData(cell) as unknown as CellData;
+    const stub = new StubCellData(cell);
 
-    render(<Action cellData={stub} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
     expect(screen.getByTestId("cell-console")).toBeTruthy();
 
     await act(async () => {
@@ -301,7 +306,7 @@ describe("Action component", () => {
       | HTMLSelectElement
       | null;
     expect(selector).toBeTruthy();
-    fireEvent.change(selector, { target: { value: "markdown" } });
+    fireEvent.change(selector as HTMLSelectElement, { target: { value: "markdown" } });
 
     expect(stub.update).toHaveBeenCalledTimes(1);
     const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell;

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1772,9 +1772,19 @@ export default function Actions() {
   // }, [cellsInitialized, currentDocUri, ensureNotebook, run, runName, setCurrentDoc]);
 
   const { registerRenderer, unregisterRenderer } = useOutput();
+  const workspaceDocumentUris = useMemo(
+    () => new Set(workspaceDocuments.map((document) => document.uri)),
+    [workspaceDocuments],
+  );
+  const selectedTabIsOpen = selectedTabUri
+    ? workspaceDocumentUris.has(selectedTabUri)
+    : false;
+  const currentDocIsOpen = currentDocUri
+    ? workspaceDocumentUris.has(currentDocUri)
+    : false;
   const resolvedSelectedTabUri =
-    selectedTabUri ??
-    currentDocUri ??
+    (selectedTabIsOpen ? selectedTabUri : null) ??
+    (currentDocIsOpen ? currentDocUri : null) ??
     workspaceDocuments[0]?.uri ??
     "";
 
@@ -1800,19 +1810,38 @@ export default function Actions() {
   );
 
   // Keep Radix tab selection in sync with the shared current document URI.
+  // CurrentDocContext may restore a non-restorable URI, such as a diff/status
+  // document. Fall back to the first restored workspace document in that case.
   useEffect(() => {
-    if (!currentDocUri) {
+    if (statusTabVisible) {
       return;
     }
-    setSelectedTabUri(currentDocUri);
-  }, [currentDocUri]);
+    if (currentDocUri && currentDocIsOpen) {
+      setSelectedTabUri(currentDocUri);
+      return;
+    }
+    if (selectedTabUri && !selectedTabIsOpen) {
+      setSelectedTabUri(null);
+    }
+    if (currentDocUri && !currentDocIsOpen) {
+      setCurrentDoc(workspaceDocuments[0]?.uri ?? null);
+    }
+  }, [
+    currentDocIsOpen,
+    currentDocUri,
+    selectedTabIsOpen,
+    selectedTabUri,
+    setCurrentDoc,
+    statusTabVisible,
+    workspaceDocuments,
+  ]);
 
   useEffect(() => {
     if (statusTabVisible) {
       showDocument(DRIVE_LINK_STATUS_TAB_URI, {
         title: "Drive Link Status",
       });
-      if (!currentDocUri) {
+      if (!currentDocUri || !currentDocIsOpen) {
         setCurrentDoc(DRIVE_LINK_STATUS_TAB_URI);
       }
       return;
@@ -1823,6 +1852,7 @@ export default function Actions() {
     }
   }, [
     closeWorkspaceDocument,
+    currentDocIsOpen,
     currentDocUri,
     setCurrentDoc,
     showDocument,

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -12,18 +12,18 @@ import {
 
 import { create } from "@bufbuild/protobuf";
 import { Button, ScrollArea, Tabs, Text } from "@radix-ui/themes";
-import { useParams } from "react-router-dom";
 
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import {
   MimeType,
   RunmeMetadataKey,
   parser_pb,
-} from "../../runme/client";;
+} from "../../runme/client";
 import { CellData } from "../../lib/notebookData";
 import { useNotebookContext } from "../../contexts/NotebookContext";
 import type { OpenNotebookEntry } from "../../lib/notebookDataController";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
+import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
 import { useOutput } from "../../contexts/OutputContext";
 import CellConsole, { fontSettings } from "./CellConsole";
 import Editor from "./Editor";
@@ -62,10 +62,18 @@ import {
   DRIVE_LINK_STATUS_TAB_URI,
   useDriveLinkCoordinatorSnapshot,
 } from "../../lib/driveLinkCoordinator";
+import {
+  isDriveLinkStatusUri,
+  isNotebookDiffUri,
+  isNotebookDocumentUri,
+  type WorkspaceDocument,
+} from "../../lib/workspaceDocuments/workspaceDocumentTypes";
+import { getNotebookDiffDocument } from "../../lib/notebookDiff/registry";
 import { parseDriveItem } from "../../storage/drive";
 import type { NotebookSyncState } from "../../storage/local";
 import { NotebookStoreItemType } from "../../storage/notebook";
 import DriveLinkStatusTab from "../DriveLinkStatusTab";
+import { NotebookDiffContent } from "../NotebookDiff/NotebookDiffView";
 import React from "react";
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -1617,17 +1625,103 @@ function NotebookTabContent({
   );
 }
 
+function NotebookDiffTabContent({ diffUri }: { diffUri: string }) {
+  const diffId = diffUri.slice("diff://notebook/".length);
+  const document = diffId ? getNotebookDiffDocument(decodeURIComponent(diffId)) : null;
+  if (document) {
+    return <NotebookDiffContent document={document} />;
+  }
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-nb-text-muted">
+      <Text size="3" weight="bold" as="p" className="text-nb-text">
+        Diff no longer available
+      </Text>
+      <Text size="2" as="p">
+        Recompute the notebook diff from a browser JavaScript cell, then call
+        notebookDiff.openDiffTab(diff) again.
+      </Text>
+    </div>
+  );
+}
+
+function UnknownDocumentTab({ uri }: { uri: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-nb-text-muted">
+      <Text size="3" weight="bold" as="p" className="text-nb-text">
+        Unsupported document
+      </Text>
+      <Text size="2" as="p">
+        {uri}
+      </Text>
+    </div>
+  );
+}
+
+function renderWorkspaceDocument({
+  document,
+  activeCell,
+  isWindowFocused,
+  onCellFocus,
+  onDriveLogin,
+  onDriveRetry,
+}: {
+  document: WorkspaceDocument;
+  activeCell: NotebookActiveCellState | null;
+  isWindowFocused: boolean;
+  onCellFocus: (docUri: string, state: NotebookActiveCellState) => void;
+  onDriveLogin: () => void;
+  onDriveRetry: () => void;
+}) {
+  if (isNotebookDocumentUri(document.uri)) {
+    const entry: OpenNotebookEntry = {
+      uri: document.uri,
+      requestedUri: document.requestedUri ?? document.uri,
+      name: document.title,
+      state: document.state ?? "loading",
+      errorMessage: document.errorMessage,
+      ...(document.owner !== undefined ? { owner: document.owner } : {}),
+    };
+    return (
+      <NotebookTabContent
+        docUri={document.uri}
+        entry={entry}
+        activeCell={activeCell}
+        isWindowFocused={isWindowFocused}
+        onCellFocus={onCellFocus}
+      />
+    );
+  }
+
+  if (isNotebookDiffUri(document.uri)) {
+    return <NotebookDiffTabContent diffUri={document.uri} />;
+  }
+
+  if (isDriveLinkStatusUri(document.uri)) {
+    return (
+      <DriveLinkStatusTab
+        onLogin={onDriveLogin}
+        onRetry={onDriveRetry}
+      />
+    );
+  }
+
+  return <UnknownDocumentTab uri={document.uri} />;
+}
+
 export default function Actions() {
-  const { useNotebookList, removeNotebook } = useNotebookContext();
+  const {
+    useWorkspaceDocuments,
+    showDocument,
+    closeWorkspaceDocument,
+  } = useWorkspaceDocumentContext();
   const { store } = useNotebookStore();
-  const openNotebooks = useNotebookList();
+  const workspaceDocuments = useWorkspaceDocuments();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
   const currentDocUri = getCurrentDoc();
   const driveLinkSnapshot = useDriveLinkCoordinatorSnapshot();
   const statusTabVisible =
     driveLinkSnapshot.intents.length > 0 ||
     Boolean(driveLinkSnapshot.lastErrorMessage);
-  const [mountedTabs, setMountedTabs] = useState<Set<string>>(() => new Set());
   const [selectedTabUri, setSelectedTabUri] = useState<string | null>(null);
   const [activeCellsByDoc, setActiveCellsByDoc] = useState<NotebookActiveCellMap>(
     () => loadNotebookActiveCellMap(),
@@ -1649,9 +1743,7 @@ export default function Actions() {
     googleDriveUri: string | null;
   } | null>(null);
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const { runName } = useParams<{ runName?: string }>();
   //const { data: run } = useRun(runName);
-  const [cellsInitialized, setCellsInitialized] = useState(false);
 
   // useEffect(() => {
   //   if (cellsInitialized) {
@@ -1683,7 +1775,8 @@ export default function Actions() {
   const resolvedSelectedTabUri =
     selectedTabUri ??
     currentDocUri ??
-    (statusTabVisible ? DRIVE_LINK_STATUS_TAB_URI : openNotebooks[0]?.uri ?? "");
+    workspaceDocuments[0]?.uri ??
+    "";
 
   const handleCellFocus = useCallback(
     (docUri: string, state: NotebookActiveCellState) => {
@@ -1706,34 +1799,36 @@ export default function Actions() {
     [],
   );
 
-  // Ensure the active tab is tracked as mounted on first render/whenever it changes.
+  // Keep Radix tab selection in sync with the shared current document URI.
   useEffect(() => {
     if (!currentDocUri) {
       return;
     }
-    setMountedTabs((prev) => {
-      if (prev.has(currentDocUri)) {
-        return prev;
-      }
-      const next = new Set(prev);
-      next.add(currentDocUri);
-      return next;
-    });
-    setSelectedTabUri((prev) =>
-      prev === DRIVE_LINK_STATUS_TAB_URI ? prev : currentDocUri,
-    );
+    setSelectedTabUri(currentDocUri);
   }, [currentDocUri]);
 
   useEffect(() => {
-    if (statusTabVisible && !currentDocUri) {
-      setSelectedTabUri((prev) => prev ?? DRIVE_LINK_STATUS_TAB_URI);
+    if (statusTabVisible) {
+      showDocument(DRIVE_LINK_STATUS_TAB_URI, {
+        title: "Drive Link Status",
+      });
+      if (!currentDocUri) {
+        setCurrentDoc(DRIVE_LINK_STATUS_TAB_URI);
+      }
       return;
     }
 
-    if (!statusTabVisible && selectedTabUri === DRIVE_LINK_STATUS_TAB_URI) {
-      setSelectedTabUri(currentDocUri ?? openNotebooks[0]?.uri ?? null);
+    if (workspaceDocuments.some((doc) => doc.uri === DRIVE_LINK_STATUS_TAB_URI)) {
+      closeWorkspaceDocument(DRIVE_LINK_STATUS_TAB_URI);
     }
-  }, [currentDocUri, openNotebooks, selectedTabUri, statusTabVisible]);
+  }, [
+    closeWorkspaceDocument,
+    currentDocUri,
+    setCurrentDoc,
+    showDocument,
+    statusTabVisible,
+    workspaceDocuments,
+  ]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") {
@@ -1808,12 +1903,9 @@ export default function Actions() {
 
   const handleCloseTab = useCallback(
     (uri: string) => {
-      const next = removeNotebook(uri);
-      if (uri === currentDocUri) {
-        setCurrentDoc(next ?? null);
-      }
+      closeWorkspaceDocument(uri);
     },
-    [currentDocUri, removeNotebook, setCurrentDoc],
+    [closeWorkspaceDocument],
   );
 
   useEffect(() => {
@@ -1971,7 +2063,7 @@ export default function Actions() {
 
   return (
     <div id="documents" className="flex flex-col h-full">
-      {openNotebooks.length === 0 && !statusTabVisible ? (
+      {workspaceDocuments.length === 0 ? (
         <ScrollArea
           type="auto"
           scrollbars="vertical"
@@ -2048,18 +2140,7 @@ export default function Actions() {
           value={resolvedSelectedTabUri}
           onValueChange={(nextUri) => {
             setSelectedTabUri(nextUri);
-            if (nextUri === DRIVE_LINK_STATUS_TAB_URI) {
-              return;
-            }
             if (nextUri !== currentDocUri) {
-              setMountedTabs((prev) => {
-                if (prev.has(nextUri)) {
-                  return prev;
-                }
-                const next = new Set(prev);
-                next.add(nextUri);
-                return next;
-              });
               setCurrentDoc(nextUri);
             }
           }}
@@ -2073,29 +2154,9 @@ export default function Actions() {
               id="notebook-tabs-list"
               className="flex min-w-max items-center gap-0.5 px-2 py-1"
             >
-              {statusTabVisible && (
-                <div
-                  key={`tab-${DRIVE_LINK_STATUS_TAB_URI}`}
-                  ref={(node) => {
-                    if (node) {
-                      tabTriggerRefs.current.set(DRIVE_LINK_STATUS_TAB_URI, node);
-                    } else {
-                      tabTriggerRefs.current.delete(DRIVE_LINK_STATUS_TAB_URI);
-                    }
-                  }}
-                  className="flex shrink-0 items-center gap-1"
-                >
-                  <Tabs.Trigger
-                    value={DRIVE_LINK_STATUS_TAB_URI}
-                    title="Drive Link Status"
-                    className="group flex shrink-0 items-center gap-2 rounded-nb-sm border border-transparent px-3 py-1.5 text-sm font-medium text-nb-text-muted transition-all duration-150 data-[state=active]:border-nb-border data-[state=active]:bg-nb-surface data-[state=active]:text-nb-text data-[state=active]:shadow-nb-xs data-[state=inactive]:hover:bg-nb-surface/60 data-[state=inactive]:hover:text-nb-text focus:outline-none"
-                  >
-                    <span className="max-w-[180px] truncate">Drive Link Status</span>
-                  </Tabs.Trigger>
-                </div>
-              )}
-              {openNotebooks.map((doc) => {
-                const displayName = getNotebookDisplayName(doc.uri, doc.name);
+              {workspaceDocuments.map((doc) => {
+                const displayName = getNotebookDisplayName(doc.uri, doc.title);
+                const isNotebook = isNotebookDocumentUri(doc.uri);
                 return (
                   <div
                     key={`tab-${doc.uri}`}
@@ -2110,13 +2171,17 @@ export default function Actions() {
                   >
                     <Tabs.Trigger
                       value={doc.uri}
-                      title={doc.name}
-                      onContextMenu={(event) => handleTabContextMenu(event, doc.uri)}
+                      title={doc.title}
+                      onContextMenu={
+                        isNotebook
+                          ? (event) => handleTabContextMenu(event, doc.uri)
+                          : undefined
+                      }
                       className="group flex shrink-0 items-center gap-2 rounded-nb-sm border border-transparent px-3 py-1.5 text-sm font-medium text-nb-text-muted transition-all duration-150 data-[state=active]:border-nb-border data-[state=active]:bg-nb-surface data-[state=active]:text-nb-text data-[state=active]:shadow-nb-xs data-[state=inactive]:hover:bg-nb-surface/60 data-[state=inactive]:hover:text-nb-text focus:outline-none"
                     >
                       <span className="max-w-[140px] truncate">{displayName}</span>
                     </Tabs.Trigger>
-                    <NotebookSyncIndicator docUri={doc.uri} />
+                    {isNotebook && <NotebookSyncIndicator docUri={doc.uri} />}
                     <button
                       type="button"
                       className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-nb-xs text-nb-text-faint transition-all duration-150 hover:bg-nb-surface-2 hover:text-nb-text"
@@ -2179,22 +2244,7 @@ export default function Actions() {
             </div>
           )}
           <div className="relative flex-1 min-h-0 overflow-hidden">
-          {statusTabVisible && (
-            <Tabs.Content
-              key={`content-${DRIVE_LINK_STATUS_TAB_URI}`}
-              value={DRIVE_LINK_STATUS_TAB_URI}
-              forceMount
-              asChild
-            >
-              <TabPanel className="flex-1 min-h-0">
-                <DriveLinkStatusTab
-                  onLogin={() => driveLinkCoordinator.loginToDriveAndProcess()}
-                  onRetry={() => driveLinkCoordinator.retryAuthAndProcess()}
-                />
-              </TabPanel>
-            </Tabs.Content>
-          )}
-          {openNotebooks.map((doc) => (
+          {workspaceDocuments.map((doc) => (
             <Tabs.Content
               key={`content-${doc.uri}`}
               value={doc.uri}
@@ -2202,15 +2252,15 @@ export default function Actions() {
               asChild
             >
               <TabPanel className="flex-1 min-h-0" data-document-id={doc.uri}>
-                <NotebookTabContent
-                  docUri={doc.uri}
-                  entry={doc}
-                  activeCell={activeCellsByDoc[doc.uri] ?? null}
-                  isWindowFocused={
-                    isWindowFocused && resolvedSelectedTabUri === doc.uri
-                  }
-                  onCellFocus={handleCellFocus}
-                />
+                {renderWorkspaceDocument({
+                  document: doc,
+                  activeCell: activeCellsByDoc[doc.uri] ?? null,
+                  isWindowFocused:
+                    isWindowFocused && resolvedSelectedTabUri === doc.uri,
+                  onCellFocus: handleCellFocus,
+                  onDriveLogin: () => driveLinkCoordinator.loginToDriveAndProcess(),
+                  onDriveRetry: () => driveLinkCoordinator.retryAuthAndProcess(),
+                })}
               </TabPanel>
             </Tabs.Content>
           ))}

--- a/app/src/components/AppConsole/AppConsole.test.tsx
+++ b/app/src/components/AppConsole/AppConsole.test.tsx
@@ -53,7 +53,14 @@ vi.mock("../../contexts/CurrentDocContext", () => ({
 vi.mock("../../contexts/NotebookContext", () => ({
   useNotebookContext: () => ({
     getNotebookData: () => null,
+    openNotebook: vi.fn(),
     useNotebookList: () => [],
+  }),
+}));
+
+vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: vi.fn(),
   }),
 }));
 

--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -7,6 +7,7 @@ import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
 import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { useRunners } from "../../contexts/RunnersContext";
+import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
 import { useWorkspace } from "../../contexts/WorkspaceContext";
 import { appState } from "../../lib/runtime/AppState";
 import { getAppConsoleData } from "../../lib/appConsole/appConsoleController";
@@ -17,6 +18,7 @@ import {
   createRunmeConsoleApi,
   type NotebookDataLike,
 } from "../../lib/runtime/runmeConsole";
+import { isNotebookDocumentUri } from "../../lib/workspaceDocuments/workspaceDocumentTypes";
 import { Runner } from "../../lib/runner";
 import {
   FilesystemNotebookStore,
@@ -181,6 +183,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
   const { getItems, addItem, removeItem } = useWorkspace();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
   const { getNotebookData, openNotebook, useNotebookList } = useNotebookContext();
+  const { showDocument } = useWorkspaceDocumentContext();
   const openNotebooks = useNotebookList();
   const { fsStore, setFsStore } = useFilesystemStore();
   const { store: notebookStore } = useNotebookStore();
@@ -229,11 +232,15 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
       }
 
       if (typeof target === "string" && target.trim() !== "") {
-        return getNotebookData(target) ?? null;
+        const targetUri = target.trim();
+        if (!isNotebookDocumentUri(targetUri)) {
+          return null;
+        }
+        return getNotebookData(targetUri) ?? null;
       }
 
       const currentUri = getCurrentDoc();
-      if (currentUri) {
+      if (isNotebookDocumentUri(currentUri)) {
         const currentNotebook = getNotebookData(currentUri);
         if (currentNotebook) {
           return currentNotebook;
@@ -242,7 +249,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
 
       const visibleUri = openNotebooks[0]?.uri;
       const activeUri = getVisibleNotebookUri() ?? visibleUri;
-      if (!activeUri) {
+      if (!isNotebookDocumentUri(activeUri)) {
         return null;
       }
       return getNotebookData(activeUri) ?? null;
@@ -396,6 +403,9 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
       },
       openNotebook: async (uri) => {
         const result = await openNotebook(uri);
+        showDocument(result.localUri, {
+          title: result.entry.name,
+        });
         setCurrentDoc(result.localUri);
       },
       resolveNotebook: resolveNotebookData,
@@ -463,6 +473,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
     resolveNotebookStore,
     runme,
     setCurrentDoc,
+    showDocument,
     setDefaultRunner,
     updateHistoryBrowseState,
     updateRunner,

--- a/app/src/components/CurrentDocInitializer.test.tsx
+++ b/app/src/components/CurrentDocInitializer.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   getStore: vi.fn(() => null as unknown),
   openNotebook: vi.fn(),
   setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
 }));
 
 vi.mock("../contexts/CurrentDocContext", () => ({
@@ -19,6 +20,12 @@ vi.mock("../contexts/CurrentDocContext", () => ({
 vi.mock("../contexts/NotebookContext", () => ({
   useNotebookContext: () => ({
     openNotebook: mocks.openNotebook,
+  }),
+}));
+
+vi.mock("../contexts/WorkspaceDocumentContext", () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
   }),
 }));
 
@@ -41,6 +48,7 @@ describe("CurrentDocInitializer", () => {
     mocks.getStore.mockReturnValue(null);
     mocks.openNotebook.mockReset();
     mocks.setCurrentDoc.mockReset();
+    mocks.showDocument.mockReset();
     window.history.replaceState(null, "", "/");
   });
 
@@ -90,6 +98,9 @@ describe("CurrentDocInitializer", () => {
 
     await waitFor(() => {
       expect(mocks.setCurrentDoc).toHaveBeenCalledWith("local://file/example");
+    });
+    expect(mocks.showDocument).toHaveBeenCalledWith("local://file/example", {
+      title: "example.json",
     });
     expect(window.location.search).toBe("?existing=1");
     expect(window.location.hash).toBe("#section");

--- a/app/src/components/CurrentDocInitializer.tsx
+++ b/app/src/components/CurrentDocInitializer.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useCurrentDoc } from "../contexts/CurrentDocContext";
 import { useNotebookContext } from "../contexts/NotebookContext";
 import { useNotebookStore } from "../contexts/NotebookStoreContext";
+import { useWorkspaceDocumentContext } from "../contexts/WorkspaceDocumentContext";
 
 function isNotebookDocParam(uri: string): boolean {
   return uri.startsWith("local://file/") || uri.startsWith("fs://");
@@ -25,6 +26,7 @@ export function CurrentDocInitializer() {
   const { setCurrentDoc } = useCurrentDoc();
   const { openNotebook } = useNotebookContext();
   const { store } = useNotebookStore();
+  const { showDocument } = useWorkspaceDocumentContext();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -47,6 +49,9 @@ export function CurrentDocInitializer() {
           if (cancelled) {
             return;
           }
+          showDocument(result.localUri, {
+            title: result.entry.name,
+          });
           setCurrentDoc(result.localUri);
           clearDocParam();
         } catch (error) {
@@ -58,7 +63,7 @@ export function CurrentDocInitializer() {
     return () => {
       cancelled = true;
     };
-  }, [openNotebook, setCurrentDoc, store]);
+  }, [openNotebook, setCurrentDoc, showDocument, store]);
 
   return null;
 }

--- a/app/src/components/DriveLinkCoordinatorHost.test.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   processPending: vi.fn(),
   removeItem: vi.fn(),
   setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
   store: {
     addFile: vi.fn(),
     updateFolder: vi.fn(),
@@ -54,6 +55,12 @@ vi.mock("../contexts/NotebookContext", () => ({
   }),
 }));
 
+vi.mock("../contexts/WorkspaceDocumentContext", () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
+  }),
+}));
+
 vi.mock("../lib/driveLinkCoordinator", () => ({
   driveLinkCoordinator: {
     configure: mocks.configure,
@@ -85,6 +92,7 @@ describe("DriveLinkCoordinatorHost", () => {
     mocks.processPending.mockResolvedValue(undefined);
     mocks.removeItem.mockReset();
     mocks.setCurrentDoc.mockReset();
+    mocks.showDocument.mockReset();
     mocks.store.addFile.mockReset();
     mocks.store.updateFolder.mockReset();
   });

--- a/app/src/components/DriveLinkCoordinatorHost.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.tsx
@@ -6,6 +6,7 @@ import { useNotebookStore } from "../contexts/NotebookStoreContext";
 import { useWorkspace } from "../contexts/WorkspaceContext";
 import { useCurrentDoc } from "../contexts/CurrentDocContext";
 import { useNotebookContext } from "../contexts/NotebookContext";
+import { useWorkspaceDocumentContext } from "../contexts/WorkspaceDocumentContext";
 import { driveLinkCoordinator } from "../lib/driveLinkCoordinator";
 
 export function DriveLinkCoordinatorHost() {
@@ -15,6 +16,7 @@ export function DriveLinkCoordinatorHost() {
   const { addItem, getItems, removeItem } = useWorkspace();
   const { setCurrentDoc } = useCurrentDoc();
   const { openNotebook } = useNotebookContext();
+  const { showDocument } = useWorkspaceDocumentContext();
 
   useEffect(() => {
     if (!store) {
@@ -33,6 +35,9 @@ export function DriveLinkCoordinatorHost() {
       getWorkspaceItems: getItems,
       openNotebook: async (localUri: string) => {
         const result = await openNotebook(localUri);
+        showDocument(result.localUri, {
+          title: result.entry.name,
+        });
         setCurrentDoc(result.localUri);
       },
     });
@@ -61,6 +66,7 @@ export function DriveLinkCoordinatorHost() {
     openNotebook,
     removeItem,
     setCurrentDoc,
+    showDocument,
     store,
     location.pathname,
     location.search,

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -220,10 +220,10 @@ function DiffRow({ row }: { row: CellDiff }) {
   );
 }
 
-function NotebookDiffContent({ document }: { document: NotebookDiffDocument }) {
+export function NotebookDiffContent({ document }: { document: NotebookDiffDocument }) {
   const { diff } = document;
   return (
-    <div className="flex h-screen w-screen flex-col bg-nb-surface">
+    <div className="flex h-full w-full flex-col bg-nb-surface">
       <header className="border-b border-nb-border bg-white px-5 py-4">
         <div className="flex items-center justify-between gap-4">
           <div>

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -3,13 +3,13 @@ import { useEffect } from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-type PanelKey = "explorer" | "open-notebooks" | "chatkit" | null;
+type PanelKey = "explorer" | "open-documents" | "chatkit" | null;
 
 let authData: {} | null = null;
 let isDriveSyncing = false;
 let activePanelState: PanelKey = "explorer";
 let currentDocUri: string | null = null;
-let openNotebooksState: { uri: string; name: string; state?: string }[] = [];
+let openDocumentsState: { uri: string; title: string; state?: string }[] = [];
 let chatKitMountCount = 0;
 let chatKitUnmountCount = 0;
 const ensureAccessTokenMock = vi.fn(async () => "token");
@@ -17,7 +17,7 @@ const loginWithRedirectMock = vi.fn();
 const logoutMock = vi.fn();
 const togglePanelMock = vi.fn();
 const setCurrentDocMock = vi.fn();
-const removeNotebookMock = vi.fn();
+const closeWorkspaceDocumentMock = vi.fn();
 
 vi.mock("../../browserAdapter.client", () => ({
   useBrowserAuthData: () => authData,
@@ -34,10 +34,10 @@ vi.mock("../../contexts/SidePanelContext", () => ({
   }),
 }));
 
-vi.mock("../../contexts/NotebookContext", () => ({
-  useNotebookContext: () => ({
-    useNotebookList: () => openNotebooksState,
-    removeNotebook: removeNotebookMock,
+vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
+  useWorkspaceDocumentContext: () => ({
+    useWorkspaceDocuments: () => openDocumentsState,
+    closeWorkspaceDocument: closeWorkspaceDocumentMock,
   }),
 }));
 
@@ -79,7 +79,7 @@ describe("SidePanelToolbar drive status button", () => {
     isDriveSyncing = false;
     activePanelState = "explorer";
     currentDocUri = null;
-    openNotebooksState = [];
+    openDocumentsState = [];
     chatKitMountCount = 0;
     chatKitUnmountCount = 0;
     ensureAccessTokenMock.mockClear();
@@ -87,7 +87,7 @@ describe("SidePanelToolbar drive status button", () => {
     logoutMock.mockClear();
     togglePanelMock.mockClear();
     setCurrentDocMock.mockClear();
-    removeNotebookMock.mockClear();
+    closeWorkspaceDocumentMock.mockClear();
   });
 
   it("renders the Drive status button above Login and starts auth when not syncing", async () => {
@@ -122,14 +122,14 @@ describe("SidePanelToolbar drive status button", () => {
     expect(ensureAccessTokenMock).not.toHaveBeenCalled();
   });
 
-  it("exposes an Open Notebooks button in the toolbar", () => {
+  it("exposes an Open Documents button in the toolbar", () => {
     render(<SidePanelToolbar />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Toggle Open Notebooks panel" }),
+      screen.getByRole("button", { name: "Toggle Open Documents panel" }),
     );
 
-    expect(togglePanelMock).toHaveBeenCalledWith("open-notebooks");
+    expect(togglePanelMock).toHaveBeenCalledWith("open-documents");
   });
 });
 
@@ -137,11 +137,11 @@ describe("SidePanelContent ChatKit persistence", () => {
   beforeEach(() => {
     activePanelState = "explorer";
     currentDocUri = null;
-    openNotebooksState = [];
+    openDocumentsState = [];
     chatKitMountCount = 0;
     chatKitUnmountCount = 0;
     setCurrentDocMock.mockClear();
-    removeNotebookMock.mockClear();
+    closeWorkspaceDocumentMock.mockClear();
   });
 
   it("keeps ChatKit mounted when switching from ChatKit to Explorer and back", () => {
@@ -179,34 +179,33 @@ describe("SidePanelContent ChatKit persistence", () => {
     expect(screen.getByTestId("workspace-explorer-mock")).toBeTruthy();
   });
 
-  it("renders the Open Notebooks panel and routes notebook actions through shared context state", () => {
-    activePanelState = "open-notebooks";
+  it("renders the Open Documents panel and routes document actions through shared context state", () => {
+    activePanelState = "open-documents";
     currentDocUri = "local://file/alpha.json";
-    openNotebooksState = [
-      { uri: "local://file/alpha.json", name: "alpha.json" },
-      { uri: "fs://workspace/beta.json", name: "beta.json" },
+    openDocumentsState = [
+      { uri: "local://file/alpha.json", title: "alpha.json" },
+      { uri: "diff://notebook/beta", title: "beta diff" },
     ];
-    removeNotebookMock.mockReturnValue("fs://workspace/beta.json");
+    closeWorkspaceDocumentMock.mockReturnValue("diff://notebook/beta");
 
     render(<SidePanelContent />);
 
-    expect(screen.getByText("Open Notebooks")).toBeTruthy();
+    expect(screen.getByText("Open Documents")).toBeTruthy();
 
-    fireEvent.click(screen.getByText("beta.json"));
-    expect(setCurrentDocMock).toHaveBeenCalledWith("fs://workspace/beta.json");
+    fireEvent.click(screen.getByText("beta diff"));
+    expect(setCurrentDocMock).toHaveBeenCalledWith("diff://notebook/beta");
 
     fireEvent.click(screen.getByRole("button", { name: "Close alpha.json" }));
-    expect(removeNotebookMock).toHaveBeenCalledWith("local://file/alpha.json");
-    expect(setCurrentDocMock).toHaveBeenCalledWith("fs://workspace/beta.json");
+    expect(closeWorkspaceDocumentMock).toHaveBeenCalledWith("local://file/alpha.json");
   });
 
   it("shows blocked notebook status from open entry metadata", () => {
-    activePanelState = "open-notebooks";
+    activePanelState = "open-documents";
     currentDocUri = "local://file/blocked";
-    openNotebooksState = [
+    openDocumentsState = [
       {
         uri: "local://file/blocked",
-        name: "blocked.json",
+        title: "blocked.json",
         state: "blocked",
       },
     ];

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -13,8 +13,13 @@ import WorkspaceExplorer from "../Workspace/WorkspaceExplorer";
 import { getBrowserAdapter, useBrowserAuthData } from "../../browserAdapter.client";
 import { useGoogleAuth } from "../../contexts/GoogleAuthContext";
 import { useCurrentDoc } from "../../contexts/CurrentDocContext";
-import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useSidePanel } from "../../contexts/SidePanelContext";
+import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
+import {
+  isDriveLinkStatusUri,
+  isNotebookDiffUri,
+  isNotebookDocumentUri,
+} from "../../lib/workspaceDocuments/workspaceDocumentTypes";
 
 const sideButtonBase = "group side-btn";
 
@@ -42,65 +47,70 @@ function getNotebookStatusLabel(state?: string): string | null {
 }
 
 /**
- * OpenNotebooksPanel renders a lightweight "open editors" style list driven by
- * NotebookContext. It shares the same open-notebook state as the tab strip so
+ * OpenDocumentsPanel renders a lightweight "open editors" style list driven by
+ * WorkspaceDocumentContext. It shares the same open-document state as the tab strip so
  * the sidebar remains a secondary view over the exact same source of truth.
  * Status labels come from OpenNotebookEntry metadata; blocked entries do not
  * have editable NotebookData models in this tab.
  */
-function OpenNotebooksPanel() {
-  const { useNotebookList, removeNotebook } = useNotebookContext();
+function OpenDocumentsPanel() {
+  const { useWorkspaceDocuments, closeWorkspaceDocument } =
+    useWorkspaceDocumentContext();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
-  const openNotebooks = useNotebookList();
+  const openDocuments = useWorkspaceDocuments();
   const currentDocUri = getCurrentDoc();
 
-  const handleCloseNotebook = useCallback(
+  const handleCloseDocument = useCallback(
     (uri: string) => {
-      const next = removeNotebook(uri);
-      if (uri === currentDocUri) {
-        setCurrentDoc(next ?? null);
-      }
+      closeWorkspaceDocument(uri);
     },
-    [currentDocUri, removeNotebook, setCurrentDoc],
+    [closeWorkspaceDocument],
   );
 
   return (
     <div
-      id="open-notebooks-panel"
+      id="open-documents-panel"
       className="flex h-full min-h-0 w-full flex-col bg-nb-surface"
     >
       <div
-        id="open-notebooks-panel-header"
+        id="open-documents-panel-header"
         className="border-b border-nb-border px-4 py-3"
       >
         <p className="text-xs font-semibold tracking-[0.18em] text-nb-text-faint uppercase">
-          Open Notebooks
+          Open Documents
         </p>
         <p className="mt-1 text-sm text-nb-text-muted">
-          {openNotebooks.length} {openNotebooks.length === 1 ? "notebook" : "notebooks"}
+          {openDocuments.length} {openDocuments.length === 1 ? "document" : "documents"}
         </p>
       </div>
       <div
-        id="open-notebooks-panel-list"
+        id="open-documents-panel-list"
         className="flex-1 min-h-0 overflow-y-auto px-2 py-2"
       >
-        {openNotebooks.length === 0 ? (
+        {openDocuments.length === 0 ? (
           <div
-            id="open-notebooks-panel-empty"
+            id="open-documents-panel-empty"
             className="rounded-nb-sm border border-dashed border-nb-border bg-white/60 px-3 py-4 text-sm text-nb-text-muted"
           >
-            No open notebooks yet.
+            No open documents yet.
           </div>
         ) : (
-          <ul id="open-notebooks-list" className="space-y-1">
-            {openNotebooks.map((doc) => {
-              const displayName = getNotebookDisplayName(doc.uri, doc.name);
+          <ul id="open-documents-list" className="space-y-1">
+            {openDocuments.map((doc) => {
+              const displayName = getNotebookDisplayName(doc.uri, doc.title);
               const isActive = doc.uri === currentDocUri;
               const statusLabel = getNotebookStatusLabel(doc.state);
+              const kind = isNotebookDocumentUri(doc.uri)
+                ? "Notebook"
+                : isNotebookDiffUri(doc.uri)
+                  ? "Diff"
+                  : isDriveLinkStatusUri(doc.uri)
+                    ? "Status"
+                    : "Document";
               return (
                 <li key={doc.uri}>
                   <div
-                    id={`open-notebook-row-${encodeURIComponent(doc.uri)}`}
+                    id={`open-document-row-${encodeURIComponent(doc.uri)}`}
                     className={`group flex items-center gap-2 rounded-nb-sm border px-2 py-2 transition-colors ${
                       isActive
                         ? "border-nb-accent bg-nb-accent-soft text-nb-text"
@@ -127,7 +137,7 @@ function OpenNotebooksPanel() {
                         ) : null}
                       </div>
                       <div className="truncate text-xs text-nb-text-faint">
-                        {doc.uri}
+                        {kind} · {doc.uri}
                       </div>
                     </button>
                     <button
@@ -136,7 +146,7 @@ function OpenNotebooksPanel() {
                       aria-label={`Close ${displayName}`}
                       onClick={(event) => {
                         event.stopPropagation();
-                        handleCloseNotebook(doc.uri);
+                        handleCloseDocument(doc.uri);
                       }}
                       onMouseDown={(event) => event.stopPropagation()}
                     >
@@ -195,14 +205,14 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
-            activePanel === "open-notebooks" ? sideButtonActive : sideButtonInactive
+            activePanel === "open-documents" ? sideButtonActive : sideButtonInactive
           }`}
-          aria-pressed={activePanel === "open-notebooks"}
-          aria-label="Toggle Open Notebooks panel"
-          onClick={() => togglePanel("open-notebooks")}
+          aria-pressed={activePanel === "open-documents"}
+          aria-label="Toggle Open Documents panel"
+          onClick={() => togglePanel("open-documents")}
         >
           <QueueListIcon className="h-5 w-5" />
-          <span className={tooltipBase}>Open Notebooks</span>
+          <span className={tooltipBase}>Open Documents</span>
         </button>
         <button
           type="button"
@@ -282,10 +292,10 @@ export function SidePanelContent() {
         <WorkspaceExplorer />
       </div>
       <div
-        className={`h-full min-h-0 w-full ${activePanel === "open-notebooks" ? "flex" : "hidden"}`}
-        aria-hidden={activePanel !== "open-notebooks"}
+        className={`h-full min-h-0 w-full ${activePanel === "open-documents" ? "flex" : "hidden"}`}
+        aria-hidden={activePanel !== "open-documents"}
       >
-        <OpenNotebooksPanel />
+        <OpenDocumentsPanel />
       </div>
       {shouldRenderChatKit ? (
         <div

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -36,6 +36,7 @@ import { LOCAL_FOLDER_URI } from "../../storage/local";
 import { useGoogleAuth } from "../../contexts/GoogleAuthContext";
 import { useCurrentDoc } from "../../contexts/CurrentDocContext";
 import { useNotebookContext } from "../../contexts/NotebookContext";
+import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
 
 interface ContextMenuState {
@@ -228,6 +229,7 @@ export function WorkspaceExplorer() {
   const { fsStore } = useFilesystemStore();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
   const { openNotebook } = useNotebookContext();
+  const { showDocument } = useWorkspaceDocumentContext();
   const currentDoc = getCurrentDoc();
   const { ensureAccessToken } = useGoogleAuth();
   const handledDocRef = useRef<string | null>(null);
@@ -420,6 +422,9 @@ export function WorkspaceExplorer() {
         const result = await openNotebook(targetItem.uri, {
           name: targetItem.name,
         });
+        showDocument(result.localUri, {
+          title: result.entry.name,
+        });
         setCurrentDoc(result.localUri);
         handledDocRef.current = result.localUri;
       } catch (error) {
@@ -434,6 +439,7 @@ export function WorkspaceExplorer() {
     ensureAccessToken,
     openNotebook,
     setCurrentDoc,
+    showDocument,
     store,
     workspaceUris,
   ]);

--- a/app/src/contexts/CurrentDocContext.test.tsx
+++ b/app/src/contexts/CurrentDocContext.test.tsx
@@ -78,6 +78,36 @@ describe("CurrentDocProvider", () => {
     });
   });
 
+  it("keeps non-restorable documents selected without persisting them for restore", async () => {
+    render(
+      <CurrentDocProvider>
+        <SetCurrentDocOnMount uri="diff://notebook/runtime-only" />
+        <CurrentDocProbe />
+      </CurrentDocProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-doc").textContent).toBe(
+        "diff://notebook/runtime-only",
+      );
+    });
+    expect(window.sessionStorage.getItem("runme/currentDoc")).toBe("");
+  });
+
+  it("ignores non-restorable current doc restore values", async () => {
+    window.sessionStorage.setItem("runme/currentDoc", "diff://notebook/stale");
+
+    render(
+      <CurrentDocProvider>
+        <CurrentDocProbe />
+      </CurrentDocProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-doc").textContent).toBe("none");
+    });
+  });
+
   it("does not clear pending URL doc intents when selecting a current doc on mount", async () => {
     render(
       <CurrentDocProvider>

--- a/app/src/contexts/CurrentDocContext.tsx
+++ b/app/src/contexts/CurrentDocContext.tsx
@@ -3,12 +3,12 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from "react";
 
 import { getNotebookSessionPersistence } from "../lib/notebookSessionPersistence";
+import { isRestorableWorkspaceDocument } from "../lib/workspaceDocuments/workspaceDocumentTypes";
 
 interface CurrentDocContextValue {
   getCurrentDoc: () => string | null;
@@ -19,6 +19,11 @@ const CurrentDocContext = createContext<CurrentDocContextValue | undefined>(
   undefined,
 );
 
+function loadRestorableStoredCurrentDoc(): string | null {
+  const uri = getNotebookSessionPersistence().loadCurrentDoc();
+  return uri && isRestorableWorkspaceDocument(uri) ? uri : null;
+}
+
 export function useCurrentDoc() {
   const ctx = useContext(CurrentDocContext);
   if (!ctx) {
@@ -28,15 +33,9 @@ export function useCurrentDoc() {
 }
 
 export function CurrentDocProvider({ children }: { children: ReactNode }) {
-  const [currentDoc, setCurrentDocState] = useState<string | null>(null);
-
-  const loadStoredCurrentDoc = useCallback((): string | null => {
-    return getNotebookSessionPersistence().loadCurrentDoc();
-  }, []);
-
-  useEffect(() => {
-    setCurrentDocState(loadStoredCurrentDoc());
-  }, [loadStoredCurrentDoc]);
+  const [currentDoc, setCurrentDocState] = useState<string | null>(
+    loadRestorableStoredCurrentDoc,
+  );
 
   const getCurrentDoc = useCallback(() => {
     return currentDoc;
@@ -55,7 +54,9 @@ export function CurrentDocProvider({ children }: { children: ReactNode }) {
         return localUri;
       });
 
-      getNotebookSessionPersistence().saveCurrentDoc(localUri);
+      getNotebookSessionPersistence().saveCurrentDoc(
+        localUri && isRestorableWorkspaceDocument(localUri) ? localUri : null,
+      );
     },
     [currentDoc],
   );

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -17,6 +17,7 @@ import {
 } from "../lib/notebookDataController";
 import { appLogger } from "../lib/logging/runtime";
 import { appState } from "../lib/runtime/AppState";
+import { isNotebookDocumentUri } from "../lib/workspaceDocuments/workspaceDocumentTypes";
 import { useCurrentDoc } from "./CurrentDocContext";
 import { useNotebookStore } from "./NotebookStoreContext";
 
@@ -121,12 +122,10 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
     }
     if (
       currentDoc &&
+      isNotebookDocumentUri(currentDoc) &&
       !restoredCurrentDocRef.current &&
       openNotebooks.length === 0
     ) {
-      if (!currentDoc.startsWith("local://file/") && !store) {
-        return;
-      }
       restoredCurrentDocRef.current = true;
       void controller.openNotebook(currentDoc).catch((error) => {
         appLogger.error("Failed to restore selected notebook", {

--- a/app/src/contexts/SidePanelContext.tsx
+++ b/app/src/contexts/SidePanelContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from "react";
 
-export type PanelKey = "explorer" | "open-notebooks" | "chatkit" | null;
+export type PanelKey = "explorer" | "open-documents" | "chatkit" | null;
 
 interface SidePanelContextValue {
   activePanel: PanelKey;
@@ -24,10 +24,11 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
         localStorage.getItem(LEGACY_STORAGE_KEY);
       if (
         stored === "explorer" ||
+        stored === "open-documents" ||
         stored === "open-notebooks" ||
         stored === "chatkit"
       ) {
-        return stored;
+        return stored === "open-notebooks" ? "open-documents" : stored;
       }
     } catch (error) {
       console.error("Failed to read side panel state", error);

--- a/app/src/contexts/WorkspaceDocumentContext.tsx
+++ b/app/src/contexts/WorkspaceDocumentContext.tsx
@@ -1,0 +1,111 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
+
+import { useCurrentDoc } from "./CurrentDocContext";
+import { useNotebookContext } from "./NotebookContext";
+import {
+  getWorkspaceDocumentController,
+  type ShowWorkspaceDocumentOptions,
+} from "../lib/workspaceDocuments/workspaceDocumentController";
+import {
+  isNotebookDocumentUri,
+  type WorkspaceDocument,
+} from "../lib/workspaceDocuments/workspaceDocumentTypes";
+
+type WorkspaceDocumentContextValue = {
+  useWorkspaceDocuments: () => WorkspaceDocument[];
+  showDocument: (uri: string, options?: ShowWorkspaceDocumentOptions) => void;
+  closeWorkspaceDocument: (uri: string) => string | null;
+};
+
+const WorkspaceDocumentContext = createContext<
+  WorkspaceDocumentContextValue | undefined
+>(undefined);
+
+export function useWorkspaceDocumentContext() {
+  const ctx = useContext(WorkspaceDocumentContext);
+  if (!ctx) {
+    throw new Error(
+      "useWorkspaceDocumentContext must be used within a WorkspaceDocumentProvider",
+    );
+  }
+  return ctx;
+}
+
+export function WorkspaceDocumentProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const controller = getWorkspaceDocumentController();
+  const { useNotebookList, removeNotebook } = useNotebookContext();
+  const openNotebooks = useNotebookList();
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
+
+  useEffect(() => {
+    for (const notebook of openNotebooks) {
+      controller.showDocument(notebook.uri, {
+        title: notebook.name,
+        requestedUri: notebook.requestedUri,
+        state: notebook.state,
+        errorMessage: notebook.errorMessage,
+        owner: notebook.owner,
+      });
+    }
+  }, [controller, openNotebooks]);
+
+  const showDocument = useCallback(
+    (uri: string, options?: ShowWorkspaceDocumentOptions) => {
+      controller.showDocument(uri, options);
+    },
+    [controller],
+  );
+
+  const closeWorkspaceDocument = useCallback(
+    (uri: string) => {
+      const fallback = controller.closeDocument(uri);
+      if (isNotebookDocumentUri(uri)) {
+        removeNotebook(uri);
+      }
+      if (getCurrentDoc() === uri) {
+        setCurrentDoc(fallback);
+      }
+      return fallback;
+    },
+    [controller, getCurrentDoc, removeNotebook, setCurrentDoc],
+  );
+
+  const useWorkspaceDocuments = useCallback(() => {
+    const subscribe = useCallback(
+      (listener: () => void) => controller.subscribe(listener),
+      [controller],
+    );
+    const getSnapshot = useCallback(
+      () => controller.getSnapshot().documents,
+      [controller],
+    );
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  }, [controller]);
+
+  const value = useMemo<WorkspaceDocumentContextValue>(
+    () => ({
+      useWorkspaceDocuments,
+      showDocument,
+      closeWorkspaceDocument,
+    }),
+    [closeWorkspaceDocument, showDocument, useWorkspaceDocuments],
+  );
+
+  return (
+    <WorkspaceDocumentContext.Provider value={value}>
+      {children}
+    </WorkspaceDocumentContext.Provider>
+  );
+}

--- a/app/src/lib/driveLinkCoordinator.ts
+++ b/app/src/lib/driveLinkCoordinator.ts
@@ -8,7 +8,7 @@ import {
 import { NotebookStoreItemType } from "../storage/notebook";
 
 const STORAGE_KEY = "runme/drive-link-intents";
-const STATUS_TAB_URI = "system://drive-link-status";
+const STATUS_TAB_URI = "status://drive-link";
 
 export type DriveLinkIntentStatus =
   | "pending"

--- a/app/src/lib/runtime/useCodeModeExecutor.ts
+++ b/app/src/lib/runtime/useCodeModeExecutor.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import { parser_pb } from '../../contexts/CellContext'
 import { useCurrentDoc } from '../../contexts/CurrentDocContext'
 import { useNotebookContext } from '../../contexts/NotebookContext'
+import { isNotebookDocumentUri } from '../workspaceDocuments/workspaceDocumentTypes'
 import {
   type CodeModeExecutor,
   type CodeModeRunnerMode,
@@ -65,6 +66,9 @@ export function useCodeModeExecutor(options?: {
             ? (target as { handle?: { uri?: string } }).handle?.uri
             : currentDocUriRef.current
     if (!targetUri) {
+      return null
+    }
+    if (!isNotebookDocumentUri(targetUri)) {
       return null
     }
     const data = getNotebookDataRef.current(targetUri)

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WorkspaceDocumentController } from "./workspaceDocumentController";
+
+function createMemoryPersistence(initial: Array<{ uri: string; title: string }> = []) {
+  let documents = initial;
+  return {
+    loadDocuments: vi.fn(() => documents),
+    saveDocuments: vi.fn((next: Array<{ uri: string; title: string }>) => {
+      documents = next.map((item) => ({ ...item }));
+    }),
+  };
+}
+
+describe("WorkspaceDocumentController", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("shows and deduplicates workspace documents", () => {
+    const persistence = createMemoryPersistence();
+    const controller = new WorkspaceDocumentController(persistence);
+
+    controller.showDocument("local://file/a", { title: "a.json" });
+    controller.showDocument("local://file/a", { title: "renamed.json" });
+    controller.showDocument("diff://notebook/1", { title: "Diff" });
+
+    expect(controller.getSnapshot().documents).toEqual([
+      { uri: "local://file/a", title: "renamed.json" },
+      { uri: "diff://notebook/1", title: "Diff" },
+    ]);
+  });
+
+  it("closes a document and returns the neighboring fallback", () => {
+    const controller = new WorkspaceDocumentController(createMemoryPersistence());
+    controller.showDocument("local://file/a", { title: "a.json" });
+    controller.showDocument("local://file/b", { title: "b.json" });
+    controller.showDocument("diff://notebook/1", { title: "Diff" });
+
+    expect(controller.closeDocument("local://file/b")).toBe("local://file/a");
+    expect(controller.getSnapshot().documents.map((item) => item.uri)).toEqual([
+      "local://file/a",
+      "diff://notebook/1",
+    ]);
+  });
+
+  it("persists only restorable notebook documents", () => {
+    const controller = new WorkspaceDocumentController();
+
+    controller.showDocument("local://file/a", { title: "a.json" });
+    controller.showDocument("diff://notebook/1", { title: "Diff" });
+    controller.showDocument("status://drive-link", { title: "Drive Link Status" });
+
+    expect(
+      JSON.parse(window.sessionStorage.getItem("runme/workspaceDocuments") ?? "[]"),
+    ).toEqual([
+      { uri: "local://file/a", title: "a.json" },
+    ]);
+  });
+});

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
@@ -57,4 +57,18 @@ describe("WorkspaceDocumentController", () => {
       { uri: "local://file/a", title: "a.json" },
     ]);
   });
+
+  it("restores only restorable notebook documents", () => {
+    const controller = new WorkspaceDocumentController(
+      createMemoryPersistence([
+        { uri: "diff://notebook/1", title: "Diff" },
+        { uri: "local://file/a", title: "a.json" },
+        { uri: "status://drive-link", title: "Drive Link Status" },
+      ]),
+    );
+
+    expect(controller.getSnapshot().documents).toEqual([
+      { uri: "local://file/a", title: "a.json" },
+    ]);
+  });
 });

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -173,7 +173,9 @@ export class WorkspaceDocumentController {
       return;
     }
     this.restored = true;
-    this.documents = this.persistence.loadDocuments();
+    this.documents = this.persistence
+      .loadDocuments()
+      .filter((item) => isRestorableWorkspaceDocument(item.uri));
     this.rebuildSnapshot();
   }
 

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -1,0 +1,214 @@
+import {
+  deriveWorkspaceDocumentTitle,
+  isRestorableWorkspaceDocument,
+  type WorkspaceDocument,
+} from "./workspaceDocumentTypes";
+
+const WORKSPACE_DOCUMENTS_STORAGE_KEY = "runme/workspaceDocuments";
+
+export interface WorkspaceDocumentSnapshot {
+  documents: WorkspaceDocument[];
+}
+
+export interface WorkspaceDocumentPersistence {
+  loadDocuments(): WorkspaceDocument[];
+  saveDocuments(documents: WorkspaceDocument[]): void;
+}
+
+export type ShowWorkspaceDocumentOptions = Omit<Partial<WorkspaceDocument>, "uri">;
+
+class SessionStorageWorkspaceDocumentPersistence
+  implements WorkspaceDocumentPersistence
+{
+  loadDocuments(): WorkspaceDocument[] {
+    if (typeof window === "undefined" || !window.sessionStorage) {
+      return [];
+    }
+    try {
+      const raw = window.sessionStorage.getItem(WORKSPACE_DOCUMENTS_STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed
+        .map(normalizeWorkspaceDocument)
+        .filter((item): item is WorkspaceDocument => Boolean(item));
+    } catch {
+      return [];
+    }
+  }
+
+  saveDocuments(documents: WorkspaceDocument[]): void {
+    if (typeof window === "undefined" || !window.sessionStorage) {
+      return;
+    }
+    try {
+      const restorable = documents.filter((item) =>
+        isRestorableWorkspaceDocument(item.uri),
+      );
+      if (restorable.length === 0) {
+        window.sessionStorage.removeItem(WORKSPACE_DOCUMENTS_STORAGE_KEY);
+        return;
+      }
+      const persisted = restorable.map((item) => ({
+        uri: item.uri,
+        title: item.title,
+      }));
+      window.sessionStorage.setItem(
+        WORKSPACE_DOCUMENTS_STORAGE_KEY,
+        JSON.stringify(persisted),
+      );
+    } catch {
+      // Ignore restore-state persistence failures.
+    }
+  }
+}
+
+function normalizeWorkspaceDocument(item: unknown): WorkspaceDocument | null {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const candidate = item as Partial<WorkspaceDocument>;
+  const uri = candidate.uri?.trim();
+  if (!uri) {
+    return null;
+  }
+  return {
+    uri,
+    title: candidate.title?.trim() || deriveWorkspaceDocumentTitle(uri),
+  };
+}
+
+export class WorkspaceDocumentController {
+  private documents: WorkspaceDocument[] = [];
+  private snapshot: WorkspaceDocumentSnapshot = { documents: [] };
+  private readonly listeners = new Set<() => void>();
+  private restored = false;
+
+  constructor(
+    private persistence: WorkspaceDocumentPersistence =
+      new SessionStorageWorkspaceDocumentPersistence(),
+  ) {}
+
+  getSnapshot(): WorkspaceDocumentSnapshot {
+    this.ensureRestored();
+    return this.snapshot;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.ensureRestored();
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  showDocument(uri: string, options?: ShowWorkspaceDocumentOptions): void {
+    this.ensureRestored();
+    const normalizedUri = uri.trim();
+    if (!normalizedUri) {
+      throw new Error("showDocument requires a non-empty URI");
+    }
+    const title = options?.title?.trim() || deriveWorkspaceDocumentTitle(normalizedUri);
+    const nextDocument: WorkspaceDocument = {
+      uri: normalizedUri,
+      title,
+      requestedUri: options?.requestedUri,
+      state: options?.state,
+      errorMessage: options?.errorMessage,
+      owner: options?.owner,
+    };
+    const existingIndex = this.documents.findIndex(
+      (item) => item.uri === normalizedUri,
+    );
+    if (existingIndex >= 0) {
+      const existing = this.documents[existingIndex];
+      if (
+        existing?.title === nextDocument.title &&
+        existing?.requestedUri === nextDocument.requestedUri &&
+        existing?.state === nextDocument.state &&
+        existing?.errorMessage === nextDocument.errorMessage &&
+        existing?.owner === nextDocument.owner
+      ) {
+        return;
+      }
+      this.documents = this.documents.map((item, index) =>
+        index === existingIndex ? nextDocument : item,
+      );
+    } else {
+      this.documents = [...this.documents, nextDocument];
+    }
+    this.emit();
+    this.persist();
+  }
+
+  closeDocument(uri: string): string | null {
+    this.ensureRestored();
+    const index = this.documents.findIndex((item) => item.uri === uri);
+    if (index === -1) {
+      return null;
+    }
+    const fallback =
+      index > 0
+        ? this.documents[index - 1]?.uri ?? null
+        : this.documents[index + 1]?.uri ?? null;
+    this.documents = this.documents.filter((item) => item.uri !== uri);
+    this.emit();
+    this.persist();
+    return fallback;
+  }
+
+  resetForTests(): void {
+    this.documents = [];
+    this.snapshot = { documents: [] };
+    this.listeners.clear();
+    this.restored = false;
+  }
+
+  private ensureRestored(): void {
+    if (this.restored) {
+      return;
+    }
+    this.restored = true;
+    this.documents = this.persistence.loadDocuments();
+    this.rebuildSnapshot();
+  }
+
+  private emit(): void {
+    this.rebuildSnapshot();
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch (error) {
+        console.error("WorkspaceDocumentController listener failed", error);
+      }
+    }
+  }
+
+  private persist(): void {
+    this.persistence.saveDocuments(this.documents);
+  }
+
+  private rebuildSnapshot(): void {
+    this.snapshot = {
+      documents: this.documents.map((item) => ({ ...item })),
+    };
+  }
+}
+
+let controller: WorkspaceDocumentController | null = null;
+
+export function getWorkspaceDocumentController(): WorkspaceDocumentController {
+  if (!controller) {
+    controller = new WorkspaceDocumentController();
+  }
+  return controller;
+}
+
+export function __resetWorkspaceDocumentControllerForTests(): void {
+  controller?.resetForTests();
+  controller = null;
+}

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -1,0 +1,54 @@
+import type { NotebookTabState } from "../notebookDataController";
+import type { NotebookOwnershipRecord } from "../tabCoordination/notebookOwnership";
+
+export const DRIVE_LINK_STATUS_DOCUMENT_URI = "status://drive-link";
+
+export interface WorkspaceDocument {
+  uri: string;
+  title: string;
+  requestedUri?: string;
+  state?: NotebookTabState;
+  errorMessage?: string;
+  owner?: NotebookOwnershipRecord | null;
+}
+
+export function getWorkspaceDocumentScheme(uri: string): string {
+  const index = uri.indexOf(":");
+  return index > 0 ? uri.slice(0, index) : "";
+}
+
+export function isNotebookDocumentUri(uri: string | null | undefined): uri is string {
+  return typeof uri === "string" && uri.startsWith("local://file/");
+}
+
+export function isNotebookDiffUri(uri: string | null | undefined): boolean {
+  return typeof uri === "string" && uri.startsWith("diff://notebook/");
+}
+
+export function isDriveLinkStatusUri(uri: string | null | undefined): boolean {
+  return uri === DRIVE_LINK_STATUS_DOCUMENT_URI;
+}
+
+export function isRestorableWorkspaceDocument(uri: string): boolean {
+  return isNotebookDocumentUri(uri);
+}
+
+export function deriveWorkspaceDocumentTitle(uri: string): string {
+  const documentUri = uri;
+  if (isDriveLinkStatusUri(documentUri)) {
+    return "Drive Link Status";
+  }
+  if (isNotebookDiffUri(documentUri)) {
+    return "Notebook diff";
+  }
+  try {
+    const url = new URL(documentUri);
+    const tail = url.pathname.split("/").filter(Boolean).pop();
+    if (tail) {
+      return decodeURIComponent(tail);
+    }
+  } catch {
+    // Fall through to the URI segment heuristic.
+  }
+  return documentUri.split("/").filter(Boolean).pop() ?? documentUri;
+}

--- a/docs-dev/design/20260526_workspace_document_tabs.md
+++ b/docs-dev/design/20260526_workspace_document_tabs.md
@@ -351,6 +351,11 @@ document URI
   -> data owner for that URI scheme
 ```
 
+This does not require adding route-level pages for each document kind. The
+existing workspace route remains the host for document tabs; commands and URL
+handlers show a document by creating/selecting its URI in the workspace
+document list.
+
 Concrete examples:
 
 | URI | Tab metadata | View component | Data owner |
@@ -362,7 +367,7 @@ Concrete examples:
 This keeps the system extensible. Adding a new document type means adding:
 
 1. a URI scheme or URI pattern for the document
-2. an opener method or command that creates/selects that URI
+2. an open command or existing URL handler that creates/selects that URI
 3. a rendering branch in `Actions.tsx`
 4. a document data owner if the view needs live data
 5. tests for selection, close behavior, and URI-type handling

--- a/docs-dev/design/20260526_workspace_document_tabs.md
+++ b/docs-dev/design/20260526_workspace_document_tabs.md
@@ -1,0 +1,979 @@
+# Workspace Document Tabs
+
+Date: 2026-05-26
+
+Related:
+
+- https://github.com/runmedev/web/issues/220
+- `docs-dev/design/20260520_notebook_session_refactor.md`
+- `docs-dev/design/20260520_multi_tab_support.md`
+- `docs-dev/design/20260426_getAllRendersRefbug.md`
+
+## Summary
+
+Introduce a generic workspace document/tab model so the main tab strip can host
+notebooks, notebook diffs, Drive status, and future non-notebook views.
+
+The notebook session refactor already made the most important prerequisite:
+notebook model ownership moved out of React view state and into
+`NotebookDataController`. We should continue that direction, but the next owner
+should not be another notebook-specific controller.
+
+The main decision is:
+
+- `NotebookDataController` owns notebook data, loading, save behavior, and
+  notebook runtime handles.
+- `CurrentDocContext` owns the selected document URI.
+- A new workspace document controller owns the open document URI list, tab
+  order, and generic tab metadata.
+- Notebook-specific consumers inspect the current URI before treating it as a
+  notebook URI.
+
+This lets a diff tab become a first-class tab without making
+`NotebookDataController` understand diffs.
+
+## Problem
+
+Issue #220 calls out that the main workspace tab system is still
+notebook-centric:
+
+- `Actions.tsx` builds the Radix tab strip from
+  `NotebookContext.useNotebookList()`.
+- `CurrentDocContext` stores one URI and many call sites assume that URI is a
+  notebook URI.
+- `NotebookTabContent` is the only normal tab content renderer.
+- `DRIVE_LINK_STATUS_TAB_URI` is a one-off non-notebook tab special case.
+- App Console and code mode resolve the current notebook from `currentDoc` or
+  visible notebook DOM.
+
+The current checkout reflects the post-#216 state:
+
+- `NotebookDataController` owns `openNotebooks` and loaded `NotebookData`
+  handles.
+- `NotebookContext` is a React adapter over the controller.
+- `CurrentDocContext` persists a selected URI.
+- `Actions.tsx` still merges one status-tab special case with
+  `openNotebooks.map(...)`.
+
+That is enough for notebook tabs, but it does not scale to notebook diffs or
+future views. If `currentDoc` becomes a diff id, notebook runtime helpers will
+fail or mutate the wrong state.
+
+## Background
+
+### NotebookDataController
+
+`NotebookDataController` is the current owner of notebook data and notebook-open
+state.
+
+File:
+
+- `app/src/lib/notebookDataController.ts`
+
+It owns two related but different concepts:
+
+- loaded `NotebookData` handles, keyed by stable local notebook URI
+- `openNotebooks`, the notebook tab metadata list currently used by the UI
+
+Its snapshot is notebook-specific:
+
+```ts
+interface NotebookDataControllerSnapshot {
+  openNotebooks: OpenNotebookEntry[];
+}
+
+interface OpenNotebookEntry {
+  uri: string;
+  requestedUri: string;
+  name: string;
+  state: NotebookTabState;
+  errorMessage?: string;
+}
+```
+
+`openNotebook(uri)` resolves or reserves a stable local notebook URI, creates or
+loads the `NotebookData` model, and upserts an `OpenNotebookEntry`.
+
+`closeNotebook(localUri)` removes the open entry, disposes the loaded
+`NotebookData` handle, and returns a fallback notebook URI.
+
+The controller also persists the open notebook list as restore state.
+
+### NotebookContext
+
+`NotebookContext` is currently a React adapter over `NotebookDataController`.
+
+File:
+
+- `app/src/contexts/NotebookContext.tsx`
+
+It exposes:
+
+```ts
+type NotebookContextValue = {
+  getNotebookData: (uri: string) => NotebookData | undefined;
+  openNotebook: (
+    uri: string,
+    options?: { name?: string },
+  ) => Promise<OpenNotebookResult>;
+  useNotebookSnapshot: (uri: string) => NotebookSnapshot | null;
+  useNotebookList: () => OpenNotebookEntry[];
+  removeNotebook: (uri: string) => string | null;
+};
+```
+
+The important method for issue #220 is `useNotebookList()`. It subscribes to the
+controller snapshot and returns `controller.getSnapshot().openNotebooks`.
+
+Today that list is the source for notebook tabs:
+
+```text
+NotebookDataController.openNotebooks
+  -> NotebookContext.useNotebookList()
+  -> Actions.tsx openNotebooks.map(...)
+  -> Radix Tabs.Trigger + NotebookTabContent
+```
+
+It also drives the Open Notebooks side panel, App Console notebook listing, and
+code-mode notebook listing.
+
+That means notebook model state and workspace tab state are still coupled
+through one notebook-specific list. The session refactor moved the list into a
+controller, but the list is still named and shaped as open notebooks.
+
+### CurrentDocContext
+
+`CurrentDocContext` is the current selected-URI context.
+
+File:
+
+- `app/src/contexts/CurrentDocContext.tsx`
+
+It exposes:
+
+```ts
+getCurrentDoc(): string | null;
+setCurrentDoc(uri: string | null): void;
+```
+
+It stores the selected URI in React state and persists it as restore state.
+
+Today most callers treat that URI as a notebook URI. `NotebookProvider` also has
+compatibility restore logic that opens the stored `currentDoc` as a notebook
+when there are no open notebooks.
+
+For the URI-centered workspace model, the context shape is still useful. The
+contract changes from "selected notebook URI" to "selected document URI." That
+document URI may be a notebook URI, a diff URI, or a status URI.
+
+Notebook-specific callers should inspect the URI scheme before treating
+`getCurrentDoc()` as a notebook.
+
+### Current Tab Rendering
+
+`Actions.tsx` currently renders the main tab strip from notebook state.
+
+File:
+
+- `app/src/components/Actions/Actions.tsx`
+
+The normal tabs are produced from:
+
+```ts
+const { useNotebookList, removeNotebook } = useNotebookContext();
+const openNotebooks = useNotebookList();
+```
+
+Then `Actions.tsx` maps `openNotebooks` into `Tabs.Trigger` and
+`NotebookTabContent`.
+
+The Drive link status tab is a separate special case keyed by
+`DRIVE_LINK_STATUS_TAB_URI`. It proves the tab strip can render a non-notebook
+view, but it is not part of a general document model.
+
+Issue #220 is the next step: replace the notebook-specific tab list with an
+open document URI list while leaving notebook data ownership in
+`NotebookDataController`.
+
+## Goals
+
+- Render notebook diff views as first-class tabs in the existing main workspace.
+- Keep notebook state, scroll state, editor state, and mounted DOM behavior at
+  least as stable as the current tab system.
+- Keep notebook data ownership in `NotebookDataController`.
+- Make App Console, code mode, and AppKernel helpers handle non-notebook current
+  document URIs without trying to load or mutate them as notebooks.
+- Remove the need for more one-off tab branches in `Actions.tsx`.
+- Replace the Open Notebooks side panel with an Open Documents panel that has a
+  one-to-one mapping with workspace tabs.
+
+## Non-Goals
+
+- Implementing notebook diff rendering itself.
+- Adding multi-tab browser ownership for notebooks.
+- Migrating legacy `localStorage` restore keys. Assume open/current restore
+  state is already tab-local `sessionStorage` state when this design is
+  implemented.
+- Moving notebook content persistence, autosave, or upstream sync out of
+  `NotebookDataController` / `NotebookData`.
+- Adding new diff routes or making every route a workspace document.
+- Turning notebook diffs into editable notebooks.
+
+## Consistency Review
+
+This proposal is consistent with the prior session and model/view refactors,
+but it changes which controller owns the open tab list.
+
+`20260520_notebook_session_refactor.md` split notebook opening/loading from
+selection. It made `NotebookDataController.openNotebook(...)` the explicit
+model-open path and kept `CurrentDocContext` as selection state. This design
+keeps that split and extends the selected value from "visible notebook URI" to
+"visible workspace document URI."
+
+`20260520_multi_tab_support.md` moved current/open restore state from shared
+`localStorage` to tab-local `sessionStorage`. This design keeps that storage
+policy. Workspace documents are tab-local UI state, so the generic open document
+list should also persist through `sessionStorage`.
+
+`20260426_getAllRendersRefbug.md` reinforced that notebook mutations update the
+model and views subscribe to model snapshots. This design follows the same
+direction: `WorkspaceDocumentController` owns tab/view metadata, while
+document-specific data owners such as `NotebookDataController` and
+`NotebookDiffData` own mutable document state.
+
+The deliberate change from the earlier notebook session design is that
+`NotebookDataController.openNotebooks` stops being the long-term UI tab source.
+That earlier list was useful when every tab was a notebook. Issue #220 requires
+diff and status documents in the same tab strip, so the open tab list moves to a
+generic workspace document controller.
+
+## Current Code Audit
+
+The current checkout still has these notebook-centric paths:
+
+- `app/src/components/Actions/Actions.tsx` reads
+  `useNotebookContext().useNotebookList()` and maps `openNotebooks` into Radix
+  tabs. `DRIVE_LINK_STATUS_TAB_URI` is a separate branch.
+- `app/src/components/SidePanel/SidePanel.tsx` renders `OpenNotebooksPanel`
+  from `useNotebookList()` and calls `removeNotebook(...)` to close rows.
+- `app/src/components/AppConsole/AppConsole.tsx` reads `getCurrentDoc()`,
+  `getNotebookData(...)`, and `useNotebookList()` to resolve implicit notebook
+  targets and list notebooks.
+- `app/src/lib/runtime/useCodeModeExecutor.ts` adds `currentDoc` to its
+  notebook URI candidates before resolving notebook data.
+- `app/src/components/CurrentDocInitializer.tsx` treats `?doc=` as a notebook
+  open command and calls `openNotebook(...)` before `setCurrentDoc(...)`.
+- `app/src/contexts/NotebookContext.tsx` still has compatibility logic that can
+  reopen the stored `currentDoc` as a notebook when the open notebook list is
+  empty.
+- `app/src/contexts/CurrentDocContext.tsx` stores the selected URI behind the
+  existing `getCurrentDoc()` / `setCurrentDoc(...)` API.
+
+The design addresses those paths directly:
+
+- move `Actions.tsx` and the side panel to `WorkspaceDocument[]`
+- keep `CurrentDocContext` and its API name
+- remove `useNotebookList()` from the long-term `NotebookContext` API
+- make App Console, code mode, and AppKernel notebook helpers check the current
+  URI scheme before treating it as a notebook
+- keep `?doc=` as a notebook open command and add a diff open command that
+  creates or resolves a `diff://...` URI
+
+## Prior Art: VS Code
+
+VS Code separates editor inputs, editor panes, and document models.
+
+Relevant sources:
+
+- https://code.visualstudio.com/api/extension-guides/custom-editors
+- https://code.visualstudio.com/api/extension-guides/virtual-documents
+- https://github.com/microsoft/vscode/blob/main/src/vs/workbench/common/editor/editorInput.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/workbench/common/editor.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/editor/common/editorService.ts
+
+VS Code custom editors have a view and a document model. The official docs say a
+custom editor has the view users interact with and the document model used to
+understand the underlying resource. They also state that one resource has one
+document model but can have multiple editor instances.
+
+That maps cleanly to this proposal:
+
+```text
+VS Code resource URI       -> Workspace document URI
+VS Code editor input       -> WorkspaceDocument tab entry
+VS Code editor pane/webview -> Workspace document view
+VS Code document model     -> NotebookData / NotebookDiffData / status data
+```
+
+VS Code also treats virtual documents as URI-scheme driven. A
+`TextDocumentContentProvider` claims a URI scheme, and commands that operate on
+those documents check the active document's scheme before acting. That supports
+the proposal's rule that notebook-only helpers should no-op when the current
+URI is `diff://...` or `status://...`.
+
+One VS Code distinction matters for future extensibility: custom editors use a
+`viewType` in addition to the resource URI. The `viewType` decides which editor
+implementation renders a matching resource, and users may reopen the same
+resource with another editor when multiple editors match.
+
+For Runme v1, the URI scheme is enough because each planned document kind has a
+single default view:
+
+- `local://file/<id>` -> notebook editor
+- `diff://notebook/<diffId>` -> notebook diff view
+- `status://drive-link` -> Drive status view
+
+Do not add a separate `viewType` field yet. Add it later only if the same
+document URI needs multiple user-selectable renderings, such as editing and
+previewing the same notebook URI in different tab views. Until then, a URI plus
+scheme-based switch is simpler and matches the current product need.
+
+## Design
+
+### End State
+
+The end state has three separate layers:
+
+| Layer | Owner | Responsibility |
+| --- | --- | --- |
+| Current selection | `CurrentDocContext` | The selected document URI |
+| Workspace tabs | `WorkspaceDocumentController` | Which document URIs are open, tab order, tab titles, close behavior, fallback selection |
+| View rendering | `Actions.tsx` plus document view components | Resolve a document URI to the view that renders it |
+| Document data | Document-specific data owners | Resolve a document URI to the model/data needed by its view |
+
+The tab controller stores document URIs and tab metadata. It does not own the
+underlying data for every document type.
+
+```text
+document URI
+  -> URI scheme helper
+  -> Actions.tsx switch
+  -> data owner for that URI scheme
+```
+
+Concrete examples:
+
+| URI | Tab metadata | View component | Data owner |
+| --- | --- | --- | --- |
+| `local://file/<id>` | URI, title | `NotebookTabContent` | `NotebookDataController` / `NotebookData` |
+| `diff://notebook/<diffId>` | URI, title | `NotebookDiffTabContent` | `NotebookDiffData` |
+| `status://drive-link` | URI, title | `DriveLinkStatusTab` | `driveLinkCoordinator` |
+
+This keeps the system extensible. Adding a new document type means adding:
+
+1. a URI scheme or URI pattern for the document
+2. an opener method or command that creates/selects that URI
+3. a rendering branch in `Actions.tsx`
+4. a document data owner if the view needs live data
+5. tests for selection, close behavior, and URI-type handling
+
+The workspace layer should not grow notebook-specific behavior. Notebook-only
+features remain behind URI classification helpers such as `isNotebookUri(uri)`
+or inside notebook view/data code.
+
+There is one selected document URI:
+
+- current document URI: the selected tab URI, which can point to a notebook,
+  diff, or status view
+
+Runtime helpers that only work for notebooks should inspect the URI before
+acting. If the current URI is not a notebook URI, they should return `null`,
+return an empty result, or no-op according to their existing contract.
+
+### WorkspaceDocument
+
+Add a generic tab/document model outside `NotebookDataController`. Use the URI
+as the durable identity and selection key.
+
+```ts
+interface WorkspaceDocument {
+  uri: string;
+  title: string;
+}
+```
+
+`uri` is the tab identity used by Radix `Tabs`. It must be stable and unique:
+
+- notebook: `local://file/<id>`
+- notebook diff: `diff://notebook/<diffId>`
+- Drive status: `status://drive-link`
+
+Document-specific metadata should live in the document data layer, not in the
+tab entry, unless it is needed for tab presentation. For example, a diff
+document can store its base/head notebook URIs in a `NotebookDiffData` record
+keyed by `diff://notebook/<diffId>`.
+
+Use helpers to classify URIs:
+
+```ts
+function getWorkspaceDocumentScheme(uri: string): string;
+function isNotebookDocumentUri(uri: string): boolean;
+function isNotebookDiffUri(uri: string): boolean;
+function isStatusUri(uri: string): boolean;
+```
+
+For notebooks, `local://file/<id>` remains the canonical editable notebook URI.
+For diffs, use a real URI rather than a secondary id:
+
+```text
+diff://notebook/<diffId>
+```
+
+If a diff needs embedded context, prefer storing it in the diff data model keyed
+by the diff URI. If the diff is cheap and stateless, query parameters are also
+acceptable:
+
+```text
+diff://notebook/<diffId>?base=local%3A%2F%2Ffile%2Fbase&head=local%3A%2F%2Ffile%2Fhead
+```
+
+### URI Classification And Rendering
+
+Use simple URI classification helpers and a switch in `Actions.tsx` to connect
+workspace document URIs to views.
+
+The current product needs only three document kinds, and centralizing the
+rendering decision in the tab component is easier to review.
+
+Suggested rendering shape:
+
+```tsx
+function renderWorkspaceDocument(document: WorkspaceDocument) {
+  if (isNotebookDocumentUri(document.uri)) {
+    return <NotebookTabContent docUri={document.uri} />;
+  }
+
+  if (isNotebookDiffUri(document.uri)) {
+    return <NotebookDiffTabContent diffUri={document.uri} />;
+  }
+
+  if (document.uri === "status://drive-link") {
+    return <DriveLinkStatusTab ... />;
+  }
+
+  return <UnknownDocumentTab uri={document.uri} />;
+}
+```
+
+Each view resolves its own document data through the owner for that URI scheme:
+
+- `local://file/<id>` resolves through `NotebookDataController.getNotebookData(uri)`.
+- `diff://notebook/<diffId>` resolves through `NotebookDiffData`.
+- `status://drive-link` resolves through `driveLinkCoordinator`.
+
+This keeps "document" as the data object and "view" as the renderer. A tab is
+only an open URI plus presentation metadata.
+
+Document-specific cleanup is optional. If a document data owner has no cleanup
+work, closing the workspace document only removes the URI from the open document
+list.
+
+### NotebookDiffData
+
+Use a small `NotebookDiffData` model as the data owner for
+`diff://notebook/<diffId>` documents.
+
+Responsibilities:
+
+- store the diff URI
+- store the base/head notebook URIs or enough metadata to resolve them
+- load or compute the diff payload needed by `NotebookDiffTabContent`
+- expose a snapshot/subscribe API if diff data can load asynchronously or change
+- optionally clean up in-memory diff state when the workspace document closes
+
+Suggested shape:
+
+```ts
+interface NotebookDiffSnapshot {
+  uri: string;
+  title: string;
+  baseNotebookUri?: string;
+  headNotebookUri?: string;
+  state: "loading" | "loaded" | "error";
+  errorMessage?: string;
+}
+
+class NotebookDiffData {
+  getSnapshot(): NotebookDiffSnapshot;
+  subscribe(listener: () => void): () => void;
+  close(): void;
+}
+```
+
+Add a small diff data controller only if the first implementation needs multiple
+diff documents tracked by URI:
+
+```ts
+getNotebookDiffData(uri: string): NotebookDiffData | undefined;
+openNotebookDiff(uri: string, options: NotebookDiffOpenOptions): NotebookDiffData;
+closeNotebookDiff(uri: string): void;
+```
+
+Do not put diff data into `WorkspaceDocumentController`. The workspace
+controller owns the open URI list; `NotebookDiffData` owns the diff document
+state.
+
+### WorkspaceDocumentController
+
+Add a vanilla TypeScript singleton:
+
+```text
+app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+```
+
+Suggested API:
+
+```ts
+interface WorkspaceDocumentSnapshot {
+  documents: WorkspaceDocument[];
+}
+
+class WorkspaceDocumentController {
+  getSnapshot(): WorkspaceDocumentSnapshot;
+  subscribe(listener: () => void): () => void;
+
+  showDocument(uri: string, options?: {
+    title?: string;
+  }): void;
+
+  closeDocument(uri: string): string | null;
+}
+```
+
+The controller owns:
+
+- visible workspace documents
+- close behavior that removes a URI from the open document list and returns a
+  fallback URI
+- generic tab persistence adapter
+
+It does not own:
+
+- `NotebookData`
+- notebook loading
+- notebook save/sync state
+- diff data loading
+- Drive link auth state
+
+### Notebook Opening And Showing
+
+Opening and showing a notebook remains three explicit operations:
+
+```ts
+const result = await notebookDataController.openNotebook(uri, { name });
+workspaceDocumentController.showDocument(result.localUri, {
+  title: result.entry.name,
+});
+setCurrentDoc(result.localUri);
+```
+
+This preserves the session refactor:
+
+- `NotebookDataController.openNotebook(...)` resolves or reserves the stable
+  local URI, creates/loads `NotebookData`, and returns load state.
+- `WorkspaceDocumentController.showDocument(...)` adds or updates the visible
+  workspace document entry for the notebook URI.
+- `setCurrentDoc(result.localUri)` selects the notebook tab.
+
+Do not make `WorkspaceDocumentController` call storage directly. Storage and
+notebook model lifecycle stay behind `NotebookDataController`.
+
+The workspace controller should not have document-type-specific show methods.
+It should derive defaults from the URI scheme:
+
+```ts
+showDocument("local://file/abc", { title: "notes.md" });
+showDocument("diff://notebook/123", { title: "Notebook diff" });
+showDocument("status://drive-link", { title: "Drive Link Status" });
+```
+
+Document-specific open flows can still exist outside the controller when they
+need to prepare data before showing the URI. For example, a notebook open flow
+must call `NotebookDataController.openNotebook(...)` before showing the
+workspace document URI. A future diff open flow may create a diff data record
+before showing `diff://notebook/<diffId>`.
+
+### Slimmed NotebookContext
+
+Keep `NotebookContext`, but narrow it to notebook data access. It should stop
+being the source of truth for open tabs.
+
+Target shape:
+
+```ts
+type NotebookContextValue = {
+  getNotebookData: (uri: string) => NotebookData | undefined;
+  openNotebook: (
+    uri: string,
+    options?: { name?: string },
+  ) => Promise<OpenNotebookResult>;
+  useNotebookSnapshot: (uri: string) => NotebookSnapshot | null;
+};
+```
+
+Remove these responsibilities from `NotebookContext`:
+
+- `useNotebookList()`
+- tab list persistence
+- tab close/fallback selection
+- any non-notebook document awareness
+
+Those move to the workspace document layer:
+
+```text
+WorkspaceDocumentController.documents
+  -> WorkspaceDocumentContext.useWorkspaceDocuments()
+  -> Actions tabs / Open Documents panel
+```
+
+`NotebookContext.openNotebook(...)` still prepares notebook data. It should not
+also imply the notebook is visible or selected. Callers that want to show the
+notebook should do all three operations explicitly:
+
+```ts
+const result = await openNotebook(uri, { name });
+showDocument(result.localUri, { title: result.entry.name });
+setCurrentDoc(result.localUri);
+```
+
+`removeNotebook(...)` can remain as a temporary compatibility wrapper during
+migration, but it should not be the long-term tab-close API. The long-term close
+path is `closeWorkspaceDocument(uri)`, with optional notebook cleanup when
+`isNotebookDocumentUri(uri)`.
+
+### CurrentDocContext
+
+Keep `CurrentDocContext` as the selected workspace document URI.
+
+The type already matches the URI-centered model:
+
+```ts
+currentDoc: string | null;
+setCurrentDoc(uri: string | null): void;
+```
+
+The semantic change is that `currentDoc` can be any workspace document URI:
+
+- selecting a notebook tab sets `currentDoc` to `local://file/<id>`
+- selecting a diff tab sets `currentDoc` to `diff://notebook/<diffId>`
+- selecting the Drive status tab sets `currentDoc` to `status://drive-link`
+- closing the active document sets `currentDoc` to the fallback open document
+  URI or `null`
+
+The restore backend should be tab-local `sessionStorage`. The selected document
+is tab-local UI state, just like the open document list.
+
+Keep the name `CurrentDocContext` for this refactor. The important change is the
+contract: the value is a workspace document URI, not necessarily a notebook URI.
+
+Add a separate context only for open document state:
+
+```text
+app/src/contexts/WorkspaceDocumentContext.tsx
+```
+
+It should expose the open documents and show/close helpers, but not duplicate
+current selection:
+
+```ts
+type WorkspaceDocumentContextValue = {
+  useWorkspaceDocuments: () => WorkspaceDocument[];
+  showDocument: (uri: string, options?: { title?: string }) => void;
+  closeWorkspaceDocument: (uri: string) => string | null;
+};
+```
+
+### Actions Rendering
+
+`Actions.tsx` should render tabs from `WorkspaceDocument[]`, not from
+`openNotebooks` plus status special cases.
+
+Rendering becomes a URI-scheme switch:
+
+```tsx
+if (isNotebookDocumentUri(document.uri)) {
+  return <NotebookTabContent docUri={document.uri} />;
+}
+
+if (isNotebookDiffUri(document.uri)) {
+  return <NotebookDiffTabContent diffUri={document.uri} />;
+}
+
+if (document.uri === "status://drive-link") {
+  return <DriveLinkStatusTab ... />;
+}
+
+return <UnknownDocumentTab uri={document.uri} />;
+```
+
+Notebook-only affordances stay behind the type guard:
+
+- sync indicator
+- notebook context menu
+- copy shareable link
+- close notebook via `NotebookDataController.closeNotebook`
+- active-cell persistence keyed by notebook URI
+
+Diff tabs get their own close and context actions. They must not render notebook
+sync state or appear in `NotebookDataController.getOpenNotebooks()`.
+
+All workspace documents are closeable from the workspace perspective. Closing a
+document removes its URI from the open document list and returns the next
+fallback URI. Document-specific cleanup should be optional and no-op by default.
+For example, a notebook close handler may also call
+`NotebookDataController.closeNotebook(uri)`, while closing a status document may
+only remove `status://drive-link` from the open document list.
+
+`TabPanel` with `forceMount` should remain the tab-content wrapper. It already
+preserves DOM state for inactive tabs. Diff tabs should use the same wrapper so
+switching between notebook and diff tabs has the same mounted-state behavior as
+switching between notebook tabs.
+
+### Drive Link Status
+
+Migrate the Drive link status tab into the generic document model after the
+notebook/diff path exists.
+
+`driveLinkCoordinator` should open or close the status document based on its
+snapshot:
+
+- when intents or errors exist: show `status://drive-link` with
+  `showDocument(...)`
+- when no intents or errors remain: close `status://drive-link`
+
+This removes `DRIVE_LINK_STATUS_TAB_URI` from `Actions.tsx`. If the first
+implementation slice keeps the status tab as a temporary special case, that
+should be documented as a transition step and not copied for diff tabs.
+
+### App Console And Code Mode
+
+Notebook runtime helpers can continue to start from `CurrentDocContext`.
+
+Rules:
+
+- If `getCurrentDoc()` returns a notebook URI, resolve the notebook data and
+  operate on it.
+- If `getCurrentDoc()` returns a diff or status URI, notebook-only helpers
+  should return `null`, return an empty result, or no-op according to their
+  existing contract.
+- Explicit notebook targets still win over implicit `CurrentDocContext` state.
+
+Update these consumers to validate the current URI before treating it as a
+notebook:
+
+- `AppConsole.tsx`
+- `useCodeModeExecutor.ts`
+- AppKernel notebook helpers
+- any future WebMCP notebook mutation entrypoints
+
+This is the acceptance-criteria guardrail: non-notebook tabs can be active
+without notebook-only code trying to load or mutate `diff://...` as a notebook.
+
+### Open Documents Side Panel
+
+Replace the Open Notebooks side panel with Open Documents.
+
+The panel should read from the same `WorkspaceDocumentController.documents`
+snapshot as the tab strip. There should be a one-to-one mapping between open
+workspace documents and rows in the panel:
+
+- notebook tabs appear as notebook rows
+- diff tabs appear as diff rows
+- status tabs appear as status rows, if they are represented as workspace
+  documents
+
+The panel should not read from `NotebookDataController.getOpenNotebooks()`.
+Notebook-specific metadata, such as sync state, can be rendered only for
+notebook URI rows.
+
+### URL And Open Commands
+
+Treat URL/query parameters as commands that prepare and show workspace
+documents only where URL handling already exists.
+
+Existing notebook `?doc=` handling should continue to call:
+
+```ts
+openNotebook(...)
+showDocument(...)
+setCurrentDoc(...)
+```
+
+Do not add a `/diff/:diffId` route for the initial implementation. Diff
+entrypoints should create or resolve a diff URI and show it in the existing
+workspace:
+
+```text
+create or resolve diff URI: diff://notebook/<diffId>
+showDocument(diffUri)
+setCurrentDoc(diffUri)
+```
+
+Diff documents are ephemeral in the initial design. A diff entrypoint may create
+a `diff://...` workspace document for the current tab, but reload should not
+restore that diff tab.
+
+### Persistence
+
+Persist open workspace document state through a small storage adapter. The
+adapter should use `sessionStorage` for the new workspace document state.
+
+```ts
+interface WorkspaceDocumentPersistence {
+  loadDocuments(): WorkspaceDocument[];
+  saveDocuments(documents: WorkspaceDocument[]): void;
+}
+```
+
+Do not hard-code `sessionStorage` calls throughout
+`WorkspaceDocumentController`. The adapter is intentionally small, but it keeps
+storage policy separate from open-document behavior:
+
+- the controller can be tested with an in-memory persistence backend
+- browser storage failures can be isolated from controller logic
+- the multi-tab storage decision is explicit instead of hidden in controller
+  methods
+
+The target storage split is:
+
+| State | Storage |
+| --- | --- |
+| restorable open workspace documents | `sessionStorage` |
+| current selected document URI, when restorable | `sessionStorage` |
+
+Use `sessionStorage` because open workspace documents are tab-local UI state. Two
+browser tabs should be able to show different open document sets. Shared
+`localStorage` would make same-origin tabs converge on the same open document
+list, which is the multi-tab bug this design should avoid.
+
+Not every open document has to be restorable. For the initial implementation,
+persist only notebook workspace documents. Do not persist `diff://...` entries.
+If the current document is a diff when the tab is closed or reloaded, restore to
+the next restorable document or `null`.
+
+Do not use shared `localStorage` as the authoritative store for open workspace
+documents or current document selection.
+
+Once `Actions`, App Console, code mode, and the side panel use the workspace
+document APIs, the workspace persistence can become the only open-tab restore
+store.
+
+## Implementation Slicing
+
+These slices do not have to be five separate PRs. Split by reviewability and
+rollback risk, not by this document's headings.
+
+Reasonable options:
+
+- one PR for the controller/context plus tab rendering if the diff view is small
+  and tests stay focused
+- two PRs where the first adds the generic tab model and the second moves
+  `Actions.tsx` plus diff tabs onto it
+- more PRs if App Console, code mode, URL initialization, and Drive status migration
+  would make the main tab-rendering PR hard to review
+
+The invariant is that every merged PR should leave one clear tab source of truth
+for the surfaces it migrates. Avoid a long-lived state where `Actions.tsx`,
+App Console, and the side panel each infer active/open documents differently.
+
+### Slice 1: Add Generic Workspace Documents
+
+- Add `WorkspaceDocumentController`.
+- Add `WorkspaceDocumentContext`.
+- Seed notebook workspace documents from the existing
+  `NotebookDataController.openNotebooks` snapshot.
+- Keep `CurrentDocContext` as selected document URI state.
+- Add tests for open/select/close behavior across notebook, diff, and status
+  documents.
+
+This slice should not change visible behavior.
+
+### Slice 2: Move The Main Tab Strip
+
+- Update `Actions.tsx` to render `WorkspaceDocument[]`.
+- Keep `NotebookTabContent` unchanged.
+- Add `NotebookDiffTabContent` as the renderer for diff documents.
+- Preserve `TabPanel` + `forceMount` behavior for all document URI schemes.
+- Keep notebook-only tab affordances behind `isNotebookDocumentUri(document.uri)`.
+
+This slice satisfies the core issue requirement: diff views can render as tabs next
+to notebooks.
+
+### Slice 3: Migrate Open Callers
+
+- Workspace Explorer: `openNotebook` then `showDocument`.
+- URL initializer: treat `?doc=` as a notebook open command.
+- App Console `app.openNotebook(...)`: open the notebook data model, show the
+  workspace document, then select the workspace document.
+- Drive link coordinator: show successful notebook URIs with `showDocument`,
+  then select them with `setCurrentDoc`.
+- Diff entrypoints: create or resolve a `diff://...` URI, then call
+  `showDocument(diffUri)`.
+
+After this slice, callers should use `setCurrentDoc(...)` for selected document
+URIs, not as an implicit notebook-open command.
+
+### Slice 4: Fix Notebook Runtime Resolution
+
+- Move App Console and code mode onto URI-scheme checks before notebook work.
+- Keep explicit notebook target resolution unchanged.
+- Add tests where a diff tab is active and notebook-only helpers no-op or return
+  `null`.
+
+### Slice 5: Remove Transitional Duplication
+
+- Stop treating `NotebookDataController.openNotebooks` as the tab-strip source
+  of truth.
+- Keep notebook data handles and load state in `NotebookDataController`.
+- Keep notebook tab metadata in `WorkspaceDocumentController`.
+- Remove `useNotebookList()` from the long-term `NotebookContext` API.
+- Either migrate Drive Link Status to `WorkspaceDocumentController` or leave it
+  as an explicitly documented temporary exception.
+
+## Testing
+
+Unit tests:
+
+- `WorkspaceDocumentController` shows, deduplicates, selects, closes, and
+  returns fallback URIs for each document URI scheme.
+- Selecting a diff/status document updates the current document URI.
+- Selecting a notebook document updates the current document URI.
+- Closing the active document chooses the next open document URI.
+
+React tests:
+
+- `Actions` renders notebook and diff tabs from the same tab list.
+- Switching notebook -> diff -> notebook keeps notebook content mounted.
+- Diff tabs do not render notebook sync indicators or notebook context-menu
+  actions.
+- Diff tabs are not restored from `sessionStorage` after reload.
+- Open Documents side panel has one row per workspace tab, including diffs.
+- App Console does not treat a `diff://...` current document as a notebook.
+
+Manual checks:
+
+- Open two notebooks, switch between them, confirm editor and scroll state
+  remain stable.
+- Open a diff tab next to notebooks, switch back and forth, confirm notebook
+  state remains stable.
+- Close a diff tab and confirm notebook selection is unchanged.
+- Close the active document while a diff tab exists and confirm the current
+  document URI falls back to the next open document.
+
+## Risks
+
+The main risk is creating two competing sources of truth during migration:
+`NotebookDataController.openNotebooks` and `WorkspaceDocumentController`.
+Mitigate this by making the migration direction explicit:
+
+- notebook data ownership remains in `NotebookDataController`
+- tab ownership moves to `WorkspaceDocumentController`
+- temporary adapters should be deleted after call sites move
+
+The second risk is changing App Console behavior subtly. Avoid that by making
+notebook-only helpers check the current URI scheme before resolving notebook
+data.
+
+## Open Questions
+
+None.


### PR DESCRIPTION
## Summary

- Add WorkspaceDocumentController and WorkspaceDocumentContext to own the visible workspace document URI list, tab metadata, close behavior, and sessionStorage restore state.
- Switch Actions tabs and the side panel from notebook-only lists to workspace documents, including notebook, diff, and Drive Link status URI handling.
- Keep CurrentDocContext as the selected URI while guarding notebook-only helpers so diff/status URIs do not load or mutate notebooks.
- Route notebook-open call sites through showDocument before selecting the URI, and keep diff documents URI-driven without adding /diff routes.
- Update the design doc to clarify that the existing workspace route hosts URI-driven tabs.

## Context

Related to #220. This PR implements the initial workspace document/tab infrastructure. Notebook diff rendering remains a placeholder and diff documents are intentionally not restorable in this slice.

## Validation

- runme run build test
- pnpm -C app exec vitest run src/lib/workspaceDocuments/workspaceDocumentController.test.ts src/lib/notebookDataController.test.ts src/contexts/CurrentDocContext.test.tsx src/components/CurrentDocInitializer.test.tsx src/components/DriveLinkCoordinatorHost.test.tsx src/components/SidePanel/SidePanel.test.tsx src/components/AppConsole/AppConsole.test.tsx src/components/Actions/Actions.test.tsx
- git -c core.fsmonitor=false diff --check

## Notes

- gh reports no status checks configured for this branch.
- pnpm -C app run typecheck still fails on the existing broad repository TypeScript backlog; the new workspace helper error found during this work was fixed.