### PR TITLE
[codex] Remove legacy notebook localStorage restore

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -25,7 +25,7 @@
 - React views subscribe via `useNotebookSnapshot` (backed by `useSyncExternalStore`) and render from immutable snapshots to avoid tearing under concurrent rendering.
 - Snapshots are clones; do not mutate them directly. Use NotebookData/CellData methods for updates.
 - `loaded` distinguishes placeholder models (created before async load) from fully loaded notebooks; only `loadNotebook` flips it true.
-- NotebookContext seeds `storeRef` and `openNotebooks` once from localStorage so models exist early; async loads populate existing models and emit.
+- NotebookContext seeds `storeRef` and `openNotebooks` once from sessionStorage so models exist early; async loads populate existing models and emit.
 - Tabs keep content mounted with `Tabs.Content forceMount` and `TabPanel` hides inactive tabs via `visibility`/`position` to preserve scroll/Monaco layout.
 - Loading gates live inside `NotebookTabContent` and use snapshot.loaded to decide when to show content.
 

--- a/app/src/contexts/CurrentDocContext.test.tsx
+++ b/app/src/contexts/CurrentDocContext.test.tsx
@@ -43,7 +43,6 @@ describe("CurrentDocProvider", () => {
   });
 
   it("restores current doc from per-tab sessionStorage", async () => {
-    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
     window.sessionStorage.setItem("runme/currentDoc", "local://file/session");
 
     render(
@@ -71,7 +70,6 @@ describe("CurrentDocProvider", () => {
     expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
       "local://file/selected",
     );
-    expect(window.localStorage.getItem("runme/currentDoc")).toBeNull();
     expect(window.location.search).toContain("doc=");
     await waitFor(() => {
       expect(screen.getByTestId("current-doc").textContent).toBe(

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -259,8 +259,8 @@ describe("NotebookDataController", () => {
     ]);
   });
 
-  it("restores legacy open-notebook storage without changing the storage shape", () => {
-    window.localStorage.setItem(
+  it("restores session open-notebook storage without changing the storage shape", () => {
+    window.sessionStorage.setItem(
       "runme/openNotebooks",
       JSON.stringify([
         {

--- a/app/src/lib/notebookSessionPersistence.test.ts
+++ b/app/src/lib/notebookSessionPersistence.test.ts
@@ -10,23 +10,11 @@ describe("NotebookSessionPersistence", () => {
     window.sessionStorage.clear();
   });
 
-  it("uses sessionStorage for current doc before legacy localStorage", () => {
+  it("restores current doc from sessionStorage", () => {
     const persistence = new NotebookSessionPersistence();
-    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
     window.sessionStorage.setItem("runme/currentDoc", "local://file/session");
 
     expect(persistence.loadCurrentDoc()).toBe("local://file/session");
-  });
-
-  it("imports legacy current doc into sessionStorage", () => {
-    const persistence = new NotebookSessionPersistence();
-    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
-
-    expect(persistence.loadCurrentDoc()).toBe("local://file/legacy");
-    expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
-      "local://file/legacy",
-    );
-    expect(window.localStorage.getItem("runme/currentDoc")).toBeNull();
   });
 
   it("writes only sessionStorage for current doc changes", () => {
@@ -37,21 +25,19 @@ describe("NotebookSessionPersistence", () => {
     expect(window.sessionStorage.getItem("runme/currentDoc")).toBe(
       "local://file/current",
     );
-    expect(window.localStorage.getItem("runme/currentDoc")).toBeNull();
   });
 
-  it("does not fall back to legacy current doc after the session clears selection", () => {
+  it("restores empty current doc selections from sessionStorage", () => {
     const persistence = new NotebookSessionPersistence();
-    window.localStorage.setItem("runme/currentDoc", "local://file/legacy");
 
     persistence.saveCurrentDoc(null);
 
     expect(persistence.loadCurrentDoc()).toBeNull();
   });
 
-  it("imports legacy open notebooks as OpenNotebookEntry records", () => {
+  it("restores session open notebooks as OpenNotebookEntry records", () => {
     const persistence = new NotebookSessionPersistence();
-    window.localStorage.setItem(
+    window.sessionStorage.setItem(
       "runme/openNotebooks",
       JSON.stringify([
         {
@@ -82,49 +68,10 @@ describe("NotebookSessionPersistence", () => {
         name: "legacy.json",
       }),
     ]);
-    expect(window.localStorage.getItem("runme/openNotebooks")).toBeNull();
   });
 
-  it("clears older legacy open notebooks after importing them", () => {
+  it("restores empty open-notebook lists from sessionStorage", () => {
     const persistence = new NotebookSessionPersistence();
-    window.localStorage.setItem(
-      "aisre/openNotebooks",
-      JSON.stringify([
-        {
-          uri: "local://file/legacy",
-          name: "legacy.json",
-          type: NotebookStoreItemType.File,
-          children: [],
-          parents: [],
-        },
-      ]),
-    );
-
-    expect(persistence.loadOpenNotebooks()).toEqual([
-      expect.objectContaining({
-        uri: "local://file/legacy",
-        requestedUri: "local://file/legacy",
-        name: "legacy.json",
-      }),
-    ]);
-    expect(window.sessionStorage.getItem("runme/openNotebooks")).toBeTruthy();
-    expect(window.localStorage.getItem("aisre/openNotebooks")).toBeNull();
-  });
-
-  it("does not fall back to legacy open notebooks when session list is empty", () => {
-    const persistence = new NotebookSessionPersistence();
-    window.localStorage.setItem(
-      "runme/openNotebooks",
-      JSON.stringify([
-        {
-          uri: "local://file/legacy",
-          name: "legacy.json",
-          type: NotebookStoreItemType.File,
-          children: [],
-          parents: [],
-        },
-      ]),
-    );
     window.sessionStorage.setItem("runme/openNotebooks", "[]");
 
     expect(persistence.loadOpenNotebooks()).toEqual([]);

--- a/app/src/lib/notebookSessionPersistence.ts
+++ b/app/src/lib/notebookSessionPersistence.ts
@@ -6,7 +6,6 @@ import type { OpenNotebookEntry } from "./notebookDataController";
 
 const CURRENT_DOC_STORAGE_KEY = "runme/currentDoc";
 const OPEN_NOTEBOOKS_STORAGE_KEY = "runme/openNotebooks";
-const LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY = "aisre/openNotebooks";
 
 function getSessionStorage(): Storage | null {
   if (typeof window === "undefined") {
@@ -14,17 +13,6 @@ function getSessionStorage(): Storage | null {
   }
   try {
     return window.sessionStorage;
-  } catch {
-    return null;
-  }
-}
-
-function getLocalStorage(): Storage | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  try {
-    return window.localStorage;
   } catch {
     return null;
   }
@@ -77,8 +65,8 @@ function parseOpenNotebooks(raw: string | null): OpenNotebookEntry[] {
  *
  * Runtime state still lives in `CurrentDocContext` and
  * `NotebookDataController`; this class only hydrates them on startup and saves
- * snapshots after changes. It reads legacy localStorage keys as an initial
- * import path but only writes sessionStorage so same-origin tabs can diverge.
+ * snapshots after changes. It only uses sessionStorage so same-origin tabs can
+ * diverge.
  */
 export class NotebookSessionPersistence {
   loadCurrentDoc(): string | null {
@@ -87,17 +75,7 @@ export class NotebookSessionPersistence {
     if (fromSession !== undefined && fromSession !== null) {
       return fromSession.trim() || null;
     }
-    const local = getLocalStorage();
-    const fromLegacy = local?.getItem(CURRENT_DOC_STORAGE_KEY)?.trim() || null;
-    if (fromLegacy) {
-      this.saveCurrentDoc(fromLegacy);
-      try {
-        local?.removeItem(CURRENT_DOC_STORAGE_KEY);
-      } catch {
-        // Ignore legacy cleanup failures. The migrated session value is usable.
-      }
-    }
-    return fromLegacy;
+    return null;
   }
 
   saveCurrentDoc(uri: string | null): void {
@@ -122,23 +100,7 @@ export class NotebookSessionPersistence {
     if (fromSession !== undefined && fromSession !== null) {
       return parseOpenNotebooks(fromSession);
     }
-
-    const local = getLocalStorage();
-    const fromLegacy = parseOpenNotebooks(
-      local?.getItem(OPEN_NOTEBOOKS_STORAGE_KEY) ??
-        local?.getItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY) ??
-        null,
-    );
-    if (fromLegacy.length > 0) {
-      this.saveOpenNotebooks(fromLegacy);
-      try {
-        local?.removeItem(OPEN_NOTEBOOKS_STORAGE_KEY);
-        local?.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
-      } catch {
-        // Ignore legacy cleanup failures. The migrated session value is usable.
-      }
-    }
-    return fromLegacy;
+    return [];
   }
 
   saveOpenNotebooks(entries: OpenNotebookEntry[]): void {
@@ -148,7 +110,6 @@ export class NotebookSessionPersistence {
     }
     try {
       session.setItem(OPEN_NOTEBOOKS_STORAGE_KEY, JSON.stringify(entries));
-      session.removeItem(LEGACY_OPEN_NOTEBOOKS_STORAGE_KEY);
     } catch {
       // Ignore restore persistence failures. Live state has already changed.
     }

--- a/app/test/browser/test-scenario-ai-codex.ts
+++ b/app/test/browser/test-scenario-ai-codex.ts
@@ -773,7 +773,7 @@ try {
         remoteId: '',
         lastRemoteChecksum: ''
       });
-      localStorage.setItem('runme/openNotebooks', JSON.stringify([
+      sessionStorage.setItem('runme/openNotebooks', JSON.stringify([
         {
           uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}',
           name: '${SCENARIO_NOTEBOOK_NAME}',
@@ -781,7 +781,7 @@ try {
           children: []
         }
       ]));
-      localStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
+      sessionStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
       return 'ok';
     })()"`,
   ).stdout;

--- a/app/test/browser/test-scenario-appkernel-javascript.ts
+++ b/app/test/browser/test-scenario-appkernel-javascript.ts
@@ -361,10 +361,10 @@ const seedResult = run(
       remoteId: '',
       lastRemoteChecksum: ''
     });
-    localStorage.setItem('runme/openNotebooks', JSON.stringify([
+    sessionStorage.setItem('runme/openNotebooks', JSON.stringify([
       { uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }
     ]));
-    localStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
+    sessionStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
     return 'ok';
   })()"`,
 ).stdout;

--- a/app/test/browser/test-scenario-hello-world.ts
+++ b/app/test/browser/test-scenario-hello-world.ts
@@ -314,10 +314,10 @@ const seedResult = run(
     remoteId: '',
     lastRemoteChecksum: ''
   });
-  localStorage.setItem('runme/openNotebooks', JSON.stringify([
+  sessionStorage.setItem('runme/openNotebooks', JSON.stringify([
     { uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }
   ]));
-  localStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
+  sessionStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
   return 'ok';
 })()"`,
 ).stdout;

--- a/app/test/browser/test-scenario-html-cell.ts
+++ b/app/test/browser/test-scenario-html-cell.ts
@@ -162,10 +162,10 @@ const seedResult = run(
       remoteId: '',
       lastRemoteChecksum: ''
     });
-    localStorage.setItem('runme/openNotebooks', JSON.stringify([
+    sessionStorage.setItem('runme/openNotebooks', JSON.stringify([
       { uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }
     ]));
-    localStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
+    sessionStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
     return 'ok';
   })()"`,
 ).stdout;

--- a/app/test/browser/test-scenario-jupyter.ts
+++ b/app/test/browser/test-scenario-jupyter.ts
@@ -1224,8 +1224,8 @@ const seedCommandResult = run(
       remoteId: '',
       lastRemoteChecksum: ''
     });
-    localStorage.setItem('runme/openNotebooks', JSON.stringify([{ uri: '${SCENARIO_NOTEBOOK_URI}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }]));
-    localStorage.setItem('runme/currentDoc', '${SCENARIO_NOTEBOOK_URI}');
+    sessionStorage.setItem('runme/openNotebooks', JSON.stringify([{ uri: '${SCENARIO_NOTEBOOK_URI}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }]));
+    sessionStorage.setItem('runme/currentDoc', '${SCENARIO_NOTEBOOK_URI}');
     return 'ok';
   })()"`),
 );

--- a/app/test/browser/test-scenario-no-runner-logs.ts
+++ b/app/test/browser/test-scenario-no-runner-logs.ts
@@ -338,10 +338,10 @@ const seedResult = run(
       remoteId: '',
       lastRemoteChecksum: ''
     });
-    localStorage.setItem('runme/openNotebooks', JSON.stringify([
+    sessionStorage.setItem('runme/openNotebooks', JSON.stringify([
       { uri: 'local://file/${SCENARIO_NOTEBOOK_NAME}', name: '${SCENARIO_NOTEBOOK_NAME}', type: 'file', children: [] }
     ]));
-    localStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
+    sessionStorage.setItem('runme/currentDoc', 'local://file/${SCENARIO_NOTEBOOK_NAME}');
     return 'ok';
   })()"`,
 ).stdout;

--- a/app/test/browser/test-scenario-notebook-focus-persistence.ts
+++ b/app/test/browser/test-scenario-notebook-focus-persistence.ts
@@ -218,10 +218,10 @@ try {
         md5Checksum: ''
       }));
       db.close();
-      localStorage.setItem('runme/openNotebooks', JSON.stringify([
+      sessionStorage.setItem('runme/openNotebooks', JSON.stringify([
         { uri: '${NOTEBOOK_URI}', name: '${NOTEBOOK_NAME}', type: 'file', children: [], parents: ['local://folder/local'] }
       ]));
-      localStorage.setItem('runme/currentDoc', '${NOTEBOOK_URI}');
+      sessionStorage.setItem('runme/currentDoc', '${NOTEBOOK_URI}');
       localStorage.removeItem('${STORAGE_KEY}');
       return JSON.stringify({ status: 'ok' });
     })()"`,

--- a/app/test/browser/test-scenario-open-shared-drive-link.ts
+++ b/app/test/browser/test-scenario-open-shared-drive-link.ts
@@ -277,7 +277,6 @@ const seedRuntime = run(
     localStorage.setItem('${GOOGLE_DRIVE_RUNTIME_STORAGE_KEY}', JSON.stringify({ baseUrl: '${FAKE_DRIVE_URL}' }));
     localStorage.setItem('${GOOGLE_CLIENT_STORAGE_KEY}', JSON.stringify({}));
     localStorage.removeItem('${GOOGLE_AUTH_STORAGE_KEY}');
-    localStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     sessionStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     localStorage.setItem('${WORKSPACE_STORAGE_KEY}', JSON.stringify({ items: [] }));
     return 'ok';
@@ -438,7 +437,6 @@ if (/Share link copied/i.test(folderShareToast)) {
 run(
   `agent-browser eval "(async () => {
     localStorage.removeItem('${GOOGLE_AUTH_STORAGE_KEY}');
-    localStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     sessionStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     localStorage.setItem('${WORKSPACE_STORAGE_KEY}', JSON.stringify({ items: [] }));
     return 'ok';

--- a/docs-dev/architecture/global-singletons.md
+++ b/docs-dev/architecture/global-singletons.md
@@ -51,12 +51,10 @@ call only `setCurrentDoc(localUri)` for notebooks that are already open.
 
 ## Persistence
 
-The current notebook-session refactor keeps the existing shared `localStorage`
-keys:
+Notebook session restore state is stored in per-tab `sessionStorage` keys:
 
 - `runme/currentDoc`
 - `runme/openNotebooks`
 
-Future multi-tab work will move current/open restore state to tab-local storage.
-Keep persistence code isolated enough that this storage swap does not require
-changing notebook loading or selection semantics.
+Keep persistence code isolated so notebook loading and selection semantics do
+not depend on the storage backend.


### PR DESCRIPTION
## Summary
- Remove one-time legacy localStorage imports for current doc and open notebooks
- Keep notebook restore state sessionStorage-only
- Update app and browser tests to seed/verify sessionStorage restore state

## Impact
This completes the migration away from the old shared localStorage keys for current/open notebook restore state. Existing sessionStorage restore behavior is unchanged.

## Validation
- pnpm -C app test src/lib/notebookSessionPersistence.test.ts src/contexts/CurrentDocContext.test.tsx src/lib/notebookDataController.test.ts --run
- runme run build test