### PR TITLE
[codex] Render notebook diffs in workspace tabs

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,80 +1,76 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { Helmet } from "react-helmet";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
-import Callback from "./routes/callback";
-import RunRoute from "./routes/run";
-import RunsRoute from "./routes/runs";
-import NotebookDiffView from "./components/NotebookDiff/NotebookDiffView";
-import { Theme } from "@radix-ui/themes";
-import "@radix-ui/themes/styles.css";
-import AuthStatus from "./components/AuthStatus/AuthStatus";
-import runmeIcon from "./assets/runme-icon.svg";
-import { WebAppConfig } from "@buf/stateful_runme.bufbuild_es/agent/v1/webapp_pb";
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { Helmet } from 'react-helmet'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import Callback from './routes/callback'
+import RunRoute from './routes/run'
+import RunsRoute from './routes/runs'
+import { Theme } from '@radix-ui/themes'
+import '@radix-ui/themes/styles.css'
+import AuthStatus from './components/AuthStatus/AuthStatus'
+import runmeIcon from './assets/runme-icon.svg'
+import { WebAppConfig } from '@buf/stateful_runme.bufbuild_es/agent/v1/webapp_pb'
 
 // import Actions from "./components/Actions/Actions";
 // import Chat from "./components/Chat/Chat";
 // import FileViewer from "./components/Files/Viewer";
-import NotFound from "./components/NotFound";
-import { SettingsProvider } from "./contexts/SettingsContext";
-import { OutputProvider } from "./contexts/OutputContext";
-import { WorkspaceProvider } from "./contexts/WorkspaceContext";
+import NotFound from './components/NotFound'
+import { SettingsProvider } from './contexts/SettingsContext'
+import { OutputProvider } from './contexts/OutputContext'
+import { WorkspaceProvider } from './contexts/WorkspaceContext'
 import {
   NotebookStoreProvider,
   useNotebookStore,
-} from "./contexts/NotebookStoreContext";
-import { NotebookProvider } from "./contexts/NotebookContext";
-import {
-  GoogleAuthProvider,
-  useGoogleAuth,
-} from "./contexts/GoogleAuthContext";
-import { DriveNotebookStore } from "./storage/drive";
-import { FilesystemNotebookStore } from "./storage/fs";
-import { isFileSystemAccessSupported } from "./storage/fs";
-import LocalNotebooks from "./storage/local";
-import { CurrentDocProvider } from "./contexts/CurrentDocContext";
-import { WorkspaceDocumentProvider } from "./contexts/WorkspaceDocumentContext";
+} from './contexts/NotebookStoreContext'
+import { NotebookProvider } from './contexts/NotebookContext'
+import { GoogleAuthProvider, useGoogleAuth } from './contexts/GoogleAuthContext'
+import { DriveNotebookStore } from './storage/drive'
+import { FilesystemNotebookStore } from './storage/fs'
+import { isFileSystemAccessSupported } from './storage/fs'
+import LocalNotebooks from './storage/local'
+import { CurrentDocProvider } from './contexts/CurrentDocContext'
+import { WorkspaceDocumentProvider } from './contexts/WorkspaceDocumentContext'
 import {
   FilesystemStoreProvider,
   useFilesystemStore,
-} from "./contexts/FilesystemStoreContext";
+} from './contexts/FilesystemStoreContext'
 
-import MainPage from "./components/MainPage/MainPage";
+import MainPage from './components/MainPage/MainPage'
 
-import { RunnersProvider } from "./contexts/RunnersContext";
-import { Runner } from "./lib/runner";
-import { getBrowserAdapter, useBrowserAuthData } from "./browserAdapter.client";
-import { getAuthData } from "./token";
-import { Interceptor } from "@connectrpc/connect";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { SidePanelProvider } from "./contexts/SidePanelContext";
-import { appState } from "./lib/runtime/AppState";
-import GlobalToast from "./components/Toast";
-import DriveLinkCoordinatorHost from "./components/DriveLinkCoordinatorHost";
-import WebMcpToolRegistrationHost from "./components/WebMcp/WebMcpToolRegistrationHost";
-import { appLogger } from "./lib/logging/runtime";
+import { RunnersProvider } from './contexts/RunnersContext'
+import { Runner } from './lib/runner'
+import { getBrowserAdapter, useBrowserAuthData } from './browserAdapter.client'
+import { getAuthData } from './token'
+import { Interceptor } from '@connectrpc/connect'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SidePanelProvider } from './contexts/SidePanelContext'
+import { appState } from './lib/runtime/AppState'
+import GlobalToast from './components/Toast'
+import DriveLinkCoordinatorHost from './components/DriveLinkCoordinatorHost'
+import WebMcpToolRegistrationHost from './components/WebMcp/WebMcpToolRegistrationHost'
+import { appLogger } from './lib/logging/runtime'
 import {
   getConfiguredAgentEndpoint,
   getConfiguredDefaultRunnerEndpoint,
-} from "./lib/appConfig";
-import { APP_ROUTE_PATHS, getAppRouterBasename } from "./lib/appBase";
+} from './lib/appConfig'
+import { APP_ROUTE_PATHS, getAppRouterBasename } from './lib/appBase'
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient()
 
-let hasLoggedStartup = false;
+let hasLoggedStartup = false
 
 export interface AppBranding {
-  name: string;
-  logo: string;
+  name: string
+  logo: string
 }
 
 export interface AppProps {
-  branding?: AppBranding;
+  branding?: AppBranding
 }
 
 function AppRouter() {
-  const basename = getAppRouterBasename();
+  const basename = getAppRouterBasename()
   return (
-    <BrowserRouter basename={basename === "/" ? undefined : basename}>
+    <BrowserRouter basename={basename === '/' ? undefined : basename}>
       <DriveLinkCoordinatorHost />
       <Routes>
         <Route path="/" element={<MainPage />} />
@@ -85,7 +81,6 @@ function AppRouter() {
         <Route path="/runs" element={<RunsRoute />} />
         <Route path="/runs/:runName" element={<RunRoute />} />
         <Route path="/runs/:runName/edit" element={<MainPage />} />
-        <Route path="/diff/:diffId" element={<NotebookDiffView />} />
         <Route path="/auth/status" element={<BrowserAuthStatus />} />
         <Route path="/oidc/callback" element={<Callback />} />
         <Route
@@ -95,49 +90,49 @@ function AppRouter() {
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
-  );
+  )
 }
 
 function App({ branding }: AppProps) {
   const appBranding = {
-    name: branding?.name ?? "runme notebook",
+    name: branding?.name ?? 'runme notebook',
     logo: branding?.logo ?? runmeIcon,
-  };
-  const makeInterceptors = useCallback(makeAuthInterceptor, []);
-  const configuredRunnerEndpoint = getConfiguredDefaultRunnerEndpoint();
-  const initialRunnerEndpoint = configuredRunnerEndpoint;
-  const initialRunnerReconnect = true;
-  const configuredAgentEndpoint = getConfiguredAgentEndpoint();
+  }
+  const makeInterceptors = useCallback(makeAuthInterceptor, [])
+  const configuredRunnerEndpoint = getConfiguredDefaultRunnerEndpoint()
+  const initialRunnerEndpoint = configuredRunnerEndpoint
+  const initialRunnerReconnect = true
+  const configuredAgentEndpoint = getConfiguredAgentEndpoint()
   const initialRunnerList = useMemo(
     () => [
       new Runner({
-        name: "default",
+        name: 'default',
         endpoint: initialRunnerEndpoint,
         reconnect: initialRunnerReconnect,
         interceptors: makeInterceptors(),
       }),
     ],
-    [initialRunnerEndpoint, initialRunnerReconnect, makeInterceptors],
-  );
+    [initialRunnerEndpoint, initialRunnerReconnect, makeInterceptors]
+  )
 
   useEffect(() => {
     // Store app state in window for debugging.
     // This should allow us to access it inside the chrome console.
-    if (typeof window !== "undefined") {
-      (window as any).app = appState;
+    if (typeof window !== 'undefined') {
+      ;(window as any).app = appState
     }
 
     // React StrictMode can mount/unmount components twice in development.
     // We gate this message so startup emits exactly one validation event.
     if (!hasLoggedStartup) {
-      appLogger.info("Application startup complete", {
+      appLogger.info('Application startup complete', {
         attrs: {
           routeCount: 9,
         },
-      });
-      hasLoggedStartup = true;
+      })
+      hasLoggedStartup = true
     }
-  }, []);
+  }, [])
 
   return (
     <>
@@ -151,144 +146,147 @@ function App({ branding }: AppProps) {
           <GoogleAuthProvider>
             <WorkspaceProvider>
               <NotebookStoreProvider>
-              <FilesystemStoreProvider>
-              <CurrentDocProvider>
-                  <NotebookStoreInitializer />
-                  <SettingsProvider
-                    agentEndpoint={configuredAgentEndpoint}
-                    webApp={
-                      {
-                        runner: configuredRunnerEndpoint,
-                      } as WebAppConfig
-                    }
-                    createAuthInterceptors={makeInterceptors}
-                  >
-                    <RunnersProvider
-                      initialRunners={initialRunnerList}
-                      initialDefaultRunnerName="default"
-                      makeInterceptors={makeInterceptors}
+                <FilesystemStoreProvider>
+                  <CurrentDocProvider>
+                    <NotebookStoreInitializer />
+                    <SettingsProvider
+                      agentEndpoint={configuredAgentEndpoint}
+                      webApp={
+                        {
+                          runner: configuredRunnerEndpoint,
+                        } as WebAppConfig
+                      }
+                      createAuthInterceptors={makeInterceptors}
                     >
-                      <OutputProvider>
-                        <NotebookProvider>
-                          <WorkspaceDocumentProvider>
-                            <WebMcpToolRegistrationHost />
-                            <SidePanelProvider>
-                              <GlobalToast />
-                              <AppRouter />
-                            </SidePanelProvider>
-                          </WorkspaceDocumentProvider>
-                        </NotebookProvider>
-                      </OutputProvider>
-                    </RunnersProvider>
-                  </SettingsProvider>                
-                </CurrentDocProvider>
-              </FilesystemStoreProvider>
+                      <RunnersProvider
+                        initialRunners={initialRunnerList}
+                        initialDefaultRunnerName="default"
+                        makeInterceptors={makeInterceptors}
+                      >
+                        <OutputProvider>
+                          <NotebookProvider>
+                            <WorkspaceDocumentProvider>
+                              <WebMcpToolRegistrationHost />
+                              <SidePanelProvider>
+                                <GlobalToast />
+                                <AppRouter />
+                              </SidePanelProvider>
+                            </WorkspaceDocumentProvider>
+                          </NotebookProvider>
+                        </OutputProvider>
+                      </RunnersProvider>
+                    </SettingsProvider>
+                  </CurrentDocProvider>
+                </FilesystemStoreProvider>
               </NotebookStoreProvider>
             </WorkspaceProvider>
           </GoogleAuthProvider>
         </QueryClientProvider>
       </Theme>
     </>
-  );
+  )
 }
 
 function NotebookStoreInitializer() {
-  const { ensureAccessToken, isDriveSyncing } = useGoogleAuth();
-  const { store, setStore } = useNotebookStore();
-  const { fsStore, setFsStore } = useFilesystemStore();
-  const instanceRef = useRef<LocalNotebooks | null>(null);
-  const fsInstanceRef = useRef<FilesystemNotebookStore | null>(null);
-  const wasDriveSyncingRef = useRef(false);
+  const { ensureAccessToken, isDriveSyncing } = useGoogleAuth()
+  const { store, setStore } = useNotebookStore()
+  const { fsStore, setFsStore } = useFilesystemStore()
+  const instanceRef = useRef<LocalNotebooks | null>(null)
+  const fsInstanceRef = useRef<FilesystemNotebookStore | null>(null)
+  const wasDriveSyncingRef = useRef(false)
 
   useEffect(() => {
     if (instanceRef.current || store) {
-      return;
+      return
     }
 
     // Background Drive store operations should never force an OAuth redirect.
     // Interactive login is handled explicitly via UI actions (picker/status tab).
     const driveStore = new DriveNotebookStore(() =>
-      ensureAccessToken({ interactive: false }),
-    );
-    const localStore = new LocalNotebooks(driveStore);
-    localStore.setFilesystemStore(fsInstanceRef.current);
+      ensureAccessToken({ interactive: false })
+    )
+    const localStore = new LocalNotebooks(driveStore)
+    localStore.setFilesystemStore(fsInstanceRef.current)
 
-    appState.setDriveNotebookStore(driveStore);
-    appState.setLocalNotebooks(localStore);
+    appState.setDriveNotebookStore(driveStore)
+    appState.setLocalNotebooks(localStore)
 
-    instanceRef.current = localStore;
-    setStore(localStore);
-  }, [ensureAccessToken, setStore, store]);
+    instanceRef.current = localStore
+    setStore(localStore)
+  }, [ensureAccessToken, setStore, store])
 
   // When Drive auth/connectivity recovers, enqueue all drive-backed files with
   // unapplied local edits so sync resumes without requiring a fresh manual edit.
   useEffect(() => {
-    const localStore = instanceRef.current;
+    const localStore = instanceRef.current
     if (!localStore) {
-      return;
+      return
     }
 
-    const becameSyncable = isDriveSyncing && !wasDriveSyncingRef.current;
-    wasDriveSyncingRef.current = isDriveSyncing;
+    const becameSyncable = isDriveSyncing && !wasDriveSyncingRef.current
+    wasDriveSyncingRef.current = isDriveSyncing
     if (!becameSyncable) {
-      return;
+      return
     }
 
     void (async () => {
       try {
-        appLogger.info("Drive sync became available; reconciling pending notebooks", {
+        appLogger.info(
+          'Drive sync became available; reconciling pending notebooks',
+          {
+            attrs: {
+              scope: 'storage.drive.sync',
+              code: 'DRIVE_RESYNC_AUTH_RECOVERED',
+            },
+          }
+        )
+        const enqueued = await localStore.enqueueDriveBackedFilesNeedingSync()
+        appLogger.info('Drive resync reconciliation completed', {
           attrs: {
-            scope: "storage.drive.sync",
-            code: "DRIVE_RESYNC_AUTH_RECOVERED",
-          },
-        });
-        const enqueued = await localStore.enqueueDriveBackedFilesNeedingSync();
-        appLogger.info("Drive resync reconciliation completed", {
-          attrs: {
-            scope: "storage.drive.sync",
-            code: "DRIVE_RESYNC_RECONCILE_COMPLETE",
+            scope: 'storage.drive.sync',
+            code: 'DRIVE_RESYNC_RECONCILE_COMPLETE',
             enqueuedCount: enqueued.length,
             localUris: enqueued,
           },
-        });
+        })
       } catch (error) {
-        appLogger.error("Failed to enqueue drive-backed notebooks for resync", {
+        appLogger.error('Failed to enqueue drive-backed notebooks for resync', {
           attrs: {
-            scope: "storage.drive.sync",
-            code: "DRIVE_RESYNC_RECONCILE_FAILED",
+            scope: 'storage.drive.sync',
+            code: 'DRIVE_RESYNC_RECONCILE_FAILED',
             error: String(error),
           },
-        });
+        })
       }
-    })();
-  }, [isDriveSyncing, store]);
+    })()
+  }, [isDriveSyncing, store])
 
   useEffect(() => {
     if (fsInstanceRef.current || fsStore) {
-      return;
+      return
     }
 
     if (!isFileSystemAccessSupported()) {
-      return;
+      return
     }
 
-    const filesystemStore = new FilesystemNotebookStore();
-    appState.setFilesystemStore(filesystemStore);
-    instanceRef.current?.setFilesystemStore(filesystemStore);
+    const filesystemStore = new FilesystemNotebookStore()
+    appState.setFilesystemStore(filesystemStore)
+    instanceRef.current?.setFilesystemStore(filesystemStore)
 
-    fsInstanceRef.current = filesystemStore;
-    setFsStore(filesystemStore);
-  }, [fsStore, setFsStore]);
+    fsInstanceRef.current = filesystemStore
+    setFsStore(filesystemStore)
+  }, [fsStore, setFsStore])
 
-  return null;
+  return null
 }
 
-export default App;
+export default App
 
 const BrowserAuthStatus = () => {
-  const authData = useBrowserAuthData();
+  const authData = useBrowserAuthData()
 
-  const browserAdapter = getBrowserAdapter();
+  const browserAdapter = getBrowserAdapter()
   return (
     <AuthStatus
       authData={authData}
@@ -296,25 +294,25 @@ const BrowserAuthStatus = () => {
       onLogout={() => browserAdapter.logout()}
       description="Current browser authentication state for Runme Web."
     />
-  );
-};
+  )
+}
 
 const GoogleDriveOAuthCallback = () => {
-  return <div className="p-6 text-sm">Completing Google Drive sign-in...</div>;
-};
+  return <div className="p-6 text-sm">Completing Google Drive sign-in...</div>
+}
 
 export function makeAuthInterceptor(): Interceptor[] {
-  console.log("Creating auth interceptor");
+  console.log('Creating auth interceptor')
   return [
     (next) => async (req) => {
-      const authData = await getAuthData();
-      const token = authData?.idToken || "";
-      if (token !== "") {
-        req.header.set("Authorization", `Bearer ${token}`);
+      const authData = await getAuthData()
+      const token = authData?.idToken || ''
+      if (token !== '') {
+        req.header.set('Authorization', `Bearer ${token}`)
       } else {
-        console.log("Error; no token found in browser adapter");
+        console.log('Error; no token found in browser adapter')
       }
-      return next(req);
+      return next(req)
     },
-  ];
+  ]
 }

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -9,6 +9,11 @@ import {
 
 import { parser_pb, RunmeMetadataKey } from "../../runme/client";
 import type { CellData } from "../../lib/notebookData";
+import { computeNotebookDiff } from "../../lib/notebookDiff/diff";
+import {
+  getNotebookDiffDocumentUri,
+  registerNotebookDiffDocument,
+} from "../../lib/notebookDiff/registry";
 import Actions, { Action } from "./Actions";
 
 const contextMocks = vi.hoisted(() => ({
@@ -278,6 +283,110 @@ describe("Actions tabs", () => {
       "local://file/restored",
       { title: "renamed.json" },
     );
+  });
+
+  it("renders a selected notebook diff workspace document as a tab", () => {
+    const baseNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: "cell-1",
+          kind: parser_pb.CellKind.CODE,
+          languageId: "python",
+          value: "print('base')",
+        }),
+      ],
+      metadata: {},
+    });
+    const compareNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: "cell-1",
+          kind: parser_pb.CellKind.CODE,
+          languageId: "python",
+          value: "print('compare')",
+        }),
+      ],
+      metadata: {},
+    });
+    const doc = registerNotebookDiffDocument({
+      id: "diff-1",
+      base: { label: "Drive revision 1", revisionId: "1" },
+      compare: { label: "Local copy", revisionId: "local" },
+      diff: computeNotebookDiff(baseNotebook, compareNotebook),
+    });
+    const diffUri = getNotebookDiffDocumentUri(doc.id);
+    contextMocks.currentDoc = diffUri;
+    contextMocks.workspaceDocuments = [
+      { uri: diffUri, title: "Drive revision 1 vs Local copy" },
+    ];
+
+    render(<Actions />);
+
+    expect(
+      screen.getByRole("tab", { name: "Drive revision 1 vs Local copy" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Notebook Diff")).toBeTruthy();
+    expect(
+      screen.getByText(/Drive revision 1 compared with Local copy/),
+    ).toBeTruthy();
+    expect(screen.getByText("print('base')")).toBeTruthy();
+    expect(screen.getByText("print('compare')")).toBeTruthy();
+    expect(screen.queryByText("Back to notebooks")).toBeNull();
+  });
+
+  it("keeps a clicked diff tab selected while current doc state catches up", async () => {
+    const diff = computeNotebookDiff(
+      create(parser_pb.NotebookSchema, {
+        cells: [
+          create(parser_pb.CellSchema, {
+            refId: "cell-1",
+            kind: parser_pb.CellKind.CODE,
+            languageId: "python",
+            value: "print('base')",
+          }),
+        ],
+        metadata: {},
+      }),
+      create(parser_pb.NotebookSchema, {
+        cells: [
+          create(parser_pb.CellSchema, {
+            refId: "cell-1",
+            kind: parser_pb.CellKind.CODE,
+            languageId: "python",
+            value: "print('compare')",
+          }),
+        ],
+        metadata: {},
+      }),
+    );
+    const doc = registerNotebookDiffDocument({
+      id: "diff-click",
+      base: { label: "Drive revision 1", revisionId: "1" },
+      compare: { label: "Local copy", revisionId: "local" },
+      diff,
+    });
+    const diffUri = getNotebookDiffDocumentUri(doc.id);
+    contextMocks.currentDoc = "local://file/first";
+    contextMocks.workspaceDocuments = [
+      { uri: "local://file/first", title: "first.json" },
+      { uri: diffUri, title: "Drive revision 1 vs Local copy" },
+    ];
+
+    render(<Actions />);
+
+    const firstTab = screen.getByRole("tab", { name: "first.json" });
+    const diffTab = screen.getByRole("tab", {
+      name: "Drive revision 1 vs Local copy",
+    });
+    expect(firstTab.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.mouseDown(diffTab, { button: 0, ctrlKey: false });
+
+    expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(diffUri);
+    await waitFor(() => {
+      expect(diffTab.getAttribute("aria-selected")).toBe("true");
+      expect(firstTab.getAttribute("aria-selected")).toBe("false");
+    });
   });
 });
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1745,6 +1745,7 @@ export default function Actions() {
     googleDriveUri: string | null;
   } | null>(null);
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const pendingSelectedTabUriRef = useRef<string | null>(null);
   //const { data: run } = useRun(runName);
 
   // useEffect(() => {
@@ -1818,6 +1819,19 @@ export default function Actions() {
     if (statusTabVisible) {
       return;
     }
+    const pendingSelectedTabUri = pendingSelectedTabUriRef.current;
+    if (pendingSelectedTabUri) {
+      if (pendingSelectedTabUri === currentDocUri) {
+        pendingSelectedTabUriRef.current = null;
+      } else if (workspaceDocumentUris.has(pendingSelectedTabUri)) {
+        if (selectedTabUri !== pendingSelectedTabUri) {
+          setSelectedTabUri(pendingSelectedTabUri);
+        }
+        return;
+      } else {
+        pendingSelectedTabUriRef.current = null;
+      }
+    }
     if (currentDocUri && currentDocIsOpen) {
       setSelectedTabUri(currentDocUri);
       return;
@@ -1835,6 +1849,7 @@ export default function Actions() {
     selectedTabUri,
     setCurrentDoc,
     statusTabVisible,
+    workspaceDocumentUris,
     workspaceDocuments,
   ]);
 
@@ -2216,6 +2231,7 @@ export default function Actions() {
         <Tabs.Root
           value={resolvedSelectedTabUri}
           onValueChange={(nextUri) => {
+            pendingSelectedTabUriRef.current = nextUri;
             setSelectedTabUri(nextUri);
             if (nextUri !== currentDocUri) {
               setCurrentDoc(nextUri);

--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -1,85 +1,65 @@
-import { create } from "@bufbuild/protobuf";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { create } from '@bufbuild/protobuf'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 
-import { parser_pb } from "../../runme/client";
-import { computeNotebookDiff } from "../../lib/notebookDiff/diff";
-import { registerNotebookDiffDocument } from "../../lib/notebookDiff/registry";
-import NotebookDiffView from "./NotebookDiffView";
-
-function renderRoute(path: string) {
-  render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/diff/:diffId" element={<NotebookDiffView />} />
-      </Routes>
-    </MemoryRouter>,
-  );
-}
+import { parser_pb } from '../../runme/client'
+import { computeNotebookDiff } from '../../lib/notebookDiff/diff'
+import { NotebookDiffContent } from './NotebookDiffView'
 
 function notebook(value: string) {
   return create(parser_pb.NotebookSchema, {
     cells: [
       create(parser_pb.CellSchema, {
-        refId: "cell-1",
+        refId: 'cell-1',
         kind: parser_pb.CellKind.CODE,
-        languageId: "python",
+        languageId: 'python',
         value,
       }),
     ],
     metadata: {},
-  });
+  })
 }
 
-describe("NotebookDiffView", () => {
-  it("renders a registered side-by-side diff document", () => {
+describe('NotebookDiffContent', () => {
+  it('renders a registered side-by-side diff document', () => {
     const diff = computeNotebookDiff(
       notebook("print('base')"),
-      notebook("print('compare')"),
-    );
-    const doc = registerNotebookDiffDocument({
-      base: { label: "Drive revision 1", revisionId: "1" },
-      compare: { label: "Local copy", revisionId: "local" },
+      notebook("print('compare')")
+    )
+    const doc = {
+      id: 'diff-1',
+      base: { label: 'Drive revision 1', revisionId: '1' },
+      compare: { label: 'Local copy', revisionId: 'local' },
       diff,
-    });
+    }
 
-    renderRoute(`/diff/${encodeURIComponent(doc.id)}`);
+    render(<NotebookDiffContent document={doc} />)
 
-    expect(screen.getByText("Notebook Diff")).toBeTruthy();
-    expect(screen.getByText(/Drive revision 1 compared with Local copy/)).toBeTruthy();
-    expect(screen.getByText("Base: Drive revision 1")).toBeTruthy();
-    expect(screen.getByText("Compare: Local copy")).toBeTruthy();
-    expect(screen.getByText("print('base')")).toBeTruthy();
-    expect(screen.getByText("print('compare')")).toBeTruthy();
-  });
+    expect(screen.getByText('Notebook Diff')).toBeTruthy()
+    expect(
+      screen.getByText(/Drive revision 1 compared with Local copy/)
+    ).toBeTruthy()
+    expect(screen.getByText('Base: Drive revision 1')).toBeTruthy()
+    expect(screen.getByText('Compare: Local copy')).toBeTruthy()
+    expect(screen.getByText("print('base')")).toBeTruthy()
+    expect(screen.getByText("print('compare')")).toBeTruthy()
+  })
 
-  it("renders unchanged cell contents inside the expandable row", () => {
+  it('renders unchanged cell contents inside the expandable row', () => {
     const diff = computeNotebookDiff(
       notebook("print('same')"),
-      notebook("print('same')"),
-    );
-    const doc = registerNotebookDiffDocument({
-      base: { label: "Drive revision 1", revisionId: "1" },
-      compare: { label: "Local copy", revisionId: "local" },
+      notebook("print('same')")
+    )
+    const doc = {
+      id: 'diff-1',
+      base: { label: 'Drive revision 1', revisionId: '1' },
+      compare: { label: 'Local copy', revisionId: 'local' },
       diff,
-    });
+    }
 
-    renderRoute(`/diff/${encodeURIComponent(doc.id)}`);
+    render(<NotebookDiffContent document={doc} />)
 
-    expect(screen.getByText("Unchanged cell cell-1")).toBeTruthy();
-    expect(screen.getAllByText("print('same')")).toHaveLength(2);
-  });
-
-  it("shows a recompute message for missing in-memory diff documents", () => {
-    renderRoute("/diff/missing");
-
-    expect(screen.getByText("Diff no longer available")).toBeTruthy();
-  });
-
-  it("does not double-decode encoded diff ids", () => {
-    renderRoute("/diff/%25");
-
-    expect(screen.getByText("Diff no longer available")).toBeTruthy();
-  });
-});
+    expect(screen.getByText('Unchanged cell cell-1')).toBeTruthy()
+    expect(screen.getAllByText("print('same')")).toHaveLength(2)
+  })
+})

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -1,75 +1,75 @@
-import { Badge, Button, ScrollArea, Text } from "@radix-ui/themes";
-import { Link, useParams } from "react-router-dom";
+import { Badge, ScrollArea, Text } from '@radix-ui/themes'
 
-import { parser_pb } from "../../runme/client";
-import { getNotebookDiffDocument } from "../../lib/notebookDiff/registry";
+import { parser_pb } from '../../runme/client'
 import type {
   CellDiff,
   NotebookDiffDocument,
   OutputItemSummary,
   TextDiff,
   TextDiffLine,
-} from "../../lib/notebookDiff/model";
+} from '../../lib/notebookDiff/model'
 
 function cellKindLabel(cell?: parser_pb.Cell): string {
   if (!cell) {
-    return "";
+    return ''
   }
   if (cell.kind === parser_pb.CellKind.MARKUP) {
-    return "Markdown";
+    return 'Markdown'
   }
   if (cell.kind === parser_pb.CellKind.CODE) {
-    return cell.languageId || "Code";
+    return cell.languageId || 'Code'
   }
-  return cell.languageId || "Cell";
+  return cell.languageId || 'Cell'
 }
 
-function changeBadgeColor(kind: CellDiff["kind"]): "gray" | "green" | "red" | "amber" {
+function changeBadgeColor(
+  kind: CellDiff['kind']
+): 'gray' | 'green' | 'red' | 'amber' {
   switch (kind) {
-    case "inserted":
-      return "green";
-    case "deleted":
-      return "red";
-    case "modified":
-      return "amber";
+    case 'inserted':
+      return 'green'
+    case 'deleted':
+      return 'red'
+    case 'modified':
+      return 'amber'
     default:
-      return "gray";
+      return 'gray'
   }
 }
 
 function statusText(row: CellDiff): string {
-  if (row.kind === "inserted") {
-    return "Inserted";
+  if (row.kind === 'inserted') {
+    return 'Inserted'
   }
-  if (row.kind === "deleted") {
-    return "Deleted";
+  if (row.kind === 'deleted') {
+    return 'Deleted'
   }
-  if (row.kind === "unchanged") {
-    return row.moved ? "Moved" : "Unchanged";
+  if (row.kind === 'unchanged') {
+    return row.moved ? 'Moved' : 'Unchanged'
   }
   return row.changedFields
-    .map((field) => (field === "move" ? "moved" : field))
-    .join(", ");
+    .map((field) => (field === 'move' ? 'moved' : field))
+    .join(', ')
 }
 
-function lineClass(line: TextDiffLine, side: "base" | "compare"): string {
-  if (line.kind === "equal") {
-    return "text-nb-text";
+function lineClass(line: TextDiffLine, side: 'base' | 'compare'): string {
+  if (line.kind === 'equal') {
+    return 'text-nb-text'
   }
-  if (side === "base" && line.kind === "removed") {
-    return "bg-red-50 text-red-900";
+  if (side === 'base' && line.kind === 'removed') {
+    return 'bg-red-50 text-red-900'
   }
-  if (side === "compare" && line.kind === "added") {
-    return "bg-emerald-50 text-emerald-900";
+  if (side === 'compare' && line.kind === 'added') {
+    return 'bg-emerald-50 text-emerald-900'
   }
-  return "text-nb-text-faint";
+  return 'text-nb-text-faint'
 }
 
-function lineText(line: TextDiffLine, side: "base" | "compare"): string {
-  if (side === "base") {
-    return line.baseLine ?? "";
+function lineText(line: TextDiffLine, side: 'base' | 'compare'): string {
+  if (side === 'base') {
+    return line.baseLine ?? ''
   }
-  return line.compareLine ?? "";
+  return line.compareLine ?? ''
 }
 
 function SourceDiff({
@@ -77,12 +77,15 @@ function SourceDiff({
   side,
   fallback,
 }: {
-  diff?: TextDiff;
-  side: "base" | "compare";
-  fallback: string;
+  diff?: TextDiff
+  side: 'base' | 'compare'
+  fallback: string
 }) {
-  const lines =
-    diff?.lines.length ? diff.lines : fallback ? fallback.split(/\r?\n/) : [];
+  const lines = diff?.lines.length
+    ? diff.lines
+    : fallback
+      ? fallback.split(/\r?\n/)
+      : []
   return (
     <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words p-3 font-mono text-xs leading-5">
       {lines.length === 0 ? (
@@ -90,37 +93,44 @@ function SourceDiff({
       ) : (
         lines.map((line, index) => {
           const normalizedLine =
-            typeof line === "string"
-              ? ({ kind: "equal", baseLine: line, compareLine: line } as TextDiffLine)
-              : line;
+            typeof line === 'string'
+              ? ({
+                  kind: 'equal',
+                  baseLine: line,
+                  compareLine: line,
+                } as TextDiffLine)
+              : line
           return (
             <div
               key={`${side}-line-${index}`}
               className={`min-h-5 rounded px-1 ${lineClass(normalizedLine, side)}`}
             >
-              {lineText(normalizedLine, side) || " "}
+              {lineText(normalizedLine, side) || ' '}
             </div>
-          );
+          )
         })
       )}
     </pre>
-  );
+  )
 }
 
 function OutputSummary({
   items,
   side,
 }: {
-  items: OutputItemSummary[];
-  side: "base" | "compare";
+  items: OutputItemSummary[]
+  side: 'base' | 'compare'
 }) {
   if (items.length === 0) {
-    return <div className="text-xs text-nb-text-faint">No outputs</div>;
+    return <div className="text-xs text-nb-text-faint">No outputs</div>
   }
   return (
-    <details className="rounded border border-nb-border bg-nb-surface-2 p-2 text-xs" open={false}>
+    <details
+      className="rounded border border-nb-border bg-nb-surface-2 p-2 text-xs"
+      open={false}
+    >
       <summary className="cursor-pointer text-nb-text-muted">
-        {items.length} output item{items.length === 1 ? "" : "s"} on {side}
+        {items.length} output item{items.length === 1 ? '' : 's'} on {side}
       </summary>
       <div className="mt-2 space-y-2">
         {items.map((item, index) => (
@@ -137,31 +147,25 @@ function OutputSummary({
         ))}
       </div>
     </details>
-  );
+  )
 }
 
-function CellPanel({
-  row,
-  side,
-}: {
-  row: CellDiff;
-  side: "base" | "compare";
-}) {
-  const cell = side === "base" ? row.baseCell : row.compareCell;
+function CellPanel({ row, side }: { row: CellDiff; side: 'base' | 'compare' }) {
+  const cell = side === 'base' ? row.baseCell : row.compareCell
   const empty =
-    (side === "base" && row.kind === "inserted") ||
-    (side === "compare" && row.kind === "deleted");
+    (side === 'base' && row.kind === 'inserted') ||
+    (side === 'compare' && row.kind === 'deleted')
   const outputItems =
-    side === "base"
-      ? row.outputDiff?.baseItems ?? []
-      : row.outputDiff?.compareItems ?? [];
+    side === 'base'
+      ? (row.outputDiff?.baseItems ?? [])
+      : (row.outputDiff?.compareItems ?? [])
 
   if (empty) {
     return (
       <div className="flex min-h-28 items-center justify-center rounded border border-dashed border-nb-border bg-nb-surface-2 text-sm text-nb-text-faint">
         No cell on this side
       </div>
-    );
+    )
   }
 
   return (
@@ -171,13 +175,13 @@ function CellPanel({
           {cellKindLabel(cell)}
         </span>
         <span className="font-mono text-[11px] text-nb-text-faint">
-          {cell?.refId || "no-ref"}
+          {cell?.refId || 'no-ref'}
         </span>
       </div>
       <SourceDiff
         diff={row.sourceDiff}
         side={side}
-        fallback={cell?.value ?? ""}
+        fallback={cell?.value ?? ''}
       />
       {row.outputDiff?.changed && (
         <div className="border-t border-nb-border p-3">
@@ -185,15 +189,15 @@ function CellPanel({
         </div>
       )}
     </div>
-  );
+  )
 }
 
 function DiffRow({ row }: { row: CellDiff }) {
-  if (row.kind === "unchanged") {
+  if (row.kind === 'unchanged') {
     return (
       <details className="rounded border border-nb-border bg-nb-surface-2 text-sm text-nb-text-muted">
         <summary className="cursor-pointer px-3 py-2">
-          Unchanged cell {row.baseCell?.refId || row.compareCell?.refId || ""}
+          Unchanged cell {row.baseCell?.refId || row.compareCell?.refId || ''}
         </summary>
         <div className="border-t border-nb-border bg-nb-bg p-3">
           <div className="grid min-w-[920px] grid-cols-2 gap-3">
@@ -202,7 +206,7 @@ function DiffRow({ row }: { row: CellDiff }) {
           </div>
         </div>
       </details>
-    );
+    )
   }
 
   return (
@@ -210,39 +214,42 @@ function DiffRow({ row }: { row: CellDiff }) {
       <div className="mb-3 flex items-center gap-2">
         <Badge color={changeBadgeColor(row.kind)}>{statusText(row)}</Badge>
         {row.outputDiff?.changed && <Badge color="blue">outputs changed</Badge>}
-        {row.metadataDiff?.changed && <Badge color="purple">metadata changed</Badge>}
+        {row.metadataDiff?.changed && (
+          <Badge color="purple">metadata changed</Badge>
+        )}
       </div>
       <div className="grid min-w-[920px] grid-cols-2 gap-3">
         <CellPanel row={row} side="base" />
         <CellPanel row={row} side="compare" />
       </div>
     </section>
-  );
+  )
 }
 
-export function NotebookDiffContent({ document }: { document: NotebookDiffDocument }) {
-  const { diff } = document;
+export function NotebookDiffContent({
+  document,
+}: {
+  document: NotebookDiffDocument
+}) {
+  const { diff } = document
   return (
     <div className="flex h-full w-full flex-col bg-nb-surface">
       <header className="border-b border-nb-border bg-white px-5 py-4">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <Text as="p" size="5" weight="bold" className="text-nb-text">
-              Notebook Diff
-            </Text>
-            <Text as="p" size="2" className="text-nb-text-muted">
-              {document.base.label} compared with {document.compare.label}
-            </Text>
-          </div>
-          <Button asChild variant="soft">
-            <Link to="/">Back to notebooks</Link>
-          </Button>
+        <div>
+          <Text as="p" size="5" weight="bold" className="text-nb-text">
+            Notebook Diff
+          </Text>
+          <Text as="p" size="2" className="text-nb-text-muted">
+            {document.base.label} compared with {document.compare.label}
+          </Text>
         </div>
         <div className="mt-3 flex flex-wrap gap-2 text-sm text-nb-text-muted">
           <Badge color="green">{diff.summary.insertedCells} inserted</Badge>
           <Badge color="red">{diff.summary.deletedCells} deleted</Badge>
           <Badge color="amber">{diff.summary.modifiedCells} modified</Badge>
-          <Badge color="blue">{diff.summary.outputChanges} output changes</Badge>
+          <Badge color="blue">
+            {diff.summary.outputChanges} output changes
+          </Badge>
           <Badge color="gray">{diff.summary.unchangedCells} unchanged</Badge>
         </div>
         <div className="mt-4 grid min-w-[920px] grid-cols-2 gap-3 overflow-x-auto text-xs font-medium uppercase tracking-wide text-nb-text-muted">
@@ -262,31 +269,5 @@ export function NotebookDiffContent({ document }: { document: NotebookDiffDocume
         </div>
       </ScrollArea>
     </div>
-  );
-}
-
-export default function NotebookDiffView() {
-  const params = useParams<{ diffId: string }>();
-  const document = params.diffId
-    ? getNotebookDiffDocument(params.diffId)
-    : null;
-
-  if (!document) {
-    return (
-      <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-nb-surface text-center">
-        <Text as="p" size="4" weight="bold">
-          Diff no longer available
-        </Text>
-        <Text as="p" size="2" className="max-w-md text-nb-text-muted">
-          Recompute the notebook diff from a browser JavaScript cell, then call
-          notebookDiff.openDiffTab(diff) again.
-        </Text>
-        <Button asChild variant="soft">
-          <Link to="/">Back to notebooks</Link>
-        </Button>
-      </div>
-    );
-  }
-
-  return <NotebookDiffContent document={document} />;
+  )
 }

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookStoreItemType } from '../../storage/notebook'
+import { WorkspaceExplorer } from './WorkspaceExplorer'
+
+const mocks = vi.hoisted(() => ({
+  currentDoc: 'diff://notebook/diff-1',
+  setCurrentDoc: vi.fn(),
+  fetchDriveItemWithParents: vi.fn(),
+  parseDriveItem: vi.fn(),
+  isDriveItemUri: vi.fn(),
+  openNotebook: vi.fn(),
+  showDocument: vi.fn(),
+}))
+
+vi.mock('react-arborist', () => ({
+  Tree: () => <div data-testid="tree" />,
+}))
+
+vi.mock('./GoogleDrivePickerButton', () => ({
+  GoogleDrivePickerButton: () => <button type="button">Pick Drive</button>,
+}))
+
+vi.mock('../../contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({
+    getItems: () => [],
+    addItem: vi.fn(),
+    removeItem: vi.fn(),
+  }),
+}))
+
+vi.mock('../../contexts/NotebookStoreContext', () => ({
+  useNotebookStore: () => ({
+    store: {},
+  }),
+}))
+
+vi.mock('../../contexts/FilesystemStoreContext', () => ({
+  useFilesystemStore: () => ({
+    fsStore: null,
+  }),
+}))
+
+vi.mock('../../contexts/GoogleAuthContext', () => ({
+  useGoogleAuth: () => ({
+    ensureAccessToken: vi.fn(),
+  }),
+}))
+
+vi.mock('../../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({
+    getCurrentDoc: () => mocks.currentDoc,
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}))
+
+vi.mock('../../contexts/NotebookContext', () => ({
+  useNotebookContext: () => ({
+    openNotebook: mocks.openNotebook,
+  }),
+}))
+
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
+  }),
+}))
+
+vi.mock('../../storage/drive', () => ({
+  fetchDriveItemWithParents: mocks.fetchDriveItemWithParents,
+  isDriveItemUri: mocks.isDriveItemUri,
+  parseDriveItem: mocks.parseDriveItem,
+}))
+
+describe('WorkspaceExplorer current document handling', () => {
+  beforeEach(() => {
+    mocks.currentDoc = 'diff://notebook/diff-1'
+    mocks.setCurrentDoc.mockReset()
+    mocks.fetchDriveItemWithParents.mockReset()
+    mocks.fetchDriveItemWithParents.mockRejectedValue(
+      new Error('auth required')
+    )
+    mocks.parseDriveItem.mockReset()
+    mocks.parseDriveItem.mockReturnValue({
+      id: 'diff-1',
+      type: NotebookStoreItemType.File,
+    })
+    mocks.isDriveItemUri.mockReset()
+    mocks.isDriveItemUri.mockReturnValue(false)
+    mocks.openNotebook.mockReset()
+    mocks.showDocument.mockReset()
+  })
+
+  it('does not treat notebook diff URIs as Google Drive documents', async () => {
+    render(<WorkspaceExplorer />)
+
+    await waitFor(() => {
+      expect(mocks.isDriveItemUri).toHaveBeenCalledWith(
+        'diff://notebook/diff-1'
+      )
+    })
+    expect(mocks.parseDriveItem).not.toHaveBeenCalled()
+    expect(mocks.fetchDriveItemWithParents).not.toHaveBeenCalled()
+    expect(mocks.setCurrentDoc).not.toHaveBeenCalledWith(null)
+  })
+})

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -450,6 +450,11 @@ export function WorkspaceExplorer() {
       return;
     }
 
+    if (!isDriveItemUri(currentDoc)) {
+      handledDocRef.current = currentDoc;
+      return;
+    }
+
     let parsed = null;
     try {
       parsed = parseDriveItem(currentDoc);

--- a/app/src/contexts/WorkspaceDocumentContext.tsx
+++ b/app/src/contexts/WorkspaceDocumentContext.tsx
@@ -6,48 +6,50 @@ import {
   useEffect,
   useMemo,
   useSyncExternalStore,
-} from "react";
+} from 'react'
 
-import { useCurrentDoc } from "./CurrentDocContext";
-import { useNotebookContext } from "./NotebookContext";
+import { useCurrentDoc } from './CurrentDocContext'
+import { useNotebookContext } from './NotebookContext'
 import {
+  WORKSPACE_DOCUMENT_FOCUS_EVENT,
   getWorkspaceDocumentController,
   type ShowWorkspaceDocumentOptions,
-} from "../lib/workspaceDocuments/workspaceDocumentController";
+  type WorkspaceDocumentFocusEventDetail,
+} from '../lib/workspaceDocuments/workspaceDocumentController'
 import {
   isNotebookDocumentUri,
   type WorkspaceDocument,
-} from "../lib/workspaceDocuments/workspaceDocumentTypes";
+} from '../lib/workspaceDocuments/workspaceDocumentTypes'
 
 type WorkspaceDocumentContextValue = {
-  useWorkspaceDocuments: () => WorkspaceDocument[];
-  showDocument: (uri: string, options?: ShowWorkspaceDocumentOptions) => void;
-  closeWorkspaceDocument: (uri: string) => string | null;
-};
+  useWorkspaceDocuments: () => WorkspaceDocument[]
+  showDocument: (uri: string, options?: ShowWorkspaceDocumentOptions) => void
+  closeWorkspaceDocument: (uri: string) => string | null
+}
 
 const WorkspaceDocumentContext = createContext<
   WorkspaceDocumentContextValue | undefined
->(undefined);
+>(undefined)
 
 export function useWorkspaceDocumentContext() {
-  const ctx = useContext(WorkspaceDocumentContext);
+  const ctx = useContext(WorkspaceDocumentContext)
   if (!ctx) {
     throw new Error(
-      "useWorkspaceDocumentContext must be used within a WorkspaceDocumentProvider",
-    );
+      'useWorkspaceDocumentContext must be used within a WorkspaceDocumentProvider'
+    )
   }
-  return ctx;
+  return ctx
 }
 
 export function WorkspaceDocumentProvider({
   children,
 }: {
-  children: ReactNode;
+  children: ReactNode
 }) {
-  const controller = getWorkspaceDocumentController();
-  const { useNotebookList, removeNotebook } = useNotebookContext();
-  const openNotebooks = useNotebookList();
-  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
+  const controller = getWorkspaceDocumentController()
+  const { useNotebookList, removeNotebook } = useNotebookContext()
+  const openNotebooks = useNotebookList()
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
 
   useEffect(() => {
     for (const notebook of openNotebooks) {
@@ -57,42 +59,62 @@ export function WorkspaceDocumentProvider({
         state: notebook.state,
         errorMessage: notebook.errorMessage,
         owner: notebook.owner,
-      });
+      })
     }
-  }, [controller, openNotebooks]);
+  }, [controller, openNotebooks])
 
   const showDocument = useCallback(
     (uri: string, options?: ShowWorkspaceDocumentOptions) => {
-      controller.showDocument(uri, options);
+      controller.showDocument(uri, options)
     },
-    [controller],
-  );
+    [controller]
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const handleFocusRequest = (event: Event) => {
+      const uri = (event as CustomEvent<WorkspaceDocumentFocusEventDetail>)
+        .detail?.uri
+      if (typeof uri === 'string' && uri.trim()) {
+        setCurrentDoc(uri)
+      }
+    }
+    window.addEventListener(WORKSPACE_DOCUMENT_FOCUS_EVENT, handleFocusRequest)
+    return () => {
+      window.removeEventListener(
+        WORKSPACE_DOCUMENT_FOCUS_EVENT,
+        handleFocusRequest
+      )
+    }
+  }, [setCurrentDoc])
 
   const closeWorkspaceDocument = useCallback(
     (uri: string) => {
-      const fallback = controller.closeDocument(uri);
+      const fallback = controller.closeDocument(uri)
       if (isNotebookDocumentUri(uri)) {
-        removeNotebook(uri);
+        removeNotebook(uri)
       }
       if (getCurrentDoc() === uri) {
-        setCurrentDoc(fallback);
+        setCurrentDoc(fallback)
       }
-      return fallback;
+      return fallback
     },
-    [controller, getCurrentDoc, removeNotebook, setCurrentDoc],
-  );
+    [controller, getCurrentDoc, removeNotebook, setCurrentDoc]
+  )
 
   const useWorkspaceDocuments = useCallback(() => {
     const subscribe = useCallback(
       (listener: () => void) => controller.subscribe(listener),
-      [controller],
-    );
+      [controller]
+    )
     const getSnapshot = useCallback(
       () => controller.getSnapshot().documents,
-      [controller],
-    );
-    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-  }, [controller]);
+      [controller]
+    )
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  }, [controller])
 
   const value = useMemo<WorkspaceDocumentContextValue>(
     () => ({
@@ -100,12 +122,12 @@ export function WorkspaceDocumentProvider({
       showDocument,
       closeWorkspaceDocument,
     }),
-    [closeWorkspaceDocument, showDocument, useWorkspaceDocuments],
-  );
+    [closeWorkspaceDocument, showDocument, useWorkspaceDocuments]
+  )
 
   return (
     <WorkspaceDocumentContext.Provider value={value}>
       {children}
     </WorkspaceDocumentContext.Provider>
-  );
+  )
 }

--- a/app/src/lib/notebookDiff/registry.test.ts
+++ b/app/src/lib/notebookDiff/registry.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { parser_pb } from '../../runme/client'
+import {
+  WORKSPACE_DOCUMENT_FOCUS_EVENT,
+  __resetWorkspaceDocumentControllerForTests,
+  getWorkspaceDocumentController,
+} from '../workspaceDocuments/workspaceDocumentController'
+import { computeNotebookDiff } from './diff'
+import {
+  getNotebookDiffDocumentUri,
+  openNotebookDiffDocument,
+  registerNotebookDiffDocument,
+} from './registry'
+
+function notebook(value: string) {
+  return create(parser_pb.NotebookSchema, {
+    cells: [
+      create(parser_pb.CellSchema, {
+        refId: 'cell-1',
+        kind: parser_pb.CellKind.CODE,
+        languageId: 'python',
+        value,
+      }),
+    ],
+    metadata: {},
+  })
+}
+
+describe('notebook diff registry', () => {
+  beforeEach(() => {
+    __resetWorkspaceDocumentControllerForTests()
+    window.sessionStorage.clear()
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('opens notebook diffs as focused workspace documents', () => {
+    const focusListener = vi.fn()
+    window.addEventListener(WORKSPACE_DOCUMENT_FOCUS_EVENT, focusListener)
+    const diff = computeNotebookDiff(
+      notebook("print('base')"),
+      notebook("print('compare')")
+    )
+    const doc = registerNotebookDiffDocument({
+      id: '%',
+      base: { label: 'Drive revision 1', revisionId: '1' },
+      compare: { label: 'Local copy', revisionId: 'local' },
+      diff,
+    })
+
+    openNotebookDiffDocument(doc)
+
+    const diffUri = getNotebookDiffDocumentUri(doc.id)
+    expect(diffUri).toBe('diff://notebook/%25')
+    expect(getWorkspaceDocumentController().getSnapshot().documents).toEqual([
+      {
+        uri: diffUri,
+        title: 'Drive revision 1 vs Local copy',
+      },
+    ])
+    expect(focusListener).toHaveBeenCalledTimes(1)
+    expect((focusListener.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({
+      uri: diffUri,
+    })
+    expect(window.location.pathname).toBe('/')
+
+    window.removeEventListener(WORKSPACE_DOCUMENT_FOCUS_EVENT, focusListener)
+  })
+})

--- a/app/src/lib/notebookDiff/registry.ts
+++ b/app/src/lib/notebookDiff/registry.ts
@@ -1,32 +1,47 @@
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid'
 
-import { getAppPath } from "../appBase";
-import type { NotebookDiffDocument } from "./model";
+import { showWorkspaceDocument } from '../workspaceDocuments/workspaceDocumentController'
+import type { NotebookDiffDocument } from './model'
 
-const documents = new Map<string, NotebookDiffDocument>();
+const documents = new Map<string, NotebookDiffDocument>()
 
 export function registerNotebookDiffDocument(
-  document: Omit<NotebookDiffDocument, "id"> & { id?: string },
+  document: Omit<NotebookDiffDocument, 'id'> & { id?: string }
 ): NotebookDiffDocument {
-  const id = document.id?.trim() || `notebook-diff-${uuidv4()}`;
-  const stored = { ...document, id };
-  documents.set(id, stored);
-  return stored;
+  const id = document.id?.trim() || `notebook-diff-${uuidv4()}`
+  const stored = { ...document, id }
+  documents.set(id, stored)
+  return stored
 }
 
-export function getNotebookDiffDocument(id: string): NotebookDiffDocument | null {
-  return documents.get(id) ?? null;
+export function getNotebookDiffDocument(
+  id: string
+): NotebookDiffDocument | null {
+  return documents.get(id) ?? null
+}
+
+export function getNotebookDiffDocumentUri(id: string): string {
+  return `diff://notebook/${encodeURIComponent(id)}`
+}
+
+function getNotebookDiffDocumentTitle(
+  document: NotebookDiffDocument | null
+): string {
+  if (!document) {
+    return 'Notebook diff'
+  }
+  return `${document.base.label} vs ${document.compare.label}`
 }
 
 export function openNotebookDiffDocument(
-  document: NotebookDiffDocument | { id: string },
+  document: NotebookDiffDocument | { id: string }
 ): void {
-  const id = document.id.trim();
+  const id = document.id.trim()
   if (!id) {
-    throw new Error("openDiffTab requires a diff document id");
+    throw new Error('openDiffTab requires a diff document id')
   }
-  const path = getAppPath(`/diff/${encodeURIComponent(id)}`);
-  window.history.pushState(null, "", path);
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  const storedDocument = getNotebookDiffDocument(id)
+  showWorkspaceDocument(getNotebookDiffDocumentUri(id), {
+    title: getNotebookDiffDocumentTitle(storedDocument),
+  })
 }
-

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -1,66 +1,97 @@
 import {
+  type WorkspaceDocument,
   deriveWorkspaceDocumentTitle,
   isRestorableWorkspaceDocument,
-  type WorkspaceDocument,
-} from "./workspaceDocumentTypes";
+} from './workspaceDocumentTypes'
 
-const WORKSPACE_DOCUMENTS_STORAGE_KEY = "runme/workspaceDocuments";
+const WORKSPACE_DOCUMENTS_STORAGE_KEY = 'runme/workspaceDocuments'
 
 export interface WorkspaceDocumentSnapshot {
-  documents: WorkspaceDocument[];
+  documents: WorkspaceDocument[]
 }
 
 export interface WorkspaceDocumentPersistence {
-  loadDocuments(): WorkspaceDocument[];
-  saveDocuments(documents: WorkspaceDocument[]): void;
+  loadDocuments(): WorkspaceDocument[]
+  saveDocuments(documents: WorkspaceDocument[]): void
 }
 
-export type ShowWorkspaceDocumentOptions = Omit<Partial<WorkspaceDocument>, "uri">;
+export type ShowWorkspaceDocumentOptions = Omit<
+  Partial<WorkspaceDocument>,
+  'uri'
+>
+
+export const WORKSPACE_DOCUMENT_FOCUS_EVENT = 'runme:workspace-document-focus'
+
+export interface WorkspaceDocumentFocusEventDetail {
+  uri: string
+}
+
+export function focusWorkspaceDocument(uri: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  window.dispatchEvent(
+    new CustomEvent<WorkspaceDocumentFocusEventDetail>(
+      WORKSPACE_DOCUMENT_FOCUS_EVENT,
+      {
+        detail: { uri },
+      }
+    )
+  )
+}
+
+export function showWorkspaceDocument(
+  uri: string,
+  options?: ShowWorkspaceDocumentOptions
+): void {
+  getWorkspaceDocumentController().showDocument(uri, options)
+  focusWorkspaceDocument(uri)
+}
 
 class SessionStorageWorkspaceDocumentPersistence
   implements WorkspaceDocumentPersistence
 {
   loadDocuments(): WorkspaceDocument[] {
-    if (typeof window === "undefined" || !window.sessionStorage) {
-      return [];
+    if (typeof window === 'undefined' || !window.sessionStorage) {
+      return []
     }
     try {
-      const raw = window.sessionStorage.getItem(WORKSPACE_DOCUMENTS_STORAGE_KEY);
+      const raw = window.sessionStorage.getItem(WORKSPACE_DOCUMENTS_STORAGE_KEY)
       if (!raw) {
-        return [];
+        return []
       }
-      const parsed = JSON.parse(raw);
+      const parsed = JSON.parse(raw)
       if (!Array.isArray(parsed)) {
-        return [];
+        return []
       }
       return parsed
         .map(normalizeWorkspaceDocument)
-        .filter((item): item is WorkspaceDocument => Boolean(item));
+        .filter((item): item is WorkspaceDocument => Boolean(item))
     } catch {
-      return [];
+      return []
     }
   }
 
   saveDocuments(documents: WorkspaceDocument[]): void {
-    if (typeof window === "undefined" || !window.sessionStorage) {
-      return;
+    if (typeof window === 'undefined' || !window.sessionStorage) {
+      return
     }
     try {
       const restorable = documents.filter((item) =>
-        isRestorableWorkspaceDocument(item.uri),
-      );
+        isRestorableWorkspaceDocument(item.uri)
+      )
       if (restorable.length === 0) {
-        window.sessionStorage.removeItem(WORKSPACE_DOCUMENTS_STORAGE_KEY);
-        return;
+        window.sessionStorage.removeItem(WORKSPACE_DOCUMENTS_STORAGE_KEY)
+        return
       }
       const persisted = restorable.map((item) => ({
         uri: item.uri,
         title: item.title,
-      }));
+      }))
       window.sessionStorage.setItem(
         WORKSPACE_DOCUMENTS_STORAGE_KEY,
-        JSON.stringify(persisted),
-      );
+        JSON.stringify(persisted)
+      )
     } catch {
       // Ignore restore-state persistence failures.
     }
@@ -68,51 +99,51 @@ class SessionStorageWorkspaceDocumentPersistence
 }
 
 function normalizeWorkspaceDocument(item: unknown): WorkspaceDocument | null {
-  if (!item || typeof item !== "object") {
-    return null;
+  if (!item || typeof item !== 'object') {
+    return null
   }
-  const candidate = item as Partial<WorkspaceDocument>;
-  const uri = candidate.uri?.trim();
+  const candidate = item as Partial<WorkspaceDocument>
+  const uri = candidate.uri?.trim()
   if (!uri) {
-    return null;
+    return null
   }
   return {
     uri,
     title: candidate.title?.trim() || deriveWorkspaceDocumentTitle(uri),
-  };
+  }
 }
 
 export class WorkspaceDocumentController {
-  private documents: WorkspaceDocument[] = [];
-  private snapshot: WorkspaceDocumentSnapshot = { documents: [] };
-  private readonly listeners = new Set<() => void>();
-  private restored = false;
+  private documents: WorkspaceDocument[] = []
+  private snapshot: WorkspaceDocumentSnapshot = { documents: [] }
+  private readonly listeners = new Set<() => void>()
+  private restored = false
 
   constructor(
-    private persistence: WorkspaceDocumentPersistence =
-      new SessionStorageWorkspaceDocumentPersistence(),
+    private persistence: WorkspaceDocumentPersistence = new SessionStorageWorkspaceDocumentPersistence()
   ) {}
 
   getSnapshot(): WorkspaceDocumentSnapshot {
-    this.ensureRestored();
-    return this.snapshot;
+    this.ensureRestored()
+    return this.snapshot
   }
 
   subscribe(listener: () => void): () => void {
-    this.ensureRestored();
-    this.listeners.add(listener);
+    this.ensureRestored()
+    this.listeners.add(listener)
     return () => {
-      this.listeners.delete(listener);
-    };
+      this.listeners.delete(listener)
+    }
   }
 
   showDocument(uri: string, options?: ShowWorkspaceDocumentOptions): void {
-    this.ensureRestored();
-    const normalizedUri = uri.trim();
+    this.ensureRestored()
+    const normalizedUri = uri.trim()
     if (!normalizedUri) {
-      throw new Error("showDocument requires a non-empty URI");
+      throw new Error('showDocument requires a non-empty URI')
     }
-    const title = options?.title?.trim() || deriveWorkspaceDocumentTitle(normalizedUri);
+    const title =
+      options?.title?.trim() || deriveWorkspaceDocumentTitle(normalizedUri)
     const nextDocument: WorkspaceDocument = {
       uri: normalizedUri,
       title,
@@ -120,12 +151,12 @@ export class WorkspaceDocumentController {
       state: options?.state,
       errorMessage: options?.errorMessage,
       owner: options?.owner,
-    };
+    }
     const existingIndex = this.documents.findIndex(
-      (item) => item.uri === normalizedUri,
-    );
+      (item) => item.uri === normalizedUri
+    )
     if (existingIndex >= 0) {
-      const existing = this.documents[existingIndex];
+      const existing = this.documents[existingIndex]
       if (
         existing?.title === nextDocument.title &&
         existing?.requestedUri === nextDocument.requestedUri &&
@@ -133,84 +164,84 @@ export class WorkspaceDocumentController {
         existing?.errorMessage === nextDocument.errorMessage &&
         existing?.owner === nextDocument.owner
       ) {
-        return;
+        return
       }
       this.documents = this.documents.map((item, index) =>
-        index === existingIndex ? nextDocument : item,
-      );
+        index === existingIndex ? nextDocument : item
+      )
     } else {
-      this.documents = [...this.documents, nextDocument];
+      this.documents = [...this.documents, nextDocument]
     }
-    this.emit();
-    this.persist();
+    this.emit()
+    this.persist()
   }
 
   closeDocument(uri: string): string | null {
-    this.ensureRestored();
-    const index = this.documents.findIndex((item) => item.uri === uri);
+    this.ensureRestored()
+    const index = this.documents.findIndex((item) => item.uri === uri)
     if (index === -1) {
-      return null;
+      return null
     }
     const fallback =
       index > 0
-        ? this.documents[index - 1]?.uri ?? null
-        : this.documents[index + 1]?.uri ?? null;
-    this.documents = this.documents.filter((item) => item.uri !== uri);
-    this.emit();
-    this.persist();
-    return fallback;
+        ? (this.documents[index - 1]?.uri ?? null)
+        : (this.documents[index + 1]?.uri ?? null)
+    this.documents = this.documents.filter((item) => item.uri !== uri)
+    this.emit()
+    this.persist()
+    return fallback
   }
 
   resetForTests(): void {
-    this.documents = [];
-    this.snapshot = { documents: [] };
-    this.listeners.clear();
-    this.restored = false;
+    this.documents = []
+    this.snapshot = { documents: [] }
+    this.listeners.clear()
+    this.restored = false
   }
 
   private ensureRestored(): void {
     if (this.restored) {
-      return;
+      return
     }
-    this.restored = true;
+    this.restored = true
     this.documents = this.persistence
       .loadDocuments()
-      .filter((item) => isRestorableWorkspaceDocument(item.uri));
-    this.rebuildSnapshot();
+      .filter((item) => isRestorableWorkspaceDocument(item.uri))
+    this.rebuildSnapshot()
   }
 
   private emit(): void {
-    this.rebuildSnapshot();
+    this.rebuildSnapshot()
     for (const listener of this.listeners) {
       try {
-        listener();
+        listener()
       } catch (error) {
-        console.error("WorkspaceDocumentController listener failed", error);
+        console.error('WorkspaceDocumentController listener failed', error)
       }
     }
   }
 
   private persist(): void {
-    this.persistence.saveDocuments(this.documents);
+    this.persistence.saveDocuments(this.documents)
   }
 
   private rebuildSnapshot(): void {
     this.snapshot = {
       documents: this.documents.map((item) => ({ ...item })),
-    };
+    }
   }
 }
 
-let controller: WorkspaceDocumentController | null = null;
+let controller: WorkspaceDocumentController | null = null
 
 export function getWorkspaceDocumentController(): WorkspaceDocumentController {
   if (!controller) {
-    controller = new WorkspaceDocumentController();
+    controller = new WorkspaceDocumentController()
   }
-  return controller;
+  return controller
 }
 
 export function __resetWorkspaceDocumentControllerForTests(): void {
-  controller?.resetForTests();
-  controller = null;
+  controller?.resetForTests()
+  controller = null
 }


### PR DESCRIPTION
## Summary
- render notebook diff documents as workspace tabs instead of a /diff route
- focus newly opened diff tabs through the workspace document controller
- prevent WorkspaceExplorer from treating diff:// notebook documents as Drive files
- add regression coverage for diff-tab rendering and focus retention

## Validation
- pnpm -C app exec vitest run src/components/Workspace/WorkspaceExplorer.test.tsx src/components/Actions/Actions.test.tsx src/components/NotebookDiff/NotebookDiffView.test.tsx src/lib/notebookDiff/registry.test.ts
- runme run build test
- git diff --check origin/main