### PR TITLE
[codex] Add explorer rename for Drive files

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -17,6 +17,13 @@ const contextMocks = vi.hoisted(() => ({
   setCurrentDoc: vi.fn(),
   showDocument: vi.fn(),
   closeWorkspaceDocument: vi.fn(),
+  getNotebookData: vi.fn(),
+  notebookStore: null as null | {
+    getMetadata: ReturnType<typeof vi.fn>;
+    getSyncState: ReturnType<typeof vi.fn>;
+    rename: ReturnType<typeof vi.fn>;
+    subscribeSync: ReturnType<typeof vi.fn>;
+  },
 }));
 
 // Minimal mocks for contexts Action consumes
@@ -47,7 +54,7 @@ vi.mock("../../contexts/SettingsContext", () => ({
 
 vi.mock("../../contexts/NotebookContext", () => ({
   useNotebookContext: () => ({
-    getNotebookData: () => null,
+    getNotebookData: contextMocks.getNotebookData,
     useNotebookSnapshot: () => null,
   }),
 }));
@@ -62,7 +69,7 @@ vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
 
 vi.mock("../../contexts/NotebookStoreContext", () => ({
   useNotebookStore: () => ({
-    store: null,
+    store: contextMocks.notebookStore,
   }),
 }));
 
@@ -200,6 +207,9 @@ beforeEach(() => {
   });
   contextMocks.showDocument.mockReset();
   contextMocks.closeWorkspaceDocument.mockReset();
+  contextMocks.getNotebookData.mockReset();
+  contextMocks.getNotebookData.mockReturnValue(null);
+  contextMocks.notebookStore = null;
 });
 
 describe("Actions tabs", () => {
@@ -216,6 +226,58 @@ describe("Actions tabs", () => {
         "local://file/restored",
       );
     });
+  });
+
+  it("renames the notebook from the tab context menu", async () => {
+    const rename = vi.fn(async () => ({
+      uri: "local://file/restored",
+      name: "renamed.json",
+      type: "file",
+      children: [],
+      remoteUri: "https://drive.google.com/file/d/file123/view",
+      parents: [],
+    }));
+    const setName = vi.fn();
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: "local://file/restored",
+        name: "restored.json",
+        type: "file",
+        children: [],
+        remoteUri: "https://drive.google.com/file/d/file123/view",
+        parents: [],
+      })),
+      getSyncState: vi.fn(async () => ({
+        status: "synced",
+        localUri: "local://file/restored",
+        remoteId: "https://drive.google.com/file/d/file123/view",
+      })),
+      rename,
+      subscribeSync: vi.fn(() => () => {}),
+    };
+    contextMocks.getNotebookData.mockReturnValue({ setName });
+    contextMocks.currentDoc = "local://file/restored";
+    contextMocks.workspaceDocuments = [
+      { uri: "local://file/restored", title: "restored.json" },
+    ];
+    vi.spyOn(window, "prompt").mockReturnValue("renamed.json");
+
+    render(<Actions />);
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: "restored.json" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Rename" }));
+
+    await waitFor(() => {
+      expect(rename).toHaveBeenCalledWith(
+        "local://file/restored",
+        "renamed.json",
+      );
+    });
+    expect(setName).toHaveBeenCalledWith("renamed.json");
+    expect(contextMocks.showDocument).toHaveBeenCalledWith(
+      "local://file/restored",
+      { title: "renamed.json" },
+    );
   });
 });
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1714,6 +1714,7 @@ export default function Actions() {
     showDocument,
     closeWorkspaceDocument,
   } = useWorkspaceDocumentContext();
+  const { getNotebookData } = useNotebookContext();
   const { store } = useNotebookStore();
   const workspaceDocuments = useWorkspaceDocuments();
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
@@ -1739,6 +1740,7 @@ export default function Actions() {
     x: number;
     y: number;
     docUri: string;
+    title: string;
     shareableUri: string;
     googleDriveUri: string | null;
   } | null>(null);
@@ -1963,7 +1965,7 @@ export default function Actions() {
     if (typeof window === "undefined") {
       return tabContextMenu;
     }
-    const itemCount = tabContextMenu.googleDriveUri ? 3 : 2;
+    const itemCount = tabContextMenu.googleDriveUri ? 4 : 3;
     const menuWidth = 220;
     const menuHeight = itemCount * 36 + 8;
     return {
@@ -1980,10 +1982,15 @@ export default function Actions() {
     (event: ReactMouseEvent<HTMLElement>, docUri: string) => {
       event.preventDefault();
       event.stopPropagation();
+      const document = workspaceDocuments.find((doc) => doc.uri === docUri);
+      const title =
+        document?.title?.trim() ||
+        getNotebookDisplayName(docUri, document?.title ?? docUri);
       setTabContextMenu({
         x: event.clientX,
         y: event.clientY,
         docUri,
+        title,
         shareableUri: docUri,
         googleDriveUri: isGoogleDriveFileUri(docUri) ? docUri : null,
       });
@@ -2018,8 +2025,48 @@ export default function Actions() {
         }
       })();
     },
-    [store],
+    [store, workspaceDocuments],
   );
+
+  const handleRenameTab = useCallback(async () => {
+    if (!tabContextMenu) {
+      return;
+    }
+    if (!store) {
+      setTabContextMenu(null);
+      return;
+    }
+
+    const nextName = window.prompt("Rename notebook", tabContextMenu.title);
+    if (nextName === null) {
+      setTabContextMenu(null);
+      return;
+    }
+
+    const trimmed = nextName.trim();
+    const renamedName = trimmed === "" ? "untitled.json" : trimmed;
+    try {
+      const renamed = await store.rename(tabContextMenu.docUri, renamedName);
+      const title = renamed.name || renamedName;
+      getNotebookData(tabContextMenu.docUri)?.setName(title);
+      showDocument(tabContextMenu.docUri, { title });
+      setTabContextMenu(null);
+    } catch (error) {
+      appLogger.error("Failed to rename notebook from tab context menu", {
+        attrs: {
+          scope: "storage.rename",
+          code: "TAB_RENAME_FAILED",
+          uri: tabContextMenu.docUri,
+          error: String(error),
+        },
+      });
+      showToast({
+        message: "Unable to rename document. Please try again.",
+        tone: "error",
+      });
+      setTabContextMenu(null);
+    }
+  }, [getNotebookData, showDocument, store, tabContextMenu]);
 
   const handleCopyTabShareableLink = useCallback(async () => {
     if (!tabContextMenu) {
@@ -2239,6 +2286,16 @@ export default function Actions() {
               onClick={(event) => event.stopPropagation()}
               onContextMenu={(event) => event.preventDefault()}
             >
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void handleRenameTab();
+                }}
+              >
+                Rename
+              </button>
               <button
                 type="button"
                 className="ctx-menu-item"

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -168,6 +168,63 @@ function updateNodeMetadata(
   return changed ? next : nodes;
 }
 
+const CONTEXT_MENU_VIEWPORT_PADDING = 8;
+const CONTEXT_MENU_WIDTH = 220;
+const CONTEXT_MENU_VERTICAL_PADDING = 8;
+const CONTEXT_MENU_ITEM_HEIGHT = 38;
+
+function getContextMenuItemCount(menu: ContextMenuState): number {
+  if (menu.type === NotebookStoreItemType.File) {
+    return (
+      (menu.uri.startsWith("fs://") ? 0 : 1) +
+      2 +
+      (menu.remoteUri ? 2 : 0)
+    );
+  }
+
+  if (menu.type === NotebookStoreItemType.Folder) {
+    return (
+      (menu.uri.startsWith("fs://") ? 0 : 1) +
+      1 +
+      (menu.remoteUri ? 2 : 0) +
+      (menu.uri === LOCAL_FOLDER_URI ? 0 : 1)
+    );
+  }
+
+  return 0;
+}
+
+function adjustContextMenuPosition(
+  menu: ContextMenuState | null,
+): ContextMenuState | null {
+  if (!menu || typeof window === "undefined") {
+    return menu;
+  }
+
+  const menuHeight =
+    CONTEXT_MENU_VERTICAL_PADDING +
+    getContextMenuItemCount(menu) * CONTEXT_MENU_ITEM_HEIGHT;
+  const left = Math.max(
+    CONTEXT_MENU_VIEWPORT_PADDING,
+    Math.min(
+      menu.position.x,
+      window.innerWidth - CONTEXT_MENU_WIDTH - CONTEXT_MENU_VIEWPORT_PADDING,
+    ),
+  );
+  const top = Math.max(
+    CONTEXT_MENU_VIEWPORT_PADDING,
+    Math.min(
+      menu.position.y,
+      window.innerHeight - menuHeight - CONTEXT_MENU_VIEWPORT_PADDING,
+    ),
+  );
+
+  return {
+    ...menu,
+    position: { x: left, y: top },
+  };
+}
+
 function EditableTreeNode({
   node,
   style,
@@ -247,6 +304,10 @@ export function WorkspaceExplorer() {
   const [pendingEditId, setPendingEditId] = useState<string | null>(null);
 
   const workspaceUris = useMemo(() => getItems(), [getItems]);
+  const adjustedContextMenu = useMemo(
+    () => adjustContextMenuPosition(contextMenu),
+    [contextMenu],
+  );
 
   useEffect(() => {
     if (!workspaceUris.includes(LOCAL_FOLDER_URI)) {
@@ -961,18 +1022,19 @@ function formatShortTimestamp(date: Date): string {
           />
         </div>
       )}
-      {contextMenu && (
+      {adjustedContextMenu && (
         <div
           className="ctx-menu"
           style={{
-            top: contextMenu.position.y,
-            left: contextMenu.position.x,
+            top: adjustedContextMenu.position.y,
+            left: adjustedContextMenu.position.x,
+            width: CONTEXT_MENU_WIDTH,
           }}
           onClick={(event) => event.stopPropagation()}
         >
-          {contextMenu.type === NotebookStoreItemType.File ? (
+          {adjustedContextMenu.type === NotebookStoreItemType.File ? (
             <>
-              {!contextMenu.uri.startsWith("fs://") && (
+              {!adjustedContextMenu.uri.startsWith("fs://") && (
                 <button
                   type="button"
                   className="ctx-menu-item"
@@ -982,7 +1044,7 @@ function formatShortTimestamp(date: Date): string {
                     setContextMenu(null);
                     void (async () => {
                       try {
-                        await store?.sync(contextMenu.uri);
+                        await store?.sync(adjustedContextMenu.uri);
                       } catch (error) {
                         console.error("Failed to sync file", error);
                       }
@@ -998,7 +1060,7 @@ function formatShortTimestamp(date: Date): string {
                 onMouseDown={(event) => event.stopPropagation()}
                 onClick={(event) => {
                   event.stopPropagation();
-                  handleStartRename(contextMenu.uri);
+                  handleStartRename(adjustedContextMenu.uri);
                 }}
               >
                 Rename
@@ -1010,19 +1072,19 @@ function formatShortTimestamp(date: Date): string {
                 onClick={(event) => {
                   event.stopPropagation();
                   setContextMenu(null);
-                  if (contextMenu.parentUri) {
-                    void handleCreateDocument(contextMenu.parentUri);
+                  if (adjustedContextMenu.parentUri) {
+                    void handleCreateDocument(adjustedContextMenu.parentUri);
                   } else {
                     console.warn(
                       "Cannot create document: no parent folder for",
-                      contextMenu.uri,
+                      adjustedContextMenu.uri,
                     );
                   }
                 }}
               >
                 New Document
               </button>
-              {contextMenu.remoteUri && (
+              {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"
                   className="ctx-menu-item"
@@ -1030,16 +1092,16 @@ function formatShortTimestamp(date: Date): string {
                   onClick={(event) => {
                     event.stopPropagation();
                     setContextMenu(null);
-                    void handleCopyShareLink(contextMenu.remoteUri);
+                    void handleCopyShareLink(adjustedContextMenu.remoteUri);
                   }}
                 >
                   Copy Share Link
                 </button>
               )}
-              {contextMenu.remoteUri && (
+              {adjustedContextMenu.remoteUri && (
                 <a
                   className="ctx-menu-item"
-                  href={contextMenu.remoteUri}
+                  href={adjustedContextMenu.remoteUri}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={(event) => {
@@ -1051,9 +1113,9 @@ function formatShortTimestamp(date: Date): string {
                 </a>
               )}
             </>
-          ) : contextMenu.type === NotebookStoreItemType.Folder ? (
+          ) : adjustedContextMenu.type === NotebookStoreItemType.Folder ? (
             <>
-              {!contextMenu.uri.startsWith("fs://") && (
+              {!adjustedContextMenu.uri.startsWith("fs://") && (
               <button
                 type="button"
                 className="ctx-menu-item"
@@ -1065,12 +1127,12 @@ function formatShortTimestamp(date: Date): string {
                   void (async () => {
                     try {
                       if (store) {
-                        await store.sync(contextMenu.uri);
+                        await store.sync(adjustedContextMenu.uri);
                       }
                     } catch (error) {
                       console.error("Failed to sync folder", error);
                     } finally {
-                      await fetchChildren(contextMenu.uri);
+                      await fetchChildren(adjustedContextMenu.uri);
                     }
                   })();
                 }}
@@ -1085,12 +1147,12 @@ function formatShortTimestamp(date: Date): string {
                 onClick={(event) => {
                   event.stopPropagation();
                   setContextMenu(null);
-                  void handleCreateDocument(contextMenu.uri);
+                  void handleCreateDocument(adjustedContextMenu.uri);
                 }}
               >
                 New Document
               </button>
-              {contextMenu.remoteUri && (
+              {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"
                   className="ctx-menu-item"
@@ -1098,30 +1160,30 @@ function formatShortTimestamp(date: Date): string {
                   onClick={(event) => {
                     event.stopPropagation();
                     setContextMenu(null);
-                    void handleCopyShareLink(contextMenu.remoteUri);
+                    void handleCopyShareLink(adjustedContextMenu.remoteUri);
                   }}
                 >
                   Copy Share Link
                 </button>
               )}
-          {contextMenu.uri !== LOCAL_FOLDER_URI && (
+          {adjustedContextMenu.uri !== LOCAL_FOLDER_URI && (
                 <button
                   type="button"
                   className="ctx-menu-item text-red-600"
                   onMouseDown={(event) => event.stopPropagation()}
                   onClick={(event) => {
                     event.stopPropagation();
-                    removeItem(contextMenu.uri);
+                    removeItem(adjustedContextMenu.uri);
                     setContextMenu(null);
                   }}
                 >
-                  Remove "{contextMenu.name}"
+                  Remove "{adjustedContextMenu.name}"
                 </button>
               )}
-              {contextMenu.remoteUri && (
+              {adjustedContextMenu.remoteUri && (
                 <a
                   className="ctx-menu-item"
-                  href={contextMenu.remoteUri}
+                  href={adjustedContextMenu.remoteUri}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={(event) => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -658,6 +658,11 @@ export function WorkspaceExplorer() {
     [fetchChildren, fsStore, store],
   );
 
+  const handleStartRename = useCallback((uri: string) => {
+    setContextMenu(null);
+    setPendingEditId(uri);
+  }, []);
+
 function formatShortTimestamp(date: Date): string {
   const pad = (value: number) => value.toString().padStart(2, "0");
   const year = date.getFullYear();
@@ -987,6 +992,17 @@ function formatShortTimestamp(date: Date): string {
                   Sync
                 </button>
               )}
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleStartRename(contextMenu.uri);
+                }}
+              >
+                Rename
+              </button>
               <button
                 type="button"
                 className="ctx-menu-item"

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -198,6 +198,40 @@ describe("NotebookDataController", () => {
     );
   });
 
+  it("updates the open notebook entry when the loaded notebook name changes", async () => {
+    const localStore = createFakeLocalNotebooks();
+    localStore.records.set("local://file/demo", {
+      id: "local://file/demo",
+      name: "demo.json",
+      remoteId: "local://file/demo",
+      notebook: createNotebook("console.log('demo')"),
+    });
+    const controller = getNotebookDataController();
+    controller.configureOwnershipManager(createFakeOwnershipManager());
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    });
+    await controller.openNotebook("local://file/demo");
+
+    controller.getNotebookData("local://file/demo")?.setName("renamed.json");
+
+    expect(controller.getOpenNotebooks()[0]).toEqual(
+      expect.objectContaining({
+        uri: "local://file/demo",
+        name: "renamed.json",
+        state: "loaded",
+      }),
+    );
+    expect(
+      JSON.parse(window.sessionStorage.getItem("runme/openNotebooks") ?? "[]"),
+    ).toEqual([
+      expect.objectContaining({
+        uri: "local://file/demo",
+        name: "renamed.json",
+      }),
+    ]);
+  });
+
   it("closes a notebook, disposes its model, and returns a fallback URI", async () => {
     const localStore = createFakeLocalNotebooks();
     localStore.records.set("local://file/a", {

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -294,7 +294,10 @@ export class NotebookDataController {
       },
       listNotebooksForAppKernel: () => this.listNotebookDataLike(uri),
     });
-    const unsubscribe = data.subscribe(() => this.emit());
+    const unsubscribe = data.subscribe(() => {
+      this.updateOpenEntryName(data.getUri(), data.getName());
+      this.emit();
+    });
     const handle = { data, unsubscribe, loaded };
     this.notebooks.set(uri, handle);
     this.emit();
@@ -347,6 +350,23 @@ export class NotebookDataController {
       return null;
     }
     return this.notebooks.get(uri)?.data ?? null;
+  }
+
+  private updateOpenEntryName(uri: string, name: string): void {
+    let changed = false;
+    this.openNotebooks = this.openNotebooks.map((item) => {
+      if (item.uri !== uri || item.name === name) {
+        return item;
+      }
+      changed = true;
+      return {
+        ...item,
+        name,
+      };
+    });
+    if (changed) {
+      this.persist();
+    }
   }
 
   private upsertOpenEntry(entry: OpenNotebookEntry): OpenNotebookEntry {

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -84,6 +84,46 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("renames Drive files through the metadata update API", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/file123");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.method).toBe("PATCH");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          name: "renamed.json",
+        });
+        return new Response(
+          JSON.stringify({
+            id: "file123",
+            name: "renamed.json",
+            mimeType: "application/json",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.rename(
+      "https://drive.google.com/file/d/file123/view",
+      "renamed.json",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      uri: "https://drive.google.com/file/d/file123/view",
+      name: "renamed.json",
+      type: NotebookStoreItemType.File,
+      remoteUri: "https://drive.google.com/file/d/file123/view",
+    });
+  });
+
   it("paginates Drive revisions", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -279,6 +279,79 @@ describe("LocalNotebooks pending Drive create", () => {
   });
 });
 
+describe("LocalNotebooks rename", () => {
+  it("renames Drive-backed files upstream before updating the local mirror", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const driveStore = {
+      rename: vi.fn(async () => ({
+        uri: remoteUri,
+        name: "renamed.json",
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri,
+        parents: [],
+      })),
+    };
+    const store = createTestStore(driveStore);
+    await store.files.put({
+      id: "local://file/drive",
+      name: "original.json",
+      remoteId: remoteUri,
+      lastRemoteChecksum: "",
+      lastSynced: "",
+      doc: "",
+      md5Checksum: "",
+    });
+    await store.folders.put({
+      id: "local://folder/drive",
+      name: "Drive",
+      remoteId: "https://drive.google.com/drive/folders/folder123",
+      children: ["local://file/drive"],
+      lastSynced: "",
+    });
+
+    const result = await store.rename("local://file/drive", "renamed.json");
+
+    expect(driveStore.rename).toHaveBeenCalledWith(remoteUri, "renamed.json");
+    expect(result).toMatchObject({
+      uri: "local://file/drive",
+      name: "renamed.json",
+      remoteUri,
+      parents: ["local://folder/drive"],
+    });
+    expect((await store.files.get("local://file/drive"))?.name).toBe(
+      "renamed.json",
+    );
+  });
+
+  it("does not update Drive-backed local metadata when the upstream rename fails", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const driveStore = {
+      rename: vi.fn(async () => {
+        throw new Error("permission denied");
+      }),
+    };
+    const store = createTestStore(driveStore);
+    await store.files.put({
+      id: "local://file/drive",
+      name: "original.json",
+      remoteId: remoteUri,
+      lastRemoteChecksum: "",
+      lastSynced: "",
+      doc: "",
+      md5Checksum: "",
+    });
+
+    await expect(
+      store.rename("local://file/drive", "renamed.json"),
+    ).rejects.toThrow("permission denied");
+
+    expect((await store.files.get("local://file/drive"))?.name).toBe(
+      "original.json",
+    );
+  });
+});
+
 describe("LocalNotebooks markdown sidecar sync", () => {
   it("serializes notebooks to markdown locally before uploading the sidecar", async () => {
     const markdownUri = "https://drive.google.com/file/d/sidecar123/view";

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -715,35 +715,37 @@ export class LocalNotebooks extends Dexie {
       throw new Error(`Local notebook record not found for ${uri}`);
     }
 
-    await this.files.update(uri, { name });
+    let nextName = name;
+    let nextRemoteId = record.remoteId;
+
+    if (isDriveUri(record.remoteId)) {
+      const remoteItem = await this.driveStore.rename(record.remoteId, name);
+      nextName = remoteItem.name || name;
+      nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId;
+    }
+
+    await this.files.update(uri, { name: nextName, remoteId: nextRemoteId });
 
     const parentFolder = await this.findParentFolder(uri);
 
     if (canDispatchWindowEvents()) {
       window.dispatchEvent(
         new CustomEvent("local-notebook-updated", {
-          detail: { uri, name, remoteUri: publicRemoteUri(record) },
+          detail: {
+            uri,
+            name: nextName,
+            remoteUri: publicRemoteUri({ ...record, remoteId: nextRemoteId }),
+          },
         }),
       );
     }
 
-    void (async () => {
-      if (!isDriveUri(record.remoteId)) {
-        return;
-      }
-      try {
-        await this.driveStore.rename(record.remoteId, name);
-      } catch (error) {
-        console.error("Failed to rename remote Drive notebook", error);
-      }
-    })();
-
     return {
       uri,
-      name,
+      name: nextName,
       type: NotebookStoreItemType.File,
       children: [],
-      remoteUri: publicRemoteUri(record),
+      remoteUri: publicRemoteUri({ ...record, remoteId: nextRemoteId }),
       parents: parentFolder ? [parentFolder.id] : [],
     };
   }


### PR DESCRIPTION
## Summary
- Add Rename actions to notebook file right-click menus in both the Explorer and notebook tab strip
- Keep the Explorer context menu inside the viewport when opened near the bottom or right edge
- Make Drive-backed local notebook renames await the upstream Google Drive rename before updating local metadata
- Keep open notebook tab/session titles in sync after a loaded notebook is renamed
- Add coverage for Drive rename API calls, Drive-backed local rename failure behavior, tab context menu rename behavior, and open notebook title updates

## Validation
- pnpm -C app test --run src/lib/notebookDataController.test.ts src/components/Actions/Actions.test.tsx src/storage/drive.test.ts src/storage/local.test.ts
- runme run build test

## Notes
- The dev server is running locally at http://localhost:5173/.