### PR TITLE
Add notebook conflict resolution flow

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1,20 +1,20 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
-import { clone, create } from "@bufbuild/protobuf";
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react'
+import { clone, create } from '@bufbuild/protobuf'
 import {
   APPKERNEL_RUNNER_NAME,
   APPKERNEL_SANDBOX_RUNNER_NAME,
-} from "../../lib/runtime/appKernel";
+} from '../../lib/runtime/appKernel'
 
-import { parser_pb, RunmeMetadataKey } from "../../runme/client";
-import type { CellData } from "../../lib/notebookData";
-import { computeNotebookDiff } from "../../lib/notebookDiff/diff";
+import { parser_pb, RunmeMetadataKey } from '../../runme/client'
+import type { CellData } from '../../lib/notebookData'
+import { computeNotebookDiff } from '../../lib/notebookDiff/diff'
 import {
   getNotebookDiffDocumentUri,
   registerNotebookDiffDocument,
-} from "../../lib/notebookDiff/registry";
-import Actions, { Action } from "./Actions";
+} from '../../lib/notebookDiff/registry'
+import Actions, { Action } from './Actions'
 
 const contextMocks = vi.hoisted(() => ({
   workspaceDocuments: [] as Array<{ uri: string; title: string }>,
@@ -24,165 +24,177 @@ const contextMocks = vi.hoisted(() => ({
   closeWorkspaceDocument: vi.fn(),
   getNotebookData: vi.fn(),
   notebookStore: null as null | {
-    getMetadata: ReturnType<typeof vi.fn>;
-    getSyncState: ReturnType<typeof vi.fn>;
-    rename: ReturnType<typeof vi.fn>;
-    subscribeSync: ReturnType<typeof vi.fn>;
+    files?: { get: ReturnType<typeof vi.fn> }
+    getMetadata: ReturnType<typeof vi.fn>
+    getSyncState: ReturnType<typeof vi.fn>
+    rename: ReturnType<typeof vi.fn>
+    resolveConflictWithLocal?: ReturnType<typeof vi.fn>
+    sync?: ReturnType<typeof vi.fn>
+    subscribeSync: ReturnType<typeof vi.fn>
   },
-}));
+}))
+
+const conflictMocks = vi.hoisted(() => ({
+  openNotebookConflictDiff: vi.fn(async () => undefined),
+}))
 
 // Minimal mocks for contexts Action consumes
-vi.mock("../../contexts/OutputContext", () => ({
+vi.mock('../../contexts/OutputContext', () => ({
   useOutput: () => ({
     getRenderer: () => undefined,
     getAllRenderers: () => {
-      throw new Error("Action should not query renderers during local mutation");
+      throw new Error('Action should not query renderers during local mutation')
     },
     registerRenderer: () => {},
     unregisterRenderer: () => {},
   }),
-}));
+}))
 
-vi.mock("../../contexts/RunnersContext", () => ({
+vi.mock('../../contexts/RunnersContext', () => ({
   useRunners: () => ({
     listRunners: () => [],
-    defaultRunnerName: "<default>",
+    defaultRunnerName: '<default>',
   }),
-}));
+}))
 
-vi.mock("../../contexts/SettingsContext", () => ({
+vi.mock('../../contexts/SettingsContext', () => ({
   useSettings: () => ({
     createAuthInterceptors: () => [],
-    webAppSettings: { runner: "", language: "" },
+    webAppSettings: { runner: '', language: '' },
   }),
-}));
+}))
 
-vi.mock("../../contexts/NotebookContext", () => ({
+vi.mock('../../contexts/NotebookContext', () => ({
   useNotebookContext: () => ({
     getNotebookData: contextMocks.getNotebookData,
     useNotebookSnapshot: () => null,
   }),
-}));
+}))
 
-vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
   useWorkspaceDocumentContext: () => ({
     useWorkspaceDocuments: () => contextMocks.workspaceDocuments,
     showDocument: contextMocks.showDocument,
     closeWorkspaceDocument: contextMocks.closeWorkspaceDocument,
   }),
-}));
+}))
 
-vi.mock("../../contexts/NotebookStoreContext", () => ({
+vi.mock('../../contexts/NotebookStoreContext', () => ({
   useNotebookStore: () => ({
     store: contextMocks.notebookStore,
   }),
-}));
+}))
 
-vi.mock("../../contexts/FilesystemStoreContext", () => ({
+vi.mock('../../contexts/FilesystemStoreContext', () => ({
   useFilesystemStore: () => ({
     fsStore: null,
     setFsStore: () => {},
   }),
-}));
+}))
 
-vi.mock("../../contexts/CurrentDocContext", () => ({
+vi.mock('../../contexts/CurrentDocContext', () => ({
   useCurrentDoc: () => ({
     getCurrentDoc: () => contextMocks.currentDoc,
     setCurrentDoc: contextMocks.setCurrentDoc,
   }),
-}));
+}))
 
-vi.mock("../../lib/runtime/jupyterManager", () => ({
+vi.mock('../../lib/notebookDiff/conflict', () => ({
+  openNotebookConflictDiff: conflictMocks.openNotebookConflictDiff,
+}))
+
+vi.mock('../../lib/runtime/jupyterManager', () => ({
   getJupyterManager: () => ({
     subscribe: () => () => {},
     getVersion: () => 0,
     ensureRunnerData: async () => {},
     getKernelOptionsForRunner: () => [],
-    getKernelOptionKey: (serverName: string, kernelId: string) => `${serverName}:${kernelId}`,
+    getKernelOptionKey: (serverName: string, kernelId: string) =>
+      `${serverName}:${kernelId}`,
     parseKernelOptionKey: (key: string) => {
-      if (!key.includes(":")) return null;
-      const [serverName, kernelId] = key.split(":", 2);
-      if (!serverName || !kernelId) return null;
-      return { serverName, kernelId };
+      if (!key.includes(':')) return null
+      const [serverName, kernelId] = key.split(':', 2)
+      if (!serverName || !kernelId) return null
+      return { serverName, kernelId }
     },
   }),
-}));
+}))
 
 // Mock runmedev/renderers to avoid registering the real web component,
 // which depends on adoptedStyleSheets and other browser-only APIs.
-vi.mock("@runmedev/renderers", () => ({
+vi.mock('@runmedev/renderers', () => ({
   ClientMessages: {
-    terminalStdin: "terminal:stdin",
-    terminalStdout: "terminal:stdout",
+    terminalStdin: 'terminal:stdin',
+    terminalStdout: 'terminal:stdout',
   },
   setContext: vi.fn(),
-}));
+}))
 
-vi.mock("../../contexts/CellContext", () => ({}));
+vi.mock('../../contexts/CellContext', () => ({}))
 
 // Minimal stub CellData to drive runID changes.
 class StubCellData {
-  snapshot: parser_pb.Cell;
-  private listeners = new Set<() => void>();
-  getRunnerName = () => "<default>";
-  getJupyterServerName = () => "";
-  getJupyterKernelID = () => "";
-  getJupyterKernelName = () => "";
+  snapshot: parser_pb.Cell
+  private listeners = new Set<() => void>()
+  getRunnerName = () => '<default>'
+  getJupyterServerName = () => ''
+  getJupyterKernelID = () => ''
+  getJupyterKernelName = () => ''
   setRunner = vi.fn((name: string) => {
-    const next = clone(parser_pb.CellSchema, this.snapshot);
-    next.metadata = { ...(next.metadata ?? {}) };
-    if (name === "<default>") {
-      delete next.metadata[RunmeMetadataKey.RunnerName];
+    const next = clone(parser_pb.CellSchema, this.snapshot)
+    next.metadata = { ...(next.metadata ?? {}) }
+    if (name === '<default>') {
+      delete next.metadata[RunmeMetadataKey.RunnerName]
     } else {
-      next.metadata[RunmeMetadataKey.RunnerName] = name;
+      next.metadata[RunmeMetadataKey.RunnerName] = name
     }
-    this.update(next);
-  });
-  setJupyterKernel = () => {};
-  clearJupyterKernel = () => {};
+    this.update(next)
+  })
+  setJupyterKernel = () => {}
+  clearJupyterKernel = () => {}
   update = vi.fn((nextCell: parser_pb.Cell) => {
-    this.snapshot = clone(parser_pb.CellSchema, nextCell);
-    this.listeners.forEach((listener) => listener());
-  });
+    this.snapshot = clone(parser_pb.CellSchema, nextCell)
+    this.listeners.forEach((listener) => listener())
+  })
 
   constructor(cell: parser_pb.Cell) {
-    this.snapshot = cell;
+    this.snapshot = cell
   }
 
   subscribe(listener: () => void) {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
   }
 
   subscribeToContentChange(listener: () => void) {
-    return this.subscribe(listener);
+    return this.subscribe(listener)
   }
 
   subscribeToRunIDChange(_listener: (id: string) => void) {
-    return () => {};
+    return () => {}
   }
 
   getRunID() {
-    const runID = this.snapshot.metadata?.[RunmeMetadataKey.LastRunID];
-    return typeof runID === "string" ? runID : "";
+    const runID = this.snapshot.metadata?.[RunmeMetadataKey.LastRunID]
+    return typeof runID === 'string' ? runID : ''
   }
 
   setRunID(id: string) {
-    const next = clone(parser_pb.CellSchema, this.snapshot);
-    next.metadata = { ...(next.metadata ?? {}) };
+    const next = clone(parser_pb.CellSchema, this.snapshot)
+    next.metadata = { ...(next.metadata ?? {}) }
     if (id) {
-      next.metadata[RunmeMetadataKey.LastRunID] = id;
+      next.metadata[RunmeMetadataKey.LastRunID] = id
     } else {
-      delete next.metadata[RunmeMetadataKey.LastRunID];
+      delete next.metadata[RunmeMetadataKey.LastRunID]
     }
-    this.update(next);
+    this.update(next)
   }
 
   getStreams() {
     if (!this.getRunID()) {
-      return null;
+      return null
     }
-    const sub = () => ({ unsubscribe: () => {} });
+    const sub = () => ({ unsubscribe: () => {} })
     return {
       stdout: { subscribe: sub },
       stderr: { subscribe: sub },
@@ -194,7 +206,7 @@ class StubCellData {
       setCallback: () => {},
       close: () => {},
       connect: () => ({ subscribe: () => ({ unsubscribe: () => {} }) }),
-    } as any;
+    } as any
   }
   addBefore() {}
   addAfter() {}
@@ -203,145 +215,252 @@ class StubCellData {
 }
 
 beforeEach(() => {
-  Element.prototype.scrollIntoView = vi.fn();
-  contextMocks.workspaceDocuments = [];
-  contextMocks.currentDoc = null;
-  contextMocks.setCurrentDoc.mockReset();
+  Element.prototype.scrollIntoView = vi.fn()
+  contextMocks.workspaceDocuments = []
+  contextMocks.currentDoc = null
+  contextMocks.setCurrentDoc.mockReset()
   contextMocks.setCurrentDoc.mockImplementation((uri: string | null) => {
-    contextMocks.currentDoc = uri;
-  });
-  contextMocks.showDocument.mockReset();
-  contextMocks.closeWorkspaceDocument.mockReset();
-  contextMocks.getNotebookData.mockReset();
-  contextMocks.getNotebookData.mockReturnValue(null);
-  contextMocks.notebookStore = null;
-});
+    contextMocks.currentDoc = uri
+  })
+  contextMocks.showDocument.mockReset()
+  contextMocks.closeWorkspaceDocument.mockReset()
+  contextMocks.getNotebookData.mockReset()
+  contextMocks.getNotebookData.mockReturnValue(null)
+  contextMocks.notebookStore = null
+  conflictMocks.openNotebookConflictDiff.mockReset()
+  conflictMocks.openNotebookConflictDiff.mockResolvedValue(undefined)
+})
 
-describe("Actions tabs", () => {
-  it("falls back from a stale current URI to an open workspace document", async () => {
-    contextMocks.currentDoc = "diff://notebook/not-restored";
+describe('Actions tabs', () => {
+  it('falls back from a stale current URI to an open workspace document', async () => {
+    contextMocks.currentDoc = 'diff://notebook/not-restored'
     contextMocks.workspaceDocuments = [
-      { uri: "local://file/restored", title: "restored.json" },
-    ];
+      { uri: 'local://file/restored', title: 'restored.json' },
+    ]
 
-    render(<Actions />);
+    render(<Actions />)
 
     await waitFor(() => {
       expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(
-        "local://file/restored",
-      );
-    });
-  });
+        'local://file/restored'
+      )
+    })
+  })
 
-  it("renames the notebook from the tab context menu", async () => {
+  it('renames the notebook from the tab context menu', async () => {
     const rename = vi.fn(async () => ({
-      uri: "local://file/restored",
-      name: "renamed.json",
-      type: "file",
+      uri: 'local://file/restored',
+      name: 'renamed.json',
+      type: 'file',
       children: [],
-      remoteUri: "https://drive.google.com/file/d/file123/view",
+      remoteUri: 'https://drive.google.com/file/d/file123/view',
       parents: [],
-    }));
-    const setName = vi.fn();
+    }))
+    const setName = vi.fn()
     contextMocks.notebookStore = {
       getMetadata: vi.fn(async () => ({
-        uri: "local://file/restored",
-        name: "restored.json",
-        type: "file",
+        uri: 'local://file/restored',
+        name: 'restored.json',
+        type: 'file',
         children: [],
-        remoteUri: "https://drive.google.com/file/d/file123/view",
+        remoteUri: 'https://drive.google.com/file/d/file123/view',
         parents: [],
       })),
       getSyncState: vi.fn(async () => ({
-        status: "synced",
-        localUri: "local://file/restored",
-        remoteId: "https://drive.google.com/file/d/file123/view",
+        status: 'synced',
+        localUri: 'local://file/restored',
+        remoteId: 'https://drive.google.com/file/d/file123/view',
       })),
       rename,
       subscribeSync: vi.fn(() => () => {}),
-    };
-    contextMocks.getNotebookData.mockReturnValue({ setName });
-    contextMocks.currentDoc = "local://file/restored";
+    }
+    contextMocks.getNotebookData.mockReturnValue({ setName })
+    contextMocks.currentDoc = 'local://file/restored'
     contextMocks.workspaceDocuments = [
-      { uri: "local://file/restored", title: "restored.json" },
-    ];
-    vi.spyOn(window, "prompt").mockReturnValue("renamed.json");
+      { uri: 'local://file/restored', title: 'restored.json' },
+    ]
+    vi.spyOn(window, 'prompt').mockReturnValue('renamed.json')
 
-    render(<Actions />);
+    render(<Actions />)
 
-    fireEvent.contextMenu(screen.getByRole("tab", { name: "restored.json" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Rename" }));
+    fireEvent.contextMenu(screen.getByRole('tab', { name: 'restored.json' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Rename' }))
 
     await waitFor(() => {
       expect(rename).toHaveBeenCalledWith(
-        "local://file/restored",
-        "renamed.json",
-      );
-    });
-    expect(setName).toHaveBeenCalledWith("renamed.json");
+        'local://file/restored',
+        'renamed.json'
+      )
+    })
+    expect(setName).toHaveBeenCalledWith('renamed.json')
     expect(contextMocks.showDocument).toHaveBeenCalledWith(
-      "local://file/restored",
-      { title: "renamed.json" },
-    );
-  });
+      'local://file/restored',
+      { title: 'renamed.json' }
+    )
+  })
 
-  it("renders a selected notebook diff workspace document as a tab", () => {
+  it('opens a conflict diff from the notebook sync indicator', async () => {
+    const store = {
+      getMetadata: vi.fn(async () => ({
+        uri: 'local://file/conflict',
+        name: 'conflict.json',
+        type: 'file',
+        children: [],
+        remoteUri: 'https://drive.google.com/file/d/file123/view',
+        parents: [],
+      })),
+      getSyncState: vi.fn(async () => ({
+        status: 'conflicted',
+        localUri: 'local://file/conflict',
+        remoteId: 'https://drive.google.com/file/d/file123/view',
+        conflict: {
+          detectedAt: '2026-05-30T00:00:00.000Z',
+          upstreamChecksum: 'upstream-checksum',
+          upstreamDoc: '{}',
+          localChecksumAtDetection: 'local-checksum',
+        },
+      })),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.notebookStore = store
+    contextMocks.currentDoc = 'local://file/conflict'
+    contextMocks.workspaceDocuments = [
+      { uri: 'local://file/conflict', title: 'conflict.json' },
+    ]
+
+    render(<Actions />)
+
+    const indicator = await screen.findByRole('button', {
+      name: 'Notebook has a sync conflict. Click to review differences.',
+    })
+    fireEvent.click(indicator)
+
+    await waitFor(() => {
+      expect(conflictMocks.openNotebookConflictDiff).toHaveBeenCalledWith(
+        store,
+        'local://file/conflict'
+      )
+    })
+  })
+
+  it('renders a selected notebook diff workspace document as a tab', () => {
     const baseNotebook = create(parser_pb.NotebookSchema, {
       cells: [
         create(parser_pb.CellSchema, {
-          refId: "cell-1",
+          refId: 'cell-1',
           kind: parser_pb.CellKind.CODE,
-          languageId: "python",
+          languageId: 'python',
           value: "print('base')",
         }),
       ],
       metadata: {},
-    });
+    })
     const compareNotebook = create(parser_pb.NotebookSchema, {
       cells: [
         create(parser_pb.CellSchema, {
-          refId: "cell-1",
+          refId: 'cell-1',
           kind: parser_pb.CellKind.CODE,
-          languageId: "python",
+          languageId: 'python',
           value: "print('compare')",
         }),
       ],
       metadata: {},
-    });
+    })
     const doc = registerNotebookDiffDocument({
-      id: "diff-1",
-      base: { label: "Drive revision 1", revisionId: "1" },
-      compare: { label: "Local copy", revisionId: "local" },
+      id: 'diff-1',
+      base: { label: 'Drive revision 1', revisionId: '1' },
+      compare: { label: 'Local copy', revisionId: 'local' },
       diff: computeNotebookDiff(baseNotebook, compareNotebook),
-    });
-    const diffUri = getNotebookDiffDocumentUri(doc.id);
-    contextMocks.currentDoc = diffUri;
+    })
+    const diffUri = getNotebookDiffDocumentUri(doc.id)
+    contextMocks.currentDoc = diffUri
     contextMocks.workspaceDocuments = [
-      { uri: diffUri, title: "Drive revision 1 vs Local copy" },
-    ];
+      { uri: diffUri, title: 'Drive revision 1 vs Local copy' },
+    ]
 
-    render(<Actions />);
+    render(<Actions />)
 
     expect(
-      screen.getByRole("tab", { name: "Drive revision 1 vs Local copy" }),
-    ).toBeTruthy();
-    expect(screen.getByText("Notebook Diff")).toBeTruthy();
+      screen.getByRole('tab', { name: 'Drive revision 1 vs Local copy' })
+    ).toBeTruthy()
+    expect(screen.getByText('Notebook Diff')).toBeTruthy()
     expect(
-      screen.getByText(/Drive revision 1 compared with Local copy/),
-    ).toBeTruthy();
-    expect(screen.getByText("print('base')")).toBeTruthy();
-    expect(screen.getByText("print('compare')")).toBeTruthy();
-    expect(screen.queryByText("Back to notebooks")).toBeNull();
-  });
+      screen.getByText(/Drive revision 1 compared with Local copy/)
+    ).toBeTruthy()
+    expect(screen.getByText("print('base')")).toBeTruthy()
+    expect(screen.getByText("print('compare')")).toBeTruthy()
+    expect(screen.queryByText('Back to notebooks')).toBeNull()
+  })
 
-  it("keeps a clicked diff tab selected while current doc state catches up", async () => {
+  it('saves local version from a conflict diff tab', async () => {
+    const resolveConflictWithLocal = vi.fn(async () => undefined)
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(),
+      getSyncState: vi.fn(),
+      rename: vi.fn(),
+      resolveConflictWithLocal,
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    const doc = registerNotebookDiffDocument({
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(
+        create(parser_pb.NotebookSchema, {
+          cells: [
+            create(parser_pb.CellSchema, {
+              refId: 'cell-1',
+              kind: parser_pb.CellKind.CODE,
+              languageId: 'python',
+              value: "print('upstream')",
+            }),
+          ],
+          metadata: {},
+        }),
+        create(parser_pb.NotebookSchema, {
+          cells: [
+            create(parser_pb.CellSchema, {
+              refId: 'cell-1',
+              kind: parser_pb.CellKind.CODE,
+              languageId: 'python',
+              value: "print('local')",
+            }),
+          ],
+          metadata: {},
+        })
+      ),
+      resolution: {
+        kind: 'notebook-sync-conflict',
+        localUri: 'local://file/conflict',
+      },
+    })
+    const diffUri = getNotebookDiffDocumentUri(doc.id)
+    contextMocks.currentDoc = diffUri
+    contextMocks.workspaceDocuments = [
+      { uri: diffUri, title: 'Upstream version vs Local version' },
+    ]
+
+    render(<Actions />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save local version' }))
+
+    await waitFor(() => {
+      expect(resolveConflictWithLocal).toHaveBeenCalledWith(
+        'local://file/conflict',
+        { force: false }
+      )
+    })
+  })
+
+  it('keeps a clicked diff tab selected while current doc state catches up', async () => {
     const diff = computeNotebookDiff(
       create(parser_pb.NotebookSchema, {
         cells: [
           create(parser_pb.CellSchema, {
-            refId: "cell-1",
+            refId: 'cell-1',
             kind: parser_pb.CellKind.CODE,
-            languageId: "python",
+            languageId: 'python',
             value: "print('base')",
           }),
         ],
@@ -350,354 +469,372 @@ describe("Actions tabs", () => {
       create(parser_pb.NotebookSchema, {
         cells: [
           create(parser_pb.CellSchema, {
-            refId: "cell-1",
+            refId: 'cell-1',
             kind: parser_pb.CellKind.CODE,
-            languageId: "python",
+            languageId: 'python',
             value: "print('compare')",
           }),
         ],
         metadata: {},
-      }),
-    );
+      })
+    )
     const doc = registerNotebookDiffDocument({
-      id: "diff-click",
-      base: { label: "Drive revision 1", revisionId: "1" },
-      compare: { label: "Local copy", revisionId: "local" },
+      id: 'diff-click',
+      base: { label: 'Drive revision 1', revisionId: '1' },
+      compare: { label: 'Local copy', revisionId: 'local' },
       diff,
-    });
-    const diffUri = getNotebookDiffDocumentUri(doc.id);
-    contextMocks.currentDoc = "local://file/first";
+    })
+    const diffUri = getNotebookDiffDocumentUri(doc.id)
+    contextMocks.currentDoc = 'local://file/first'
     contextMocks.workspaceDocuments = [
-      { uri: "local://file/first", title: "first.json" },
-      { uri: diffUri, title: "Drive revision 1 vs Local copy" },
-    ];
+      { uri: 'local://file/first', title: 'first.json' },
+      { uri: diffUri, title: 'Drive revision 1 vs Local copy' },
+    ]
 
-    render(<Actions />);
+    render(<Actions />)
 
-    const firstTab = screen.getByRole("tab", { name: "first.json" });
-    const diffTab = screen.getByRole("tab", {
-      name: "Drive revision 1 vs Local copy",
-    });
-    expect(firstTab.getAttribute("aria-selected")).toBe("true");
+    const firstTab = screen.getByRole('tab', { name: 'first.json' })
+    const diffTab = screen.getByRole('tab', {
+      name: 'Drive revision 1 vs Local copy',
+    })
+    expect(firstTab.getAttribute('aria-selected')).toBe('true')
 
-    fireEvent.mouseDown(diffTab, { button: 0, ctrlKey: false });
+    fireEvent.mouseDown(diffTab, { button: 0, ctrlKey: false })
 
-    expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(diffUri);
+    expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(diffUri)
     await waitFor(() => {
-      expect(diffTab.getAttribute("aria-selected")).toBe("true");
-      expect(firstTab.getAttribute("aria-selected")).toBe("false");
-    });
-  });
-});
+      expect(diffTab.getAttribute('aria-selected')).toBe('true')
+      expect(firstTab.getAttribute('aria-selected')).toBe('false')
+    })
+  })
+})
 
-describe("Action component", () => {
-  it("updates CellConsole key when runID changes", async () => {
-    const cell =  create(parser_pb.CellSchema,{
-      refId: "cell-1",
-      kind: parser_pb.CellKind.CODE,
-      languageId: "bash",
-      outputs: [],
-      metadata: {
-        [RunmeMetadataKey.LastRunID]: "run-0",
-      },
-      value: "echo hi",
-    });
-    const stub = new StubCellData(cell);
-
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
-
-    const first = screen.getByTestId("cell-console") as HTMLElement;
-    const firstKey = first.dataset.runkey;
-
-    await act(async () => {
-      stub.setRunID("run-123");
-      await Promise.resolve();
-    });
-
-    const second = screen.getByTestId("cell-console") as HTMLElement;
-    const secondKey = second.dataset.runkey;
-
-    expect(firstKey).not.toBe(secondKey);
-  });
-
-  it("hides console output area when runID is cleared and outputs are empty", async () => {
+describe('Action component', () => {
+  it('updates CellConsole key when runID changes', async () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-clear",
+      refId: 'cell-1',
       kind: parser_pb.CellKind.CODE,
-      languageId: "bash",
+      languageId: 'bash',
       outputs: [],
       metadata: {
-        [RunmeMetadataKey.LastRunID]: "run-0",
+        [RunmeMetadataKey.LastRunID]: 'run-0',
       },
-      value: "echo hi",
-    });
-    const stub = new StubCellData(cell);
+      value: 'echo hi',
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
-    expect(screen.getByTestId("cell-console")).toBeTruthy();
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
+
+    const first = screen.getByTestId('cell-console') as HTMLElement
+    const firstKey = first.dataset.runkey
 
     await act(async () => {
-      stub.setRunID("");
-      await Promise.resolve();
-    });
+      stub.setRunID('run-123')
+      await Promise.resolve()
+    })
 
-    expect(screen.queryByTestId("cell-console")).toBeNull();
-  });
+    const second = screen.getByTestId('cell-console') as HTMLElement
+    const secondKey = second.dataset.runkey
 
-  it("suppresses duplicate stdout output items while a live console stream is active", () => {
+    expect(firstKey).not.toBe(secondKey)
+  })
+
+  it('hides console output area when runID is cleared and outputs are empty', async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-clear',
+      kind: parser_pb.CellKind.CODE,
+      languageId: 'bash',
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: 'run-0',
+      },
+      value: 'echo hi',
+    })
+    const stub = new StubCellData(cell)
+
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
+    expect(screen.getByTestId('cell-console')).toBeTruthy()
+
+    await act(async () => {
+      stub.setRunID('')
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByTestId('cell-console')).toBeNull()
+  })
+
+  it('suppresses duplicate stdout output items while a live console stream is active', () => {
     const stdoutOutput = create(parser_pb.CellOutputSchema, {
       items: [
         create(parser_pb.CellOutputItemSchema, {
-          mime: "application/vnd.code.notebook.stdout",
-          type: "Buffer",
-          data: new TextEncoder().encode("prompt"),
+          mime: 'application/vnd.code.notebook.stdout',
+          type: 'Buffer',
+          data: new TextEncoder().encode('prompt'),
         }),
       ],
-    });
+    })
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-live-stdout",
+      refId: 'cell-live-stdout',
       kind: parser_pb.CellKind.CODE,
-      languageId: "bash",
+      languageId: 'bash',
       outputs: [stdoutOutput],
       metadata: {
-        [RunmeMetadataKey.LastRunID]: "run-live-stdout",
+        [RunmeMetadataKey.LastRunID]: 'run-live-stdout',
       },
-      value: "echo hi",
-    });
-    const stub = new StubCellData(cell) as unknown as CellData;
+      value: 'echo hi',
+    })
+    const stub = new StubCellData(cell) as unknown as CellData
 
-    render(<Action cellData={stub} isFirst={false} />);
+    render(<Action cellData={stub} isFirst={false} />)
 
-    expect(screen.getByTestId("cell-console")).toBeTruthy();
-    expect(screen.queryByText(/mime=application\/vnd\.code\.notebook\.stdout/)).toBeNull();
-  });
+    expect(screen.getByTestId('cell-console')).toBeTruthy()
+    expect(
+      screen.queryByText(/mime=application\/vnd\.code\.notebook\.stdout/)
+    ).toBeNull()
+  })
 
-  it("shows language selector in markdown edit mode and converts to code language", () => {
+  it('shows language selector in markdown edit mode and converts to code language', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-md",
+      refId: 'cell-md',
       kind: parser_pb.CellKind.MARKUP,
-      languageId: "markdown",
+      languageId: 'markdown',
       outputs: [],
       metadata: {},
-      value: "",
-    });
-    const stub = new StubCellData(cell);
+      value: '',
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const selector = screen.getByRole("combobox");
-    expect(selector).toBeTruthy();
-    expect((selector as HTMLSelectElement).value).toBe("markdown");
+    const selector = screen.getByRole('combobox')
+    expect(selector).toBeTruthy()
+    expect((selector as HTMLSelectElement).value).toBe('markdown')
 
-    fireEvent.change(selector, { target: { value: "bash" } });
+    fireEvent.change(selector, { target: { value: 'bash' } })
 
-    expect(stub.update).toHaveBeenCalledTimes(1);
-    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell;
-    expect(updatedCell.kind).toBe(parser_pb.CellKind.CODE);
-    expect(updatedCell.languageId).toBe("bash");
-  });
+    expect(stub.update).toHaveBeenCalledTimes(1)
+    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell
+    expect(updatedCell.kind).toBe(parser_pb.CellKind.CODE)
+    expect(updatedCell.languageId).toBe('bash')
+  })
 
-  it("converts code cell to markdown kind when switching to markdown", () => {
+  it('converts code cell to markdown kind when switching to markdown', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-code",
+      refId: 'cell-code',
       kind: parser_pb.CellKind.CODE,
-      languageId: "bash",
+      languageId: 'bash',
       outputs: [],
       metadata: {},
-      value: "echo hi",
-    });
-    const stub = new StubCellData(cell);
+      value: 'echo hi',
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const selector = document.getElementById("language-select-cell-code") as
-      | HTMLSelectElement
-      | null;
-    expect(selector).toBeTruthy();
-    fireEvent.change(selector as HTMLSelectElement, { target: { value: "markdown" } });
+    const selector = document.getElementById(
+      'language-select-cell-code'
+    ) as HTMLSelectElement | null
+    expect(selector).toBeTruthy()
+    fireEvent.change(selector as HTMLSelectElement, {
+      target: { value: 'markdown' },
+    })
 
-    expect(stub.update).toHaveBeenCalledTimes(1);
-    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell;
-    expect(updatedCell.kind).toBe(parser_pb.CellKind.MARKUP);
-    expect(updatedCell.languageId).toBe("markdown");
-  });
+    expect(stub.update).toHaveBeenCalledTimes(1)
+    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell
+    expect(updatedCell.kind).toBe(parser_pb.CellKind.MARKUP)
+    expect(updatedCell.languageId).toBe('markdown')
+  })
 
-  it("converts markdown cells to html code cells", () => {
+  it('converts markdown cells to html code cells', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-html-convert",
+      refId: 'cell-html-convert',
       kind: parser_pb.CellKind.MARKUP,
-      languageId: "markdown",
+      languageId: 'markdown',
       outputs: [],
       metadata: {},
-      value: "",
-    });
-    const stub = new StubCellData(cell);
+      value: '',
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const selector = screen.getByRole("combobox");
-    fireEvent.change(selector, { target: { value: "html" } });
+    const selector = screen.getByRole('combobox')
+    fireEvent.change(selector, { target: { value: 'html' } })
 
-    expect(stub.update).toHaveBeenCalledTimes(1);
-    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell;
-    expect(updatedCell.kind).toBe(parser_pb.CellKind.CODE);
-    expect(updatedCell.languageId).toBe("html");
-  });
+    expect(stub.update).toHaveBeenCalledTimes(1)
+    const updatedCell = stub.update.mock.calls[0][0] as parser_pb.Cell
+    expect(updatedCell.kind).toBe(parser_pb.CellKind.CODE)
+    expect(updatedCell.languageId).toBe('html')
+  })
 
-  it("renders html cells in-place without the code run toolbar", () => {
+  it('renders html cells in-place without the code run toolbar', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-html-rendered",
+      refId: 'cell-html-rendered',
       kind: parser_pb.CellKind.CODE,
-      languageId: "html",
+      languageId: 'html',
       outputs: [],
       metadata: {},
-      value: "<div><strong>Hello HTML</strong></div>",
-    });
-    const stub = new StubCellData(cell);
+      value: '<div><strong>Hello HTML</strong></div>',
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    expect(screen.getByTestId("html-action")).toBeTruthy();
-    expect(screen.getByTestId("html-rendered")).toBeTruthy();
-    const frame = screen.getByTestId("html-preview-frame") as HTMLIFrameElement;
-    expect(frame.getAttribute("srcdoc")).toBe("<div><strong>Hello HTML</strong></div>");
-    expect(frame.getAttribute("sandbox")).toBe("");
-    expect(screen.queryByLabelText("Run code")).toBeNull();
-  });
+    expect(screen.getByTestId('html-action')).toBeTruthy()
+    expect(screen.getByTestId('html-rendered')).toBeTruthy()
+    const frame = screen.getByTestId('html-preview-frame') as HTMLIFrameElement
+    expect(frame.getAttribute('srcdoc')).toBe(
+      '<div><strong>Hello HTML</strong></div>'
+    )
+    expect(frame.getAttribute('sandbox')).toBe('')
+    expect(screen.queryByLabelText('Run code')).toBeNull()
+  })
 
-  it("switches rendered html cells back to edit mode on Escape", () => {
+  it('switches rendered html cells back to edit mode on Escape', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-html-escape",
+      refId: 'cell-html-escape',
       kind: parser_pb.CellKind.CODE,
-      languageId: "html",
+      languageId: 'html',
       outputs: [],
       metadata: {},
-      value: "<div><strong>Hello HTML</strong></div>",
-    });
-    const stub = new StubCellData(cell);
+      value: '<div><strong>Hello HTML</strong></div>',
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const rendered = screen.getByTestId("html-rendered");
-    fireEvent.keyDown(rendered, { key: "Escape" });
+    const rendered = screen.getByTestId('html-rendered')
+    fireEvent.keyDown(rendered, { key: 'Escape' })
 
-    expect(screen.getByTestId("html-editor")).toBeTruthy();
-  });
+    expect(screen.getByTestId('html-editor')).toBeTruthy()
+  })
 
-  it("shows browser/sandbox runner selector for javascript cells", () => {
+  it('shows browser/sandbox runner selector for javascript cells', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-runner-select",
+      refId: 'cell-runner-select',
       kind: parser_pb.CellKind.CODE,
-      languageId: "javascript",
+      languageId: 'javascript',
       outputs: [],
       metadata: {
         [RunmeMetadataKey.RunnerName]: APPKERNEL_RUNNER_NAME,
       },
       value: 'console.log("hi")',
-    });
-    const stub = new StubCellData(cell);
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const runnerSelect = document.getElementById("runner-select-cell-runner-select");
-    const kernelSelect = document.getElementById("kernel-select-cell-runner-select");
-    expect(runnerSelect).toBeTruthy();
-    expect(kernelSelect).toBeNull();
-    const select = runnerSelect as HTMLSelectElement;
-    expect(select.value).toBe(APPKERNEL_RUNNER_NAME);
-    const optionValues = [...select.options].map((option) => option.value);
+    const runnerSelect = document.getElementById(
+      'runner-select-cell-runner-select'
+    )
+    const kernelSelect = document.getElementById(
+      'kernel-select-cell-runner-select'
+    )
+    expect(runnerSelect).toBeTruthy()
+    expect(kernelSelect).toBeNull()
+    const select = runnerSelect as HTMLSelectElement
+    expect(select.value).toBe(APPKERNEL_RUNNER_NAME)
+    const optionValues = [...select.options].map((option) => option.value)
     expect(optionValues).toEqual([
       APPKERNEL_RUNNER_NAME,
       APPKERNEL_SANDBOX_RUNNER_NAME,
-    ]);
-  });
+    ])
+  })
 
-  it("switches javascript runner to sandbox", () => {
+  it('switches javascript runner to sandbox', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-runner-sandbox",
+      refId: 'cell-runner-sandbox',
       kind: parser_pb.CellKind.CODE,
-      languageId: "javascript",
+      languageId: 'javascript',
       outputs: [],
       metadata: {
         [RunmeMetadataKey.RunnerName]: APPKERNEL_RUNNER_NAME,
       },
       value: 'console.log("hi")',
-    });
-    const stub = new StubCellData(cell);
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
     const runnerSelect = document.getElementById(
-      "runner-select-cell-runner-sandbox",
-    ) as HTMLSelectElement | null;
-    expect(runnerSelect).toBeTruthy();
+      'runner-select-cell-runner-sandbox'
+    ) as HTMLSelectElement | null
+    expect(runnerSelect).toBeTruthy()
     fireEvent.change(runnerSelect!, {
       target: { value: APPKERNEL_SANDBOX_RUNNER_NAME },
-    });
+    })
 
-    expect(stub.setRunner).toHaveBeenCalledWith(APPKERNEL_SANDBOX_RUNNER_NAME);
-  });
+    expect(stub.setRunner).toHaveBeenCalledWith(APPKERNEL_SANDBOX_RUNNER_NAME)
+  })
 
-  it("shows runner selector for python cells", () => {
+  it('shows runner selector for python cells', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-python-select",
+      refId: 'cell-python-select',
       kind: parser_pb.CellKind.CODE,
-      languageId: "python",
+      languageId: 'python',
       outputs: [],
       metadata: {},
       value: "print('hi')",
-    });
-    const stub = new StubCellData(cell);
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const runnerSelect = document.getElementById("runner-select-cell-python-select");
-    const kernelSelect = document.getElementById("kernel-select-cell-python-select");
-    expect(runnerSelect).toBeTruthy();
-    expect(kernelSelect).toBeNull();
-  });
+    const runnerSelect = document.getElementById(
+      'runner-select-cell-python-select'
+    )
+    const kernelSelect = document.getElementById(
+      'kernel-select-cell-python-select'
+    )
+    expect(runnerSelect).toBeTruthy()
+    expect(kernelSelect).toBeNull()
+  })
 
-  it("shows kernel selector (not runner selector) for jupyter cells", () => {
+  it('shows kernel selector (not runner selector) for jupyter cells', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-jupyter-select",
+      refId: 'cell-jupyter-select',
       kind: parser_pb.CellKind.CODE,
-      languageId: "jupyter",
+      languageId: 'jupyter',
       outputs: [],
       metadata: {},
       value: "print('hi')",
-    });
-    const stub = new StubCellData(cell);
+    })
+    const stub = new StubCellData(cell)
 
-    render(<Action cellData={stub as unknown as CellData} isFirst={false} />);
+    render(<Action cellData={stub as unknown as CellData} isFirst={false} />)
 
-    const runnerSelect = document.getElementById("runner-select-cell-jupyter-select");
-    const kernelSelect = document.getElementById("kernel-select-cell-jupyter-select");
-    expect(runnerSelect).toBeNull();
-    expect(kernelSelect).toBeTruthy();
-  });
+    const runnerSelect = document.getElementById(
+      'runner-select-cell-jupyter-select'
+    )
+    const kernelSelect = document.getElementById(
+      'kernel-select-cell-jupyter-select'
+    )
+    expect(runnerSelect).toBeNull()
+    expect(kernelSelect).toBeTruthy()
+  })
 
-  it("ignores focus on rendered markdown controls that are outside a focus-role surface", () => {
+  it('ignores focus on rendered markdown controls that are outside a focus-role surface', () => {
     const cell = create(parser_pb.CellSchema, {
-      refId: "cell-md-rendered-controls",
+      refId: 'cell-md-rendered-controls',
       kind: parser_pb.CellKind.MARKUP,
-      languageId: "markdown",
+      languageId: 'markdown',
       outputs: [],
       metadata: {},
-      value: "hello",
-    });
-    const stub = new StubCellData(cell);
-    const onFocusStateChange = vi.fn();
+      value: 'hello',
+    })
+    const stub = new StubCellData(cell)
+    const onFocusStateChange = vi.fn()
 
     render(
       <Action
         cellData={stub as unknown as CellData}
         isFirst={false}
         onFocusStateChange={onFocusStateChange}
-      />,
-    );
+      />
+    )
 
-    fireEvent.focus(screen.getByRole("button", { name: "Delete cell" }));
+    fireEvent.focus(screen.getByRole('button', { name: 'Delete cell' }))
 
-    expect(onFocusStateChange).not.toHaveBeenCalled();
-  });
-});
+    expect(onFocusStateChange).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -28,6 +28,7 @@ const contextMocks = vi.hoisted(() => ({
     getMetadata: ReturnType<typeof vi.fn>
     getSyncState: ReturnType<typeof vi.fn>
     rename: ReturnType<typeof vi.fn>
+    refreshConflictWithLatestUpstream?: ReturnType<typeof vi.fn>
     resolveConflictWithLocal?: ReturnType<typeof vi.fn>
     sync?: ReturnType<typeof vi.fn>
     subscribeSync: ReturnType<typeof vi.fn>
@@ -36,6 +37,7 @@ const contextMocks = vi.hoisted(() => ({
 
 const conflictMocks = vi.hoisted(() => ({
   openNotebookConflictDiff: vi.fn(async () => undefined),
+  refreshNotebookConflictDiff: vi.fn(async () => undefined),
 }))
 
 // Minimal mocks for contexts Action consumes
@@ -101,6 +103,7 @@ vi.mock('../../contexts/CurrentDocContext', () => ({
 
 vi.mock('../../lib/notebookDiff/conflict', () => ({
   openNotebookConflictDiff: conflictMocks.openNotebookConflictDiff,
+  refreshNotebookConflictDiff: conflictMocks.refreshNotebookConflictDiff,
 }))
 
 vi.mock('../../lib/runtime/jupyterManager', () => ({
@@ -229,6 +232,8 @@ beforeEach(() => {
   contextMocks.notebookStore = null
   conflictMocks.openNotebookConflictDiff.mockReset()
   conflictMocks.openNotebookConflictDiff.mockResolvedValue(undefined)
+  conflictMocks.refreshNotebookConflictDiff.mockReset()
+  conflictMocks.refreshNotebookConflictDiff.mockResolvedValue(undefined)
 })
 
 describe('Actions tabs', () => {
@@ -449,6 +454,75 @@ describe('Actions tabs', () => {
       expect(resolveConflictWithLocal).toHaveBeenCalledWith(
         'local://file/conflict',
         { force: false }
+      )
+    })
+  })
+
+  it('refreshes a conflict diff tab against latest upstream and local versions', async () => {
+    const refreshConflictWithLatestUpstream = vi.fn(async () => ({
+      detectedAt: '2026-05-30T00:00:00.000Z',
+      upstreamChecksum: 'upstream-head-checksum',
+      upstreamVersion: {
+        checksum: 'upstream-head-checksum',
+        revisionId: 'upstream-head',
+      },
+      upstreamDoc: '',
+      localChecksumAtDetection: 'local-checksum',
+    }))
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(),
+      getSyncState: vi.fn(),
+      rename: vi.fn(),
+      refreshConflictWithLatestUpstream,
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    const doc = registerNotebookDiffDocument({
+      id: 'conflict-refresh-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(
+        create(parser_pb.NotebookSchema, {
+          cells: [
+            create(parser_pb.CellSchema, {
+              refId: 'cell-1',
+              kind: parser_pb.CellKind.CODE,
+              languageId: 'python',
+              value: "print('upstream')",
+            }),
+          ],
+          metadata: {},
+        }),
+        create(parser_pb.NotebookSchema, {
+          cells: [
+            create(parser_pb.CellSchema, {
+              refId: 'cell-1',
+              kind: parser_pb.CellKind.CODE,
+              languageId: 'python',
+              value: "print('local')",
+            }),
+          ],
+          metadata: {},
+        })
+      ),
+      resolution: {
+        kind: 'notebook-sync-conflict',
+        localUri: 'local://file/conflict',
+      },
+    })
+    const diffUri = getNotebookDiffDocumentUri(doc.id)
+    contextMocks.currentDoc = diffUri
+    contextMocks.workspaceDocuments = [
+      { uri: diffUri, title: 'Upstream version vs Local version' },
+    ]
+
+    render(<Actions />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh diff' }))
+
+    await waitFor(() => {
+      expect(conflictMocks.refreshNotebookConflictDiff).toHaveBeenCalledWith(
+        contextMocks.notebookStore,
+        'local://file/conflict'
       )
     })
   })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -59,7 +59,10 @@ import {
   isNotebookDocumentUri,
   type WorkspaceDocument,
 } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
-import { getNotebookDiffDocument } from '../../lib/notebookDiff/registry'
+import {
+  getNotebookDiffDocument,
+  NOTEBOOK_DIFF_DOCUMENT_CHANGED,
+} from '../../lib/notebookDiff/registry'
 import { openNotebookConflictDiff } from '../../lib/notebookDiff/conflict'
 import { parseDriveItem } from '../../storage/drive'
 import type { NotebookSyncState } from '../../storage/local'
@@ -1701,9 +1704,31 @@ function NotebookTabContent({
 
 function NotebookDiffTabContent({ diffUri }: { diffUri: string }) {
   const diffId = diffUri.slice('diff://notebook/'.length)
-  const document = diffId
-    ? getNotebookDiffDocument(decodeURIComponent(diffId))
-    : null
+  const decodedDiffId = diffId ? decodeURIComponent(diffId) : ''
+  const [, setDiffDocumentVersion] = useState(0)
+  useEffect(() => {
+    if (!decodedDiffId || typeof window === 'undefined') {
+      return
+    }
+    const onDiffDocumentChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{ id?: string }>).detail
+      if (detail?.id === decodedDiffId) {
+        setDiffDocumentVersion((version) => version + 1)
+      }
+    }
+    window.addEventListener(
+      NOTEBOOK_DIFF_DOCUMENT_CHANGED,
+      onDiffDocumentChanged
+    )
+    return () => {
+      window.removeEventListener(
+        NOTEBOOK_DIFF_DOCUMENT_CHANGED,
+        onDiffDocumentChanged
+      )
+    }
+  }, [decodedDiffId])
+
+  const document = decodedDiffId ? getNotebookDiffDocument(decodedDiffId) : null
   if (document) {
     return <NotebookDiffContent document={document} />
   }

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -8,29 +8,25 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
-} from "react";
+} from 'react'
 
-import { create } from "@bufbuild/protobuf";
-import { Button, ScrollArea, Tabs, Text } from "@radix-ui/themes";
+import { create } from '@bufbuild/protobuf'
+import { Button, ScrollArea, Tabs, Text } from '@radix-ui/themes'
 
-import { XMarkIcon } from "@heroicons/react/20/solid";
-import {
-  MimeType,
-  RunmeMetadataKey,
-  parser_pb,
-} from "../../runme/client";
-import { CellData } from "../../lib/notebookData";
-import { useNotebookContext } from "../../contexts/NotebookContext";
-import type { OpenNotebookEntry } from "../../lib/notebookDataController";
-import { useNotebookStore } from "../../contexts/NotebookStoreContext";
-import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
-import { useOutput } from "../../contexts/OutputContext";
-import CellConsole, { fontSettings } from "./CellConsole";
-import Editor from "./Editor";
-import HtmlCell from "./HtmlCell";
-import MarkdownCell from "./MarkdownCell";
-import { IOPUB_INCOMPLETE_METADATA_KEY } from "../../lib/ipykernel";
-import { appLogger } from "../../lib/logging/runtime";
+import { XMarkIcon } from '@heroicons/react/20/solid'
+import { MimeType, RunmeMetadataKey, parser_pb } from '../../runme/client'
+import { CellData } from '../../lib/notebookData'
+import { useNotebookContext } from '../../contexts/NotebookContext'
+import type { OpenNotebookEntry } from '../../lib/notebookDataController'
+import { useNotebookStore } from '../../contexts/NotebookStoreContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
+import { useOutput } from '../../contexts/OutputContext'
+import CellConsole, { fontSettings } from './CellConsole'
+import Editor from './Editor'
+import HtmlCell from './HtmlCell'
+import MarkdownCell from './MarkdownCell'
+import { IOPUB_INCOMPLETE_METADATA_KEY } from '../../lib/ipykernel'
+import { appLogger } from '../../lib/logging/runtime'
 import {
   createNotebookActiveCellState,
   loadNotebookActiveCellMap,
@@ -38,206 +34,227 @@ import {
   type CellFocusRole,
   type NotebookActiveCellMap,
   type NotebookActiveCellState,
-} from "../../lib/notebookActiveCellState";
-import { copyNotebookShareUrl } from "../../lib/shareLinks";
-import { isHtmlLanguageId, isMarkdownLanguageId } from "../../lib/cellContent";
-import {
-  PlayIcon,
-  PlusIcon,
-  SpinnerIcon,
-  TrashIcon,
-} from "./icons";
+} from '../../lib/notebookActiveCellState'
+import { copyNotebookShareUrl } from '../../lib/shareLinks'
+import { isHtmlLanguageId, isMarkdownLanguageId } from '../../lib/cellContent'
+import { PlayIcon, PlusIcon, SpinnerIcon, TrashIcon } from './icons'
 //import { useRun } from "../../lib/useRun.js";
-import { useCurrentDoc } from "../../contexts/CurrentDocContext";
-import { useRunners } from "../../contexts/RunnersContext";
-import { DEFAULT_RUNNER_PLACEHOLDER } from "../../lib/runtime/runnersManager";
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useRunners } from '../../contexts/RunnersContext'
+import { DEFAULT_RUNNER_PLACEHOLDER } from '../../lib/runtime/runnersManager'
 import {
   APPKERNEL_RUNNER_NAME,
   APPKERNEL_SANDBOX_RUNNER_NAME,
   isAppKernelRunnerName,
-} from "../../lib/runtime/appKernel";
-import { getJupyterManager } from "../../lib/runtime/jupyterManager";
+} from '../../lib/runtime/appKernel'
+import { getJupyterManager } from '../../lib/runtime/jupyterManager'
 import {
   driveLinkCoordinator,
   DRIVE_LINK_STATUS_TAB_URI,
   useDriveLinkCoordinatorSnapshot,
-} from "../../lib/driveLinkCoordinator";
+} from '../../lib/driveLinkCoordinator'
 import {
   isDriveLinkStatusUri,
   isNotebookDiffUri,
   isNotebookDocumentUri,
   type WorkspaceDocument,
-} from "../../lib/workspaceDocuments/workspaceDocumentTypes";
-import { getNotebookDiffDocument } from "../../lib/notebookDiff/registry";
-import { parseDriveItem } from "../../storage/drive";
-import type { NotebookSyncState } from "../../storage/local";
-import { NotebookStoreItemType } from "../../storage/notebook";
-import DriveLinkStatusTab from "../DriveLinkStatusTab";
-import { NotebookDiffContent } from "../NotebookDiff/NotebookDiffView";
-import React from "react";
+} from '../../lib/workspaceDocuments/workspaceDocumentTypes'
+import { getNotebookDiffDocument } from '../../lib/notebookDiff/registry'
+import { openNotebookConflictDiff } from '../../lib/notebookDiff/conflict'
+import { parseDriveItem } from '../../storage/drive'
+import type { NotebookSyncState } from '../../storage/local'
+import { NotebookStoreItemType } from '../../storage/notebook'
+import { showToast } from '../../lib/toast'
+import DriveLinkStatusTab from '../DriveLinkStatusTab'
+import { NotebookDiffContent } from '../NotebookDiff/NotebookDiffView'
+import React from 'react'
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
-  "data-state"?: "active" | "inactive";
-  hidden?: boolean;
-};
+  'data-state'?: 'active' | 'inactive'
+  hidden?: boolean
+}
 
 const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
-  ({ hidden: _hiddenProp, "data-state": state, style, ...rest }, ref) => {
-    const inactive = state !== "active";
+  ({ hidden: _hiddenProp, 'data-state': state, style, ...rest }, ref) => {
+    const inactive = state !== 'active'
     return (
       <div
         ref={ref}
         data-state={state}
         style={{
           ...style,
-          visibility: inactive ? "hidden" : "visible",
-          position: inactive ? "absolute" : "relative",
+          visibility: inactive ? 'hidden' : 'visible',
+          position: inactive ? 'absolute' : 'relative',
           inset: inactive ? 0 : undefined,
-          height: "100%",
-          pointerEvents: inactive ? "none" : "auto",
+          height: '100%',
+          pointerEvents: inactive ? 'none' : 'auto',
           zIndex: inactive ? 0 : 1,
-          transition: "none",
+          transition: 'none',
         }}
         {...rest}
       />
-    );
-  },
-);
-TabPanel.displayName = "TabPanel";
+    )
+  }
+)
+TabPanel.displayName = 'TabPanel'
 // TabPanel is used with Tabs.Content + forceMount to keep every tab's DOM alive
 // (preserving scroll/Monaco layout) while hiding inactive tabs without stacking
 // them. Inactive tabs are taken out of flow via absolute positioning and hidden
 // visibility so they don't visually overlap yet retain their state.
 
 function getNotebookDisplayName(uri: string, name?: string): string {
-  return name || uri.split("/").filter(Boolean).pop() || uri;
+  return name || uri.split('/').filter(Boolean).pop() || uri
 }
 
 function syncIndicatorPresentation(state: NotebookSyncState | null): {
-  label: string;
-  className: string;
-  clickable: boolean;
+  label: string
+  className: string
+  clickable: boolean
 } {
   switch (state?.status) {
-    case "synced":
+    case 'synced':
       return {
-        label: "Notebook is synced",
-        className: "bg-emerald-500",
+        label: 'Notebook is synced',
+        className: 'bg-emerald-500',
         clickable: false,
-      };
-    case "pending":
+      }
+    case 'pending':
       return {
-        label: "Notebook has local changes pending upstream sync. Click to sync now.",
-        className: "bg-red-500",
+        label:
+          'Notebook has local changes pending upstream sync. Click to sync now.',
+        className: 'bg-red-500',
         clickable: true,
-      };
-    case "pending-upstream-create":
+      }
+    case 'pending-upstream-create':
       return {
-        label: "Notebook is waiting for its upstream file to be created. Click to sync now.",
-        className: "bg-amber-500",
+        label:
+          'Notebook is waiting for its upstream file to be created. Click to sync now.',
+        className: 'bg-amber-500',
         clickable: true,
-      };
-    case "syncing":
+      }
+    case 'syncing':
       return {
-        label: "Notebook is syncing",
-        className: "bg-sky-500 animate-pulse",
+        label: 'Notebook is syncing',
+        className: 'bg-sky-500 animate-pulse',
         clickable: false,
-      };
-    case "error":
+      }
+    case 'conflicted':
+      return {
+        label: 'Notebook has a sync conflict. Click to review differences.',
+        className: 'bg-amber-600',
+        clickable: true,
+      }
+    case 'error':
       return {
         label: state.lastError
           ? `Notebook sync failed: ${state.lastError}. Click to retry.`
-          : "Notebook sync failed. Click to retry.",
-        className: "bg-red-700",
+          : 'Notebook sync failed. Click to retry.',
+        className: 'bg-red-700',
         clickable: true,
-      };
-    case "local-only":
+      }
+    case 'local-only':
       return {
-        label: "Notebook is stored only in this browser",
-        className: "border border-nb-text-faint bg-transparent",
+        label: 'Notebook is stored only in this browser',
+        className: 'border border-nb-text-faint bg-transparent',
         clickable: false,
-      };
+      }
     default:
       return {
-        label: "Notebook sync state is loading",
-        className: "border border-nb-text-faint bg-transparent",
+        label: 'Notebook sync state is loading',
+        className: 'border border-nb-text-faint bg-transparent',
         clickable: false,
-      };
+      }
   }
 }
 
 function NotebookSyncIndicator({ docUri }: { docUri: string }) {
-  const { store } = useNotebookStore();
-  const [syncState, setSyncState] = useState<NotebookSyncState | null>(null);
+  const { store } = useNotebookStore()
+  const [syncState, setSyncState] = useState<NotebookSyncState | null>(null)
 
   useEffect(() => {
-    if (!store || !docUri.startsWith("local://file/")) {
-      setSyncState(null);
-      return;
+    if (!store || !docUri.startsWith('local://file/')) {
+      setSyncState(null)
+      return
     }
 
-    let cancelled = false;
+    let cancelled = false
     const refresh = () => {
       void (async () => {
         try {
-          const next = await store.getSyncState(docUri);
+          const next = await store.getSyncState(docUri)
           if (!cancelled) {
-            setSyncState(next);
+            setSyncState(next)
           }
         } catch (error) {
           if (!cancelled) {
             setSyncState({
-              status: "error",
+              status: 'error',
               localUri: docUri,
-              remoteId: "",
+              remoteId: '',
               lastError: String(error),
-            });
+            })
           }
         }
-      })();
-    };
+      })()
+    }
 
-    refresh();
-    const unsubscribe = store.subscribeSync(docUri, refresh);
+    refresh()
+    const unsubscribe = store.subscribeSync(docUri, refresh)
     const onSyncUpdated = (event: Event) => {
-      const detail = (event as CustomEvent<{ uri?: string }>).detail;
+      const detail = (event as CustomEvent<{ uri?: string }>).detail
       if (detail?.uri === docUri) {
-        refresh();
+        refresh()
       }
-    };
-    window.addEventListener("local-notebook-sync-updated", onSyncUpdated);
-    window.addEventListener("local-notebook-updated", onSyncUpdated);
+    }
+    window.addEventListener('local-notebook-sync-updated', onSyncUpdated)
+    window.addEventListener('local-notebook-updated', onSyncUpdated)
     return () => {
-      cancelled = true;
-      unsubscribe();
-      window.removeEventListener("local-notebook-sync-updated", onSyncUpdated);
-      window.removeEventListener("local-notebook-updated", onSyncUpdated);
-    };
-  }, [docUri, store]);
+      cancelled = true
+      unsubscribe()
+      window.removeEventListener('local-notebook-sync-updated', onSyncUpdated)
+      window.removeEventListener('local-notebook-updated', onSyncUpdated)
+    }
+  }, [docUri, store])
 
-  const presentation = syncIndicatorPresentation(syncState);
+  const presentation = syncIndicatorPresentation(syncState)
   const handleClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
+      event.preventDefault()
+      event.stopPropagation()
       if (!store || !presentation.clickable) {
-        return;
+        return
+      }
+      if (syncState?.status === 'conflicted') {
+        void openNotebookConflictDiff(store, docUri).catch((error) => {
+          appLogger.warn('Notebook conflict diff failed to open', {
+            attrs: {
+              scope: 'storage.local.sync',
+              localUri: docUri,
+              error: String(error),
+            },
+          })
+          showToast({
+            message: 'Unable to open conflict diff. Please try again.',
+            tone: 'error',
+          })
+        })
+        return
       }
       void store.sync(docUri).catch((error) => {
-        appLogger.warn("Notebook tab immediate sync failed", {
+        appLogger.warn('Notebook tab immediate sync failed', {
           attrs: {
-            scope: "storage.local.sync",
+            scope: 'storage.local.sync',
             localUri: docUri,
             error: String(error),
           },
-        });
-      });
+        })
+      })
     },
-    [docUri, presentation.clickable, store],
-  );
+    [docUri, presentation.clickable, store, syncState?.status]
+  )
 
-  if (!store || !docUri.startsWith("local://file/")) {
-    return null;
+  if (!store || !docUri.startsWith('local://file/')) {
+    return null
   }
 
   return (
@@ -253,7 +270,7 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
         className={`block h-2.5 w-2.5 rounded-full ${presentation.className}`}
       />
     </button>
-  );
+  )
 }
 
 /** Compact icon-only run button that sits in the cell toolbar.
@@ -262,16 +279,16 @@ function RunActionButton({
   pid,
   onClick,
 }: {
-  pid: number | null;
-  onClick: () => void;
+  pid: number | null
+  onClick: () => void
 }) {
-  const isRunning = pid !== null;
+  const isRunning = pid !== null
 
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label={isRunning ? "Running..." : "Run code"}
+      aria-label={isRunning ? 'Running...' : 'Run code'}
       className="icon-btn h-7 w-7"
     >
       {isRunning ? (
@@ -282,128 +299,134 @@ function RunActionButton({
         <PlayIcon />
       )}
     </button>
-  );
+  )
 }
 
 // Action is an editor and an optional Runme console
 const LANGUAGE_OPTIONS = [
-  { label: "Markdown", value: "markdown" },
-  { label: "HTML", value: "html" },
-  { label: "Bash", value: "bash" },
-  { label: "Jupyter", value: "jupyter" },
-  { label: "Python", value: "python" },
-  { label: "JS", value: "javascript" },
-] as const;
+  { label: 'Markdown', value: 'markdown' },
+  { label: 'HTML', value: 'html' },
+  { label: 'Bash', value: 'bash' },
+  { label: 'Jupyter', value: 'jupyter' },
+  { label: 'Python', value: 'python' },
+  { label: 'JS', value: 'javascript' },
+] as const
 
 const JAVASCRIPT_RUNNER_OPTIONS = [
-  { label: "browser", value: APPKERNEL_RUNNER_NAME },
-  { label: "sandbox", value: APPKERNEL_SANDBOX_RUNNER_NAME },
-] as const;
+  { label: 'browser', value: APPKERNEL_RUNNER_NAME },
+  { label: 'sandbox', value: APPKERNEL_SANDBOX_RUNNER_NAME },
+] as const
 
 type SupportedLanguage =
-  | "bash"
-  | "html"
-  | "jupyter"
-  | "javascript"
-  | "markdown"
-  | "python";
+  | 'bash'
+  | 'html'
+  | 'jupyter'
+  | 'javascript'
+  | 'markdown'
+  | 'python'
 
-const outputTextDecoder = new TextDecoder();
-const ALWAYS_SKIP_MIMES = new Set<string>([MimeType.StatefulRunmeTerminal]);
+const outputTextDecoder = new TextDecoder()
+const ALWAYS_SKIP_MIMES = new Set<string>([MimeType.StatefulRunmeTerminal])
 
-function normalizeBinaryData(data?: Uint8Array | ArrayLike<number> | null): Uint8Array {
+function normalizeBinaryData(
+  data?: Uint8Array | ArrayLike<number> | null
+): Uint8Array {
   if (!data) {
-    return new Uint8Array();
+    return new Uint8Array()
   }
-  return data instanceof Uint8Array ? data : Uint8Array.from(data);
+  return data instanceof Uint8Array ? data : Uint8Array.from(data)
 }
 
 function isGoogleDriveFileUri(uri: string | null | undefined): uri is string {
   if (!uri) {
-    return false;
+    return false
   }
-  let url: URL;
+  let url: URL
   try {
-    url = new URL(uri);
+    url = new URL(uri)
   } catch {
-    return false;
+    return false
   }
   if (!/(^|\.)drive\.google\.com$/i.test(url.hostname)) {
-    return false;
+    return false
   }
   try {
-    return parseDriveItem(uri).type === NotebookStoreItemType.File;
+    return parseDriveItem(uri).type === NotebookStoreItemType.File
   } catch {
-    return false;
+    return false
   }
 }
 
 function normalizeLanguageId(
   kind: parser_pb.CellKind,
-  languageId?: string | null,
+  languageId?: string | null
 ): SupportedLanguage {
   switch (kind) {
     case parser_pb.CellKind.CODE:
-      const normalized = (languageId ?? "").toLowerCase();
+      const normalized = (languageId ?? '').toLowerCase()
       if (isMarkdownLanguageId(normalized)) {
-        return "markdown";
+        return 'markdown'
       }
       if (isHtmlLanguageId(normalized)) {
-        return "html";
+        return 'html'
       }
-      if (normalized === "python" || normalized === "py") {
-        return "python";
+      if (normalized === 'python' || normalized === 'py') {
+        return 'python'
       }
-      if (normalized === "jupyter" || normalized === "ipython") {
-        return "jupyter";
+      if (normalized === 'jupyter' || normalized === 'ipython') {
+        return 'jupyter'
       }
       if (
-        normalized === "javascript" ||
-        normalized === "typescript" ||
-        normalized === "js" ||
-        normalized === "ts" ||
-        normalized === "observable" ||
-        normalized === "d3"
+        normalized === 'javascript' ||
+        normalized === 'typescript' ||
+        normalized === 'js' ||
+        normalized === 'ts' ||
+        normalized === 'observable' ||
+        normalized === 'd3'
       ) {
-        return "javascript";
+        return 'javascript'
       }
-      return "bash";
+      return 'bash'
     case parser_pb.CellKind.MARKUP:
-      return "markdown";
+      return 'markdown'
     default:
-      return "bash";
+      return 'bash'
   }
 }
 
-function decodeOutputText(data?: Uint8Array | ArrayLike<number> | null): string {
-  const normalized = normalizeBinaryData(data);
+function decodeOutputText(
+  data?: Uint8Array | ArrayLike<number> | null
+): string {
+  const normalized = normalizeBinaryData(data)
   if (normalized.length === 0) {
-    return "";
+    return ''
   }
   try {
-    return outputTextDecoder.decode(normalized);
+    return outputTextDecoder.decode(normalized)
   } catch {
-    return "";
+    return ''
   }
 }
 
-function uint8ArrayToBase64(data?: Uint8Array | ArrayLike<number> | null): string {
-  const normalized = normalizeBinaryData(data);
+function uint8ArrayToBase64(
+  data?: Uint8Array | ArrayLike<number> | null
+): string {
+  const normalized = normalizeBinaryData(data)
   if (normalized.length === 0) {
-    return "";
+    return ''
   }
 
-  let binary = "";
-  const chunkSize = 0x8000;
+  let binary = ''
+  const chunkSize = 0x8000
   for (let i = 0; i < normalized.length; i += chunkSize) {
-    const chunk = normalized.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
+    const chunk = normalized.subarray(i, i + chunkSize)
+    binary += String.fromCharCode(...chunk)
   }
 
-  if (typeof globalThis.btoa === "function") {
-    return globalThis.btoa(binary);
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis.btoa(binary)
   }
-  return "";
+  return ''
 }
 
 function ActionOutputItemView({
@@ -411,20 +434,20 @@ function ActionOutputItemView({
   outputIndex,
   itemIndex,
 }: {
-  item: parser_pb.CellOutputItem;
-  outputIndex: number;
-  itemIndex: number;
+  item: parser_pb.CellOutputItem
+  outputIndex: number
+  itemIndex: number
 }) {
-  const mime = item.mime || "";
-  const text = decodeOutputText(item.data ?? new Uint8Array());
-  const isStreaming = item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === "true";
+  const mime = item.mime || ''
+  const text = decodeOutputText(item.data ?? new Uint8Array())
+  const isStreaming = item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === 'true'
   const hasIopubMetadata =
-    item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === "true" ||
-    item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === "false";
+    item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === 'true' ||
+    item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === 'false'
 
-  let content: React.ReactNode = null;
+  let content: React.ReactNode = null
 
-  if (mime === "text/html") {
+  if (mime === 'text/html') {
     content = (
       <iframe
         title={`cell-output-${outputIndex}-${itemIndex}`}
@@ -432,27 +455,27 @@ function ActionOutputItemView({
         srcDoc={text}
         className="h-[420px] w-full rounded-md border border-nb-cell-border bg-white"
       />
-    );
+    )
   } else if (
-    mime === "image/png" ||
-    mime === "image/jpeg" ||
-    mime === "image/svg+xml"
+    mime === 'image/png' ||
+    mime === 'image/jpeg' ||
+    mime === 'image/svg+xml'
   ) {
-    const base64 = uint8ArrayToBase64(item.data ?? new Uint8Array());
-    const src = `data:${mime};base64,${base64}`;
+    const base64 = uint8ArrayToBase64(item.data ?? new Uint8Array())
+    const src = `data:${mime};base64,${base64}`
     content = (
       <img
         alt={`Cell output ${outputIndex}-${itemIndex}`}
         src={src}
         className="max-h-[480px] w-full rounded-md border border-nb-cell-border bg-white object-contain"
       />
-    );
+    )
   } else {
     content = (
       <pre className="whitespace-pre-wrap break-words text-xs leading-relaxed text-nb-text">
         {text}
       </pre>
-    );
+    )
   }
 
   return (
@@ -462,42 +485,45 @@ function ActionOutputItemView({
     >
       <div className="text-[10px] font-medium uppercase tracking-wide text-nb-text-faint">
         Output {outputIndex} / Item {itemIndex} - mime={mime}
-        {hasIopubMetadata ? (isStreaming ? " (streaming)" : " (complete)") : ""}
+        {hasIopubMetadata ? (isStreaming ? ' (streaming)' : ' (complete)') : ''}
       </div>
       <div className="mt-2">{content}</div>
     </div>
-  );
+  )
 }
 
 export function ActionOutputItems({
   outputs,
   suppressStdText = false,
 }: {
-  outputs: parser_pb.CellOutput[];
-  suppressStdText?: boolean;
+  outputs: parser_pb.CellOutput[]
+  suppressStdText?: boolean
 }) {
   const hasTerminalOutput = outputs.some((output) =>
-    (output.items ?? []).some((item) => item?.mime === MimeType.StatefulRunmeTerminal),
-  );
+    (output.items ?? []).some(
+      (item) => item?.mime === MimeType.StatefulRunmeTerminal
+    )
+  )
 
   const displayableItems = outputs.flatMap((output, outputIndex) =>
     (output.items ?? [])
       .map((item, itemIndex) => {
         if (!item) {
-          return null;
+          return null
         }
-        const mime = item.mime || "";
+        const mime = item.mime || ''
         if (ALWAYS_SKIP_MIMES.has(mime)) {
-          return null;
+          return null
         }
         if (
           (hasTerminalOutput || suppressStdText) &&
-          (mime === MimeType.VSCodeNotebookStdOut || mime === MimeType.VSCodeNotebookStdErr)
+          (mime === MimeType.VSCodeNotebookStdOut ||
+            mime === MimeType.VSCodeNotebookStdErr)
         ) {
-          return null;
+          return null
         }
         if (normalizeBinaryData(item.data).length === 0) {
-          return null;
+          return null
         }
         return (
           <ActionOutputItemView
@@ -506,565 +532,601 @@ export function ActionOutputItems({
             outputIndex={outputIndex}
             itemIndex={itemIndex}
           />
-        );
+        )
       })
-      .filter(Boolean),
-  );
+      .filter(Boolean)
+  )
 
   if (displayableItems.length === 0) {
-    return null;
+    return null
   }
 
-  return <div className="mt-2 space-y-2">{displayableItems}</div>;
+  return <div className="mt-2 space-y-2">{displayableItems}</div>
 }
 
 export function Action({
   cellData,
-  docUri = "",
+  docUri = '',
   isFirst,
   isActiveCell = false,
-  activeFocusRole = "editor",
+  activeFocusRole = 'editor',
   isWindowFocused = false,
   onFocusStateChange,
 }: {
-  cellData: CellData;
-  docUri?: string;
-  isFirst: boolean;
-  isActiveCell?: boolean;
-  activeFocusRole?: CellFocusRole;
-  isWindowFocused?: boolean;
-  onFocusStateChange?: (state: NotebookActiveCellState) => void;
+  cellData: CellData
+  docUri?: string
+  isFirst: boolean
+  isActiveCell?: boolean
+  activeFocusRole?: CellFocusRole
+  isWindowFocused?: boolean
+  onFocusStateChange?: (state: NotebookActiveCellState) => void
 }) {
-  const { store } = useNotebookStore();
-  const { listRunners, defaultRunnerName } = useRunners();
-  const jupyterManager = useMemo(() => getJupyterManager(), []);
+  const { store } = useNotebookStore()
+  const { listRunners, defaultRunnerName } = useRunners()
+  const jupyterManager = useMemo(() => getJupyterManager(), [])
   const jupyterVersion = useSyncExternalStore(
-    useCallback((listener) => jupyterManager.subscribe(listener), [jupyterManager]),
+    useCallback(
+      (listener) => jupyterManager.subscribe(listener),
+      [jupyterManager]
+    ),
     useCallback(() => jupyterManager.getVersion(), [jupyterManager]),
-    useCallback(() => jupyterManager.getVersion(), [jupyterManager]),
-  );
+    useCallback(() => jupyterManager.getVersion(), [jupyterManager])
+  )
   const cell = useSyncExternalStore(
     useCallback(
       (listener) => cellData.subscribeToContentChange(listener),
-      [cellData],
+      [cellData]
     ),
     useCallback(() => cellData.snapshot, [cellData]),
-    useCallback(() => cellData.snapshot, [cellData]),
-  );
+    useCallback(() => cellData.snapshot, [cellData])
+  )
   // Derive runID from the current cell snapshot so clear/reset operations
   // immediately repaint output visibility without requiring a separate listener.
-  const runID = cellData.getRunID();
+  const runID = cellData.getRunID()
 
   const handleAddCellBefore = useCallback(() => {
-    cellData.addBefore(parser_pb.CellKind.CODE, cell?.languageId);
-  }, [cell?.languageId, cellData]);
+    cellData.addBefore(parser_pb.CellKind.CODE, cell?.languageId)
+  }, [cell?.languageId, cellData])
 
   const handleAddCellAfter = useCallback(() => {
-    cellData.addAfter(parser_pb.CellKind.CODE, cell?.languageId);
-  }, [cell?.languageId, cellData]);
+    cellData.addAfter(parser_pb.CellKind.CODE, cell?.languageId)
+  }, [cell?.languageId, cellData])
 
   const updateCellLocal = useCallback(
     (nextCell: parser_pb.Cell) => {
-      cellData.update(nextCell);
+      cellData.update(nextCell)
     },
-    [cellData],
-  );
+    [cellData]
+  )
 
   const [contextMenu, setContextMenu] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
-  const [shareRemoteUri, setShareRemoteUri] = useState<string | null>(null);
-  const [htmlEditRequest, setHtmlEditRequest] = useState(0);
-  const [markdownEditRequest, setMarkdownEditRequest] = useState(0);
-  const [pid, setPid] = useState<number | null>(null);
-  const [exitCode, setExitCode] = useState<number | null>(null);
+    x: number
+    y: number
+  } | null>(null)
+  const [shareRemoteUri, setShareRemoteUri] = useState<string | null>(null)
+  const [htmlEditRequest, setHtmlEditRequest] = useState(0)
+  const [markdownEditRequest, setMarkdownEditRequest] = useState(0)
+  const [pid, setPid] = useState<number | null>(null)
+  const [exitCode, setExitCode] = useState<number | null>(null)
 
   useEffect(() => {
-    if (!store || !docUri.startsWith("local://")) {
-      setShareRemoteUri(null);
-      return;
+    if (!store || !docUri.startsWith('local://')) {
+      setShareRemoteUri(null)
+      return
     }
 
-    let cancelled = false;
+    let cancelled = false
     void (async () => {
       try {
-        const metadata = await store.getMetadata(docUri);
+        const metadata = await store.getMetadata(docUri)
         if (!cancelled) {
-          setShareRemoteUri(metadata?.remoteUri ?? null);
+          setShareRemoteUri(metadata?.remoteUri ?? null)
         }
       } catch {
         if (!cancelled) {
-          setShareRemoteUri(null);
+          setShareRemoteUri(null)
         }
       }
-    })();
+    })()
 
     return () => {
-      cancelled = true;
-    };
-  }, [docUri, store]);
+      cancelled = true
+    }
+  }, [docUri, store])
 
   // When an exit code arrives, clear the pid so the spinner stops.
   const handleExitCode = useCallback((code: number | null) => {
-    setExitCode(code);
+    setExitCode(code)
     if (code !== null) {
-      setPid(null);
+      setPid(null)
     }
-  }, []);
+  }, [])
 
   useEffect(() => {
     if (!contextMenu) {
-      return;
+      return
     }
 
-    const handleClick = () => setContextMenu(null);
+    const handleClick = () => setContextMenu(null)
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setContextMenu(null);
+      if (event.key === 'Escape') {
+        setContextMenu(null)
       }
-    };
+    }
 
-    window.addEventListener("click", handleClick);
-    window.addEventListener("keydown", handleKey);
+    window.addEventListener('click', handleClick)
+    window.addEventListener('keydown', handleKey)
 
     return () => {
-      window.removeEventListener("click", handleClick);
-      window.removeEventListener("keydown", handleKey);
-    };
-  }, [contextMenu]);
+      window.removeEventListener('click', handleClick)
+      window.removeEventListener('keydown', handleKey)
+    }
+  }, [contextMenu])
 
   const adjustedContextMenu = useMemo(() => {
     if (!contextMenu) {
-      return null;
+      return null
     }
 
-    if (typeof window === "undefined") {
-      return contextMenu;
+    if (typeof window === 'undefined') {
+      return contextMenu
     }
 
-    const menuWidth = 200;
-    const menuHeight = shareRemoteUri ? 88 : 48;
+    const menuWidth = 200
+    const menuHeight = shareRemoteUri ? 88 : 48
     const left = Math.max(
       0,
-      Math.min(contextMenu.x, window.innerWidth - menuWidth),
-    );
+      Math.min(contextMenu.x, window.innerWidth - menuWidth)
+    )
     const top = Math.max(
       0,
-      Math.min(contextMenu.y, window.innerHeight - menuHeight),
-    );
-    return { x: left, y: top };
-  }, [contextMenu, shareRemoteUri]);
+      Math.min(contextMenu.y, window.innerHeight - menuHeight)
+    )
+    return { x: left, y: top }
+  }, [contextMenu, shareRemoteUri])
 
   const runCode = useCallback(() => {
-    cellData.run();
-  }, [cellData]);
+    cellData.run()
+  }, [cellData])
 
   const handleContextMenu = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-      setContextMenu({ x: event.clientX, y: event.clientY });
+      event.preventDefault()
+      event.stopPropagation()
+      setContextMenu({ x: event.clientX, y: event.clientY })
     },
-    [],
-  );
+    []
+  )
 
   const handleFocusCapture = useCallback(
     (event: React.FocusEvent<HTMLDivElement>) => {
       if (!cell?.refId || !onFocusStateChange) {
-        return;
+        return
       }
-      const target = event.target;
+      const target = event.target
       if (!(target instanceof HTMLElement)) {
-        return;
+        return
       }
       const focusRoleElement = target.closest<HTMLElement>(
-        "[data-cell-focus-role]",
-      );
+        '[data-cell-focus-role]'
+      )
       if (!focusRoleElement) {
-        return;
+        return
       }
       const focusRole =
-        focusRoleElement.dataset.cellFocusRole === "rendered"
-          ? "rendered"
-          : "editor";
-      const nextState = createNotebookActiveCellState(cell.refId, focusRole);
+        focusRoleElement.dataset.cellFocusRole === 'rendered'
+          ? 'rendered'
+          : 'editor'
+      const nextState = createNotebookActiveCellState(cell.refId, focusRole)
       if (!nextState) {
-        return;
+        return
       }
-      onFocusStateChange(nextState);
+      onFocusStateChange(nextState)
     },
-    [cell?.refId, onFocusStateChange],
-  );
+    [cell?.refId, onFocusStateChange]
+  )
 
   const handleMarkdownFocusRoleChange = useCallback(
     (focusRole: CellFocusRole) => {
       if (!cell?.refId || !onFocusStateChange) {
-        return;
+        return
       }
-      const nextState = createNotebookActiveCellState(cell.refId, focusRole);
+      const nextState = createNotebookActiveCellState(cell.refId, focusRole)
       if (!nextState) {
-        return;
+        return
       }
-      onFocusStateChange(nextState);
+      onFocusStateChange(nextState)
     },
-    [cell?.refId, onFocusStateChange],
-  );
+    [cell?.refId, onFocusStateChange]
+  )
 
   const handleRemoveCell = useCallback(() => {
-    cellData.remove();
-    setContextMenu(null);
-  }, [cellData]);
+    cellData.remove()
+    setContextMenu(null)
+  }, [cellData])
 
   const handleCopyShareLink = useCallback(async () => {
     if (!shareRemoteUri) {
-      setContextMenu(null);
-      return;
+      setContextMenu(null)
+      return
     }
 
     try {
-      await copyNotebookShareUrl(shareRemoteUri);
+      await copyNotebookShareUrl(shareRemoteUri)
     } catch (error) {
-      appLogger.error("Failed to copy notebook share link from document menu", {
+      appLogger.error('Failed to copy notebook share link from document menu', {
         attrs: {
-          scope: "storage.drive.share",
-          code: "DRIVE_SHARE_LINK_COPY_FAILED",
+          scope: 'storage.drive.share',
+          code: 'DRIVE_SHARE_LINK_COPY_FAILED',
           remoteUri: shareRemoteUri,
           error: String(error),
         },
-      });
+      })
     } finally {
-      setContextMenu(null);
+      setContextMenu(null)
     }
-  }, [shareRemoteUri]);
+  }, [shareRemoteUri])
 
   const sequenceLabel = useMemo(() => {
     if (!cell) {
-      return " ";
+      return ' '
     }
-    const seq = Number(cell.metadata[RunmeMetadataKey.Sequence]);
+    const seq = Number(cell.metadata[RunmeMetadataKey.Sequence])
     if (!seq) {
-      return " ";
+      return ' '
     }
-    return seq.toString();
-  }, [cell, pid, exitCode]);
+    return seq.toString()
+  }, [cell, pid, exitCode])
 
   const selectedLanguage = useMemo(() => {
     if (!cell) {
-      return "bash";
+      return 'bash'
     }
-    return normalizeLanguageId(cell.kind, cell.languageId);
-  }, [cell]);
+    return normalizeLanguageId(cell.kind, cell.languageId)
+  }, [cell])
 
   const editorLanguage = useMemo(() => {
     switch (selectedLanguage) {
-      case "html":
-        return "html";
-      case "markdown":
-        return "markdown";
-      case "javascript":
-        return "javascript";
-      case "jupyter":
-        return "python";
-      case "python":
-        return "python";
+      case 'html':
+        return 'html'
+      case 'markdown':
+        return 'markdown'
+      case 'javascript':
+        return 'javascript'
+      case 'jupyter':
+        return 'python'
+      case 'python':
+        return 'python'
       default:
-        return "shellscript";
+        return 'shellscript'
     }
-  }, [selectedLanguage]);
+  }, [selectedLanguage])
 
   const languageSelectId = useMemo(
-    () => `language-select-${cell?.refId ?? "unknown"}`,
-    [cell?.refId],
-  );
+    () => `language-select-${cell?.refId ?? 'unknown'}`,
+    [cell?.refId]
+  )
   const runnerSelectId = useMemo(
-    () => `runner-select-${cell?.refId ?? "unknown"}`,
-    [cell?.refId],
-  );
+    () => `runner-select-${cell?.refId ?? 'unknown'}`,
+    [cell?.refId]
+  )
   const kernelSelectId = useMemo(
-    () => `kernel-select-${cell?.refId ?? "unknown"}`,
-    [cell?.refId],
-  );
+    () => `kernel-select-${cell?.refId ?? 'unknown'}`,
+    [cell?.refId]
+  )
 
-  var initialRunnerName = cellData.getRunnerName();
+  var initialRunnerName = cellData.getRunnerName()
   if (!initialRunnerName) {
-    initialRunnerName = DEFAULT_RUNNER_PLACEHOLDER;
+    initialRunnerName = DEFAULT_RUNNER_PLACEHOLDER
   }
-  const isJavascriptLanguage = selectedLanguage === "javascript";
+  const isJavascriptLanguage = selectedLanguage === 'javascript'
   const runnerSelectionName =
-    selectedLanguage === "jupyter" && isAppKernelRunnerName(initialRunnerName)
+    selectedLanguage === 'jupyter' && isAppKernelRunnerName(initialRunnerName)
       ? DEFAULT_RUNNER_PLACEHOLDER
-      : initialRunnerName;
+      : initialRunnerName
   const resolvedRunnerName =
     runnerSelectionName === DEFAULT_RUNNER_PLACEHOLDER
-      ? (defaultRunnerName ?? "")
-      : runnerSelectionName;
+      ? (defaultRunnerName ?? '')
+      : runnerSelectionName
   const showRunnerSelector =
-    selectedLanguage === "bash" ||
-    selectedLanguage === "python" ||
-    isJavascriptLanguage;
-  const showKernelSelector = selectedLanguage === "jupyter";
-  const runnerSelectValue =
+    selectedLanguage === 'bash' ||
+    selectedLanguage === 'python' ||
     isJavascriptLanguage
-      ? initialRunnerName === APPKERNEL_SANDBOX_RUNNER_NAME
-        ? APPKERNEL_SANDBOX_RUNNER_NAME
-        : APPKERNEL_RUNNER_NAME
-      : isAppKernelRunnerName(initialRunnerName)
-        ? DEFAULT_RUNNER_PLACEHOLDER
-        : initialRunnerName;
+  const showKernelSelector = selectedLanguage === 'jupyter'
+  const runnerSelectValue = isJavascriptLanguage
+    ? initialRunnerName === APPKERNEL_SANDBOX_RUNNER_NAME
+      ? APPKERNEL_SANDBOX_RUNNER_NAME
+      : APPKERNEL_RUNNER_NAME
+    : isAppKernelRunnerName(initialRunnerName)
+      ? DEFAULT_RUNNER_PLACEHOLDER
+      : initialRunnerName
   const hasJupyterSelection =
     Boolean(cell?.metadata?.[RunmeMetadataKey.JupyterServerName]) ||
     Boolean(cell?.metadata?.[RunmeMetadataKey.JupyterKernelID]) ||
-    Boolean(cell?.metadata?.[RunmeMetadataKey.JupyterKernelName]);
+    Boolean(cell?.metadata?.[RunmeMetadataKey.JupyterKernelName])
   const availableRunnerNames = useMemo(
-    () => listRunners().map((runner) => runner.name).filter((name) => !isAppKernelRunnerName(name)),
-    [listRunners],
-  );
+    () =>
+      listRunners()
+        .map((runner) => runner.name)
+        .filter((name) => !isAppKernelRunnerName(name)),
+    [listRunners]
+  )
   const jupyterRunnerNames = useMemo(() => {
-    const names = new Set<string>();
+    const names = new Set<string>()
     if (resolvedRunnerName) {
-      names.add(resolvedRunnerName);
+      names.add(resolvedRunnerName)
     }
-    availableRunnerNames.forEach((name) => names.add(name));
-    return [...names];
-  }, [availableRunnerNames, resolvedRunnerName]);
+    availableRunnerNames.forEach((name) => names.add(name))
+    return [...names]
+  }, [availableRunnerNames, resolvedRunnerName])
 
   useEffect(() => {
-    if (selectedLanguage !== "jupyter") {
-      return;
+    if (selectedLanguage !== 'jupyter') {
+      return
     }
     if (jupyterRunnerNames.length === 0) {
-      return;
+      return
     }
     void Promise.all(
       jupyterRunnerNames.map((runnerName) =>
         jupyterManager.ensureRunnerData(runnerName).catch((error) => {
-          console.error("Failed to load Jupyter kernels for runner", {
+          console.error('Failed to load Jupyter kernels for runner', {
             runner: runnerName,
             error,
-          });
-        }),
-      ),
-    );
-  }, [jupyterManager, jupyterRunnerNames, resolvedRunnerName, selectedLanguage]);
+          })
+        })
+      )
+    )
+  }, [jupyterManager, jupyterRunnerNames, resolvedRunnerName, selectedLanguage])
 
   useEffect(() => {
-    if (selectedLanguage === "javascript" && !isAppKernelRunnerName(initialRunnerName)) {
-      cellData.setRunner(APPKERNEL_RUNNER_NAME);
+    if (
+      selectedLanguage === 'javascript' &&
+      !isAppKernelRunnerName(initialRunnerName)
+    ) {
+      cellData.setRunner(APPKERNEL_RUNNER_NAME)
       if (hasJupyterSelection) {
-        cellData.clearJupyterKernel();
+        cellData.clearJupyterKernel()
       }
-      return;
+      return
     }
-    if (selectedLanguage === "markdown") {
+    if (selectedLanguage === 'markdown') {
       if (initialRunnerName !== DEFAULT_RUNNER_PLACEHOLDER) {
-        cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER);
+        cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER)
       }
       if (hasJupyterSelection) {
-        cellData.clearJupyterKernel();
+        cellData.clearJupyterKernel()
       }
-      return;
+      return
     }
-    if (selectedLanguage === "html") {
+    if (selectedLanguage === 'html') {
       if (initialRunnerName !== DEFAULT_RUNNER_PLACEHOLDER) {
-        cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER);
+        cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER)
       }
       if (hasJupyterSelection) {
-        cellData.clearJupyterKernel();
+        cellData.clearJupyterKernel()
       }
-      return;
+      return
     }
-    if (selectedLanguage === "jupyter" && isAppKernelRunnerName(initialRunnerName)) {
-      cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER);
+    if (
+      selectedLanguage === 'jupyter' &&
+      isAppKernelRunnerName(initialRunnerName)
+    ) {
+      cellData.setRunner(DEFAULT_RUNNER_PLACEHOLDER)
       if (hasJupyterSelection) {
-        cellData.clearJupyterKernel();
+        cellData.clearJupyterKernel()
       }
     }
-  }, [cellData, hasJupyterSelection, initialRunnerName, selectedLanguage]);
+  }, [cellData, hasJupyterSelection, initialRunnerName, selectedLanguage])
 
   const kernelOptions = useMemo(() => {
     if (!showKernelSelector || jupyterRunnerNames.length === 0) {
-      return [];
+      return []
     }
-    const deduped = new Map<string, ReturnType<typeof jupyterManager.getKernelOptionsForRunner>[number]>();
+    const deduped = new Map<
+      string,
+      ReturnType<typeof jupyterManager.getKernelOptionsForRunner>[number]
+    >()
     jupyterRunnerNames.forEach((runnerName) => {
       try {
-        const options = jupyterManager.getKernelOptionsForRunner(runnerName);
+        const options = jupyterManager.getKernelOptionsForRunner(runnerName)
         options.forEach((option) => {
-          deduped.set(option.key, option);
-        });
+          deduped.set(option.key, option)
+        })
       } catch (error) {
-        console.error("Failed to build Jupyter kernel options for runner", {
+        console.error('Failed to build Jupyter kernel options for runner', {
           runner: runnerName,
           error,
-        });
+        })
       }
-    });
+    })
     return [...deduped.values()].sort(
       (a, b) =>
         a.label.localeCompare(b.label) ||
-        a.runnerName.localeCompare(b.runnerName),
-    );
-  }, [jupyterManager, jupyterRunnerNames, jupyterVersion, showKernelSelector]);
+        a.runnerName.localeCompare(b.runnerName)
+    )
+  }, [jupyterManager, jupyterRunnerNames, jupyterVersion, showKernelSelector])
   const selectedKernelKey = useMemo(() => {
     const serverName =
-      (cell?.metadata?.[RunmeMetadataKey.JupyterServerName] as string | undefined) ?? "";
+      (cell?.metadata?.[RunmeMetadataKey.JupyterServerName] as
+        | string
+        | undefined) ?? ''
     const kernelID =
-      (cell?.metadata?.[RunmeMetadataKey.JupyterKernelID] as string | undefined) ?? "";
+      (cell?.metadata?.[RunmeMetadataKey.JupyterKernelID] as
+        | string
+        | undefined) ?? ''
     if (!serverName || !kernelID) {
-      return "";
+      return ''
     }
     const runnerName =
-      (cell?.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ?? "";
+      (cell?.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ??
+      ''
     if (runnerName && !isAppKernelRunnerName(runnerName)) {
-      return jupyterManager.getKernelOptionKey(serverName, kernelID, runnerName);
+      return jupyterManager.getKernelOptionKey(serverName, kernelID, runnerName)
     }
     if (resolvedRunnerName) {
-      return jupyterManager.getKernelOptionKey(serverName, kernelID, resolvedRunnerName);
+      return jupyterManager.getKernelOptionKey(
+        serverName,
+        kernelID,
+        resolvedRunnerName
+      )
     }
-    return jupyterManager.getKernelOptionKey(serverName, kernelID);
-  }, [cell, jupyterManager, resolvedRunnerName]);
+    return jupyterManager.getKernelOptionKey(serverName, kernelID)
+  }, [cell, jupyterManager, resolvedRunnerName])
 
   useEffect(() => {
-    if (selectedLanguage !== "jupyter") {
-      return;
+    if (selectedLanguage !== 'jupyter') {
+      return
     }
     if (selectedKernelKey) {
-      return;
+      return
     }
     if (kernelOptions.length !== 1) {
-      return;
+      return
     }
-    const option = kernelOptions[0];
-    const parsed = jupyterManager.parseKernelOptionKey(option.key);
+    const option = kernelOptions[0]
+    const parsed = jupyterManager.parseKernelOptionKey(option.key)
     if (!parsed) {
-      return;
+      return
     }
     cellData.setJupyterKernel({
       runnerName: option.runnerName,
       serverName: parsed.serverName,
       kernelId: parsed.kernelId,
       kernelName: option.label,
-    });
+    })
   }, [
     cellData,
     jupyterManager,
     kernelOptions,
     selectedKernelKey,
     selectedLanguage,
-  ]);
+  ])
 
   const renderedOutputs = useMemo(() => {
     const hasTerminalOutput = (cell?.outputs ?? []).some((output) =>
-      (output.items ?? []).some((item) => item.mime === MimeType.StatefulRunmeTerminal),
-    );
-    const hasActiveStream = Boolean(cellData.getStreams());
+      (output.items ?? []).some(
+        (item) => item.mime === MimeType.StatefulRunmeTerminal
+      )
+    )
+    const hasActiveStream = Boolean(cellData.getStreams())
     if (!hasTerminalOutput && !hasActiveStream) {
-      return null;
+      return null
     }
 
     return (
       <CellConsole
-        key={`console-${cell?.refId ?? "cell"}-${runID}`}
+        key={`console-${cell?.refId ?? 'cell'}-${runID}`}
         cellData={cellData}
         onPid={setPid}
         onExitCode={handleExitCode}
       />
-    );
-  }, [cell, cellData, handleExitCode, runID]);
+    )
+  }, [cell, cellData, handleExitCode, runID])
 
   const renderedOutputItems = useMemo(() => {
     if (!cell?.outputs || cell.outputs.length === 0) {
-      return null;
+      return null
     }
     return (
       <ActionOutputItems
         outputs={cell.outputs}
         suppressStdText={Boolean(cellData.getStreams())}
       />
-    );
-  }, [cell?.outputs, cellData]);
+    )
+  }, [cell?.outputs, cellData])
 
   const handleLanguageChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
       if (!cell) {
-        return;
+        return
       }
       const nextValue = event.target
-        .value as (typeof LANGUAGE_OPTIONS)[number]["value"];
+        .value as (typeof LANGUAGE_OPTIONS)[number]['value']
       if (nextValue === selectedLanguage) {
-        return;
+        return
       }
 
-      const updatedCell = create(parser_pb.CellSchema, cell);
-      updatedCell.metadata ??= {};
+      const updatedCell = create(parser_pb.CellSchema, cell)
+      updatedCell.metadata ??= {}
       const clearRuntimeMetadata = () => {
-        delete updatedCell.metadata[RunmeMetadataKey.RunnerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
-      };
-      if (nextValue === "markdown") {
-        setMarkdownEditRequest((request) => request + 1);
-        updatedCell.kind = parser_pb.CellKind.MARKUP;
-        updatedCell.languageId = "markdown";
-        clearRuntimeMetadata();
-      } else if (nextValue === "html") {
-        setHtmlEditRequest((request) => request + 1);
-        updatedCell.kind = parser_pb.CellKind.CODE;
-        updatedCell.languageId = "html";
-        clearRuntimeMetadata();
-      } else if (nextValue === "jupyter") {
-        updatedCell.kind = parser_pb.CellKind.CODE;
-        updatedCell.languageId = "jupyter";
-        clearRuntimeMetadata();
-      } else if (nextValue === "javascript") {
-        updatedCell.kind = parser_pb.CellKind.CODE;
-        updatedCell.languageId = "javascript";
-        updatedCell.metadata[RunmeMetadataKey.RunnerName] = APPKERNEL_RUNNER_NAME;
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
-      } else if (nextValue === "python") {
-        updatedCell.kind = parser_pb.CellKind.CODE;
-        updatedCell.languageId = "python";
-        if (isAppKernelRunnerName(updatedCell.metadata[RunmeMetadataKey.RunnerName])) {
-          delete updatedCell.metadata[RunmeMetadataKey.RunnerName];
+        delete updatedCell.metadata[RunmeMetadataKey.RunnerName]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName]
+      }
+      if (nextValue === 'markdown') {
+        setMarkdownEditRequest((request) => request + 1)
+        updatedCell.kind = parser_pb.CellKind.MARKUP
+        updatedCell.languageId = 'markdown'
+        clearRuntimeMetadata()
+      } else if (nextValue === 'html') {
+        setHtmlEditRequest((request) => request + 1)
+        updatedCell.kind = parser_pb.CellKind.CODE
+        updatedCell.languageId = 'html'
+        clearRuntimeMetadata()
+      } else if (nextValue === 'jupyter') {
+        updatedCell.kind = parser_pb.CellKind.CODE
+        updatedCell.languageId = 'jupyter'
+        clearRuntimeMetadata()
+      } else if (nextValue === 'javascript') {
+        updatedCell.kind = parser_pb.CellKind.CODE
+        updatedCell.languageId = 'javascript'
+        updatedCell.metadata[RunmeMetadataKey.RunnerName] =
+          APPKERNEL_RUNNER_NAME
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName]
+      } else if (nextValue === 'python') {
+        updatedCell.kind = parser_pb.CellKind.CODE
+        updatedCell.languageId = 'python'
+        if (
+          isAppKernelRunnerName(
+            updatedCell.metadata[RunmeMetadataKey.RunnerName]
+          )
+        ) {
+          delete updatedCell.metadata[RunmeMetadataKey.RunnerName]
         }
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName]
       } else {
-        updatedCell.kind = parser_pb.CellKind.CODE;
-        updatedCell.languageId = "bash";
-        if (isAppKernelRunnerName(updatedCell.metadata[RunmeMetadataKey.RunnerName])) {
-          delete updatedCell.metadata[RunmeMetadataKey.RunnerName];
+        updatedCell.kind = parser_pb.CellKind.CODE
+        updatedCell.languageId = 'bash'
+        if (
+          isAppKernelRunnerName(
+            updatedCell.metadata[RunmeMetadataKey.RunnerName]
+          )
+        ) {
+          delete updatedCell.metadata[RunmeMetadataKey.RunnerName]
         }
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID];
-        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName];
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterServerName]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelID]
+        delete updatedCell.metadata[RunmeMetadataKey.JupyterKernelName]
       }
 
-      updateCellLocal(updatedCell);
-      setPid(null);
-      setExitCode(null);
+      updateCellLocal(updatedCell)
+      setPid(null)
+      setExitCode(null)
     },
-    [cell, selectedLanguage, updateCellLocal],
-  );
+    [cell, selectedLanguage, updateCellLocal]
+  )
 
   // Determine if this cell is a markdown cell (either MARKUP kind or CODE with markdown language)
   const isMarkdownCell = useMemo(() => {
-    if (!cell) return false;
-    if (cell.kind === parser_pb.CellKind.MARKUP) return true;
-    return isMarkdownLanguageId(cell.languageId);
-  }, [cell]);
+    if (!cell) return false
+    if (cell.kind === parser_pb.CellKind.MARKUP) return true
+    return isMarkdownLanguageId(cell.languageId)
+  }, [cell])
   const isHtmlCell = useMemo(() => {
-    if (!cell) return false;
-    return cell.kind === parser_pb.CellKind.CODE && isHtmlLanguageId(cell.languageId);
-  }, [cell]);
+    if (!cell) return false
+    return (
+      cell.kind === parser_pb.CellKind.CODE && isHtmlLanguageId(cell.languageId)
+    )
+  }, [cell])
 
   if (!cell) {
-    return null;
+    return null
   }
 
   // Render markdown cells with in-place rendering (Jupyter-style)
@@ -1080,7 +1142,10 @@ export function Action({
         data-cell-ref-id={cell.refId}
       >
         {/* Left gutter: top + bottom add-cell buttons */}
-        <div id={`markdown-gutter-${cell.refId}`} className="flex w-7 shrink-0 flex-col items-center justify-between py-1">
+        <div
+          id={`markdown-gutter-${cell.refId}`}
+          className="flex w-7 shrink-0 flex-col items-center justify-between py-1"
+        >
           <button
             type="button"
             aria-label="Add cell above"
@@ -1138,8 +1203,8 @@ export function Action({
                 type="button"
                 className="ctx-menu-item"
                 onClick={(event) => {
-                  event.stopPropagation();
-                  void handleCopyShareLink();
+                  event.stopPropagation()
+                  void handleCopyShareLink()
                 }}
               >
                 Copy Share Link
@@ -1149,8 +1214,8 @@ export function Action({
               type="button"
               className="ctx-menu-item text-red-600"
               onClick={(event) => {
-                event.stopPropagation();
-                handleRemoveCell();
+                event.stopPropagation()
+                handleRemoveCell()
               }}
             >
               Remove Cell
@@ -1158,7 +1223,7 @@ export function Action({
           </div>
         )}
       </div>
-    );
+    )
   }
 
   if (isHtmlCell) {
@@ -1169,7 +1234,10 @@ export function Action({
         onContextMenu={handleContextMenu}
         data-testid="html-action"
       >
-        <div id={`html-gutter-${cell.refId}`} className="flex w-7 shrink-0 flex-col items-center justify-between py-1">
+        <div
+          id={`html-gutter-${cell.refId}`}
+          className="flex w-7 shrink-0 flex-col items-center justify-between py-1"
+        >
           <button
             type="button"
             aria-label="Add cell above"
@@ -1221,8 +1289,8 @@ export function Action({
                 type="button"
                 className="ctx-menu-item"
                 onClick={(event) => {
-                  event.stopPropagation();
-                  void handleCopyShareLink();
+                  event.stopPropagation()
+                  void handleCopyShareLink()
                 }}
               >
                 Copy Share Link
@@ -1232,8 +1300,8 @@ export function Action({
               type="button"
               className="ctx-menu-item text-red-600"
               onClick={(event) => {
-                event.stopPropagation();
-                handleRemoveCell();
+                event.stopPropagation()
+                handleRemoveCell()
               }}
             >
               Remove Cell
@@ -1241,7 +1309,7 @@ export function Action({
           </div>
         )}
       </div>
-    );
+    )
   }
 
   // Render code cells as a unified Marimo-style card: editor + toolbar + output
@@ -1257,7 +1325,10 @@ export function Action({
       data-cell-ref-id={cell.refId}
     >
       {/* Left gutter: top + bottom add-cell buttons */}
-      <div id={`code-gutter-${cell.refId}`} className="flex w-7 shrink-0 flex-col items-center justify-between py-1">
+      <div
+        id={`code-gutter-${cell.refId}`}
+        className="flex w-7 shrink-0 flex-col items-center justify-between py-1"
+      >
         <button
           type="button"
           aria-label="Add cell above"
@@ -1278,10 +1349,7 @@ export function Action({
 
       {/* Cell card: editor + toolbar + output */}
       <div className="min-w-0 flex-1">
-        <div
-          id={`cell-card-${cell.refId}`}
-          className="cell-card"
-        >
+        <div id={`cell-card-${cell.refId}`} className="cell-card">
           {/* Code editor section — overflow-hidden keeps border-radius clipping on the editor */}
           <div
             className="overflow-hidden rounded-t-nb-md"
@@ -1296,19 +1364,16 @@ export function Action({
               fontFamily={fontSettings.fontFamily}
               shouldFocus={isActiveCell && isWindowFocused}
               onChange={(v) => {
-                const updated = create(parser_pb.CellSchema, cell);
-                updated.value = v;
-                updateCellLocal(updated);
+                const updated = create(parser_pb.CellSchema, cell)
+                updated.value = v
+                updateCellLocal(updated)
               }}
               onEnter={runCode}
             />
           </div>
 
           {/* Minimal toolbar: language + runner selectors + run/trash buttons */}
-          <div
-            id={`cell-toolbar-${cell.refId}`}
-            className="cell-toolbar"
-          >
+          <div id={`cell-toolbar-${cell.refId}`} className="cell-toolbar">
             <div className="flex items-center gap-3">
               <select
                 id={languageSelectId}
@@ -1327,25 +1392,25 @@ export function Action({
                   id={runnerSelectId}
                   value={runnerSelectValue}
                   onChange={(event) => {
-                    const nextName = event.target.value;
+                    const nextName = event.target.value
                     if (isJavascriptLanguage) {
                       const validJsRunner = JAVASCRIPT_RUNNER_OPTIONS.some(
-                        (option) => option.value === nextName,
-                      );
+                        (option) => option.value === nextName
+                      )
                       if (!validJsRunner) {
-                        return;
+                        return
                       }
-                      cellData.setRunner(nextName);
-                      return;
+                      cellData.setRunner(nextName)
+                      return
                     }
-                    const names = new Set(listRunners().map((r) => r.name));
+                    const names = new Set(listRunners().map((r) => r.name))
                     if (
                       !names.has(nextName) &&
                       nextName !== DEFAULT_RUNNER_PLACEHOLDER
                     ) {
-                      return;
+                      return
                     }
-                    cellData.setRunner(nextName);
+                    cellData.setRunner(nextName)
                   }}
                   className="toolbar-select"
                 >
@@ -1358,7 +1423,7 @@ export function Action({
                   ) : (
                     <>
                       <option value={DEFAULT_RUNNER_PLACEHOLDER}>
-                        {defaultRunnerName ? `${defaultRunnerName}` : "default"}
+                        {defaultRunnerName ? `${defaultRunnerName}` : 'default'}
                       </option>
                       {listRunners()
                         .filter((runner) => !isAppKernelRunnerName(runner.name))
@@ -1376,25 +1441,27 @@ export function Action({
                   id={kernelSelectId}
                   value={selectedKernelKey}
                   onChange={(event) => {
-                    const nextKey = event.target.value;
+                    const nextKey = event.target.value
                     if (!nextKey) {
-                      cellData.clearJupyterKernel();
-                      return;
+                      cellData.clearJupyterKernel()
+                      return
                     }
-                    const parsed = jupyterManager.parseKernelOptionKey(nextKey);
+                    const parsed = jupyterManager.parseKernelOptionKey(nextKey)
                     if (!parsed) {
-                      return;
+                      return
                     }
-                    const option = kernelOptions.find((item) => item.key === nextKey);
+                    const option = kernelOptions.find(
+                      (item) => item.key === nextKey
+                    )
                     if (!option) {
-                      return;
+                      return
                     }
                     cellData.setJupyterKernel({
                       runnerName: option.runnerName,
                       serverName: parsed.serverName,
                       kernelId: parsed.kernelId,
                       kernelName: option.label,
-                    });
+                    })
                   }}
                   className="toolbar-select"
                 >
@@ -1430,7 +1497,10 @@ export function Action({
           {(renderedOutputs || renderedOutputItems) && (
             <div id={`cell-output-${cell.refId}`}>
               <div className="border-t border-nb-tray-border" />
-              <div className="overflow-auto p-[14.4px]" style={{ maxHeight: 'var(--nb-cell-output-max-h)' }}>
+              <div
+                className="overflow-auto p-[14.4px]"
+                style={{ maxHeight: 'var(--nb-cell-output-max-h)' }}
+              >
                 {renderedOutputs}
                 {renderedOutputItems}
               </div>
@@ -1454,8 +1524,8 @@ export function Action({
               type="button"
               className="ctx-menu-item"
               onClick={(event) => {
-                event.stopPropagation();
-                void handleCopyShareLink();
+                event.stopPropagation()
+                void handleCopyShareLink()
               }}
             >
               Copy Share Link
@@ -1465,8 +1535,8 @@ export function Action({
             type="button"
             className="ctx-menu-item text-red-600"
             onClick={(event) => {
-              event.stopPropagation();
-              handleRemoveCell();
+              event.stopPropagation()
+              handleRemoveCell()
             }}
           >
             Remove Cell
@@ -1474,7 +1544,7 @@ export function Action({
         </div>
       )}
     </div>
-  );
+  )
 }
 
 function NotebookTabContent({
@@ -1484,31 +1554,32 @@ function NotebookTabContent({
   isWindowFocused,
   onCellFocus,
 }: {
-  docUri: string;
-  entry: OpenNotebookEntry;
-  activeCell: NotebookActiveCellState | null;
-  isWindowFocused: boolean;
-  onCellFocus: (docUri: string, state: NotebookActiveCellState) => void;
+  docUri: string
+  entry: OpenNotebookEntry
+  activeCell: NotebookActiveCellState | null
+  isWindowFocused: boolean
+  onCellFocus: (docUri: string, state: NotebookActiveCellState) => void
 }) {
-  const { getNotebookData, openNotebook, useNotebookSnapshot } = useNotebookContext();
-  const notebookSnapshot = useNotebookSnapshot(docUri);
+  const { getNotebookData, openNotebook, useNotebookSnapshot } =
+    useNotebookContext()
+  const notebookSnapshot = useNotebookSnapshot(docUri)
   const cellDatas = useMemo(() => {
     if (!notebookSnapshot) {
-      return [];
+      return []
     }
-    const data = getNotebookData(notebookSnapshot.uri);
+    const data = getNotebookData(notebookSnapshot.uri)
     if (!data) {
-      return [];
+      return []
     }
     return (notebookSnapshot.notebook.cells ?? [])
       .map((c) => (c?.refId ? data.getCell(c.refId) : null))
-      .filter((c): c is CellData => Boolean(c));
-  }, [getNotebookData, notebookSnapshot]);
+      .filter((c): c is CellData => Boolean(c))
+  }, [getNotebookData, notebookSnapshot])
 
-  if (entry.state === "blocked") {
+  if (entry.state === 'blocked') {
     const ownerText = entry.owner?.ownerStartedAt
       ? `Tab opened at ${new Date(entry.owner.ownerStartedAt).toLocaleTimeString()}`
-      : "Another browser tab";
+      : 'Another browser tab'
     return (
       <div
         className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center text-sm text-nb-text-muted"
@@ -1531,16 +1602,16 @@ function NotebookTabContent({
         <Button
           variant="soft"
           onClick={() => {
-            void openNotebook(docUri, { name: entry.name });
+            void openNotebook(docUri, { name: entry.name })
           }}
         >
           Retry
         </Button>
       </div>
-    );
+    )
   }
 
-  if (entry.state === "error") {
+  if (entry.state === 'error') {
     return (
       <div
         className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center text-sm text-nb-text-muted"
@@ -1550,10 +1621,10 @@ function NotebookTabContent({
           Notebook could not be opened
         </Text>
         <Text size="2" as="p">
-          {entry.errorMessage ?? "An unknown error occurred."}
+          {entry.errorMessage ?? 'An unknown error occurred.'}
         </Text>
       </div>
-    );
+    )
   }
 
   if (!notebookSnapshot || !notebookSnapshot.loaded) {
@@ -1561,10 +1632,10 @@ function NotebookTabContent({
       <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-nb-text-muted">
         <span>Loading…</span>
       </div>
-    );
+    )
   }
 
-  const data = getNotebookData(notebookSnapshot.uri);
+  const data = getNotebookData(notebookSnapshot.uri)
 
   return (
     <ScrollArea
@@ -1578,7 +1649,10 @@ function NotebookTabContent({
           Cells expand to fill the available width of the tab content area. */}
       <div id="notebook-column" className="w-full py-2 px-8">
         {cellDatas.length === 0 ? (
-          <div id="empty-notebook-prompt" className="flex flex-col items-center justify-center gap-3 py-16 text-sm text-nb-text-muted">
+          <div
+            id="empty-notebook-prompt"
+            className="flex flex-col items-center justify-center gap-3 py-16 text-sm text-nb-text-muted"
+          >
             <p>This notebook has no cells yet.</p>
             <button
               type="button"
@@ -1592,7 +1666,7 @@ function NotebookTabContent({
         ) : (
           <div className="space-y-3">
             {cellDatas.map((cellData, index) => {
-              const refId = cellData.snapshot?.refId ?? `cell-${index}`;
+              const refId = cellData.snapshot?.refId ?? `cell-${index}`
               return (
                 <Action
                   key={`action-${refId}`}
@@ -1600,11 +1674,11 @@ function NotebookTabContent({
                   docUri={docUri}
                   isFirst={index === 0}
                   isActiveCell={activeCell?.refId === refId}
-                  activeFocusRole={activeCell?.focusRole ?? "editor"}
+                  activeFocusRole={activeCell?.focusRole ?? 'editor'}
                   isWindowFocused={isWindowFocused}
                   onFocusStateChange={(state) => onCellFocus(docUri, state)}
                 />
-              );
+              )
             })}
             {/* Add cell button at the bottom of the notebook */}
             <div className="flex justify-center py-3">
@@ -1622,14 +1696,16 @@ function NotebookTabContent({
         )}
       </div>
     </ScrollArea>
-  );
+  )
 }
 
 function NotebookDiffTabContent({ diffUri }: { diffUri: string }) {
-  const diffId = diffUri.slice("diff://notebook/".length);
-  const document = diffId ? getNotebookDiffDocument(decodeURIComponent(diffId)) : null;
+  const diffId = diffUri.slice('diff://notebook/'.length)
+  const document = diffId
+    ? getNotebookDiffDocument(decodeURIComponent(diffId))
+    : null
   if (document) {
-    return <NotebookDiffContent document={document} />;
+    return <NotebookDiffContent document={document} />
   }
   return (
     <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-nb-text-muted">
@@ -1641,7 +1717,7 @@ function NotebookDiffTabContent({ diffUri }: { diffUri: string }) {
         notebookDiff.openDiffTab(diff) again.
       </Text>
     </div>
-  );
+  )
 }
 
 function UnknownDocumentTab({ uri }: { uri: string }) {
@@ -1654,7 +1730,7 @@ function UnknownDocumentTab({ uri }: { uri: string }) {
         {uri}
       </Text>
     </div>
-  );
+  )
 }
 
 function renderWorkspaceDocument({
@@ -1665,22 +1741,22 @@ function renderWorkspaceDocument({
   onDriveLogin,
   onDriveRetry,
 }: {
-  document: WorkspaceDocument;
-  activeCell: NotebookActiveCellState | null;
-  isWindowFocused: boolean;
-  onCellFocus: (docUri: string, state: NotebookActiveCellState) => void;
-  onDriveLogin: () => void;
-  onDriveRetry: () => void;
+  document: WorkspaceDocument
+  activeCell: NotebookActiveCellState | null
+  isWindowFocused: boolean
+  onCellFocus: (docUri: string, state: NotebookActiveCellState) => void
+  onDriveLogin: () => void
+  onDriveRetry: () => void
 }) {
   if (isNotebookDocumentUri(document.uri)) {
     const entry: OpenNotebookEntry = {
       uri: document.uri,
       requestedUri: document.requestedUri ?? document.uri,
       name: document.title,
-      state: document.state ?? "loading",
+      state: document.state ?? 'loading',
       errorMessage: document.errorMessage,
       ...(document.owner !== undefined ? { owner: document.owner } : {}),
-    };
+    }
     return (
       <NotebookTabContent
         docUri={document.uri}
@@ -1689,63 +1765,54 @@ function renderWorkspaceDocument({
         isWindowFocused={isWindowFocused}
         onCellFocus={onCellFocus}
       />
-    );
+    )
   }
 
   if (isNotebookDiffUri(document.uri)) {
-    return <NotebookDiffTabContent diffUri={document.uri} />;
+    return <NotebookDiffTabContent diffUri={document.uri} />
   }
 
   if (isDriveLinkStatusUri(document.uri)) {
-    return (
-      <DriveLinkStatusTab
-        onLogin={onDriveLogin}
-        onRetry={onDriveRetry}
-      />
-    );
+    return <DriveLinkStatusTab onLogin={onDriveLogin} onRetry={onDriveRetry} />
   }
 
-  return <UnknownDocumentTab uri={document.uri} />;
+  return <UnknownDocumentTab uri={document.uri} />
 }
 
 export default function Actions() {
-  const {
-    useWorkspaceDocuments,
-    showDocument,
-    closeWorkspaceDocument,
-  } = useWorkspaceDocumentContext();
-  const { getNotebookData } = useNotebookContext();
-  const { store } = useNotebookStore();
-  const workspaceDocuments = useWorkspaceDocuments();
-  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
-  const currentDocUri = getCurrentDoc();
-  const driveLinkSnapshot = useDriveLinkCoordinatorSnapshot();
+  const { useWorkspaceDocuments, showDocument, closeWorkspaceDocument } =
+    useWorkspaceDocumentContext()
+  const { getNotebookData } = useNotebookContext()
+  const { store } = useNotebookStore()
+  const workspaceDocuments = useWorkspaceDocuments()
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
+  const currentDocUri = getCurrentDoc()
+  const driveLinkSnapshot = useDriveLinkCoordinatorSnapshot()
   const statusTabVisible =
     driveLinkSnapshot.intents.length > 0 ||
-    Boolean(driveLinkSnapshot.lastErrorMessage);
-  const [selectedTabUri, setSelectedTabUri] = useState<string | null>(null);
-  const [activeCellsByDoc, setActiveCellsByDoc] = useState<NotebookActiveCellMap>(
-    () => loadNotebookActiveCellMap(),
-  );
+    Boolean(driveLinkSnapshot.lastErrorMessage)
+  const [selectedTabUri, setSelectedTabUri] = useState<string | null>(null)
+  const [activeCellsByDoc, setActiveCellsByDoc] =
+    useState<NotebookActiveCellMap>(() => loadNotebookActiveCellMap())
   const [isWindowFocused, setIsWindowFocused] = useState(() => {
-    if (typeof document === "undefined") {
-      return false;
+    if (typeof document === 'undefined') {
+      return false
     }
-    return document.visibilityState === "visible" && document.hasFocus();
-  });
+    return document.visibilityState === 'visible' && document.hasFocus()
+  })
   // Empty-state hint visibility is stored locally so the hint panel can be
   // revealed on demand without cluttering the default view.
-  const [showConsoleHints, setShowConsoleHints] = useState(false);
+  const [showConsoleHints, setShowConsoleHints] = useState(false)
   const [tabContextMenu, setTabContextMenu] = useState<{
-    x: number;
-    y: number;
-    docUri: string;
-    title: string;
-    shareableUri: string;
-    googleDriveUri: string | null;
-  } | null>(null);
-  const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const pendingSelectedTabUriRef = useRef<string | null>(null);
+    x: number
+    y: number
+    docUri: string
+    title: string
+    shareableUri: string
+    googleDriveUri: string | null
+  } | null>(null)
+  const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+  const pendingSelectedTabUriRef = useRef<string | null>(null)
   //const { data: run } = useRun(runName);
 
   // useEffect(() => {
@@ -1774,73 +1841,73 @@ export default function Actions() {
   //   }
   // }, [cellsInitialized, currentDocUri, ensureNotebook, run, runName, setCurrentDoc]);
 
-  const { registerRenderer, unregisterRenderer } = useOutput();
+  const { registerRenderer, unregisterRenderer } = useOutput()
   const workspaceDocumentUris = useMemo(
     () => new Set(workspaceDocuments.map((document) => document.uri)),
-    [workspaceDocuments],
-  );
+    [workspaceDocuments]
+  )
   const selectedTabIsOpen = selectedTabUri
     ? workspaceDocumentUris.has(selectedTabUri)
-    : false;
+    : false
   const currentDocIsOpen = currentDocUri
     ? workspaceDocumentUris.has(currentDocUri)
-    : false;
+    : false
   const resolvedSelectedTabUri =
     (selectedTabIsOpen ? selectedTabUri : null) ??
     (currentDocIsOpen ? currentDocUri : null) ??
     workspaceDocuments[0]?.uri ??
-    "";
+    ''
 
   const handleCellFocus = useCallback(
     (docUri: string, state: NotebookActiveCellState) => {
       setActiveCellsByDoc((prev) => {
-        const current = prev[docUri];
+        const current = prev[docUri]
         if (
           current?.refId === state.refId &&
           current.focusRole === state.focusRole
         ) {
-          return prev;
+          return prev
         }
         const next = {
           ...prev,
           [docUri]: state,
-        };
-        persistNotebookActiveCellMap(next);
-        return next;
-      });
+        }
+        persistNotebookActiveCellMap(next)
+        return next
+      })
     },
-    [],
-  );
+    []
+  )
 
   // Keep Radix tab selection in sync with the shared current document URI.
   // CurrentDocContext may restore a non-restorable URI, such as a diff/status
   // document. Fall back to the first restored workspace document in that case.
   useEffect(() => {
     if (statusTabVisible) {
-      return;
+      return
     }
-    const pendingSelectedTabUri = pendingSelectedTabUriRef.current;
+    const pendingSelectedTabUri = pendingSelectedTabUriRef.current
     if (pendingSelectedTabUri) {
       if (pendingSelectedTabUri === currentDocUri) {
-        pendingSelectedTabUriRef.current = null;
+        pendingSelectedTabUriRef.current = null
       } else if (workspaceDocumentUris.has(pendingSelectedTabUri)) {
         if (selectedTabUri !== pendingSelectedTabUri) {
-          setSelectedTabUri(pendingSelectedTabUri);
+          setSelectedTabUri(pendingSelectedTabUri)
         }
-        return;
+        return
       } else {
-        pendingSelectedTabUriRef.current = null;
+        pendingSelectedTabUriRef.current = null
       }
     }
     if (currentDocUri && currentDocIsOpen) {
-      setSelectedTabUri(currentDocUri);
-      return;
+      setSelectedTabUri(currentDocUri)
+      return
     }
     if (selectedTabUri && !selectedTabIsOpen) {
-      setSelectedTabUri(null);
+      setSelectedTabUri(null)
     }
     if (currentDocUri && !currentDocIsOpen) {
-      setCurrentDoc(workspaceDocuments[0]?.uri ?? null);
+      setCurrentDoc(workspaceDocuments[0]?.uri ?? null)
     }
   }, [
     currentDocIsOpen,
@@ -1851,21 +1918,23 @@ export default function Actions() {
     statusTabVisible,
     workspaceDocumentUris,
     workspaceDocuments,
-  ]);
+  ])
 
   useEffect(() => {
     if (statusTabVisible) {
       showDocument(DRIVE_LINK_STATUS_TAB_URI, {
-        title: "Drive Link Status",
-      });
+        title: 'Drive Link Status',
+      })
       if (!currentDocUri || !currentDocIsOpen) {
-        setCurrentDoc(DRIVE_LINK_STATUS_TAB_URI);
+        setCurrentDoc(DRIVE_LINK_STATUS_TAB_URI)
       }
-      return;
+      return
     }
 
-    if (workspaceDocuments.some((doc) => doc.uri === DRIVE_LINK_STATUS_TAB_URI)) {
-      closeWorkspaceDocument(DRIVE_LINK_STATUS_TAB_URI);
+    if (
+      workspaceDocuments.some((doc) => doc.uri === DRIVE_LINK_STATUS_TAB_URI)
+    ) {
+      closeWorkspaceDocument(DRIVE_LINK_STATUS_TAB_URI)
     }
   }, [
     closeWorkspaceDocument,
@@ -1875,43 +1944,43 @@ export default function Actions() {
     showDocument,
     statusTabVisible,
     workspaceDocuments,
-  ]);
+  ])
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof document === "undefined") {
-      return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return
     }
 
     const syncWindowFocus = () => {
       setIsWindowFocused(
-        document.visibilityState === "visible" && document.hasFocus(),
-      );
-    };
+        document.visibilityState === 'visible' && document.hasFocus()
+      )
+    }
 
-    syncWindowFocus();
-    window.addEventListener("focus", syncWindowFocus);
-    window.addEventListener("blur", syncWindowFocus);
-    document.addEventListener("visibilitychange", syncWindowFocus);
+    syncWindowFocus()
+    window.addEventListener('focus', syncWindowFocus)
+    window.addEventListener('blur', syncWindowFocus)
+    document.addEventListener('visibilitychange', syncWindowFocus)
     return () => {
-      window.removeEventListener("focus", syncWindowFocus);
-      window.removeEventListener("blur", syncWindowFocus);
-      document.removeEventListener("visibilitychange", syncWindowFocus);
-    };
-  }, []);
+      window.removeEventListener('focus', syncWindowFocus)
+      window.removeEventListener('blur', syncWindowFocus)
+      document.removeEventListener('visibilitychange', syncWindowFocus)
+    }
+  }, [])
 
   // Keep the active tab discoverable when the tab rail overflows horizontally.
   // We track each rendered tab node and ask the browser to reveal the selected
   // one so keyboard/mouse tab changes do not leave the active notebook clipped.
   useLayoutEffect(() => {
     if (!resolvedSelectedTabUri) {
-      return;
+      return
     }
-    const node = tabTriggerRefs.current.get(resolvedSelectedTabUri);
+    const node = tabTriggerRefs.current.get(resolvedSelectedTabUri)
     node?.scrollIntoView({
-      block: "nearest",
-      inline: "nearest",
-    });
-  }, [resolvedSelectedTabUri]);
+      block: 'nearest',
+      inline: 'nearest',
+    })
+  }, [resolvedSelectedTabUri])
 
   // TODO(jlewi): Does it still make sense to have a registration pattern for renderers? What does that buy us over
   // just hardcoding an "if" statement when rendering the outputs. Is that a legacy of the vscode extension where
@@ -1926,10 +1995,10 @@ export default function Actions() {
         onPid,
         onExitCode,
       }: {
-        cell: parser_pb.Cell;
-        cellData: CellData;
-        onPid: (pid: number | null) => void;
-        onExitCode: (exitCode: number | null) => void;
+        cell: parser_pb.Cell
+        cellData: CellData
+        onPid: (pid: number | null) => void
+        onExitCode: (exitCode: number | null) => void
       }) => {
         return (
           // TODO(jlewi): Why do we pass cell which is parser_pb.Cell? Rather than CellData?
@@ -1939,68 +2008,68 @@ export default function Actions() {
             onPid={onPid}
             onExitCode={onExitCode}
           />
-        );
+        )
       },
-    });
+    })
 
     return () => {
-      unregisterRenderer(MimeType.StatefulRunmeTerminal);
-    };
-  }, [registerRenderer, unregisterRenderer]);
+      unregisterRenderer(MimeType.StatefulRunmeTerminal)
+    }
+  }, [registerRenderer, unregisterRenderer])
 
   const handleCloseTab = useCallback(
     (uri: string) => {
-      closeWorkspaceDocument(uri);
+      closeWorkspaceDocument(uri)
     },
-    [closeWorkspaceDocument],
-  );
+    [closeWorkspaceDocument]
+  )
 
   useEffect(() => {
     if (!tabContextMenu) {
-      return;
+      return
     }
-    const handleClick = () => setTabContextMenu(null);
+    const handleClick = () => setTabContextMenu(null)
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setTabContextMenu(null);
+      if (event.key === 'Escape') {
+        setTabContextMenu(null)
       }
-    };
-    window.addEventListener("click", handleClick);
-    window.addEventListener("keydown", handleKey);
+    }
+    window.addEventListener('click', handleClick)
+    window.addEventListener('keydown', handleKey)
     return () => {
-      window.removeEventListener("click", handleClick);
-      window.removeEventListener("keydown", handleKey);
-    };
-  }, [tabContextMenu]);
+      window.removeEventListener('click', handleClick)
+      window.removeEventListener('keydown', handleKey)
+    }
+  }, [tabContextMenu])
 
   const adjustedTabContextMenu = useMemo(() => {
     if (!tabContextMenu) {
-      return null;
+      return null
     }
-    if (typeof window === "undefined") {
-      return tabContextMenu;
+    if (typeof window === 'undefined') {
+      return tabContextMenu
     }
-    const itemCount = tabContextMenu.googleDriveUri ? 4 : 3;
-    const menuWidth = 220;
-    const menuHeight = itemCount * 36 + 8;
+    const itemCount = tabContextMenu.googleDriveUri ? 4 : 3
+    const menuWidth = 220
+    const menuHeight = itemCount * 36 + 8
     return {
       ...tabContextMenu,
       x: Math.max(0, Math.min(tabContextMenu.x, window.innerWidth - menuWidth)),
       y: Math.max(
         0,
-        Math.min(tabContextMenu.y, window.innerHeight - menuHeight),
+        Math.min(tabContextMenu.y, window.innerHeight - menuHeight)
       ),
-    };
-  }, [tabContextMenu]);
+    }
+  }, [tabContextMenu])
 
   const handleTabContextMenu = useCallback(
     (event: ReactMouseEvent<HTMLElement>, docUri: string) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const document = workspaceDocuments.find((doc) => doc.uri === docUri);
+      event.preventDefault()
+      event.stopPropagation()
+      const document = workspaceDocuments.find((doc) => doc.uri === docUri)
       const title =
         document?.title?.trim() ||
-        getNotebookDisplayName(docUri, document?.title ?? docUri);
+        getNotebookDisplayName(docUri, document?.title ?? docUri)
       setTabContextMenu({
         x: event.clientX,
         y: event.clientY,
@@ -2008,147 +2077,158 @@ export default function Actions() {
         title,
         shareableUri: docUri,
         googleDriveUri: isGoogleDriveFileUri(docUri) ? docUri : null,
-      });
+      })
 
-      if (!store || !docUri.startsWith("local://")) {
-        return;
+      if (!store || !docUri.startsWith('local://')) {
+        return
       }
 
       void (async () => {
         try {
-          const metadata = await store.getMetadata(docUri);
-          const remoteUri = metadata?.remoteUri?.trim() || null;
+          const metadata = await store.getMetadata(docUri)
+          const remoteUri = metadata?.remoteUri?.trim() || null
           setTabContextMenu((current) => {
             if (!current || current.docUri !== docUri) {
-              return current;
+              return current
             }
             return {
               ...current,
               shareableUri: remoteUri ?? docUri,
-              googleDriveUri: isGoogleDriveFileUri(remoteUri) ? remoteUri : current.googleDriveUri,
-            };
-          });
+              googleDriveUri: isGoogleDriveFileUri(remoteUri)
+                ? remoteUri
+                : current.googleDriveUri,
+            }
+          })
         } catch (error) {
-          appLogger.error("Failed to resolve tab metadata for context menu", {
+          appLogger.error('Failed to resolve tab metadata for context menu', {
             attrs: {
-              scope: "storage.metadata",
-              code: "TAB_CONTEXT_METADATA_LOOKUP_FAILED",
+              scope: 'storage.metadata',
+              code: 'TAB_CONTEXT_METADATA_LOOKUP_FAILED',
               docUri,
               error: String(error),
             },
-          });
+          })
         }
-      })();
+      })()
     },
-    [store, workspaceDocuments],
-  );
+    [store, workspaceDocuments]
+  )
 
   const handleRenameTab = useCallback(async () => {
     if (!tabContextMenu) {
-      return;
+      return
     }
     if (!store) {
-      setTabContextMenu(null);
-      return;
+      setTabContextMenu(null)
+      return
     }
 
-    const nextName = window.prompt("Rename notebook", tabContextMenu.title);
+    const nextName = window.prompt('Rename notebook', tabContextMenu.title)
     if (nextName === null) {
-      setTabContextMenu(null);
-      return;
+      setTabContextMenu(null)
+      return
     }
 
-    const trimmed = nextName.trim();
-    const renamedName = trimmed === "" ? "untitled.json" : trimmed;
+    const trimmed = nextName.trim()
+    const renamedName = trimmed === '' ? 'untitled.json' : trimmed
     try {
-      const renamed = await store.rename(tabContextMenu.docUri, renamedName);
-      const title = renamed.name || renamedName;
-      getNotebookData(tabContextMenu.docUri)?.setName(title);
-      showDocument(tabContextMenu.docUri, { title });
-      setTabContextMenu(null);
+      const renamed = await store.rename(tabContextMenu.docUri, renamedName)
+      const title = renamed.name || renamedName
+      getNotebookData(tabContextMenu.docUri)?.setName(title)
+      showDocument(tabContextMenu.docUri, { title })
+      setTabContextMenu(null)
     } catch (error) {
-      appLogger.error("Failed to rename notebook from tab context menu", {
+      appLogger.error('Failed to rename notebook from tab context menu', {
         attrs: {
-          scope: "storage.rename",
-          code: "TAB_RENAME_FAILED",
+          scope: 'storage.rename',
+          code: 'TAB_RENAME_FAILED',
           uri: tabContextMenu.docUri,
           error: String(error),
         },
-      });
+      })
       showToast({
-        message: "Unable to rename document. Please try again.",
-        tone: "error",
-      });
-      setTabContextMenu(null);
+        message: 'Unable to rename document. Please try again.',
+        tone: 'error',
+      })
+      setTabContextMenu(null)
     }
-  }, [getNotebookData, showDocument, store, tabContextMenu]);
+  }, [getNotebookData, showDocument, store, tabContextMenu])
 
   const handleCopyTabShareableLink = useCallback(async () => {
     if (!tabContextMenu) {
-      return;
+      return
     }
     try {
-      await copyNotebookShareUrl(tabContextMenu.shareableUri);
+      await copyNotebookShareUrl(tabContextMenu.shareableUri)
     } catch (error) {
-      appLogger.error("Failed to copy shareable link from tab context menu", {
+      appLogger.error('Failed to copy shareable link from tab context menu', {
         attrs: {
-          scope: "storage.share",
-          code: "TAB_COPY_SHAREABLE_LINK_FAILED",
+          scope: 'storage.share',
+          code: 'TAB_COPY_SHAREABLE_LINK_FAILED',
           uri: tabContextMenu.shareableUri,
           error: String(error),
         },
-      });
+      })
     } finally {
-      setTabContextMenu(null);
+      setTabContextMenu(null)
     }
-  }, [tabContextMenu]);
+  }, [tabContextMenu])
 
   const handleCopyTabLocalUri = useCallback(async () => {
     if (!tabContextMenu) {
-      return;
+      return
     }
     try {
-      if (typeof window === "undefined" || !window.navigator?.clipboard?.writeText) {
-        throw new Error("Clipboard access is unavailable in this browser");
+      if (
+        typeof window === 'undefined' ||
+        !window.navigator?.clipboard?.writeText
+      ) {
+        throw new Error('Clipboard access is unavailable in this browser')
       }
-      await window.navigator.clipboard.writeText(tabContextMenu.docUri);
+      await window.navigator.clipboard.writeText(tabContextMenu.docUri)
     } catch (error) {
-      appLogger.error("Failed to copy local URI from tab context menu", {
+      appLogger.error('Failed to copy local URI from tab context menu', {
         attrs: {
-          scope: "storage.local",
-          code: "TAB_COPY_LOCAL_URI_FAILED",
+          scope: 'storage.local',
+          code: 'TAB_COPY_LOCAL_URI_FAILED',
           uri: tabContextMenu.docUri,
           error: String(error),
         },
-      });
+      })
     } finally {
-      setTabContextMenu(null);
+      setTabContextMenu(null)
     }
-  }, [tabContextMenu]);
+  }, [tabContextMenu])
 
   const handleCopyTabGoogleDriveLink = useCallback(async () => {
     if (!tabContextMenu?.googleDriveUri) {
-      setTabContextMenu(null);
-      return;
+      setTabContextMenu(null)
+      return
     }
     try {
-      if (typeof window === "undefined" || !window.navigator?.clipboard?.writeText) {
-        throw new Error("Clipboard access is unavailable in this browser");
+      if (
+        typeof window === 'undefined' ||
+        !window.navigator?.clipboard?.writeText
+      ) {
+        throw new Error('Clipboard access is unavailable in this browser')
       }
-      await window.navigator.clipboard.writeText(tabContextMenu.googleDriveUri);
+      await window.navigator.clipboard.writeText(tabContextMenu.googleDriveUri)
     } catch (error) {
-      appLogger.error("Failed to copy Google Drive link from tab context menu", {
-        attrs: {
-          scope: "storage.drive",
-          code: "TAB_COPY_GOOGLE_DRIVE_LINK_FAILED",
-          uri: tabContextMenu.googleDriveUri,
-          error: String(error),
-        },
-      });
+      appLogger.error(
+        'Failed to copy Google Drive link from tab context menu',
+        {
+          attrs: {
+            scope: 'storage.drive',
+            code: 'TAB_COPY_GOOGLE_DRIVE_LINK_FAILED',
+            uri: tabContextMenu.googleDriveUri,
+            error: String(error),
+          },
+        }
+      )
     } finally {
-      setTabContextMenu(null);
+      setTabContextMenu(null)
     }
-  }, [tabContextMenu]);
+  }, [tabContextMenu])
 
   // Each document gets its own scroll container keyed by URI so the browser
   // does not reuse the previous document's scroll position.
@@ -2176,15 +2256,18 @@ export default function Actions() {
               </Text>
             </div>
 
-            <div id="actions-empty-hints" className="flex flex-col items-center">
+            <div
+              id="actions-empty-hints"
+              className="flex flex-col items-center"
+            >
               <Button
                 id="actions-empty-hints-toggle"
                 variant="soft"
                 onClick={() => setShowConsoleHints((prev) => !prev)}
               >
                 {showConsoleHints
-                  ? "Hide Console Commands"
-                  : "Show Console Commands"}
+                  ? 'Hide Console Commands'
+                  : 'Show Console Commands'}
               </Button>
             </div>
 
@@ -2206,22 +2289,24 @@ export default function Actions() {
                   id="actions-empty-quickstart-code"
                   className="quickstart-console-code mt-3 whitespace-pre-wrap rounded-md bg-gray-900 p-3 text-xs text-gray-100 select-text cursor-text"
                   style={{
-                    userSelect: "text",
-                    WebkitUserSelect: "text",
+                    userSelect: 'text',
+                    WebkitUserSelect: 'text',
                   }}
                 >
-                  explorer.addFolder(){"\n"}
-                  explorer.mountDrive(driveUrl){"\n"}
-                  explorer.openPicker(){"\n"}
-                  explorer.listFolders(){"\n"}
-                  runme.getCurrentNotebook(){"\n"}
-                  runme.clear(){"\n"}
-                  runme.runAll(){"\n"}
-                  runme.rerun(){"\n"}
-                  help(){"\n\n"}
-                  To attach test notebooks: use the Explorer + button to pick the fixtures folder
-                  {"\n"}
-                  To mount a local file: use the Explorer + button or explorer.openPicker()
+                  explorer.addFolder(){'\n'}
+                  explorer.mountDrive(driveUrl){'\n'}
+                  explorer.openPicker(){'\n'}
+                  explorer.listFolders(){'\n'}
+                  runme.getCurrentNotebook(){'\n'}
+                  runme.clear(){'\n'}
+                  runme.runAll(){'\n'}
+                  runme.rerun(){'\n'}
+                  help(){'\n\n'}
+                  To attach test notebooks: use the Explorer + button to pick
+                  the fixtures folder
+                  {'\n'}
+                  To mount a local file: use the Explorer + button or
+                  explorer.openPicker()
                 </pre>
               </div>
             )}
@@ -2231,10 +2316,10 @@ export default function Actions() {
         <Tabs.Root
           value={resolvedSelectedTabUri}
           onValueChange={(nextUri) => {
-            pendingSelectedTabUriRef.current = nextUri;
-            setSelectedTabUri(nextUri);
+            pendingSelectedTabUriRef.current = nextUri
+            setSelectedTabUri(nextUri)
             if (nextUri !== currentDocUri) {
-              setCurrentDoc(nextUri);
+              setCurrentDoc(nextUri)
             }
           }}
           className="flex flex-col flex-1 min-h-0 overflow-hidden bg-white"
@@ -2248,16 +2333,16 @@ export default function Actions() {
               className="flex min-w-max items-center gap-0.5 px-2 py-1"
             >
               {workspaceDocuments.map((doc) => {
-                const displayName = getNotebookDisplayName(doc.uri, doc.title);
-                const isNotebook = isNotebookDocumentUri(doc.uri);
+                const displayName = getNotebookDisplayName(doc.uri, doc.title)
+                const isNotebook = isNotebookDocumentUri(doc.uri)
                 return (
                   <div
                     key={`tab-${doc.uri}`}
                     ref={(node) => {
                       if (node) {
-                        tabTriggerRefs.current.set(doc.uri, node);
+                        tabTriggerRefs.current.set(doc.uri, node)
                       } else {
-                        tabTriggerRefs.current.delete(doc.uri);
+                        tabTriggerRefs.current.delete(doc.uri)
                       }
                     }}
                     className="flex shrink-0 items-center gap-1"
@@ -2272,7 +2357,9 @@ export default function Actions() {
                       }
                       className="group flex shrink-0 items-center gap-2 rounded-nb-sm border border-transparent px-3 py-1.5 text-sm font-medium text-nb-text-muted transition-all duration-150 data-[state=active]:border-nb-border data-[state=active]:bg-nb-surface data-[state=active]:text-nb-text data-[state=active]:shadow-nb-xs data-[state=inactive]:hover:bg-nb-surface/60 data-[state=inactive]:hover:text-nb-text focus:outline-none"
                     >
-                      <span className="max-w-[140px] truncate">{displayName}</span>
+                      <span className="max-w-[140px] truncate">
+                        {displayName}
+                      </span>
                     </Tabs.Trigger>
                     {isNotebook && <NotebookSyncIndicator docUri={doc.uri} />}
                     <button
@@ -2280,15 +2367,15 @@ export default function Actions() {
                       className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-nb-xs text-nb-text-faint transition-all duration-150 hover:bg-nb-surface-2 hover:text-nb-text"
                       aria-label={`Close ${displayName}`}
                       onClick={(event) => {
-                        event.stopPropagation();
-                        handleCloseTab(doc.uri);
+                        event.stopPropagation()
+                        handleCloseTab(doc.uri)
                       }}
                       onMouseDown={(event) => event.stopPropagation()}
                     >
                       <XMarkIcon className="h-3 w-3" />
                     </button>
                   </div>
-                );
+                )
               })}
             </Tabs.List>
           </div>
@@ -2306,8 +2393,8 @@ export default function Actions() {
                 type="button"
                 className="ctx-menu-item"
                 onClick={(event) => {
-                  event.stopPropagation();
-                  void handleRenameTab();
+                  event.stopPropagation()
+                  void handleRenameTab()
                 }}
               >
                 Rename
@@ -2316,8 +2403,8 @@ export default function Actions() {
                 type="button"
                 className="ctx-menu-item"
                 onClick={(event) => {
-                  event.stopPropagation();
-                  void handleCopyTabShareableLink();
+                  event.stopPropagation()
+                  void handleCopyTabShareableLink()
                 }}
               >
                 Copy Shareable Link
@@ -2326,8 +2413,8 @@ export default function Actions() {
                 type="button"
                 className="ctx-menu-item"
                 onClick={(event) => {
-                  event.stopPropagation();
-                  void handleCopyTabLocalUri();
+                  event.stopPropagation()
+                  void handleCopyTabLocalUri()
                 }}
               >
                 Copy local URI
@@ -2337,8 +2424,8 @@ export default function Actions() {
                   type="button"
                   className="ctx-menu-item"
                   onClick={(event) => {
-                    event.stopPropagation();
-                    void handleCopyTabGoogleDriveLink();
+                    event.stopPropagation()
+                    void handleCopyTabGoogleDriveLink()
                   }}
                 >
                   Copy Google Drive Link
@@ -2347,29 +2434,31 @@ export default function Actions() {
             </div>
           )}
           <div className="relative flex-1 min-h-0 overflow-hidden">
-          {workspaceDocuments.map((doc) => (
-            <Tabs.Content
-              key={`content-${doc.uri}`}
-              value={doc.uri}
-              forceMount
-              asChild
-            >
-              <TabPanel className="flex-1 min-h-0" data-document-id={doc.uri}>
-                {renderWorkspaceDocument({
-                  document: doc,
-                  activeCell: activeCellsByDoc[doc.uri] ?? null,
-                  isWindowFocused:
-                    isWindowFocused && resolvedSelectedTabUri === doc.uri,
-                  onCellFocus: handleCellFocus,
-                  onDriveLogin: () => driveLinkCoordinator.loginToDriveAndProcess(),
-                  onDriveRetry: () => driveLinkCoordinator.retryAuthAndProcess(),
-                })}
-              </TabPanel>
-            </Tabs.Content>
-          ))}
+            {workspaceDocuments.map((doc) => (
+              <Tabs.Content
+                key={`content-${doc.uri}`}
+                value={doc.uri}
+                forceMount
+                asChild
+              >
+                <TabPanel className="flex-1 min-h-0" data-document-id={doc.uri}>
+                  {renderWorkspaceDocument({
+                    document: doc,
+                    activeCell: activeCellsByDoc[doc.uri] ?? null,
+                    isWindowFocused:
+                      isWindowFocused && resolvedSelectedTabUri === doc.uri,
+                    onCellFocus: handleCellFocus,
+                    onDriveLogin: () =>
+                      driveLinkCoordinator.loginToDriveAndProcess(),
+                    onDriveRetry: () =>
+                      driveLinkCoordinator.retryAuthAndProcess(),
+                  })}
+                </TabPanel>
+              </Tabs.Content>
+            ))}
           </div>
         </Tabs.Root>
       )}
     </div>
-  );
+  )
 }

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -1,6 +1,9 @@
-import { Badge, ScrollArea, Text } from '@radix-ui/themes'
+import { useState } from 'react'
+
+import { Badge, Button, ScrollArea, Text } from '@radix-ui/themes'
 
 import { parser_pb } from '../../runme/client'
+import { useNotebookStore } from '../../contexts/NotebookStoreContext'
 import type {
   CellDiff,
   NotebookDiffDocument,
@@ -8,6 +11,8 @@ import type {
   TextDiff,
   TextDiffLine,
 } from '../../lib/notebookDiff/model'
+import { NotebookConflictChangedError } from '../../storage/local'
+import { showToast } from '../../lib/toast'
 
 function cellKindLabel(cell?: parser_pb.Cell): string {
   if (!cell) {
@@ -226,22 +231,96 @@ function DiffRow({ row }: { row: CellDiff }) {
   )
 }
 
+function ConflictResolutionActions({ localUri }: { localUri: string }) {
+  const { store } = useNotebookStore()
+  const [isResolving, setIsResolving] = useState(false)
+
+  const saveLocalVersion = async (force = false) => {
+    if (!store) {
+      return
+    }
+    setIsResolving(true)
+    try {
+      await store.resolveConflictWithLocal(localUri, {
+        force,
+      })
+      showToast({
+        message: 'Saved local notebook version to upstream.',
+        tone: 'success',
+      })
+    } catch (error) {
+      if (error instanceof NotebookConflictChangedError && !force) {
+        const shouldOverwrite =
+          typeof window !== 'undefined' &&
+          window.confirm(
+            'The upstream file changed again since this conflict was detected. ' +
+              'Saving local version will replace the latest upstream version.'
+          )
+        if (shouldOverwrite) {
+          await saveLocalVersion(true)
+        }
+        return
+      }
+      showToast({
+        message: 'Unable to save local version. Please try again.',
+        tone: 'error',
+      })
+    } finally {
+      setIsResolving(false)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      color="amber"
+      disabled={!store || isResolving}
+      onClick={() => {
+        void saveLocalVersion()
+      }}
+    >
+      {isResolving ? 'Saving...' : 'Save local version'}
+    </Button>
+  )
+}
+
 export function NotebookDiffContent({
   document,
 }: {
   document: NotebookDiffDocument
 }) {
   const { diff } = document
+  const conflictResolution =
+    document.resolution?.kind === 'notebook-sync-conflict'
+      ? document.resolution
+      : null
+
   return (
     <div className="flex h-full w-full flex-col bg-nb-surface">
       <header className="border-b border-nb-border bg-white px-5 py-4">
-        <div>
-          <Text as="p" size="5" weight="bold" className="text-nb-text">
-            Notebook Diff
-          </Text>
-          <Text as="p" size="2" className="text-nb-text-muted">
-            {document.base.label} compared with {document.compare.label}
-          </Text>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <Text as="p" size="5" weight="bold" className="text-nb-text">
+              Notebook Diff
+            </Text>
+            <Text as="p" size="2" className="text-nb-text-muted">
+              {document.base.label} compared with {document.compare.label}
+            </Text>
+            {conflictResolution && (
+              <Text
+                as="p"
+                size="2"
+                className="mt-2 max-w-3xl text-nb-text-muted"
+              >
+                This notebook has local changes and upstream changes. Review the
+                diff, edit the local notebook if needed, then save the local
+                version to replace upstream.
+              </Text>
+            )}
+          </div>
+          {conflictResolution && (
+            <ConflictResolutionActions localUri={conflictResolution.localUri} />
+          )}
         </div>
         <div className="mt-3 flex flex-wrap gap-2 text-sm text-nb-text-muted">
           <Badge color="green">{diff.summary.insertedCells} inserted</Badge>

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -11,6 +11,7 @@ import type {
   TextDiff,
   TextDiffLine,
 } from '../../lib/notebookDiff/model'
+import { refreshNotebookConflictDiff } from '../../lib/notebookDiff/conflict'
 import { NotebookConflictChangedError } from '../../storage/local'
 import { showToast } from '../../lib/toast'
 
@@ -234,6 +235,7 @@ function DiffRow({ row }: { row: CellDiff }) {
 function ConflictResolutionActions({ localUri }: { localUri: string }) {
   const { store } = useNotebookStore()
   const [isResolving, setIsResolving] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
 
   const saveLocalVersion = async (force = false) => {
     if (!store) {
@@ -270,17 +272,51 @@ function ConflictResolutionActions({ localUri }: { localUri: string }) {
     }
   }
 
+  const refreshDiff = async () => {
+    if (!store) {
+      return
+    }
+    setIsRefreshing(true)
+    try {
+      await refreshNotebookConflictDiff(store, localUri)
+      showToast({
+        message: 'Refreshed diff against latest upstream version.',
+        tone: 'success',
+      })
+    } catch {
+      showToast({
+        message: 'Unable to refresh conflict diff. Please try again.',
+        tone: 'error',
+      })
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
+
   return (
-    <Button
-      type="button"
-      color="amber"
-      disabled={!store || isResolving}
-      onClick={() => {
-        void saveLocalVersion()
-      }}
-    >
-      {isResolving ? 'Saving...' : 'Save local version'}
-    </Button>
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      <Button
+        type="button"
+        color="gray"
+        variant="soft"
+        disabled={!store || isRefreshing || isResolving}
+        onClick={() => {
+          void refreshDiff()
+        }}
+      >
+        {isRefreshing ? 'Refreshing...' : 'Refresh diff'}
+      </Button>
+      <Button
+        type="button"
+        color="amber"
+        disabled={!store || isResolving || isRefreshing}
+        onClick={() => {
+          void saveLocalVersion()
+        }}
+      >
+        {isResolving ? 'Saving...' : 'Save local version'}
+      </Button>
+    </div>
   )
 }
 

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -1,7 +1,11 @@
 import { fromJsonString } from '@bufbuild/protobuf'
 
 import { parser_pb } from '../../runme/client'
-import type { LocalNotebooks } from '../../storage/local'
+import type {
+  LocalFileRecord,
+  LocalNotebooks,
+  NotebookConflictState,
+} from '../../storage/local'
 import { computeNotebookDiff } from './diff'
 import {
   openNotebookDiffDocument,
@@ -23,28 +27,18 @@ function parseNotebookJson(
   }
 }
 
-export async function openNotebookConflictDiff(
-  store: LocalNotebooks,
-  localUri: string
-): Promise<void> {
-  const record = await store.files.get(localUri)
-  if (!record) {
-    throw new Error(`Local notebook record not found for ${localUri}`)
-  }
-  if (!record.conflict) {
-    throw new Error(`Local notebook ${localUri} does not have a conflict`)
-  }
-
-  const upstreamNotebook = parseNotebookJson(
-    record.conflict.upstreamDoc,
-    'upstream'
-  )
+function registerConflictDiffDocument(
+  localUri: string,
+  record: LocalFileRecord,
+  conflict: NotebookConflictState
+) {
+  const upstreamNotebook = parseNotebookJson(conflict.upstreamDoc, 'upstream')
   const localNotebook = parseNotebookJson(record.doc ?? '', 'local')
-  const document = registerNotebookDiffDocument({
+  return registerNotebookDiffDocument({
     id: `conflict-${encodeURIComponent(localUri)}`,
     base: {
       label: 'Upstream version',
-      revisionId: record.conflict.upstreamVersion?.revisionId,
+      revisionId: conflict.upstreamVersion?.revisionId,
     },
     compare: {
       label: 'Local version',
@@ -58,5 +52,37 @@ export async function openNotebookConflictDiff(
       localUri,
     },
   })
+}
+
+export async function openNotebookConflictDiff(
+  store: LocalNotebooks,
+  localUri: string
+): Promise<void> {
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+  if (!record.conflict) {
+    throw new Error(`Local notebook ${localUri} does not have a conflict`)
+  }
+
+  const document = registerConflictDiffDocument(
+    localUri,
+    record,
+    record.conflict
+  )
   openNotebookDiffDocument(document)
+}
+
+export async function refreshNotebookConflictDiff(
+  store: LocalNotebooks,
+  localUri: string
+): Promise<void> {
+  const conflict = await store.refreshConflictWithLatestUpstream(localUri)
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+
+  registerConflictDiffDocument(localUri, record, conflict)
 }

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -1,0 +1,62 @@
+import { fromJsonString } from '@bufbuild/protobuf'
+
+import { parser_pb } from '../../runme/client'
+import type { LocalNotebooks } from '../../storage/local'
+import { computeNotebookDiff } from './diff'
+import {
+  openNotebookDiffDocument,
+  registerNotebookDiffDocument,
+} from './registry'
+
+function parseNotebookJson(
+  serialized: string,
+  label: string
+): parser_pb.Notebook {
+  try {
+    return fromJsonString(parser_pb.NotebookSchema, serialized || '{}', {
+      ignoreUnknownFields: true,
+    })
+  } catch (error) {
+    throw new Error(
+      `Unable to parse ${label} notebook for conflict diff: ${String(error)}`
+    )
+  }
+}
+
+export async function openNotebookConflictDiff(
+  store: LocalNotebooks,
+  localUri: string
+): Promise<void> {
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+  if (!record.conflict) {
+    throw new Error(`Local notebook ${localUri} does not have a conflict`)
+  }
+
+  const upstreamNotebook = parseNotebookJson(
+    record.conflict.upstreamDoc,
+    'upstream'
+  )
+  const localNotebook = parseNotebookJson(record.doc ?? '', 'local')
+  const document = registerNotebookDiffDocument({
+    id: `conflict-${encodeURIComponent(localUri)}`,
+    base: {
+      label: 'Upstream version',
+      revisionId: record.conflict.upstreamVersion?.revisionId,
+    },
+    compare: {
+      label: 'Local version',
+    },
+    diff: computeNotebookDiff(upstreamNotebook, localNotebook, {
+      includeOutputs: true,
+      includeMetadata: true,
+    }),
+    resolution: {
+      kind: 'notebook-sync-conflict',
+      localUri,
+    },
+  })
+  openNotebookDiffDocument(document)
+}

--- a/app/src/lib/notebookDiff/model.ts
+++ b/app/src/lib/notebookDiff/model.ts
@@ -1,89 +1,94 @@
-import type { parser_pb } from "../../runme/client";
+import type { parser_pb } from '../../runme/client'
 
-export type TextDiffLineKind = "equal" | "removed" | "added";
+export type TextDiffLineKind = 'equal' | 'removed' | 'added'
 
 export interface TextDiffLine {
-  kind: TextDiffLineKind;
-  baseLine?: string;
-  compareLine?: string;
+  kind: TextDiffLineKind
+  baseLine?: string
+  compareLine?: string
 }
 
 export interface TextDiff {
-  changed: boolean;
-  lines: TextDiffLine[];
+  changed: boolean
+  lines: TextDiffLine[]
 }
 
 export interface MetadataDiff {
-  changed: boolean;
-  base: Record<string, string>;
-  compare: Record<string, string>;
+  changed: boolean
+  base: Record<string, string>
+  compare: Record<string, string>
 }
 
 export interface OutputItemSummary {
-  mime: string;
-  kind: "text" | "binary";
-  text?: string;
-  sizeBytes: number;
-  checksum: string;
+  mime: string
+  kind: 'text' | 'binary'
+  text?: string
+  sizeBytes: number
+  checksum: string
 }
 
 export interface OutputDiff {
-  changed: boolean;
-  baseItems: OutputItemSummary[];
-  compareItems: OutputItemSummary[];
-  textDiff?: TextDiff;
+  changed: boolean
+  baseItems: OutputItemSummary[]
+  compareItems: OutputItemSummary[]
+  textDiff?: TextDiff
 }
 
-export type CellDiffKind = "unchanged" | "inserted" | "deleted" | "modified";
+export type CellDiffKind = 'unchanged' | 'inserted' | 'deleted' | 'modified'
 
 export interface CellDiff {
-  id: string;
-  kind: CellDiffKind;
-  baseIndex?: number;
-  compareIndex?: number;
-  moved: boolean;
-  baseCell?: parser_pb.Cell;
-  compareCell?: parser_pb.Cell;
-  sourceDiff?: TextDiff;
-  metadataDiff?: MetadataDiff;
-  outputDiff?: OutputDiff;
-  changedFields: Array<"source" | "metadata" | "outputs" | "kind" | "language" | "move">;
+  id: string
+  kind: CellDiffKind
+  baseIndex?: number
+  compareIndex?: number
+  moved: boolean
+  baseCell?: parser_pb.Cell
+  compareCell?: parser_pb.Cell
+  sourceDiff?: TextDiff
+  metadataDiff?: MetadataDiff
+  outputDiff?: OutputDiff
+  changedFields: Array<
+    'source' | 'metadata' | 'outputs' | 'kind' | 'language' | 'move'
+  >
 }
 
 export interface NotebookDiffSummary {
-  unchangedCells: number;
-  insertedCells: number;
-  deletedCells: number;
-  modifiedCells: number;
-  movedCells: number;
-  sourceChanges: number;
-  metadataChanges: number;
-  outputChanges: number;
+  unchangedCells: number
+  insertedCells: number
+  deletedCells: number
+  modifiedCells: number
+  movedCells: number
+  sourceChanges: number
+  metadataChanges: number
+  outputChanges: number
 }
 
 export interface NotebookDiff {
-  baseLabel?: string;
-  compareLabel?: string;
-  cells: CellDiff[];
-  summary: NotebookDiffSummary;
+  baseLabel?: string
+  compareLabel?: string
+  cells: CellDiff[]
+  summary: NotebookDiffSummary
 }
 
 export interface NotebookDiffOptions {
-  includeOutputs?: boolean;
-  includeMetadata?: boolean;
-  ignoreTransientMetadata?: boolean;
+  includeOutputs?: boolean
+  includeMetadata?: boolean
+  ignoreTransientMetadata?: boolean
 }
 
 export interface NotebookDiffDocument {
-  id: string;
+  id: string
   base: {
-    label: string;
-    revisionId?: string;
-  };
+    label: string
+    revisionId?: string
+  }
   compare: {
-    label: string;
-    revisionId?: string;
-  };
-  diff: NotebookDiff;
+    label: string
+    revisionId?: string
+  }
+  diff: NotebookDiff
+  resolution?: {
+    kind: 'notebook-sync-conflict'
+    localUri: string
+  }
 }
-

--- a/app/src/lib/notebookDiff/registry.ts
+++ b/app/src/lib/notebookDiff/registry.ts
@@ -5,12 +5,20 @@ import type { NotebookDiffDocument } from './model'
 
 const documents = new Map<string, NotebookDiffDocument>()
 
+export const NOTEBOOK_DIFF_DOCUMENT_CHANGED =
+  'runme:notebook-diff-document-changed'
+
+export interface NotebookDiffDocumentChangedDetail {
+  id: string
+}
+
 export function registerNotebookDiffDocument(
   document: Omit<NotebookDiffDocument, 'id'> & { id?: string }
 ): NotebookDiffDocument {
   const id = document.id?.trim() || `notebook-diff-${uuidv4()}`
   const stored = { ...document, id }
   documents.set(id, stored)
+  emitNotebookDiffDocumentChanged(id)
   return stored
 }
 
@@ -44,4 +52,18 @@ export function openNotebookDiffDocument(
   showWorkspaceDocument(getNotebookDiffDocumentUri(id), {
     title: getNotebookDiffDocumentTitle(storedDocument),
   })
+}
+
+function emitNotebookDiffDocumentChanged(id: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  window.dispatchEvent(
+    new CustomEvent<NotebookDiffDocumentChangedDetail>(
+      NOTEBOOK_DIFF_DOCUMENT_CHANGED,
+      {
+        detail: { id },
+      }
+    )
+  )
 }

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1,103 +1,105 @@
-import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
+import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 
-import { parser_pb } from "../runme/client";
-import { getGoogleDriveBaseUrl } from "../lib/googleDriveRuntime";
+import { getGoogleDriveBaseUrl } from '../lib/googleDriveRuntime'
+import { parser_pb } from '../runme/client'
 import {
   type ConflictResult,
   NotebookStoreItem,
   NotebookStoreItemType,
-} from "./notebook";
+} from './notebook'
 
-const GAPI_SCRIPT_SRC = "https://apis.google.com/js/api.js";
+const GAPI_SCRIPT_SRC = 'https://apis.google.com/js/api.js'
 
 // VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file content version.
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
-const VERSION_FIELDS = "md5Checksum,headRevisionId";
+const VERSION_FIELDS = 'md5Checksum,headRevisionId'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
-} as unknown as Parameters<typeof toJsonString>[2];
+} as unknown as Parameters<typeof toJsonString>[2]
 
-let gapiScriptPromise: Promise<void> | null = null;
-let clientPromise: Promise<DriveFilesClient> | null = null;
+let gapiScriptPromise: Promise<void> | null = null
+let clientPromise: Promise<DriveFilesClient> | null = null
 
 // Minimal type definitions that describe just the specific pieces of the global
 // gapi client that this module relies on. This keeps the usage of window.gapi
 // type-safe without pulling in the full Google typings.
 type GapiLoadOptions = {
-  callback: () => void;
-  onerror?: (error: unknown) => void;
-};
-
-export type DriveDoc = {
-  id?: string;
-  name?: string;
-  mimeType?: string;
-  parents?: string[];
-  content?: string;
-};
-
-type GapiDriveFileMethods = {
-  create: (request: Record<string, unknown>) => Promise<unknown>;
-  update: (request: Record<string, unknown>) => Promise<unknown>;
-  get: (request: Record<string, unknown>) => Promise<unknown>;
-  list: (request: Record<string, unknown>) => Promise<unknown>;
-};
-
-type GapiDriveRevisionMethods = {
-  get: (request: Record<string, unknown>) => Promise<unknown>;
-  list: (request: Record<string, unknown>) => Promise<unknown>;
-};
-
-type GapiRequestArgs = {
-  path: string;
-  method?: string;
-  params?: Record<string, string>;
-  headers?: Record<string, string>;
-  body?: string | ArrayBuffer;
-};
-
-interface GapiGlobal {
-  load: (name: string, options: GapiLoadOptions) => void;
-  client: {
-    load: (name: string, version: string) => Promise<void>;
-    setToken: (token: { access_token: string }) => void;
-    getToken?: () => { access_token?: string } | null;
-    drive: {
-      files: GapiDriveFileMethods;
-      revisions: GapiDriveRevisionMethods;
-    };
-    request: (args: GapiRequestArgs) => Promise<unknown>;
-  };
+  callback: () => void
+  onerror?: (error: unknown) => void
 }
 
-type DriveCreateResponse = { result?: DriveDoc };
-type DriveUpdateResponse = { result?: DriveDoc };
-type DriveListResponse = { result?: { files?: DriveDoc[] } };
+export type DriveDoc = {
+  id?: string
+  name?: string
+  mimeType?: string
+  parents?: string[]
+  content?: string
+}
+
+type GapiDriveFileMethods = {
+  create: (request: Record<string, unknown>) => Promise<unknown>
+  update: (request: Record<string, unknown>) => Promise<unknown>
+  get: (request: Record<string, unknown>) => Promise<unknown>
+  list: (request: Record<string, unknown>) => Promise<unknown>
+}
+
+type GapiDriveRevisionMethods = {
+  get: (request: Record<string, unknown>) => Promise<unknown>
+  list: (request: Record<string, unknown>) => Promise<unknown>
+}
+
+type GapiRequestArgs = {
+  path: string
+  method?: string
+  params?: Record<string, string>
+  headers?: Record<string, string>
+  body?: string | ArrayBuffer
+}
+
+interface GapiGlobal {
+  load: (name: string, options: GapiLoadOptions) => void
+  client: {
+    load: (name: string, version: string) => Promise<void>
+    setToken: (token: { access_token: string }) => void
+    getToken?: () => { access_token?: string } | null
+    drive: {
+      files: GapiDriveFileMethods
+      revisions: GapiDriveRevisionMethods
+    }
+    request: (args: GapiRequestArgs) => Promise<unknown>
+  }
+}
+
+type DriveCreateResponse = { result?: DriveDoc }
+type DriveUpdateResponse = { result?: DriveDoc }
+type DriveListResponse = { result?: { files?: DriveDoc[] } }
 type DriveRevisionListResponse = {
-  result?: { revisions?: DriveRevision[]; nextPageToken?: string };
-};
+  result?: { revisions?: DriveRevision[]; nextPageToken?: string }
+}
 
 interface DriveFilesClient {
-  create(doc: DriveDoc): Promise<DriveDoc>;
-  update(doc: DriveDoc): Promise<DriveDoc>;
+  create(doc: DriveDoc): Promise<DriveDoc>
+  update(doc: DriveDoc): Promise<DriveDoc>
   get(
-    request: Record<string, unknown>,
-  ): Promise<{ body?: string; result?: unknown }>;
-  list(request: Record<string, unknown>): Promise<DriveListResponse>;
-  listRevisions(request: Record<string, unknown>): Promise<DriveRevisionListResponse>;
+    request: Record<string, unknown>
+  ): Promise<{ body?: string; result?: unknown }>
+  list(request: Record<string, unknown>): Promise<DriveListResponse>
+  listRevisions(
+    request: Record<string, unknown>
+  ): Promise<DriveRevisionListResponse>
   getRevision(
-    request: Record<string, unknown>,
-  ): Promise<{ body?: string; result?: unknown }>;
-  ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc>;
+    request: Record<string, unknown>
+  ): Promise<{ body?: string; result?: unknown }>
+  ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc>
 }
 
 class GapiDriveFilesClient implements DriveFilesClient {
-  private readonly files: GapiDriveFileMethods;
-  private readonly revisions: GapiDriveRevisionMethods;
+  private readonly files: GapiDriveFileMethods
+  private readonly revisions: GapiDriveRevisionMethods
 
   constructor(private readonly gapi: GapiGlobal) {
-    this.files = this.gapi.client.drive.files;
-    this.revisions = this.gapi.client.drive.revisions;
+    this.files = this.gapi.client.drive.files
+    this.revisions = this.gapi.client.drive.revisions
   }
 
   // setContent uploads content to a Google Drive file using a media upload.
@@ -111,162 +113,163 @@ class GapiDriveFilesClient implements DriveFilesClient {
   private async setContent(
     fileId: string,
     content: string,
-    mimeType?: string,
+    mimeType?: string
   ): Promise<void> {
-    const encoder = new TextEncoder();
-    const byteLength = encoder.encode(content).byteLength;
+    const encoder = new TextEncoder()
+    const byteLength = encoder.encode(content).byteLength
     await this.gapi.client.request({
       path: `https://www.googleapis.com/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
-      method: "PATCH",
+      method: 'PATCH',
       params: {
-        uploadType: "media",
+        uploadType: 'media',
         // If we don't set this we get a 404 because the file isn't in "My Drive."
-        supportsAllDrives: "true",
+        supportsAllDrives: 'true',
       },
       headers: {
-        Authorization: `Bearer ${this.gapi.client.getToken?.()?.access_token ?? ""}`,
-        "Content-Type": mimeType ?? "application/octet-stream",
-        "Content-Length": String(byteLength),
+        Authorization: `Bearer ${this.gapi.client.getToken?.()?.access_token ?? ''}`,
+        'Content-Type': mimeType ?? 'application/octet-stream',
+        'Content-Length': String(byteLength),
       },
       body: content,
-    });
+    })
   }
 
   private buildResource(doc: DriveDoc): Record<string, unknown> {
-    const resource: Record<string, unknown> = {};
-    if (typeof doc.name === "string") {
-      resource.name = doc.name;
+    const resource: Record<string, unknown> = {}
+    if (typeof doc.name === 'string') {
+      resource.name = doc.name
     }
-    if (typeof doc.mimeType === "string") {
-      resource.mimeType = doc.mimeType;
+    if (typeof doc.mimeType === 'string') {
+      resource.mimeType = doc.mimeType
     }
     if (Array.isArray(doc.parents)) {
-      resource.parents = doc.parents;
+      resource.parents = doc.parents
     }
-    return resource;
+    return resource
   }
 
   async create(doc: DriveDoc): Promise<DriveDoc> {
-    const resource = this.buildResource(doc);
+    const resource = this.buildResource(doc)
     const response = (await this.files.create({
       resource,
-      fields: "id,name,mimeType,parents",
+      fields: 'id,name,mimeType,parents',
       supportsAllDrives: true,
-    } as Record<string, unknown>)) as DriveCreateResponse;
-    const file = response.result ?? {};
+    } as Record<string, unknown>)) as DriveCreateResponse
+    const file = response.result ?? {}
     if (file.id && doc.content !== undefined) {
-      console.log(`Setting content for new Drive file ${file.id}`);
-      await this.setContent(file.id, doc.content, doc.mimeType);
+      console.log(`Setting content for new Drive file ${file.id}`)
+      await this.setContent(file.id, doc.content, doc.mimeType)
     }
-    return file;
+    return file
   }
 
   async update(doc: DriveDoc): Promise<DriveDoc> {
     if (!doc.id) {
-      throw new Error("Drive file id is required for update");
+      throw new Error('Drive file id is required for update')
     }
-    const resource = this.buildResource(doc);
-    let file: DriveDoc = { id: doc.id };
+    const resource = this.buildResource(doc)
+    let file: DriveDoc = { id: doc.id }
     if (Object.keys(resource).length > 0) {
       const response = (await this.files.update({
         fileId: doc.id,
         resource,
-        fields: "id,name,mimeType,parents",
+        fields: 'id,name,mimeType,parents',
         supportsAllDrives: true,
-      } as Record<string, unknown>)) as DriveUpdateResponse;
-      file = response.result ?? { id: doc.id };
+      } as Record<string, unknown>)) as DriveUpdateResponse
+      file = response.result ?? { id: doc.id }
     } else {
       file = {
         id: doc.id,
         name: doc.name,
         mimeType: doc.mimeType,
         parents: doc.parents,
-      };
+      }
     }
 
     if (doc.content !== undefined && file.id) {
-      await this.setContent(file.id, doc.content, doc.mimeType);
+      await this.setContent(file.id, doc.content, doc.mimeType)
     }
 
-    return file;
+    return file
   }
 
   get(
-    request: Record<string, unknown>,
+    request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }> {
     return this.files.get(request as any) as Promise<{
-      body?: string;
-      result?: unknown;
-    }>;
+      body?: string
+      result?: unknown
+    }>
   }
 
   list(request: Record<string, unknown>): Promise<DriveListResponse> {
-    return this.files.list(request as any) as Promise<DriveListResponse>;
+    return this.files.list(request as any) as Promise<DriveListResponse>
   }
 
-  listRevisions(request: Record<string, unknown>): Promise<DriveRevisionListResponse> {
-    return this.revisions.list(request as any) as Promise<DriveRevisionListResponse>;
+  listRevisions(
+    request: Record<string, unknown>
+  ): Promise<DriveRevisionListResponse> {
+    return this.revisions.list(
+      request as any
+    ) as Promise<DriveRevisionListResponse>
   }
 
   getRevision(
-    request: Record<string, unknown>,
+    request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }> {
     return this.revisions.get(request as any) as Promise<{
-      body?: string;
-      result?: unknown;
-    }>;
+      body?: string
+      result?: unknown
+    }>
   }
 
   async ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc> {
     if (!file.id || !parentId) {
-      return file;
+      return file
     }
     if ((file.parents ?? []).includes(parentId)) {
-      return file;
+      return file
     }
     const request: Record<string, unknown> = {
       fileId: file.id,
       addParents: parentId,
       supportsAllDrives: true,
-      fields: "id,name,mimeType,parents",
-    };
-    if ((file.parents ?? []).includes("root")) {
-      request.removeParents = "root";
+      fields: 'id,name,mimeType,parents',
     }
-    const response = (await this.files.update(request)) as DriveUpdateResponse;
-    return response.result ?? file;
+    if ((file.parents ?? []).includes('root')) {
+      request.removeParents = 'root'
+    }
+    const response = (await this.files.update(request)) as DriveUpdateResponse
+    return response.result ?? file
   }
 }
 
 class FetchDriveFilesClient implements DriveFilesClient {
   constructor(
     private readonly baseUrl: string,
-    private readonly accessToken: string,
+    private readonly accessToken: string
   ) {}
 
-  private buildUrl(
-    path: string,
-    params?: Record<string, unknown>,
-  ): string {
-    const url = new URL(path.replace(/^\//, ""), `${this.baseUrl}/`);
+  private buildUrl(path: string, params?: Record<string, unknown>): string {
+    const url = new URL(path.replace(/^\//, ''), `${this.baseUrl}/`)
     for (const [key, value] of Object.entries(params ?? {})) {
-      if (value === undefined || value === null || value === "") {
-        continue;
+      if (value === undefined || value === null || value === '') {
+        continue
       }
-      url.searchParams.set(key, String(value));
+      url.searchParams.set(key, String(value))
     }
-    return url.toString();
+    return url.toString()
   }
 
   private async request(
     method: string,
     path: string,
     options: {
-      params?: Record<string, unknown>;
-      body?: string;
-      contentType?: string;
-      expectText?: boolean;
-    } = {},
+      params?: Record<string, unknown>
+      body?: string
+      contentType?: string
+      expectText?: boolean
+    } = {}
   ): Promise<{ body?: string; result?: unknown }> {
     const response = await fetch(this.buildUrl(path, options.params), {
       method,
@@ -274,171 +277,177 @@ class FetchDriveFilesClient implements DriveFilesClient {
         Authorization: `Bearer ${this.accessToken}`,
         ...(options.body !== undefined
           ? {
-              "Content-Type": options.contentType ?? "application/json",
+              'Content-Type': options.contentType ?? 'application/json',
             }
           : {}),
       },
       body: options.body,
-    });
+    })
 
     if (!response.ok) {
-      const errorBody = await response.text().catch(() => "");
+      const errorBody = await response.text().catch(() => '')
       throw new Error(
-        `Drive request failed (${response.status} ${response.statusText}): ${errorBody}`,
-      );
+        `Drive request failed (${response.status} ${response.statusText}): ${errorBody}`
+      )
     }
 
     if (options.expectText) {
-      return { body: await response.text() };
+      return { body: await response.text() }
     }
 
-    const text = await response.text();
+    const text = await response.text()
     if (!text) {
-      return { result: undefined };
+      return { result: undefined }
     }
-    return { result: JSON.parse(text) };
+    return { result: JSON.parse(text) }
   }
 
   private buildResource(doc: DriveDoc): Record<string, unknown> {
-    const resource: Record<string, unknown> = {};
-    if (typeof doc.name === "string") {
-      resource.name = doc.name;
+    const resource: Record<string, unknown> = {}
+    if (typeof doc.name === 'string') {
+      resource.name = doc.name
     }
-    if (typeof doc.mimeType === "string") {
-      resource.mimeType = doc.mimeType;
+    if (typeof doc.mimeType === 'string') {
+      resource.mimeType = doc.mimeType
     }
     if (Array.isArray(doc.parents)) {
-      resource.parents = doc.parents;
+      resource.parents = doc.parents
     }
-    return resource;
+    return resource
   }
 
   private async setContent(
     fileId: string,
     content: string,
-    mimeType?: string,
+    mimeType?: string
   ): Promise<void> {
-    await this.request("PATCH", `/upload/drive/v3/files/${encodeURIComponent(fileId)}`, {
-      params: {
-        uploadType: "media",
-        supportsAllDrives: "true",
-      },
-      body: content,
-      contentType: mimeType ?? "application/octet-stream",
-    });
+    await this.request(
+      'PATCH',
+      `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
+      {
+        params: {
+          uploadType: 'media',
+          supportsAllDrives: 'true',
+        },
+        body: content,
+        contentType: mimeType ?? 'application/octet-stream',
+      }
+    )
   }
 
   async create(doc: DriveDoc): Promise<DriveDoc> {
-    const response = await this.request("POST", "/drive/v3/files", {
+    const response = await this.request('POST', '/drive/v3/files', {
       params: {
-        fields: "id,name,mimeType,parents",
-        supportsAllDrives: "true",
+        fields: 'id,name,mimeType,parents',
+        supportsAllDrives: 'true',
       },
       body: JSON.stringify(this.buildResource(doc)),
-    });
-    const file = (response.result ?? {}) as DriveDoc;
+    })
+    const file = (response.result ?? {}) as DriveDoc
     if (file.id && doc.content !== undefined) {
-      await this.setContent(file.id, doc.content, doc.mimeType);
+      await this.setContent(file.id, doc.content, doc.mimeType)
     }
-    return file;
+    return file
   }
 
   async update(doc: DriveDoc): Promise<DriveDoc> {
     if (!doc.id) {
-      throw new Error("Drive file id is required for update");
+      throw new Error('Drive file id is required for update')
     }
-    const resource = this.buildResource(doc);
-    let file: DriveDoc = { id: doc.id };
+    const resource = this.buildResource(doc)
+    let file: DriveDoc = { id: doc.id }
     if (Object.keys(resource).length > 0) {
       const response = await this.request(
-        "PATCH",
+        'PATCH',
         `/drive/v3/files/${encodeURIComponent(doc.id)}`,
         {
           params: {
-            fields: "id,name,mimeType,parents",
-            supportsAllDrives: "true",
+            fields: 'id,name,mimeType,parents',
+            supportsAllDrives: 'true',
           },
           body: JSON.stringify(resource),
-        },
-      );
-      file = (response.result ?? {}) as DriveDoc;
+        }
+      )
+      file = (response.result ?? {}) as DriveDoc
     }
 
     if (doc.content !== undefined) {
-      await this.setContent(doc.id, doc.content, doc.mimeType);
+      await this.setContent(doc.id, doc.content, doc.mimeType)
     }
 
-    return file.id ? file : { ...doc };
+    return file.id ? file : { ...doc }
   }
 
   get(
-    request: Record<string, unknown>,
+    request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }> {
-    const fileId = String(request.fileId ?? "");
+    const fileId = String(request.fileId ?? '')
     return this.request(
-      "GET",
+      'GET',
       `/drive/v3/files/${encodeURIComponent(fileId)}`,
       {
         params: request,
-        expectText: request.alt === "media",
-      },
-    );
+        expectText: request.alt === 'media',
+      }
+    )
   }
 
   list(request: Record<string, unknown>): Promise<DriveListResponse> {
-    return this.request("GET", "/drive/v3/files", {
+    return this.request('GET', '/drive/v3/files', {
       params: request,
-    }) as Promise<DriveListResponse>;
+    }) as Promise<DriveListResponse>
   }
 
-  listRevisions(request: Record<string, unknown>): Promise<DriveRevisionListResponse> {
-    const fileId = String(request.fileId ?? "");
+  listRevisions(
+    request: Record<string, unknown>
+  ): Promise<DriveRevisionListResponse> {
+    const fileId = String(request.fileId ?? '')
     return this.request(
-      "GET",
+      'GET',
       `/drive/v3/files/${encodeURIComponent(fileId)}/revisions`,
-      { params: request },
-    ) as Promise<DriveRevisionListResponse>;
+      { params: request }
+    ) as Promise<DriveRevisionListResponse>
   }
 
   getRevision(
-    request: Record<string, unknown>,
+    request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }> {
-    const fileId = String(request.fileId ?? "");
-    const revisionId = String(request.revisionId ?? "");
+    const fileId = String(request.fileId ?? '')
+    const revisionId = String(request.revisionId ?? '')
     return this.request(
-      "GET",
+      'GET',
       `/drive/v3/files/${encodeURIComponent(fileId)}/revisions/${encodeURIComponent(revisionId)}`,
       {
         params: request,
-        expectText: request.alt === "media",
-      },
-    );
+        expectText: request.alt === 'media',
+      }
+    )
   }
 
   async ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc> {
     if (!file.id || !parentId) {
-      return file;
+      return file
     }
     if ((file.parents ?? []).includes(parentId)) {
-      return file;
+      return file
     }
 
     const response = await this.request(
-      "PATCH",
+      'PATCH',
       `/drive/v3/files/${encodeURIComponent(file.id)}`,
       {
         params: {
           addParents: parentId,
-          supportsAllDrives: "true",
-          fields: "id,name,mimeType,parents",
-          ...((file.parents ?? []).includes("root")
-            ? { removeParents: "root" }
+          supportsAllDrives: 'true',
+          fields: 'id,name,mimeType,parents',
+          ...((file.parents ?? []).includes('root')
+            ? { removeParents: 'root' }
             : {}),
         },
-      },
-    );
+      }
+    )
 
-    return (response.result ?? file) as DriveDoc;
+    return (response.result ?? file) as DriveDoc
   }
 }
 
@@ -447,66 +456,66 @@ class FetchDriveFilesClient implements DriveFilesClient {
 // access window.gapi without falling back to any-typed shims.
 declare global {
   interface Window {
-    gapi?: GapiGlobal;
+    gapi?: GapiGlobal
   }
 }
 
 function loadGapiScript(): Promise<void> {
-  if (typeof window === "undefined") {
+  if (typeof window === 'undefined') {
     return Promise.reject(
-      new Error("Google APIs are only available in a browser environment"),
-    );
+      new Error('Google APIs are only available in a browser environment')
+    )
   }
 
   if (window.gapi?.load) {
-    return Promise.resolve();
+    return Promise.resolve()
   }
 
   if (!gapiScriptPromise) {
     gapiScriptPromise = new Promise<void>((resolve, reject) => {
       const existingScript = document.querySelector<HTMLScriptElement>(
-        `script[src="${GAPI_SCRIPT_SRC}"]`,
-      );
+        `script[src="${GAPI_SCRIPT_SRC}"]`
+      )
 
       if (existingScript) {
-        existingScript.addEventListener("load", () => resolve(), {
+        existingScript.addEventListener('load', () => resolve(), {
           once: true,
-        });
-        existingScript.addEventListener("error", reject, { once: true });
-        return;
+        })
+        existingScript.addEventListener('error', reject, { once: true })
+        return
       }
 
-      const script = document.createElement("script");
-      script.src = GAPI_SCRIPT_SRC;
-      script.async = true;
-      script.defer = true;
-      script.onload = () => resolve();
-      script.onerror = reject;
-      document.head.appendChild(script);
-    });
+      const script = document.createElement('script')
+      script.src = GAPI_SCRIPT_SRC
+      script.async = true
+      script.defer = true
+      script.onload = () => resolve()
+      script.onerror = reject
+      document.head.appendChild(script)
+    })
   }
 
   return gapiScriptPromise.then(() => {
     if (!window.gapi?.load) {
-      throw new Error("Google API script loaded but gapi is unavailable");
+      throw new Error('Google API script loaded but gapi is unavailable')
     }
-  });
+  })
 }
 
 async function ensureGapi(): Promise<typeof window.gapi> {
-  if (typeof window === "undefined") {
-    throw new Error("Google APIs are only available in a browser environment");
+  if (typeof window === 'undefined') {
+    throw new Error('Google APIs are only available in a browser environment')
   }
 
   if (!window.gapi?.load) {
-    await loadGapiScript();
+    await loadGapiScript()
   }
 
   if (!window.gapi?.load) {
-    throw new Error("Google API script failed to initialize gapi");
+    throw new Error('Google API script failed to initialize gapi')
   }
 
-  return window.gapi;
+  return window.gapi
 }
 
 // ensureDriveFilesClient creates a gapi client for the Google Drive Files API
@@ -518,109 +527,109 @@ async function ensureGapi(): Promise<typeof window.gapi> {
 // The more common pattern seems to be to have the client take a reference to a class/function
 // which can be called to get get a token and which handles refreshing the token as needed.
 async function ensureDriveFilesClient(
-  accessToken: string,
+  accessToken: string
 ): Promise<DriveFilesClient> {
-  const baseUrl = getGoogleDriveBaseUrl();
+  const baseUrl = getGoogleDriveBaseUrl()
   if (baseUrl) {
-    return new FetchDriveFilesClient(baseUrl, accessToken);
+    return new FetchDriveFilesClient(baseUrl, accessToken)
   }
 
-  const gapi = await ensureGapi();
+  const gapi = await ensureGapi()
   if (!gapi) {
-    throw new Error("Google API client is unavailable");
+    throw new Error('Google API client is unavailable')
   }
 
   if (!clientPromise) {
     clientPromise = new Promise<DriveFilesClient>((resolve, reject) => {
-      gapi.load("client", {
+      gapi.load('client', {
         callback: async () => {
           try {
-            await gapi.client.load("drive", "v3");
-            resolve(new GapiDriveFilesClient(gapi));
+            await gapi.client.load('drive', 'v3')
+            resolve(new GapiDriveFilesClient(gapi))
           } catch (error) {
-            reject(error);
+            reject(error)
           }
         },
         onerror: (error: unknown) => reject(error),
-      });
+      })
     }).catch((error) => {
-      clientPromise = null;
-      throw error;
-    });
+      clientPromise = null
+      throw error
+    })
   }
 
-  const pendingClient = clientPromise;
+  const pendingClient = clientPromise
   if (!pendingClient) {
-    throw new Error("Google Drive client initialization failed");
+    throw new Error('Google Drive client initialization failed')
   }
-  const client = await pendingClient;
-  gapi.client.setToken({ access_token: accessToken });
-  return client;
+  const client = await pendingClient
+  gapi.client.setToken({ access_token: accessToken })
+  return client
 }
 
 function validateDriveId(id: string | null | undefined): string {
   if (!id) {
-    throw new Error("Google Drive URI is missing a file identifier");
+    throw new Error('Google Drive URI is missing a file identifier')
   }
-  const trimmed = id.trim();
+  const trimmed = id.trim()
   if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) {
     throw new Error(
-      `Google Drive identifier contains invalid characters: ${id}`,
-    );
+      `Google Drive identifier contains invalid characters: ${id}`
+    )
   }
-  return trimmed;
+  return trimmed
 }
 
 export function driveFileUrl(id: string): string {
-  return `https://drive.google.com/file/d/${encodeURIComponent(id)}/view`;
+  return `https://drive.google.com/file/d/${encodeURIComponent(id)}/view`
 }
 
 export function driveFolderUrl(id: string): string {
-  return `https://drive.google.com/drive/folders/${encodeURIComponent(id)}`;
+  return `https://drive.google.com/drive/folders/${encodeURIComponent(id)}`
 }
 
 export interface DriveItem {
-  id: string;
-  type: NotebookStoreItemType;
+  id: string
+  type: NotebookStoreItemType
 }
 
 type DriveFileMetadata = {
-  id?: string;
-  name?: string;
-  mimeType?: string;
-  parents?: string[];
-};
+  id?: string
+  name?: string
+  mimeType?: string
+  parents?: string[]
+}
 
 export interface DriveVersionMetadata {
-  md5Checksum?: string;
-  headRevisionId?: string;
+  md5Checksum?: string
+  headRevisionId?: string
 }
 
 export interface DriveRevision {
-  id?: string;
-  mimeType?: string;
-  modifiedTime?: string;
-  md5Checksum?: string;
-  size?: string;
-  keepForever?: boolean;
+  id?: string
+  mimeType?: string
+  modifiedTime?: string
+  md5Checksum?: string
+  size?: string
+  keepForever?: boolean
   lastModifyingUser?: {
-    displayName?: string;
-    emailAddress?: string;
-  };
+    displayName?: string
+    emailAddress?: string
+  }
 }
 
 function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
+  return typeof value === 'string' ? value : undefined
 }
 
 function normalizeDriveRevision(revision: DriveRevision): DriveRevision {
   const lastModifyingUser =
-    revision.lastModifyingUser && typeof revision.lastModifyingUser === "object"
+    revision.lastModifyingUser && typeof revision.lastModifyingUser === 'object'
       ? {
           displayName: optionalString(revision.lastModifyingUser.displayName),
           emailAddress: optionalString(revision.lastModifyingUser.emailAddress),
         }
-      : undefined;
+      : undefined
 
   return {
     id: optionalString(revision.id),
@@ -629,159 +638,162 @@ function normalizeDriveRevision(revision: DriveRevision): DriveRevision {
     md5Checksum: optionalString(revision.md5Checksum),
     size: optionalString(revision.size),
     keepForever:
-      typeof revision.keepForever === "boolean"
+      typeof revision.keepForever === 'boolean'
         ? revision.keepForever
         : undefined,
     lastModifyingUser,
-  };
+  }
 }
 
 export function parseDriveItem(uri: string): DriveItem {
   if (!uri) {
-    throw new Error("Google Drive URI must be provided");
+    throw new Error('Google Drive URI must be provided')
   }
 
-  const trimmed = uri.trim();
-  let id: string | undefined;
-  let type: NotebookStoreItemType = NotebookStoreItemType.File;
+  const trimmed = uri.trim()
+  let id: string | undefined
+  let type: NotebookStoreItemType = NotebookStoreItemType.File
 
   try {
-    const url = new URL(trimmed);
-    const pathname = url.pathname;
+    const url = new URL(trimmed)
+    const pathname = url.pathname
 
     if (/\/folders\//.test(pathname)) {
-      type = NotebookStoreItemType.Folder;
-      id = pathname.match(/\/folders\/([^/]+)/)?.[1];
+      type = NotebookStoreItemType.Folder
+      id = pathname.match(/\/folders\/([^/]+)/)?.[1]
     } else if (/\/file\//.test(pathname) || /\/d\//.test(pathname)) {
-      id = pathname.match(/\/d\/([^/]+)/)?.[1];
+      id = pathname.match(/\/d\/([^/]+)/)?.[1]
     }
 
     if (!id) {
-      const queryId = url.searchParams.get("id");
+      const queryId = url.searchParams.get('id')
       if (queryId) {
-        id = queryId;
+        id = queryId
       }
     }
 
     if (!id && url.hash) {
-      const hashId = url.hash.match(/id=([^&]+)/)?.[1];
+      const hashId = url.hash.match(/id=([^&]+)/)?.[1]
       if (hashId) {
-        id = hashId;
+        id = hashId
       }
     }
 
     if (!id) {
-      id = pathname.split("/").filter(Boolean).pop();
+      id = pathname.split('/').filter(Boolean).pop()
     }
   } catch {
     // Not a full URL, fall back to raw identifier below.
   }
 
   if (!id && /^[A-Za-z0-9_-]+$/.test(trimmed)) {
-    id = trimmed;
+    id = trimmed
   }
 
   if (!id) {
     throw new Error(
-      `Unable to extract a Google Drive identifier from URI: ${uri}`,
-    );
+      `Unable to extract a Google Drive identifier from URI: ${uri}`
+    )
   }
 
-  id = validateDriveId(id);
-  return { id, type };
+  id = validateDriveId(id)
+  return { id, type }
 }
 
 export function isDriveItemUri(uri: string | undefined): boolean {
   if (!uri) {
-    return false;
+    return false
   }
 
-  let url: URL;
+  let url: URL
   try {
-    url = new URL(uri);
+    url = new URL(uri)
   } catch {
-    return false;
+    return false
   }
 
   if (
-    (url.protocol !== "https:" && url.protocol !== "http:") ||
-    url.hostname !== "drive.google.com"
+    (url.protocol !== 'https:' && url.protocol !== 'http:') ||
+    url.hostname !== 'drive.google.com'
   ) {
-    return false;
+    return false
   }
 
-  const pathname = url.pathname;
+  const pathname = url.pathname
   const hasDrivePathId =
     /\/drive\/folders\/[^/]+/.test(pathname) ||
     /\/file\/d\/[^/]+/.test(pathname) ||
-    /\/d\/[^/]+/.test(pathname);
+    /\/d\/[^/]+/.test(pathname)
   const hasLegacyQueryId =
-    (pathname === "/open" || pathname === "/uc") &&
-    !!url.searchParams.get("id");
-  const hasHashId = /(?:^|[#&?])id=[^&]+/.test(url.hash);
+    (pathname === '/open' || pathname === '/uc') && !!url.searchParams.get('id')
+  const hasHashId = /(?:^|[#&?])id=[^&]+/.test(url.hash)
 
   if (!hasDrivePathId && !hasLegacyQueryId && !hasHashId) {
-    return false;
+    return false
   }
 
   try {
-    parseDriveItem(uri);
-    return true;
+    parseDriveItem(uri)
+    return true
   } catch {
-    return false;
+    return false
   }
 }
 
 function createInitialNotebookJson(): string {
   const notebook = create(parser_pb.NotebookSchema, {
     cells: [],
-  });
-  return toJsonString(parser_pb.NotebookSchema, notebook, NOTEBOOK_JSON_WRITE_OPTIONS);
+  })
+  return toJsonString(
+    parser_pb.NotebookSchema,
+    notebook,
+    NOTEBOOK_JSON_WRITE_OPTIONS
+  )
 }
 
 function extractBody(response: { body?: string; result?: unknown }): string {
-  if (typeof response.body === "string") {
-    return response.body;
+  if (typeof response.body === 'string') {
+    return response.body
   }
-  if (typeof response.result === "string") {
-    return response.result;
+  if (typeof response.result === 'string') {
+    return response.result
   }
-  if (response.result && typeof response.result === "object") {
-    return JSON.stringify(response.result);
+  if (response.result && typeof response.result === 'object') {
+    return JSON.stringify(response.result)
   }
-  throw new Error("Google Drive response did not include any content");
+  throw new Error('Google Drive response did not include any content')
 }
 
 export class DriveNotebookStore {
   // ensureAccessToken is injected because it comes from the GoogleAuthContext
   constructor(private readonly ensureAccessToken: () => Promise<string>) {}
 
-  private readonly lastReadVersion = new Map<string, string>();
+  private readonly lastReadVersion = new Map<string, string>()
 
   private async getFilesClient(): Promise<DriveFilesClient> {
-    const token = await this.ensureAccessToken();
-    return ensureDriveFilesClient(token);
+    const token = await this.ensureAccessToken()
+    return ensureDriveFilesClient(token)
   }
 
   async create(parentUri: string, name: string): Promise<NotebookStoreItem> {
-    const { id, type } = parseDriveItem(parentUri);
+    const { id, type } = parseDriveItem(parentUri)
     if (type !== NotebookStoreItemType.Folder) {
-      throw new Error("DriveNotebookStore.create expects a folder URI");
+      throw new Error('DriveNotebookStore.create expects a folder URI')
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     let file = await client.create({
       name,
-      mimeType: "application/json",
+      mimeType: 'application/json',
       parents: [id],
       content: createInitialNotebookJson(),
-    });
+    })
 
     if (!file.id) {
-      throw new Error("Failed to create Google Drive notebook file");
+      throw new Error('Failed to create Google Drive notebook file')
     }
-    const fileId = file.id;
-    file = await client.ensureParent(file, id);
-    const isFolder = file.mimeType === "application/vnd.google-apps.folder";
+    const fileId = file.id
+    file = await client.ensureParent(file, id)
+    const isFolder = file.mimeType === 'application/vnd.google-apps.folder'
     return {
       uri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       name: file.name ?? name,
@@ -791,215 +803,225 @@ export class DriveNotebookStore {
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       parents: [parentUri],
-    };
+    }
   }
 
-  async save(uri: string, notebook: parser_pb.Notebook): Promise<ConflictResult> {
-    const { id, type } = parseDriveItem(uri);
+  async save(
+    uri: string,
+    notebook: parser_pb.Notebook
+  ): Promise<ConflictResult> {
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.save expects a file URI");
+      throw new Error('DriveNotebookStore.save expects a file URI')
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const metadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
       //fields: "md5Checksum",
       fields: VERSION_FIELDS,
-    });
+    })
     const remoteMd5 =
       (metadataResponse.result as { md5Checksum?: string } | undefined)
-        ?.md5Checksum ?? null;
-    const lastRead = this.lastReadVersion.get(uri) ?? null;
+        ?.md5Checksum ?? null
+    const lastRead = this.lastReadVersion.get(uri) ?? null
     if (lastRead && remoteMd5 && remoteMd5 !== lastRead) {
       console.error(
-        "DriveNotebookStore.save aborted due to checksum mismatch",
+        'DriveNotebookStore.save aborted due to checksum mismatch',
         {
           uri,
           expected: lastRead,
           actual: remoteMd5,
-        },
-      );
-      return { conflicted: true };
+        }
+      )
+      return { conflicted: true }
     }
     const json = toJsonString(
       parser_pb.NotebookSchema,
       notebook,
-      NOTEBOOK_JSON_WRITE_OPTIONS,
-    );
+      NOTEBOOK_JSON_WRITE_OPTIONS
+    )
 
     await client.update({
       id,
-      mimeType: "application/json",
+      mimeType: 'application/json',
       content: json,
-    });
+    })
     const updatedMetadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
       fields: VERSION_FIELDS,
-    });
+    })
     const updatedMd5 =
       (updatedMetadataResponse.result as { md5Checksum?: string } | undefined)
-        ?.md5Checksum ?? null;
+        ?.md5Checksum ?? null
     if (updatedMd5) {
-      this.lastReadVersion.set(uri, updatedMd5);
+      this.lastReadVersion.set(uri, updatedMd5)
     } else {
-      this.lastReadVersion.delete(uri);
+      this.lastReadVersion.delete(uri)
     }
-    return { conflicted: false };
+    return { conflicted: false }
   }
 
   async load(uri: string): Promise<parser_pb.Notebook> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.load expects a file URI");
+      throw new Error('DriveNotebookStore.load expects a file URI')
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const metadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
       fields: VERSION_FIELDS,
-    });
+    })
     const md5 =
       (metadataResponse.result as { md5Checksum?: string } | undefined)
-        ?.md5Checksum ?? null;
+        ?.md5Checksum ?? null
     if (md5) {
-      this.lastReadVersion.set(uri, md5);
+      this.lastReadVersion.set(uri, md5)
     } else {
-      this.lastReadVersion.delete(uri);
+      this.lastReadVersion.delete(uri)
     }
     const response = await client.get({
       fileId: id,
       supportsAllDrives: true,
-      alt: "media",
-    });
+      alt: 'media',
+    })
 
-    const body = extractBody(response);
+    const body = extractBody(response)
 
     return fromJsonString(parser_pb.NotebookSchema, body, {
       ignoreUnknownFields: true,
-    });
+    })
   }
 
   async list(uri: string): Promise<NotebookStoreItem[]> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.Folder) {
       throw new Error(
-        "Google Drive URI must reference a folder to list contents",
-      );
+        'Google Drive URI must reference a folder to list contents'
+      )
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const response = await client.list({
       q: `'${id}' in parents and trashed = false`,
       includeItemsFromAllDrives: true,
       supportsAllDrives: true,
-      orderBy: "name",
-      fields: "files(id,name,mimeType)",
-    });
+      orderBy: 'name',
+      fields: 'files(id,name,mimeType)',
+    })
 
     const files = (response.result?.files ?? []).filter(
-      (file): file is DriveDoc & { id: string } => Boolean(file?.id),
-    );
+      (file): file is DriveDoc & { id: string } => Boolean(file?.id)
+    )
 
     return files.map((file) => {
-      const isFolder = file.mimeType === "application/vnd.google-apps.folder";
+      const isFolder = file.mimeType === 'application/vnd.google-apps.folder'
       return {
         uri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
-        name: file.name ?? "Untitled item",
+        name: file.name ?? 'Untitled item',
         type: isFolder
           ? NotebookStoreItemType.Folder
           : NotebookStoreItemType.File,
         children: [],
         remoteUri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
         parents: [],
-      };
-    });
+      }
+    })
   }
 
   async getType(uri: string): Promise<NotebookStoreItemType> {
-    return parseDriveItem(uri).type;
+    return parseDriveItem(uri).type
   }
 
   async getChecksum(uri: string): Promise<string | null> {
-    return (await this.getVersionMetadata(uri))?.md5Checksum ?? null;
+    return (await this.getVersionMetadata(uri))?.md5Checksum ?? null
   }
 
   async getVersionMetadata(uri: string): Promise<DriveVersionMetadata | null> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.getVersionMetadata expects a file URI");
+      throw new Error(
+        'DriveNotebookStore.getVersionMetadata expects a file URI'
+      )
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const metadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
       fields: VERSION_FIELDS,
-    });
-    const result = metadataResponse.result as DriveVersionMetadata | undefined;
-    return result ?? null;
+    })
+    const result = metadataResponse.result as DriveVersionMetadata | undefined
+    if (result?.md5Checksum) {
+      this.lastReadVersion.set(uri, result.md5Checksum)
+    } else {
+      this.lastReadVersion.delete(uri)
+    }
+    return result ?? null
   }
 
   async listRevisions(uri: string): Promise<DriveRevision[]> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.listRevisions expects a file URI");
+      throw new Error('DriveNotebookStore.listRevisions expects a file URI')
     }
-    const client = await this.getFilesClient();
-    const revisions: DriveRevision[] = [];
-    let pageToken: string | undefined;
+    const client = await this.getFilesClient()
+    const revisions: DriveRevision[] = []
+    let pageToken: string | undefined
 
     do {
       const response = await client.listRevisions({
         fileId: id,
         supportsAllDrives: true,
         fields:
-          "nextPageToken,revisions(id,mimeType,modifiedTime,md5Checksum,size,keepForever,lastModifyingUser(displayName,emailAddress))",
+          'nextPageToken,revisions(id,mimeType,modifiedTime,md5Checksum,size,keepForever,lastModifyingUser(displayName,emailAddress))',
         ...(pageToken ? { pageToken } : {}),
-      });
-      revisions.push(...(response.result?.revisions ?? []));
-      pageToken = optionalString(response.result?.nextPageToken);
-    } while (pageToken);
+      })
+      revisions.push(...(response.result?.revisions ?? []))
+      pageToken = optionalString(response.result?.nextPageToken)
+    } while (pageToken)
 
-    return revisions.map(normalizeDriveRevision);
+    return revisions.map(normalizeDriveRevision)
   }
 
   async loadRevision(
     uri: string,
-    revisionId: string,
+    revisionId: string
   ): Promise<parser_pb.Notebook> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.loadRevision expects a file URI");
+      throw new Error('DriveNotebookStore.loadRevision expects a file URI')
     }
     if (!revisionId?.trim()) {
-      throw new Error("DriveNotebookStore.loadRevision requires a revision id");
+      throw new Error('DriveNotebookStore.loadRevision requires a revision id')
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const response = await client.getRevision({
       fileId: id,
       revisionId: revisionId.trim(),
       supportsAllDrives: true,
-      alt: "media",
-    });
-    const body = extractBody(response);
+      alt: 'media',
+    })
+    const body = extractBody(response)
     return fromJsonString(parser_pb.NotebookSchema, body, {
       ignoreUnknownFields: true,
-    });
+    })
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.rename expects a file URI");
+      throw new Error('DriveNotebookStore.rename expects a file URI')
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const file = await client.update({
       id,
       name,
-    });
+    })
 
-    const fileId = file.id ?? id;
-    const mimeType = file.mimeType;
-    const isFolder = mimeType === "application/vnd.google-apps.folder";
+    const fileId = file.id ?? id
+    const mimeType = file.mimeType
+    const isFolder = mimeType === 'application/vnd.google-apps.folder'
     return {
       uri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       name: file.name ?? name,
@@ -1009,7 +1031,7 @@ export class DriveNotebookStore {
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       parents: [],
-    };
+    }
   }
 
   /**
@@ -1019,55 +1041,54 @@ export class DriveNotebookStore {
   async saveContent(
     uri: string,
     content: string,
-    mimeType: string = "application/octet-stream",
+    mimeType: string = 'application/octet-stream'
   ): Promise<void> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
-      throw new Error("DriveNotebookStore.saveContent expects a file URI");
+      throw new Error('DriveNotebookStore.saveContent expects a file URI')
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     await client.update({
       id,
       mimeType,
       content,
-    });
+    })
   }
 
   async getMetadata(uri: string): Promise<NotebookStoreItem | null> {
-    const { id, type } = parseDriveItem(uri);
+    const { id, type } = parseDriveItem(uri)
     if (
       type !== NotebookStoreItemType.File &&
       type !== NotebookStoreItemType.Folder
     ) {
-      return null;
+      return null
     }
-    const client = await this.getFilesClient();
+    const client = await this.getFilesClient()
     const response = await client.get({
       fileId: id,
       supportsAllDrives: true,
-      fields: "id,name,mimeType,parents",
-    });
+      fields: 'id,name,mimeType,parents',
+    })
     const result = response.result as {
-      name?: string;
-      mimeType?: string;
-      parents?: string[];
-    };
-    const isFolder =
-      result?.mimeType === "application/vnd.google-apps.folder";
+      name?: string
+      mimeType?: string
+      parents?: string[]
+    }
+    const isFolder = result?.mimeType === 'application/vnd.google-apps.folder'
     const resolvedType = isFolder
       ? NotebookStoreItemType.Folder
-      : NotebookStoreItemType.File;
+      : NotebookStoreItemType.File
     const parentIds = Array.isArray(result.parents)
       ? result.parents.filter((parentId): parentId is string =>
-          Boolean(parentId),
+          Boolean(parentId)
         )
-      : [];
+      : []
     const parentUris = parentIds.map((parentId) => {
-      if (parentId === "root") {
-        return parentId;
+      if (parentId === 'root') {
+        return parentId
       }
-      return driveFolderUrl(parentId);
-    });
+      return driveFolderUrl(parentId)
+    })
     return {
       uri,
       name: result?.name ?? uri,
@@ -1075,69 +1096,71 @@ export class DriveNotebookStore {
       children: [],
       remoteUri: uri,
       parents: parentUris,
-    };
+    }
   }
 }
 
 export async function fetchDriveItemWithParents(
   uri: string,
-  ensureAccessToken: () => Promise<string>,
+  ensureAccessToken: () => Promise<string>
 ): Promise<{ item: NotebookStoreItem; parents: NotebookStoreItem[] }> {
-  const { id, type } = parseDriveItem(uri);
+  const { id, type } = parseDriveItem(uri)
   if (
     type !== NotebookStoreItemType.File &&
     type !== NotebookStoreItemType.Folder
   ) {
-    throw new Error("Unsupported Google Drive item type");
+    throw new Error('Unsupported Google Drive item type')
   }
 
-  const client = await ensureDriveFilesClient(await ensureAccessToken());
+  const client = await ensureDriveFilesClient(await ensureAccessToken())
 
   const metadataResponse = await client.get({
     fileId: id,
     supportsAllDrives: true,
-    fields: "id,name,mimeType,parents",
-  });
+    fields: 'id,name,mimeType,parents',
+  })
 
-  const meta = (metadataResponse.result ?? {}) as DriveFileMetadata;
+  const meta = (metadataResponse.result ?? {}) as DriveFileMetadata
   if (!meta.id) {
-    throw new Error("Google Drive did not return file metadata");
+    throw new Error('Google Drive did not return file metadata')
   }
 
-  const parentIds = Array.isArray(meta.parents) ? meta.parents : [];
+  const parentIds = Array.isArray(meta.parents) ? meta.parents : []
   const parentUris = parentIds
     .filter((parentId): parentId is string => Boolean(parentId))
-    .map((parentId) => (parentId === "root" ? parentId : driveFolderUrl(parentId)));
+    .map((parentId) =>
+      parentId === 'root' ? parentId : driveFolderUrl(parentId)
+    )
 
-  const isFolder = meta.mimeType === "application/vnd.google-apps.folder";
+  const isFolder = meta.mimeType === 'application/vnd.google-apps.folder'
   const item: NotebookStoreItem = {
     uri: isFolder ? driveFolderUrl(meta.id) : driveFileUrl(meta.id),
-    name: meta.name ?? "Untitled item",
+    name: meta.name ?? 'Untitled item',
     type: isFolder ? NotebookStoreItemType.Folder : NotebookStoreItemType.File,
     children: [],
     remoteUri: isFolder ? driveFolderUrl(meta.id) : driveFileUrl(meta.id),
     parents: parentUris,
-  };
+  }
 
-  const parents: NotebookStoreItem[] = [];
+  const parents: NotebookStoreItem[] = []
   for (const parentId of parentIds) {
     try {
       const parentResponse = await client.get({
         fileId: parentId,
         supportsAllDrives: true,
-        fields: "id,name,mimeType",
-      });
-      const parentMeta = (parentResponse.result ?? {}) as DriveFileMetadata;
+        fields: 'id,name,mimeType',
+      })
+      const parentMeta = (parentResponse.result ?? {}) as DriveFileMetadata
       if (!parentMeta.id) {
-        continue;
+        continue
       }
       const parentIsFolder =
-        parentMeta.mimeType === "application/vnd.google-apps.folder";
+        parentMeta.mimeType === 'application/vnd.google-apps.folder'
       parents.push({
         uri: parentIsFolder
           ? driveFolderUrl(parentMeta.id)
           : driveFileUrl(parentMeta.id),
-        name: parentMeta.name ?? "Untitled folder",
+        name: parentMeta.name ?? 'Untitled folder',
         type: parentIsFolder
           ? NotebookStoreItemType.Folder
           : NotebookStoreItemType.File,
@@ -1146,11 +1169,11 @@ export async function fetchDriveItemWithParents(
           ? driveFolderUrl(parentMeta.id)
           : driveFileUrl(parentMeta.id),
         parents: [],
-      });
+      })
     } catch (error) {
-      console.error("Failed to fetch drive parent metadata", parentId, error);
+      console.error('Failed to fetch drive parent metadata', parentId, error)
     }
   }
 
-  return { item, parents };
+  return { item, parents }
 }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1,40 +1,42 @@
 /// <reference types="vitest" />
 // @vitest-environment node
-import { create, toJsonString } from "@bufbuild/protobuf";
-import { describe, expect, it, vi } from "vitest";
+import { create, toJsonString } from '@bufbuild/protobuf'
+import md5 from 'md5'
+import { describe, expect, it, vi } from 'vitest'
 
-import { MimeType, parser_pb } from "../runme/client";
+import { MimeType, parser_pb } from '../runme/client'
 import LocalNotebooks, {
   type LocalFileRecord,
   type LocalFolderRecord,
-} from "./local";
-import { NotebookStoreItemType } from "./notebook";
+  NotebookConflictChangedError,
+} from './local'
+import { NotebookStoreItemType } from './notebook'
 
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
-} as unknown as Parameters<typeof toJsonString>[2];
+} as unknown as Parameters<typeof toJsonString>[2]
 
 function createMockTable<T extends { id: string }>() {
-  const store = new Map<string, T>();
+  const store = new Map<string, T>()
   return {
     _store: store,
     get: vi.fn(async (id: string) => store.get(id) ?? undefined),
     put: vi.fn(async (record: T) => {
-      store.set(record.id, record);
-      return record.id;
+      store.set(record.id, record)
+      return record.id
     }),
     update: vi.fn(async (id: string, changes: Partial<T>) => {
-      const existing = store.get(id);
+      const existing = store.get(id)
       if (!existing) {
-        return 0;
+        return 0
       }
-      store.set(id, { ...existing, ...changes });
-      return 1;
+      store.set(id, { ...existing, ...changes })
+      return 1
     }),
     where: vi.fn((field: keyof T) => ({
       equals: vi.fn((value: unknown) => ({
         first: vi.fn(async () =>
-          [...store.values()].find((record) => record[field] === value),
+          [...store.values()].find((record) => record[field] === value)
         ),
       })),
     })),
@@ -42,382 +44,621 @@ function createMockTable<T extends { id: string }>() {
       toArray: vi.fn(async () => [...store.values()].filter(predicate)),
       first: vi.fn(async () => [...store.values()].find(predicate)),
     })),
-  };
+  }
 }
 
 function createTestStore(driveStore: unknown) {
-  const localStore = Object.create(LocalNotebooks.prototype) as any;
-  localStore.files = createMockTable<LocalFileRecord>();
-  localStore.folders = createMockTable<LocalFolderRecord>();
-  localStore.driveStore = driveStore;
-  localStore.filesystemStore = null;
-  localStore.inFlightSyncs = new Map();
-  localStore.syncListeners = new Map();
-  localStore.syncSubjects = new Map();
-  localStore.markdownSyncSubjects = new Map();
-  return localStore as LocalNotebooks;
+  const localStore = Object.create(LocalNotebooks.prototype) as any
+  localStore.files = createMockTable<LocalFileRecord>()
+  localStore.folders = createMockTable<LocalFolderRecord>()
+  localStore.driveStore = driveStore
+  localStore.filesystemStore = null
+  localStore.inFlightSyncs = new Map()
+  localStore.syncListeners = new Map()
+  localStore.syncSubjects = new Map()
+  localStore.markdownSyncSubjects = new Map()
+  return localStore as LocalNotebooks
 }
 
-describe("LocalNotebooks pending Drive create", () => {
-  it("persists pending upstream parent when Drive create fails", async () => {
-    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
+function notebookJson(value: string): string {
+  return toJsonString(
+    parser_pb.NotebookSchema,
+    create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value,
+        }),
+      ],
+    }),
+    NOTEBOOK_JSON_WRITE_OPTIONS
+  )
+}
+
+describe('LocalNotebooks pending Drive create', () => {
+  it('persists pending upstream parent when Drive create fails', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
     const driveStore = {
       create: vi.fn(async () => {
-        throw new Error("Google Drive authorization is required.");
+        throw new Error('Google Drive authorization is required.')
       }),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     await store.folders.put({
-      id: "local://folder/drive",
-      name: "Drive",
+      id: 'local://folder/drive',
+      name: 'Drive',
       remoteId: parentRemoteUri,
       children: [],
-      lastSynced: "",
-    });
+      lastSynced: '',
+    })
 
-    const item = await store.create("local://folder/drive", "draft.json");
+    const item = await store.create('local://folder/drive', 'draft.json')
 
-    expect(item.type).toBe(NotebookStoreItemType.File);
-    const record = await store.files.get(item.uri);
-    expect(record?.remoteId).toBe("");
-    expect(record?.parentRemoteIdWhenCreated).toBe(parentRemoteUri);
+    expect(item.type).toBe(NotebookStoreItemType.File)
+    const record = await store.files.get(item.uri)
+    expect(record?.remoteId).toBe('')
+    expect(record?.parentRemoteIdWhenCreated).toBe(parentRemoteUri)
     expect(
-      (await store.folders.get("local://folder/drive"))?.children,
-    ).toContain(item.uri);
-  });
+      (await store.folders.get('local://folder/drive'))?.children
+    ).toContain(item.uri)
+  })
 
-  it("reports pending upstream creation in sync state", async () => {
-    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
-    const store = createTestStore({});
+  it('reports pending upstream creation in sync state', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const store = createTestStore({})
     await store.files.put({
-      id: "local://file/pending",
-      name: "draft.json",
-      remoteId: "",
+      id: 'local://file/pending',
+      name: 'draft.json',
+      remoteId: '',
       parentRemoteIdWhenCreated: parentRemoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "",
-      md5Checksum: "",
-    });
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
 
     await expect(
-      store.getSyncState("local://file/pending"),
+      store.getSyncState('local://file/pending')
     ).resolves.toMatchObject({
-      status: "pending-upstream-create",
+      status: 'pending-upstream-create',
       parentRemoteIdWhenCreated: parentRemoteUri,
-    });
-  });
+    })
+  })
 
-  it("creates the Drive file on sync and clears pending parent", async () => {
-    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
-    const remoteUri = "https://drive.google.com/file/d/file123/view";
+  it('creates the Drive file on sync and clears pending parent', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const driveStore = {
       create: vi.fn(async () => ({
         uri: remoteUri,
-        name: "draft.json",
+        name: 'draft.json',
         type: NotebookStoreItemType.File,
         children: [],
         parents: [parentRemoteUri],
       })),
       getVersionMetadata: vi.fn(async () => ({
-        md5Checksum: "checksum-1",
-        headRevisionId: "revision-1",
+        md5Checksum: 'checksum-1',
+        headRevisionId: 'revision-1',
       })),
       getMetadata: vi.fn(async () => ({
         uri: remoteUri,
-        name: "draft.json",
+        name: 'draft.json',
         type: NotebookStoreItemType.File,
         children: [],
         parents: [parentRemoteUri],
       })),
       save: vi.fn(async () => ({ conflicted: false })),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     await store.files.put({
-      id: "local://file/pending",
-      name: "draft.json",
-      remoteId: "",
+      id: 'local://file/pending',
+      name: 'draft.json',
+      remoteId: '',
       parentRemoteIdWhenCreated: parentRemoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "",
-      md5Checksum: "",
-    });
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
 
-    await store.sync("local://file/pending");
+    await store.sync('local://file/pending')
 
-    const record = await store.files.get("local://file/pending");
-    expect(record?.remoteId).toBe(remoteUri);
-    expect(record?.parentRemoteIdWhenCreated).toBeUndefined();
-    expect(record?.lastRemoteChecksum).toBe("checksum-1");
+    const record = await store.files.get('local://file/pending')
+    expect(record?.remoteId).toBe(remoteUri)
+    expect(record?.parentRemoteIdWhenCreated).toBeUndefined()
+    expect(record?.lastRemoteChecksum).toBe('checksum-1')
     expect(record?.lastUpstreamVersion).toEqual({
-      checksum: "checksum-1",
-      revisionId: "revision-1",
-    });
+      checksum: 'checksum-1',
+      revisionId: 'revision-1',
+    })
     expect(driveStore.create).toHaveBeenCalledWith(
       parentRemoteUri,
-      "draft.json",
-    );
-  });
+      'draft.json'
+    )
+  })
 
-  it("does not duplicate a pending Drive file if initial metadata recording fails", async () => {
-    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
-    const remoteUri = "https://drive.google.com/file/d/file123/view";
+  it('does not duplicate a pending Drive file if initial metadata recording fails', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const driveStore = {
       create: vi.fn(async () => ({
         uri: remoteUri,
-        name: "draft.json",
+        name: 'draft.json',
         type: NotebookStoreItemType.File,
         children: [],
         parents: [parentRemoteUri],
       })),
       getVersionMetadata: vi
         .fn()
-        .mockRejectedValueOnce(new Error("metadata unavailable"))
+        .mockRejectedValueOnce(new Error('metadata unavailable'))
         .mockResolvedValueOnce({
-          md5Checksum: "remote-created",
-          headRevisionId: "revision-2",
+          md5Checksum: 'remote-created',
+          headRevisionId: 'revision-2',
         })
         .mockResolvedValueOnce({
-          md5Checksum: "local-saved",
-          headRevisionId: "revision-3",
+          md5Checksum: 'local-saved',
+          headRevisionId: 'revision-3',
         }),
       getMetadata: vi.fn(async () => ({
         uri: remoteUri,
-        name: "draft.json",
+        name: 'draft.json',
         type: NotebookStoreItemType.File,
         children: [],
         parents: [parentRemoteUri],
       })),
       save: vi.fn(async () => ({ conflicted: false })),
       saveContent: vi.fn(async () => undefined),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     await store.files.put({
-      id: "local://file/pending",
-      name: "draft.json",
-      remoteId: "",
+      id: 'local://file/pending',
+      name: 'draft.json',
+      remoteId: '',
       parentRemoteIdWhenCreated: parentRemoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "{malformed-json",
-      md5Checksum: "local-checksum",
-    });
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '{malformed-json',
+      md5Checksum: 'local-checksum',
+    })
 
-    await store.sync("local://file/pending");
+    await store.sync('local://file/pending')
 
-    const record = await store.files.get("local://file/pending");
-    expect(record?.remoteId).toBe(remoteUri);
-    expect(record?.parentRemoteIdWhenCreated).toBeUndefined();
-    expect(record?.lastRemoteChecksum).toBe("local-saved");
-    expect(driveStore.create).toHaveBeenCalledTimes(1);
+    const record = await store.files.get('local://file/pending')
+    expect(record?.remoteId).toBe(remoteUri)
+    expect(record?.parentRemoteIdWhenCreated).toBeUndefined()
+    expect(record?.lastRemoteChecksum).toBe('local-saved')
+    expect(driveStore.create).toHaveBeenCalledTimes(1)
     expect(driveStore.saveContent).toHaveBeenCalledWith(
       remoteUri,
-      "{malformed-json",
-      "application/json",
-    );
-  });
+      '{malformed-json',
+      'application/json'
+    )
+  })
 
-  it("serializes overlapping sync calls for the same pending Drive file", async () => {
-    const parentRemoteUri = "https://drive.google.com/drive/folders/folder123";
-    const remoteUri = "https://drive.google.com/file/d/file123/view";
-    let releaseCreate!: () => void;
-    let createStarted!: () => void;
+  it('serializes overlapping sync calls for the same pending Drive file', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    let releaseCreate!: () => void
+    let createStarted!: () => void
     const createStartedPromise = new Promise<void>((resolve) => {
-      createStarted = resolve;
-    });
+      createStarted = resolve
+    })
     const releaseCreatePromise = new Promise<void>((resolve) => {
-      releaseCreate = resolve;
-    });
+      releaseCreate = resolve
+    })
     const driveStore = {
       create: vi.fn(async () => {
-        createStarted();
-        await releaseCreatePromise;
+        createStarted()
+        await releaseCreatePromise
         return {
           uri: remoteUri,
-          name: "draft.json",
+          name: 'draft.json',
           type: NotebookStoreItemType.File,
           children: [],
           parents: [parentRemoteUri],
-        };
+        }
       }),
       getVersionMetadata: vi.fn(async () => ({
-        md5Checksum: "checksum-1",
-        headRevisionId: "revision-1",
+        md5Checksum: 'checksum-1',
+        headRevisionId: 'revision-1',
       })),
       getMetadata: vi.fn(async () => ({
         uri: remoteUri,
-        name: "draft.json",
+        name: 'draft.json',
         type: NotebookStoreItemType.File,
         children: [],
         parents: [parentRemoteUri],
       })),
       save: vi.fn(async () => ({ conflicted: false })),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     await store.files.put({
-      id: "local://file/pending",
-      name: "draft.json",
-      remoteId: "",
+      id: 'local://file/pending',
+      name: 'draft.json',
+      remoteId: '',
       parentRemoteIdWhenCreated: parentRemoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "",
-      md5Checksum: "",
-    });
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
 
-    const firstSync = store.sync("local://file/pending");
-    await createStartedPromise;
-    const secondSync = store.sync("local://file/pending");
-    releaseCreate();
-    await Promise.all([firstSync, secondSync]);
+    const firstSync = store.sync('local://file/pending')
+    await createStartedPromise
+    const secondSync = store.sync('local://file/pending')
+    releaseCreate()
+    await Promise.all([firstSync, secondSync])
 
-    const record = await store.files.get("local://file/pending");
-    expect(record?.remoteId).toBe(remoteUri);
-    expect(record?.parentRemoteIdWhenCreated).toBeUndefined();
-    expect(driveStore.create).toHaveBeenCalledTimes(1);
-  });
-});
+    const record = await store.files.get('local://file/pending')
+    expect(record?.remoteId).toBe(remoteUri)
+    expect(record?.parentRemoteIdWhenCreated).toBeUndefined()
+    expect(driveStore.create).toHaveBeenCalledTimes(1)
+  })
+})
 
-describe("LocalNotebooks rename", () => {
-  it("renames Drive-backed files upstream before updating the local mirror", async () => {
-    const remoteUri = "https://drive.google.com/file/d/file123/view";
+describe('LocalNotebooks rename', () => {
+  it('renames Drive-backed files upstream before updating the local mirror', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const driveStore = {
       rename: vi.fn(async () => ({
         uri: remoteUri,
-        name: "renamed.json",
+        name: 'renamed.json',
         type: NotebookStoreItemType.File,
         children: [],
         remoteUri,
         parents: [],
       })),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     await store.files.put({
-      id: "local://file/drive",
-      name: "original.json",
+      id: 'local://file/drive',
+      name: 'original.json',
       remoteId: remoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "",
-      md5Checksum: "",
-    });
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
     await store.folders.put({
-      id: "local://folder/drive",
-      name: "Drive",
-      remoteId: "https://drive.google.com/drive/folders/folder123",
-      children: ["local://file/drive"],
-      lastSynced: "",
-    });
+      id: 'local://folder/drive',
+      name: 'Drive',
+      remoteId: 'https://drive.google.com/drive/folders/folder123',
+      children: ['local://file/drive'],
+      lastSynced: '',
+    })
 
-    const result = await store.rename("local://file/drive", "renamed.json");
+    const result = await store.rename('local://file/drive', 'renamed.json')
 
-    expect(driveStore.rename).toHaveBeenCalledWith(remoteUri, "renamed.json");
+    expect(driveStore.rename).toHaveBeenCalledWith(remoteUri, 'renamed.json')
     expect(result).toMatchObject({
-      uri: "local://file/drive",
-      name: "renamed.json",
+      uri: 'local://file/drive',
+      name: 'renamed.json',
       remoteUri,
-      parents: ["local://folder/drive"],
-    });
-    expect((await store.files.get("local://file/drive"))?.name).toBe(
-      "renamed.json",
-    );
-  });
+      parents: ['local://folder/drive'],
+    })
+    expect((await store.files.get('local://file/drive'))?.name).toBe(
+      'renamed.json'
+    )
+  })
 
-  it("does not update Drive-backed local metadata when the upstream rename fails", async () => {
-    const remoteUri = "https://drive.google.com/file/d/file123/view";
+  it('does not update Drive-backed local metadata when the upstream rename fails', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const driveStore = {
       rename: vi.fn(async () => {
-        throw new Error("permission denied");
+        throw new Error('permission denied')
       }),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     await store.files.put({
-      id: "local://file/drive",
-      name: "original.json",
+      id: 'local://file/drive',
+      name: 'original.json',
       remoteId: remoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "",
-      md5Checksum: "",
-    });
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
 
     await expect(
-      store.rename("local://file/drive", "renamed.json"),
-    ).rejects.toThrow("permission denied");
+      store.rename('local://file/drive', 'renamed.json')
+    ).rejects.toThrow('permission denied')
 
-    expect((await store.files.get("local://file/drive"))?.name).toBe(
-      "original.json",
-    );
-  });
-});
+    expect((await store.files.get('local://file/drive'))?.name).toBe(
+      'original.json'
+    )
+  })
+})
 
-describe("LocalNotebooks markdown sidecar sync", () => {
-  it("serializes notebooks to markdown locally before uploading the sidecar", async () => {
-    const markdownUri = "https://drive.google.com/file/d/sidecar123/view";
-    const remoteUri = "https://drive.google.com/file/d/notebook123/view";
+describe('LocalNotebooks Drive conflict resolution', () => {
+  it('records a conflict instead of creating a timestamped Drive copy', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const localDoc = notebookJson("print('local')")
+    const upstreamNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('upstream')",
+        }),
+      ],
+    })
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'notebook.json',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: ['https://drive.google.com/drive/folders/folder123'],
+      })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'upstream-checksum',
+        headRevisionId: 'upstream-revision',
+      })),
+      load: vi.fn(async () => upstreamNotebook),
+      create: vi.fn(),
+      save: vi.fn(),
+      saveContent: vi.fn(),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastUpstreamVersion: {
+        checksum: 'base-checksum',
+        revisionId: 'base-revision',
+      },
+      lastSynced: '2026-05-01T00:00:00.000Z',
+      doc: localDoc,
+      md5Checksum: 'local-checksum',
+    })
+
+    await store.sync('local://file/conflict')
+
+    const record = await store.files.get('local://file/conflict')
+    expect(record?.remoteId).toBe(remoteUri)
+    expect(record?.name).toBe('notebook.json')
+    expect(record?.lastRemoteChecksum).toBe('base-checksum')
+    expect(record?.conflict).toMatchObject({
+      upstreamChecksum: 'upstream-checksum',
+      upstreamVersion: {
+        checksum: 'upstream-checksum',
+        revisionId: 'upstream-revision',
+      },
+      localChecksumAtDetection: 'local-checksum',
+    })
+    expect(record?.conflict?.upstreamDoc).toBe(
+      toJsonString(
+        parser_pb.NotebookSchema,
+        upstreamNotebook,
+        NOTEBOOK_JSON_WRITE_OPTIONS
+      )
+    )
+    await expect(
+      store.getSyncState('local://file/conflict')
+    ).resolves.toMatchObject({
+      status: 'conflicted',
+      remoteId: remoteUri,
+    })
+    await expect(store.listDriveBackedFilesNeedingSync()).resolves.toEqual([])
+    expect(driveStore.create).not.toHaveBeenCalled()
+    expect(driveStore.save).not.toHaveBeenCalled()
+    expect(driveStore.saveContent).not.toHaveBeenCalled()
+  })
+
+  it('keeps local edits local while a Drive conflict is active', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const store = createTestStore({})
+    const nextNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('resolved locally')",
+        }),
+      ],
+    })
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+      conflict: {
+        detectedAt: '2026-05-30T00:00:00.000Z',
+        upstreamChecksum: 'upstream-checksum',
+        upstreamDoc: notebookJson("print('upstream')"),
+        localChecksumAtDetection: 'local-checksum',
+      },
+    })
+
+    await store.save('local://file/conflict', nextNotebook)
+
+    const record = await store.files.get('local://file/conflict')
+    expect(record?.doc).toBe(
+      toJsonString(
+        parser_pb.NotebookSchema,
+        nextNotebook,
+        NOTEBOOK_JSON_WRITE_OPTIONS
+      )
+    )
+    expect(record?.conflict).toBeTruthy()
+    expect((store as any).syncSubjects.size).toBe(0)
+    expect((store as any).markdownSyncSubjects.size).toBe(0)
+  })
+
+  it('saves the local version to the original Drive URI and clears conflict', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const localDoc = notebookJson("print('local wins')")
+    const savedChecksum = md5(localDoc)
+    const driveStore = {
+      getVersionMetadata: vi
+        .fn()
+        .mockResolvedValueOnce({
+          md5Checksum: 'upstream-checksum',
+          headRevisionId: 'upstream-revision',
+        })
+        .mockResolvedValueOnce({
+          md5Checksum: savedChecksum,
+          headRevisionId: 'saved-revision',
+        }),
+      saveContent: vi.fn(async () => undefined),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: localDoc,
+      md5Checksum: 'local-checksum',
+      conflict: {
+        detectedAt: '2026-05-30T00:00:00.000Z',
+        upstreamChecksum: 'upstream-checksum',
+        upstreamVersion: {
+          checksum: 'upstream-checksum',
+          revisionId: 'upstream-revision',
+        },
+        upstreamDoc: notebookJson("print('upstream')"),
+        localChecksumAtDetection: 'local-checksum',
+      },
+    })
+
+    await store.resolveConflictWithLocal('local://file/conflict')
+
+    const record = await store.files.get('local://file/conflict')
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      remoteUri,
+      localDoc,
+      'application/json'
+    )
+    expect(record?.remoteId).toBe(remoteUri)
+    expect(record?.conflict).toBeUndefined()
+    expect(record?.lastRemoteChecksum).toBe(savedChecksum)
+    expect(record?.lastUpstreamVersion).toEqual({
+      checksum: savedChecksum,
+      revisionId: 'saved-revision',
+    })
+    await expect(
+      store.getSyncState('local://file/conflict')
+    ).resolves.toMatchObject({
+      status: 'synced',
+    })
+  })
+
+  it('requires force when upstream changed again before saving local version', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'newer-upstream-checksum',
+        headRevisionId: 'newer-upstream-revision',
+      })),
+      saveContent: vi.fn(async () => undefined),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+      conflict: {
+        detectedAt: '2026-05-30T00:00:00.000Z',
+        upstreamChecksum: 'upstream-checksum',
+        upstreamDoc: notebookJson("print('upstream')"),
+        localChecksumAtDetection: 'local-checksum',
+      },
+    })
+
+    await expect(
+      store.resolveConflictWithLocal('local://file/conflict')
+    ).rejects.toBeInstanceOf(NotebookConflictChangedError)
+    expect(driveStore.saveContent).not.toHaveBeenCalled()
+
+    await store.resolveConflictWithLocal('local://file/conflict', {
+      force: true,
+    })
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      remoteUri,
+      expect.any(String),
+      'application/json'
+    )
+  })
+})
+
+describe('LocalNotebooks markdown sidecar sync', () => {
+  it('serializes notebooks to markdown locally before uploading the sidecar', async () => {
+    const markdownUri = 'https://drive.google.com/file/d/sidecar123/view'
+    const remoteUri = 'https://drive.google.com/file/d/notebook123/view'
     const driveStore = {
       saveContent: vi.fn(async () => undefined),
-    };
-    const store = createTestStore(driveStore);
+    }
+    const store = createTestStore(driveStore)
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
         create(parser_pb.CellSchema, {
           kind: parser_pb.CellKind.MARKUP,
-          languageId: "markdown",
-          value: "# Searchable title",
+          languageId: 'markdown',
+          value: '# Searchable title',
         }),
         create(parser_pb.CellSchema, {
           kind: parser_pb.CellKind.CODE,
-          languageId: "python",
+          languageId: 'python',
           value: 'print("hello")',
           outputs: [
             create(parser_pb.CellOutputSchema, {
               items: [
                 create(parser_pb.CellOutputItemSchema, {
                   mime: MimeType.VSCodeNotebookStdOut,
-                  type: "Buffer",
-                  data: new TextEncoder().encode("hello\n"),
+                  type: 'Buffer',
+                  data: new TextEncoder().encode('hello\n'),
                 }),
               ],
             }),
           ],
         }),
       ],
-    });
+    })
 
     await store.files.put({
-      id: "local://file/notebook",
-      name: "notebook.json",
+      id: 'local://file/notebook',
+      name: 'notebook.json',
       remoteId: remoteUri,
       markdownUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
+      lastRemoteChecksum: '',
+      lastSynced: '',
       doc: toJsonString(
         parser_pb.NotebookSchema,
         notebook,
-        NOTEBOOK_JSON_WRITE_OPTIONS,
+        NOTEBOOK_JSON_WRITE_OPTIONS
       ),
-      md5Checksum: "",
-    });
+      md5Checksum: '',
+    })
 
-    await store.syncMarkdownFile("local://file/notebook");
+    await store.syncMarkdownFile('local://file/notebook')
 
     expect(driveStore.saveContent).toHaveBeenCalledWith(
       markdownUri,
       [
-        "# Searchable title",
-        "",
-        "```python",
+        '# Searchable title',
+        '',
+        '```python',
         'print("hello")',
-        "```",
-        "",
-        "```stdout",
-        "hello",
-        "```",
-        "",
-      ].join("\n"),
-      "text/markdown",
-    );
-  });
-});
+        '```',
+        '',
+        '```stdout',
+        'hello',
+        '```',
+        '',
+      ].join('\n'),
+      'text/markdown'
+    )
+  })
+})

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -591,6 +591,59 @@ describe('LocalNotebooks Drive conflict resolution', () => {
       'application/json'
     )
   })
+
+  it('refreshes conflict metadata with the latest Drive head', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const upstreamHeadDoc = notebookJson("print('upstream head')")
+    const driveStore = {
+      load: vi.fn(async () =>
+        create(parser_pb.NotebookSchema, {
+          cells: [
+            create(parser_pb.CellSchema, {
+              kind: parser_pb.CellKind.CODE,
+              languageId: 'python',
+              value: "print('upstream head')",
+            }),
+          ],
+        })
+      ),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: md5(upstreamHeadDoc),
+        headRevisionId: 'head-revision',
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: notebookJson("print('local')"),
+      md5Checksum: '',
+      conflict: {
+        detectedAt: '2026-05-30T00:00:00.000Z',
+        upstreamChecksum: 'old-upstream-checksum',
+        upstreamDoc: notebookJson("print('old upstream')"),
+        localChecksumAtDetection: 'old-local-checksum',
+      },
+    })
+
+    const conflict = await store.refreshConflictWithLatestUpstream(
+      'local://file/conflict'
+    )
+
+    const record = await store.files.get('local://file/conflict')
+    expect(driveStore.load).toHaveBeenCalledWith(remoteUri)
+    expect(conflict.upstreamChecksum).toBe(md5(upstreamHeadDoc))
+    expect(conflict.upstreamVersion).toEqual({
+      checksum: md5(upstreamHeadDoc),
+      revisionId: 'head-revision',
+    })
+    expect(conflict.upstreamDoc).toBe(upstreamHeadDoc)
+    expect(conflict.localChecksumAtDetection).toBe(md5(record?.doc ?? ''))
+    expect(record?.conflict).toEqual(conflict)
+  })
 })
 
 describe('LocalNotebooks markdown sidecar sync', () => {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1,30 +1,27 @@
-import Dexie, { Table } from "dexie";
-import { create, toJsonString, fromJsonString } from "@bufbuild/protobuf";
-import { v4 as uuidv4 } from "uuid";
-import md5 from "md5";
-import { Subject, debounceTime } from "rxjs";
+import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
+import Dexie, { Table } from 'dexie'
+import md5 from 'md5'
+import { Subject, debounceTime } from 'rxjs'
+import { v4 as uuidv4 } from 'uuid'
 
-import { parser_pb } from "../runme/client";
-import { serializeNotebookToMarkdown } from "../lib/markdown/serializeNotebookToMarkdown";
-import { appState } from "../lib/runtime/AppState";
-import { appLogger } from "../lib/logging/runtime";
+import { appLogger } from '../lib/logging/runtime'
+import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookToMarkdown'
+import { appState } from '../lib/runtime/AppState'
+import { parser_pb } from '../runme/client'
 import {
   DriveNotebookStore,
   type DriveVersionMetadata,
   isDriveItemUri,
-} from "./drive";
-import type { FilesystemNotebookStore } from "./fs";
-import {
-  NotebookStoreItem,
-  NotebookStoreItemType,
-} from "./notebook";
+} from './drive'
+import type { FilesystemNotebookStore } from './fs'
+import { NotebookStoreItem, NotebookStoreItemType } from './notebook'
 
 // Local folder URI is a special folder that contains all notebooks which are local (i.e. not synced to Drive)
-export const LOCAL_FOLDER_URI = "local://folder/local";
+export const LOCAL_FOLDER_URI = 'local://folder/local'
 
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
-} as unknown as Parameters<typeof toJsonString>[2];
+} as unknown as Parameters<typeof toJsonString>[2]
 
 /**
  * LocalFileRecord captures the information needed to persist a notebook locally.
@@ -35,61 +32,87 @@ const NOTEBOOK_JSON_WRITE_OPTIONS = {
  */
 export interface LocalFileRecord {
   /** Stable local identifier (formatted as local://file/<uuid>). */
-  id: string;
+  id: string
   /** Friendly name for the notebook, used when rendering the UI. */
-  name: string;
+  name: string
   /** Upstream URI. Browser-only notebooks use the same local://file/... URI. */
-  remoteId: string;
+  remoteId: string
   /** Creation-time upstream parent URI used to finish a pending remote create. */
-  parentRemoteIdWhenCreated?: string;
+  parentRemoteIdWhenCreated?: string
   /** Remote Drive URI of the Markdown sidecar (e.g. *.index.md) if present. */
-  markdownUri?: string;
+  markdownUri?: string
   /**
    * Checksum returned by the most recent Drive sync. Empty string means the
    * notebook has never been uploaded or the checksum was unavailable.
    */
-  lastRemoteChecksum: string;
+  lastRemoteChecksum: string
   /** ISO timestamp of the last successful sync with Drive (empty if never). */
-  lastSynced: string;
+  lastSynced: string
   /** Last successfully observed upstream revision/checksum metadata. */
-  lastUpstreamVersion?: UpstreamVersion;
+  lastUpstreamVersion?: UpstreamVersion
   /** Last sync failure, if any. Cleared after successful sync. */
-  lastSyncError?: string;
+  lastSyncError?: string
+  /** Durable local-vs-upstream conflict snapshot, if upstream sync is blocked. */
+  conflict?: NotebookConflictState
   /**
    * JSON serialized notebook document. Using a string keeps the IndexedDB
    * representation simple and defers parsing to the caller.
    */
-  doc: string;
+  doc: string
   /**
    * MD5 checksum of `doc`. Persisted so reconciler scans can detect local
    * changes without re-hashing every file on each pass.
    */
-  md5Checksum: string;
+  md5Checksum: string
 }
 
 export interface UpstreamVersion {
-  checksum?: string;
-  revisionId?: string;
-  modifiedTime?: string;
-  sizeBytes?: number;
+  checksum?: string
+  revisionId?: string
+  modifiedTime?: string
+  sizeBytes?: number
+}
+
+export interface NotebookConflictState {
+  detectedAt: string
+  upstreamChecksum: string
+  upstreamVersion?: UpstreamVersion
+  upstreamDoc: string
+  localChecksumAtDetection: string
 }
 
 export type NotebookSyncStatus =
-  | "local-only"
-  | "synced"
-  | "pending"
-  | "pending-upstream-create"
-  | "syncing"
-  | "error";
+  | 'local-only'
+  | 'synced'
+  | 'pending'
+  | 'pending-upstream-create'
+  | 'syncing'
+  | 'conflicted'
+  | 'error'
 
 export interface NotebookSyncState {
-  status: NotebookSyncStatus;
-  localUri: string;
-  remoteId: string;
-  parentRemoteIdWhenCreated?: string;
-  lastSynced?: string;
-  lastUpstreamVersion?: UpstreamVersion;
-  lastError?: string;
+  status: NotebookSyncStatus
+  localUri: string
+  remoteId: string
+  parentRemoteIdWhenCreated?: string
+  lastSynced?: string
+  lastUpstreamVersion?: UpstreamVersion
+  conflict?: NotebookConflictState
+  lastError?: string
+}
+
+export class NotebookConflictChangedError extends Error {
+  constructor(
+    readonly localUri: string,
+    readonly conflictChecksum: string,
+    readonly currentUpstreamChecksum: string
+  ) {
+    super(
+      `Upstream changed after conflict detection for ${localUri}: ` +
+        `${conflictChecksum} -> ${currentUpstreamChecksum}`
+    )
+    this.name = 'NotebookConflictChangedError'
+  }
 }
 
 /**
@@ -100,24 +123,24 @@ export interface NotebookSyncState {
  */
 export interface LocalFolderRecord {
   /** Stable local identifier (formatted as local://folder/<uuid>). */
-  id: string;
+  id: string
   /** Friendly name for the folder when displayed locally. */
-  name: string;
+  name: string
   /** Remote Drive URI if the folder is mirrored, otherwise an empty string. */
-  remoteId: string;
+  remoteId: string
   /**
    * Local URIs for the children contained in this folder. The array keeps the
    * ordering stable and allows quick traversal when rendering the notebook tree.
    */
-  children: string[];
+  children: string[]
   /** ISO timestamp of the last successful sync with Drive (empty if never). */
-  lastSynced: string;
+  lastSynced: string
 }
 
 // TODO(jlewi): I believe LocalNotebooks is improperly named at this point.
 // I think at this point it is providing a unified interface for both local and
 // remote storage systems. I believe at this point all the different parts of the
-// app that need to read and write notebooks should be using this class. 
+// app that need to read and write notebooks should be using this class.
 // This class then hides caching the notebooks locally in IndexedDB and syncing them
 // to the remote store (e.g. Google Drive).
 
@@ -129,101 +152,116 @@ export interface LocalFolderRecord {
  */
 export class LocalNotebooks extends Dexie {
   /** IndexedDB table where notebook files are stored. */
-  files!: Table<LocalFileRecord, string>;
+  files!: Table<LocalFileRecord, string>
 
   /** IndexedDB table where folder metadata is stored. */
-  folders!: Table<LocalFolderRecord, string>;
+  folders!: Table<LocalFolderRecord, string>
 
-  private readonly driveStore: DriveNotebookStore;
-  private filesystemStore: FilesystemNotebookStore | null = null;
+  private readonly driveStore: DriveNotebookStore
+  private filesystemStore: FilesystemNotebookStore | null = null
 
-  private readonly syncSubjects = new Map<string, Subject<void>>();
-  private readonly markdownSyncSubjects = new Map<string, Subject<void>>();
-  private readonly inFlightSyncs = new Map<string, Promise<void>>();
-  private readonly syncListeners = new Map<string, Set<() => void>>();
+  private readonly syncSubjects = new Map<string, Subject<void>>()
+  private readonly markdownSyncSubjects = new Map<string, Subject<void>>()
+  private readonly inFlightSyncs = new Map<string, Promise<void>>()
+  private readonly syncListeners = new Map<string, Set<() => void>>()
 
   constructor(
     driveStore: DriveNotebookStore,
-    databaseName: string = "runme-local-notebooks",
+    databaseName: string = 'runme-local-notebooks'
   ) {
-    super(databaseName);
+    super(databaseName)
 
     // Define the database schema. Version(1) gives us a clear starting point
     // for future migrations. Both tables are keyed by the `id` property.
     this.version(1).stores({
-      files: "&id, remoteId, lastRemoteChecksum, name",
-      folders: "&id, remoteId, name",
-    });
+      files: '&id, remoteId, lastRemoteChecksum, name',
+      folders: '&id, remoteId, name',
+    })
     this.version(2)
       .stores({
-        files: "&id, remoteId, lastRemoteChecksum, name, lastSynced",
-        folders: "&id, remoteId, name, lastSynced",
+        files: '&id, remoteId, lastRemoteChecksum, name, lastSynced',
+        folders: '&id, remoteId, name, lastSynced',
       })
       .upgrade(async (tx) => {
-        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
-          if (typeof file.lastSynced !== "string") {
-            file.lastSynced = "";
-          }
-        });
-        await tx.table("folders").toCollection().modify((folder: Partial<LocalFolderRecord>) => {
-          if (typeof folder.lastSynced !== "string") {
-            folder.lastSynced = "";
-          }
-        });
-      });
+        await tx
+          .table('files')
+          .toCollection()
+          .modify((file: Partial<LocalFileRecord>) => {
+            if (typeof file.lastSynced !== 'string') {
+              file.lastSynced = ''
+            }
+          })
+        await tx
+          .table('folders')
+          .toCollection()
+          .modify((folder: Partial<LocalFolderRecord>) => {
+            if (typeof folder.lastSynced !== 'string') {
+              folder.lastSynced = ''
+            }
+          })
+      })
     this.version(3)
       .stores({
-        files: "&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced",
-        folders: "&id, remoteId, name, lastSynced",
+        files:
+          '&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced',
+        folders: '&id, remoteId, name, lastSynced',
       })
       .upgrade(async (tx) => {
-        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
-          if (typeof file.md5Checksum !== "string") {
-            // Lazy backfill: keep migration cheap and compute missing checksums
-            // when we evaluate whether a file needs syncing.
-            file.md5Checksum = "";
-          }
-        });
-      });
+        await tx
+          .table('files')
+          .toCollection()
+          .modify((file: Partial<LocalFileRecord>) => {
+            if (typeof file.md5Checksum !== 'string') {
+              // Lazy backfill: keep migration cheap and compute missing checksums
+              // when we evaluate whether a file needs syncing.
+              file.md5Checksum = ''
+            }
+          })
+      })
     this.version(4)
       .stores({
-        files: "&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced",
-        folders: "&id, remoteId, name, lastSynced",
+        files:
+          '&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced',
+        folders: '&id, remoteId, name, lastSynced',
       })
       .upgrade(async (tx) => {
-        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
-          if (typeof file.remoteId !== "string" || file.remoteId === "") {
-            file.remoteId = file.id ?? "";
-          }
-        });
-      });
+        await tx
+          .table('files')
+          .toCollection()
+          .modify((file: Partial<LocalFileRecord>) => {
+            if (typeof file.remoteId !== 'string' || file.remoteId === '') {
+              file.remoteId = file.id ?? ''
+            }
+          })
+      })
     this.version(5)
       .stores({
-        files: "&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced",
-        folders: "&id, remoteId, name, lastSynced",
+        files:
+          '&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced',
+        folders: '&id, remoteId, name, lastSynced',
       })
       .upgrade(async (tx) => {
-        await tx.table("files").toCollection().modify((file: Partial<LocalFileRecord>) => {
-          delete file.lastUpstreamVersion;
-          delete file.lastSyncError;
-          delete file.parentRemoteIdWhenCreated;
-        });
-      });
+        await tx
+          .table('files')
+          .toCollection()
+          .modify((file: Partial<LocalFileRecord>) => {
+            delete file.lastUpstreamVersion
+            delete file.lastSyncError
+            delete file.parentRemoteIdWhenCreated
+          })
+      })
 
     // Bind the table helpers so callers can access them directly.
-    this.files = this.table("files");
-    this.folders = this.table("folders");
+    this.files = this.table('files')
+    this.folders = this.table('folders')
 
-    this.driveStore = driveStore;
+    this.driveStore = driveStore
 
-    void this.ensureFolderRecord(
-      LOCAL_FOLDER_URI,
-      "Local Notebooks",
-    );
+    void this.ensureFolderRecord(LOCAL_FOLDER_URI, 'Local Notebooks')
   }
 
   setFilesystemStore(store: FilesystemNotebookStore | null): void {
-    this.filesystemStore = store;
+    this.filesystemStore = store
   }
 
   /**
@@ -233,38 +271,36 @@ export class LocalNotebooks extends Dexie {
    */
   async addFile(remoteUri: string, name?: string): Promise<string> {
     if (!remoteUri) {
-      throw new Error("addFile requires a non-empty remote URI");
+      throw new Error('addFile requires a non-empty remote URI')
     }
 
     const existing = await this.files
-      .where("remoteId")
+      .where('remoteId')
       .equals(remoteUri)
-      .first();
+      .first()
     if (existing) {
       if (name && name !== existing.name) {
-        await this.files.update(existing.id, { name });
+        await this.files.update(existing.id, { name })
       }
-      return existing.id;
+      return existing.id
     }
 
-    const id = this.generateLocalUri("file");
+    const id = this.generateLocalUri('file')
     const resolvedName =
-      name ??
-      this.deriveDisplayNameFromUri(remoteUri) ??
-      "Untitled Notebook";
+      name ?? this.deriveDisplayNameFromUri(remoteUri) ?? 'Untitled Notebook'
 
     const record: LocalFileRecord = {
       id,
       name: resolvedName,
       remoteId: remoteUri,
-      lastRemoteChecksum: "",
-      lastSynced: "",
-      doc: "",
-      md5Checksum: "",
-    };
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    }
 
-    await this.files.put(record);
-    return id;
+    await this.files.put(record)
+    return id
   }
 
   /**
@@ -274,39 +310,53 @@ export class LocalNotebooks extends Dexie {
   async addNotebook(
     upstreamUri: string,
     name: string,
-    notebook: parser_pb.Notebook,
+    notebook: parser_pb.Notebook
   ): Promise<string> {
     if (!upstreamUri) {
-      throw new Error("addNotebook requires a non-empty upstream URI");
+      throw new Error('addNotebook requires a non-empty upstream URI')
     }
 
-    const serialized = serializeNotebook(notebook);
-    const checksum = checksumForSerializedNotebook(serialized);
+    const serialized = serializeNotebook(notebook)
+    const checksum = checksumForSerializedNotebook(serialized)
     const existing = await this.files
-      .where("remoteId")
+      .where('remoteId')
       .equals(upstreamUri)
-      .first();
+      .first()
 
     if (existing) {
       const existingChecksum = await this.getOrBackfillLocalChecksum(
         existing.id,
-        existing,
-      );
-      const existingBaseline = existing.lastRemoteChecksum ?? "";
+        existing
+      )
+      const existingBaseline = existing.lastRemoteChecksum ?? ''
       const hasLocalChanges =
-        existing.doc !== "" && existingChecksum !== existingBaseline;
+        existing.doc !== '' && existingChecksum !== existingBaseline
       if (hasLocalChanges) {
-        appLogger.warn("Preserving local mirror while opening changed upstream notebook", {
-          attrs: {
-            scope: "storage.local.mirror",
-            localUri: existing.id,
-            upstreamUri,
-            localChecksum: existingChecksum,
+        appLogger.warn(
+          'Preserving local mirror while opening changed upstream notebook',
+          {
+            attrs: {
+              scope: 'storage.local.mirror',
+              localUri: existing.id,
+              upstreamUri,
+              localChecksum: existingChecksum,
+              upstreamChecksum: checksum,
+              lastRemoteChecksum: existingBaseline,
+            },
+          }
+        )
+        const changes: Partial<LocalFileRecord> = { name }
+        if (checksum !== existingBaseline) {
+          changes.conflict = {
+            detectedAt: nowIsoString(),
             upstreamChecksum: checksum,
-            lastRemoteChecksum: existingBaseline,
-          },
-        });
-        await this.files.update(existing.id, { name });
+            upstreamVersion: { checksum },
+            upstreamDoc: serialized,
+            localChecksumAtDetection: existingChecksum,
+          }
+          changes.lastSyncError = undefined
+        }
+        await this.files.update(existing.id, changes)
       } else {
         await this.files.update(existing.id, {
           name,
@@ -316,12 +366,13 @@ export class LocalNotebooks extends Dexie {
           lastUpstreamVersion: { checksum },
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
-        });
+          conflict: undefined,
+        })
       }
-      return existing.id;
+      return existing.id
     }
 
-    const id = this.generateLocalUri("file");
+    const id = this.generateLocalUri('file')
     const record: LocalFileRecord = {
       id,
       name,
@@ -331,10 +382,10 @@ export class LocalNotebooks extends Dexie {
       lastSynced: nowIsoString(),
       doc: serialized,
       md5Checksum: checksum,
-    };
+    }
 
-    await this.files.put(record);
-    return id;
+    await this.files.put(record)
+    return id
   }
 
   /**
@@ -344,37 +395,35 @@ export class LocalNotebooks extends Dexie {
    */
   async updateFolder(remoteUri: string, name?: string): Promise<string> {
     if (!remoteUri) {
-      throw new Error("updateFolder requires a non-empty remote URI");
+      throw new Error('updateFolder requires a non-empty remote URI')
     }
 
     const existingFolder = await this.folders
-      .where("remoteId")
+      .where('remoteId')
       .equals(remoteUri)
-      .first();
+      .first()
 
-    const folderId =
-      existingFolder?.id ?? this.generateLocalUri("folder");
+    const folderId = existingFolder?.id ?? this.generateLocalUri('folder')
     const fallbackName =
-      this.deriveDisplayNameFromUri(remoteUri) ?? "Untitled Folder";
-    let resolvedName =
-      name ?? existingFolder?.name ?? fallbackName;
+      this.deriveDisplayNameFromUri(remoteUri) ?? 'Untitled Folder'
+    let resolvedName = name ?? existingFolder?.name ?? fallbackName
 
     // When callers don't provide a name, resolve the remote folder metadata so
     // new mounts use the human-readable Drive name instead of an id-derived
     // fallback. If an existing record still has that fallback name, upgrade it.
     if (!name && (!existingFolder || existingFolder.name === fallbackName)) {
       try {
-        const metadata = await this.driveStore.getMetadata(remoteUri);
-        const remoteName = metadata?.name?.trim();
+        const metadata = await this.driveStore.getMetadata(remoteUri)
+        const remoteName = metadata?.name?.trim()
         if (remoteName) {
-          resolvedName = remoteName;
+          resolvedName = remoteName
         }
       } catch (error) {
         console.error(
-          "Failed to resolve Drive folder name from metadata",
+          'Failed to resolve Drive folder name from metadata',
           remoteUri,
-          error,
-        );
+          error
+        )
       }
     }
 
@@ -385,149 +434,156 @@ export class LocalNotebooks extends Dexie {
         name: resolvedName,
         remoteId: remoteUri,
         children: [],
-        lastSynced: "",
-      };
-      await this.folders.put(initialRecord);
+        lastSynced: '',
+      }
+      await this.folders.put(initialRecord)
     } else if (existingFolder.name !== resolvedName) {
-      await this.folders.update(folderId, { name: resolvedName });
+      await this.folders.update(folderId, { name: resolvedName })
     }
 
     // Fetch the latest Drive listing and mirror any notebooks we discover.
-    const items = await this.driveStore.list(remoteUri);
-    const childUris: string[] = [];
+    const items = await this.driveStore.list(remoteUri)
+    const childUris: string[] = []
 
     for (const item of items) {
       if (item.type === NotebookStoreItemType.File) {
-        const localUri = await this.addFile(item.uri, item.name);
-        childUris.push(localUri);
+        const localUri = await this.addFile(item.uri, item.name)
+        childUris.push(localUri)
       } else if (item.type === NotebookStoreItemType.Folder) {
-        const localFolderUri = await this.updateFolder(item.uri, item.name);
-        childUris.push(localFolderUri);
+        const localFolderUri = await this.updateFolder(item.uri, item.name)
+        childUris.push(localFolderUri)
       }
     }
 
-    const existingChildren = existingFolder?.children ?? [];
+    const existingChildren = existingFolder?.children ?? []
     for (const childUri of existingChildren) {
-      const childRecord = childUri.startsWith("local://file/")
+      const childRecord = childUri.startsWith('local://file/')
         ? await this.files.get(childUri)
-        : null;
+        : null
       if (
-        childRecord?.remoteId === "" &&
+        childRecord?.remoteId === '' &&
         childRecord.parentRemoteIdWhenCreated === remoteUri &&
         !childUris.includes(childUri)
       ) {
-        childUris.push(childUri);
+        childUris.push(childUri)
       }
     }
 
     await this.folders.update(folderId, {
       name: resolvedName,
       children: childUris,
-    });
+    })
 
-    return folderId;
+    return folderId
   }
 
   async sync(localUri: string): Promise<void> {
-    if (localUri.startsWith("local://file/")) {
-      await this.syncFile(localUri);
-      return;
+    if (localUri.startsWith('local://file/')) {
+      await this.syncFile(localUri)
+      return
     }
 
-    if (localUri.startsWith("local://folder/")) {
-      await this.syncFolder(localUri);
-      return;
+    if (localUri.startsWith('local://folder/')) {
+      await this.syncFolder(localUri)
+      return
     }
 
-    throw new Error(`Unsupported local URI format: ${localUri}`);
+    throw new Error(`Unsupported local URI format: ${localUri}`)
   }
 
   subscribeSync(localUri: string, listener: () => void): () => void {
-    let listeners = this.syncListeners.get(localUri);
+    let listeners = this.syncListeners.get(localUri)
     if (!listeners) {
-      listeners = new Set();
-      this.syncListeners.set(localUri, listeners);
+      listeners = new Set()
+      this.syncListeners.set(localUri, listeners)
     }
-    listeners.add(listener);
+    listeners.add(listener)
     return () => {
-      const current = this.syncListeners.get(localUri);
+      const current = this.syncListeners.get(localUri)
       if (!current) {
-        return;
+        return
       }
-      current.delete(listener);
+      current.delete(listener)
       if (current.size === 0) {
-        this.syncListeners.delete(localUri);
+        this.syncListeners.delete(localUri)
       }
-    };
+    }
   }
 
   async getSyncState(localUri: string): Promise<NotebookSyncState> {
-    const record = await this.files.get(localUri);
+    const record = await this.files.get(localUri)
     if (!record) {
       return {
-        status: "error",
+        status: 'error',
         localUri,
-        remoteId: "",
+        remoteId: '',
         lastError: `Local notebook record not found for ${localUri}`,
-      };
+      }
     }
 
     if (this.inFlightSyncs.has(localUri)) {
-      return syncStateForRecord(record, "syncing");
+      return syncStateForRecord(record, 'syncing')
     }
 
-    if (record.remoteId === "" && record.parentRemoteIdWhenCreated) {
+    if (record.conflict) {
+      return syncStateForRecord(record, 'conflicted')
+    }
+
+    if (record.remoteId === '' && record.parentRemoteIdWhenCreated) {
       return syncStateForRecord(
         record,
-        record.lastSyncError ? "error" : "pending-upstream-create",
-      );
+        record.lastSyncError ? 'error' : 'pending-upstream-create'
+      )
     }
 
-    if (record.remoteId === "") {
-      return syncStateForRecord(record, "error", "Missing upstream URI");
+    if (record.remoteId === '') {
+      return syncStateForRecord(record, 'error', 'Missing upstream URI')
     }
 
     if (isLocalFileUpstream(record.remoteId, record.id)) {
-      return syncStateForRecord(record, "local-only");
+      return syncStateForRecord(record, 'local-only')
     }
 
     if (record.lastSyncError) {
-      return syncStateForRecord(record, "error");
+      return syncStateForRecord(record, 'error')
     }
 
-    const localChecksum = await this.getOrBackfillLocalChecksum(localUri, record);
-    const upstreamChecksum = record.lastRemoteChecksum ?? "";
+    const localChecksum = await this.getOrBackfillLocalChecksum(
+      localUri,
+      record
+    )
+    const upstreamChecksum = record.lastRemoteChecksum ?? ''
     return syncStateForRecord(
       { ...record, md5Checksum: localChecksum },
-      localChecksum === upstreamChecksum ? "synced" : "pending",
-    );
+      localChecksum === upstreamChecksum ? 'synced' : 'pending'
+    )
   }
 
   async getMetadata(uri: string): Promise<NotebookStoreItem | null> {
-    if (!uri.startsWith("local://")) {
-      throw new Error("getMetadata expects a local:// URI");
+    if (!uri.startsWith('local://')) {
+      throw new Error('getMetadata expects a local:// URI')
     }
 
     if (uri === LOCAL_FOLDER_URI) {
       const files = await this.files
         .filter((file) => isLocalFileUpstream(file.remoteId, file.id))
-        .toArray();
+        .toArray()
       return {
         uri,
-        name: "Local Notebooks",
+        name: 'Local Notebooks',
         type: NotebookStoreItemType.Folder,
         children: files.map((file) => file.id),
         remoteUri: undefined,
         parents: [],
-      };
+      }
     }
 
-    if (uri.startsWith("local://file/")) {
-      const record = await this.files.get(uri);
+    if (uri.startsWith('local://file/')) {
+      const record = await this.files.get(uri)
       if (!record) {
-        return null;
+        return null
       }
-      const parentFolder = await this.findParentFolder(record.id);
+      const parentFolder = await this.findParentFolder(record.id)
       return {
         uri: record.id,
         name: record.name,
@@ -535,15 +591,15 @@ export class LocalNotebooks extends Dexie {
         children: [],
         remoteUri: publicRemoteUri(record),
         parents: parentFolder ? [parentFolder.id] : [],
-      };
+      }
     }
 
-    if (uri.startsWith("local://folder/")) {
-      const record = await this.folders.get(uri);
+    if (uri.startsWith('local://folder/')) {
+      const record = await this.folders.get(uri)
       if (!record) {
-        return null;
+        return null
       }
-      const parentFolder = await this.findParentFolder(record.id);
+      const parentFolder = await this.findParentFolder(record.id)
       return {
         uri: record.id,
         name: record.name,
@@ -551,148 +607,221 @@ export class LocalNotebooks extends Dexie {
         children: [...record.children],
         remoteUri: publicRemoteUri(record),
         parents: parentFolder ? [parentFolder.id] : [],
-      };
+      }
     }
 
-    throw new Error(`Unsupported local URI format: ${uri}`);
+    throw new Error(`Unsupported local URI format: ${uri}`)
   }
 
   /**
    * Persist a notebook into the local store. The caller provides a local URI
    * (e.g. `local://file/<uuid>`) that acts as the primary key for the record.
    */
-  async save(
-    uri: string,
-    notebook: parser_pb.Notebook,
-  ): Promise<void> {
-    if (!uri.startsWith("local://file/")) {
-      throw new Error("LocalNotebooks.save expects a local://file/ URI; got " + uri);
+  async save(uri: string, notebook: parser_pb.Notebook): Promise<void> {
+    if (!uri.startsWith('local://file/')) {
+      throw new Error(
+        'LocalNotebooks.save expects a local://file/ URI; got ' + uri
+      )
     }
 
-    await this.persistNotebook(uri, notebook);
-    this.enqueueSync(uri);
-    this.enqueueMarkdownSync(uri);
+    await this.persistNotebook(uri, notebook)
+    const record = await this.files.get(uri)
+    if (!record?.conflict) {
+      this.enqueueSync(uri)
+      this.enqueueMarkdownSync(uri)
+    }
+  }
+
+  async resolveConflictWithLocal(
+    localUri: string,
+    options: { force?: boolean } = {}
+  ): Promise<void> {
+    if (!localUri.startsWith('local://file/')) {
+      throw new Error('resolveConflictWithLocal expects a local://file/ URI')
+    }
+
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (!record.conflict) {
+      throw new Error(`Local notebook ${localUri} does not have a conflict`)
+    }
+    if (!isDriveUri(record.remoteId)) {
+      throw new Error(
+        `Conflict resolution is only supported for Drive-backed notebooks; got ${record.remoteId}`
+      )
+    }
+
+    const currentVersion = driveMetadataToUpstreamVersion(
+      await this.driveStore.getVersionMetadata(record.remoteId)
+    )
+    const currentChecksum = currentVersion.checksum ?? ''
+    if (
+      currentChecksum &&
+      currentChecksum !== record.conflict.upstreamChecksum &&
+      !options.force
+    ) {
+      throw new NotebookConflictChangedError(
+        localUri,
+        record.conflict.upstreamChecksum,
+        currentChecksum
+      )
+    }
+
+    const localDoc =
+      record.doc ||
+      serializeNotebook(create(parser_pb.NotebookSchema, { cells: [] }))
+    await this.driveStore.saveContent(
+      record.remoteId,
+      localDoc,
+      'application/json'
+    )
+
+    const updatedVersion = driveMetadataToUpstreamVersion(
+      await this.driveStore.getVersionMetadata(record.remoteId)
+    )
+    const updatedChecksum =
+      updatedVersion.checksum ?? checksumForSerializedNotebook(localDoc)
+    await this.files.update(localUri, {
+      conflict: undefined,
+      lastRemoteChecksum: updatedChecksum,
+      lastUpstreamVersion: updatedVersion,
+      md5Checksum: checksumForSerializedNotebook(localDoc),
+      lastSynced: nowIsoString(),
+      lastSyncError: undefined,
+    })
+    this.notifySync(localUri)
   }
 
   private async persistNotebook(
     uri: string,
-    notebook: parser_pb.Notebook,
+    notebook: parser_pb.Notebook
   ): Promise<void> {
-    const record = await this.files.get(uri);
+    const record = await this.files.get(uri)
     if (!record) {
       throw new Error(
-        `Local notebook record not found for ${uri}. Call addFile first.`,
-      );
+        `Local notebook record not found for ${uri}. Call addFile first.`
+      )
     }
 
-    const serialized = serializeNotebook(notebook);
-    const checksum = checksumForSerializedNotebook(serialized);
+    const serialized = serializeNotebook(notebook)
+    const checksum = checksumForSerializedNotebook(serialized)
 
-    await this.files.update(uri, { doc: serialized, md5Checksum: checksum });
-    this.notifySync(uri);
+    await this.files.update(uri, { doc: serialized, md5Checksum: checksum })
+    this.notifySync(uri)
   }
 
   async load(uri: string): Promise<parser_pb.Notebook> {
-    if (!uri.startsWith("local://file/")) {
-      throw new Error("LocalNotebooks.load expects a local://file/ URI; got " + uri);
+    if (!uri.startsWith('local://file/')) {
+      throw new Error(
+        'LocalNotebooks.load expects a local://file/ URI; got ' + uri
+      )
     }
 
-    const existing = await this.files.get(uri);
+    const existing = await this.files.get(uri)
     if (!existing) {
-      throw new Error(`Local notebook record not found for ${uri}; call addFile first.`);
+      throw new Error(
+        `Local notebook record not found for ${uri}; call addFile first.`
+      )
     }
 
-    const shouldSync = needsSync(existing.lastSynced, 8 * 60 * 60 * 1000);
+    const shouldSync = needsSync(existing.lastSynced, 8 * 60 * 60 * 1000)
 
-    let record = existing;
+    let record = existing
     if (shouldSync) {
       // Best-effort attempt to ensure the local cache reflects the latest remote state
       // before we hydrate the notebook for the caller.
       try {
-        await this.syncFile(uri);
+        await this.syncFile(uri)
       } catch (error) {
-        appLogger.warn("Continuing with local notebook after sync-on-load failed", {
-          attrs: {
-            scope: "storage.local.sync",
-            localUri: uri,
-            error: String(error),
-          },
-        });
+        appLogger.warn(
+          'Continuing with local notebook after sync-on-load failed',
+          {
+            attrs: {
+              scope: 'storage.local.sync',
+              localUri: uri,
+              error: String(error),
+            },
+          }
+        )
       }
 
-      const refreshed = await this.files.get(uri);
+      const refreshed = await this.files.get(uri)
       if (!refreshed) {
-        throw new Error(`Local notebook record missing for ${uri} after sync.`);
+        throw new Error(`Local notebook record missing for ${uri} after sync.`)
       }
-      record = refreshed;
+      record = refreshed
     }
 
     if (!record.doc) {
-      return create(parser_pb.NotebookSchema, { cells: [] });
+      return create(parser_pb.NotebookSchema, { cells: [] })
     }
 
     try {
       return fromJsonString(parser_pb.NotebookSchema, record.doc, {
         ignoreUnknownFields: true,
-      });
+      })
     } catch (error) {
-      console.error("Failed to parse notebook from local store", error);
-      return create(parser_pb.NotebookSchema, { cells: [] });
+      console.error('Failed to parse notebook from local store', error)
+      return create(parser_pb.NotebookSchema, { cells: [] })
     }
   }
 
   async create(parentUri: string, name: string): Promise<NotebookStoreItem> {
-    if (!parentUri.startsWith("local://folder/")) {
-      throw new Error("LocalNotebooks.create expects a folder parent URI");
+    if (!parentUri.startsWith('local://folder/')) {
+      throw new Error('LocalNotebooks.create expects a folder parent URI')
     }
 
-    const parent = await this.folders.get(parentUri);
+    const parent = await this.folders.get(parentUri)
     if (!parent) {
-      throw new Error(`Parent folder not found for ${parentUri}`);
+      throw new Error(`Parent folder not found for ${parentUri}`)
     }
 
-    const fileUri = this.generateLocalUri("file");
-    const isDriveBackedParent = isDriveUri(parent.remoteId);
+    const fileUri = this.generateLocalUri('file')
+    const isDriveBackedParent = isDriveUri(parent.remoteId)
     const record: LocalFileRecord = {
       id: fileUri,
       name,
-      remoteId: isDriveBackedParent ? "" : fileUri,
-      parentRemoteIdWhenCreated: isDriveBackedParent ? parent.remoteId : undefined,
-      lastRemoteChecksum: "",
-      lastSynced: isDriveBackedParent ? "" : nowIsoString(),
-      doc: "",
-      md5Checksum: "",
-    };
-    await this.files.put(record);
+      remoteId: isDriveBackedParent ? '' : fileUri,
+      parentRemoteIdWhenCreated: isDriveBackedParent
+        ? parent.remoteId
+        : undefined,
+      lastRemoteChecksum: '',
+      lastSynced: isDriveBackedParent ? '' : nowIsoString(),
+      doc: '',
+      md5Checksum: '',
+    }
+    await this.files.put(record)
 
     await this.folders.update(parentUri, {
       children: [...parent.children, fileUri],
       lastSynced: nowIsoString(),
-    });
+    })
 
     if (canDispatchWindowEvents()) {
       window.dispatchEvent(
-        new CustomEvent("local-notebook-updated", {
+        new CustomEvent('local-notebook-updated', {
           detail: { uri: fileUri, name, remoteUri: undefined },
-        }),
-      );
+        })
+      )
     }
 
     if (isDriveBackedParent) {
       void (async () => {
         try {
-          await this.syncFile(fileUri);
+          await this.syncFile(fileUri)
         } catch (error) {
-          appLogger.warn("Pending Drive notebook creation did not complete", {
+          appLogger.warn('Pending Drive notebook creation did not complete', {
             attrs: {
-              scope: "storage.drive.sync",
+              scope: 'storage.drive.sync',
               localUri: fileUri,
               parentRemoteUri: parent.remoteId,
               error: String(error),
             },
-          });
+          })
         }
-      })();
+      })()
     }
 
     return {
@@ -702,42 +831,42 @@ export class LocalNotebooks extends Dexie {
       children: [],
       remoteUri: undefined,
       parents: [parentUri],
-    };
+    }
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {
-    if (!uri.startsWith("local://file/")) {
-      throw new Error("LocalNotebooks.rename expects a file URI");
+    if (!uri.startsWith('local://file/')) {
+      throw new Error('LocalNotebooks.rename expects a file URI')
     }
 
-    const record = await this.files.get(uri);
+    const record = await this.files.get(uri)
     if (!record) {
-      throw new Error(`Local notebook record not found for ${uri}`);
+      throw new Error(`Local notebook record not found for ${uri}`)
     }
 
-    let nextName = name;
-    let nextRemoteId = record.remoteId;
+    let nextName = name
+    let nextRemoteId = record.remoteId
 
     if (isDriveUri(record.remoteId)) {
-      const remoteItem = await this.driveStore.rename(record.remoteId, name);
-      nextName = remoteItem.name || name;
-      nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId;
+      const remoteItem = await this.driveStore.rename(record.remoteId, name)
+      nextName = remoteItem.name || name
+      nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId
     }
 
-    await this.files.update(uri, { name: nextName, remoteId: nextRemoteId });
+    await this.files.update(uri, { name: nextName, remoteId: nextRemoteId })
 
-    const parentFolder = await this.findParentFolder(uri);
+    const parentFolder = await this.findParentFolder(uri)
 
     if (canDispatchWindowEvents()) {
       window.dispatchEvent(
-        new CustomEvent("local-notebook-updated", {
+        new CustomEvent('local-notebook-updated', {
           detail: {
             uri,
             name: nextName,
             remoteUri: publicRemoteUri({ ...record, remoteId: nextRemoteId }),
           },
-        }),
-      );
+        })
+      )
     }
 
     return {
@@ -747,7 +876,7 @@ export class LocalNotebooks extends Dexie {
       children: [],
       remoteUri: publicRemoteUri({ ...record, remoteId: nextRemoteId }),
       parents: parentFolder ? [parentFolder.id] : [],
-    };
+    }
   }
 
   /**
@@ -758,70 +887,74 @@ export class LocalNotebooks extends Dexie {
    * by Google Drive.
    */
   async syncMarkdownFile(localUri: string): Promise<void> {
-    if (!localUri.startsWith("local://file/")) {
-      throw new Error("syncMarkdownFile expects a local://file/ URI");
+    if (!localUri.startsWith('local://file/')) {
+      throw new Error('syncMarkdownFile expects a local://file/ URI')
     }
 
-    const record = await this.files.get(localUri);
+    const record = await this.files.get(localUri)
     if (!record) {
-      throw new Error(`Local notebook record not found for ${localUri}`);
+      throw new Error(`Local notebook record not found for ${localUri}`)
     }
 
     // Only Drive-backed files need a Markdown sidecar.
     if (!isDriveUri(record.remoteId)) {
-      return;
+      return
     }
 
-    const driveStore = appState.driveNotebookStore ?? this.driveStore;
+    const driveStore = appState.driveNotebookStore ?? this.driveStore
     if (!driveStore) {
-      console.error("No DriveNotebookStore available for syncing markdown");
-      return;
+      console.error('No DriveNotebookStore available for syncing markdown')
+      return
     }
 
-    let markdownUri = record.markdownUri;
+    let markdownUri = record.markdownUri
 
     if (!markdownUri) {
-      const metadata = await driveStore.getMetadata(record.remoteId);
-      const parentUri = metadata?.parents?.[0];
-      const name = metadata?.name ?? "notebook";
+      const metadata = await driveStore.getMetadata(record.remoteId)
+      const parentUri = metadata?.parents?.[0]
+      const name = metadata?.name ?? 'notebook'
 
       if (!parentUri) {
-        console.warn("Cannot create markdown sidecar without parent folder", {
+        console.warn('Cannot create markdown sidecar without parent folder', {
           remoteId: record.remoteId,
-        });
-        return;
+        })
+        return
       }
 
-      const baseName = name.replace(/\.[^.]+$/, "");
-      const markdownName = `${baseName}.index.md`;
+      const baseName = name.replace(/\.[^.]+$/, '')
+      const markdownName = `${baseName}.index.md`
 
-      const markdownFile = await driveStore.create(parentUri, markdownName);
-      markdownUri = markdownFile.uri;
-      await this.files.update(localUri, { markdownUri });
+      const markdownFile = await driveStore.create(parentUri, markdownName)
+      markdownUri = markdownFile.uri
+      await this.files.update(localUri, { markdownUri })
     }
 
-    let markdownContent: string;
+    let markdownContent: string
     try {
-      const notebook = deserializeNotebook(record.doc ?? "");
-      markdownContent = serializeNotebookToMarkdown(notebook);
+      const notebook = deserializeNotebook(record.doc ?? '')
+      markdownContent = serializeNotebookToMarkdown(notebook)
     } catch (error) {
-      console.error("Failed to serialize notebook to markdown", error);
-      return;
+      console.error('Failed to serialize notebook to markdown', error)
+      return
     }
 
     try {
-      await driveStore.saveContent(markdownUri, markdownContent, "text/markdown");
+      await driveStore.saveContent(
+        markdownUri,
+        markdownContent,
+        'text/markdown'
+      )
     } catch (error) {
-      console.error("Failed to upload markdown sidecar to Drive", error);
+      console.error('Failed to upload markdown sidecar to Drive', error)
     }
   }
 
   /**
    * Generate a stable local URI for a file or folder using a random UUID.
    */
-  private generateLocalUri(type: "file" | "folder"): string {
-    const uuid = uuidv4();
-    return `local://${type}/${uuid}`;
+  private generateLocalUri(type: 'file' | 'folder'): string {
+    const uuid = uuidv4()
+    return `local://${type}/${uuid}`
   }
 
   /**
@@ -833,26 +966,33 @@ export class LocalNotebooks extends Dexie {
    */
   async listDriveBackedFilesNeedingSync(): Promise<string[]> {
     const driveBackedFiles = await this.files
-      .filter((record) =>
-        isDriveUri(record.remoteId) ||
-        Boolean(record.parentRemoteIdWhenCreated),
+      .filter(
+        (record) =>
+          isDriveUri(record.remoteId) ||
+          Boolean(record.parentRemoteIdWhenCreated)
       )
-      .toArray();
-    const pending: string[] = [];
+      .toArray()
+    const pending: string[] = []
 
     for (const record of driveBackedFiles) {
-      if (record.remoteId === "" && record.parentRemoteIdWhenCreated) {
-        pending.push(record.id);
-        continue;
+      if (record.conflict) {
+        continue
       }
-      const localChecksum = await this.getOrBackfillLocalChecksum(record.id, record);
-      const lastRemoteChecksum = record.lastRemoteChecksum ?? "";
+      if (record.remoteId === '' && record.parentRemoteIdWhenCreated) {
+        pending.push(record.id)
+        continue
+      }
+      const localChecksum = await this.getOrBackfillLocalChecksum(
+        record.id,
+        record
+      )
+      const lastRemoteChecksum = record.lastRemoteChecksum ?? ''
       if (localChecksum !== lastRemoteChecksum) {
-        pending.push(record.id);
+        pending.push(record.id)
       }
     }
 
-    return pending;
+    return pending
   }
 
   /**
@@ -860,117 +1000,117 @@ export class LocalNotebooks extends Dexie {
    * Returns the list of enqueued local URIs.
    */
   async enqueueDriveBackedFilesNeedingSync(): Promise<string[]> {
-    const pending = await this.listDriveBackedFilesNeedingSync();
-    appLogger.info("Drive resync reconciliation evaluated pending files", {
+    const pending = await this.listDriveBackedFilesNeedingSync()
+    appLogger.info('Drive resync reconciliation evaluated pending files', {
       attrs: {
-        scope: "storage.drive.sync",
-        code: "DRIVE_RESYNC_EVALUATED",
+        scope: 'storage.drive.sync',
+        code: 'DRIVE_RESYNC_EVALUATED',
         pendingCount: pending.length,
         localUris: pending,
       },
-    });
+    })
     for (const uri of pending) {
-      appLogger.info("Requeued Drive-backed notebook for sync", {
+      appLogger.info('Requeued Drive-backed notebook for sync', {
         attrs: {
-          scope: "storage.drive.sync",
-          code: "DRIVE_RESYNC_REQUEUED_FILE",
+          scope: 'storage.drive.sync',
+          code: 'DRIVE_RESYNC_REQUEUED_FILE',
           localUri: uri,
         },
-      });
-      this.enqueueSync(uri);
-      this.enqueueMarkdownSync(uri);
+      })
+      this.enqueueSync(uri)
+      this.enqueueMarkdownSync(uri)
     }
-    return pending;
+    return pending
   }
 
   private enqueueSync(uri: string): void {
-    let subject = this.syncSubjects.get(uri);
+    let subject = this.syncSubjects.get(uri)
     if (!subject) {
-      subject = new Subject<void>();
-      const DEBOUNCE_TIME_MS = 20 * 1000; // 20 seconds
+      subject = new Subject<void>()
+      const DEBOUNCE_TIME_MS = 20 * 1000 // 20 seconds
       subject.pipe(debounceTime(DEBOUNCE_TIME_MS)).subscribe(async () => {
         try {
-          await this.syncFile(uri);
+          await this.syncFile(uri)
         } catch (error) {
-          console.error("Failed to synchronise notebook", uri, error);
+          console.error('Failed to synchronise notebook', uri, error)
         }
-      });
-      this.syncSubjects.set(uri, subject);
+      })
+      this.syncSubjects.set(uri, subject)
     }
-    subject.next();
+    subject.next()
   }
 
   private notifySync(uri: string): void {
-    const listeners = this.syncListeners.get(uri);
+    const listeners = this.syncListeners.get(uri)
     if (listeners) {
       for (const listener of listeners) {
         try {
-          listener();
+          listener()
         } catch (error) {
-          console.error("Local notebook sync listener failed", error);
+          console.error('Local notebook sync listener failed', error)
         }
       }
     }
     if (canDispatchWindowEvents()) {
       window.dispatchEvent(
-        new CustomEvent("local-notebook-sync-updated", {
+        new CustomEvent('local-notebook-sync-updated', {
           detail: { uri },
-        }),
-      );
+        })
+      )
     }
   }
 
   private enqueueMarkdownSync(uri: string): void {
-    let mdSubject = this.markdownSyncSubjects.get(uri);
+    let mdSubject = this.markdownSyncSubjects.get(uri)
     if (!mdSubject) {
-      mdSubject = new Subject<void>();
-      const DEBOUNCE_TIME_MS = 20 * 1000; // 20 seconds
+      mdSubject = new Subject<void>()
+      const DEBOUNCE_TIME_MS = 20 * 1000 // 20 seconds
       mdSubject.pipe(debounceTime(DEBOUNCE_TIME_MS)).subscribe(async () => {
         try {
-          await this.syncMarkdownFile(uri);
+          await this.syncMarkdownFile(uri)
         } catch (error) {
-          console.error("Failed to synchronise markdown sidecar", uri, error);
+          console.error('Failed to synchronise markdown sidecar', uri, error)
         }
-      });
-      this.markdownSyncSubjects.set(uri, mdSubject);
+      })
+      this.markdownSyncSubjects.set(uri, mdSubject)
     }
-    mdSubject.next();
+    mdSubject.next()
   }
 
   private async getOrBackfillLocalChecksum(
     localUri: string,
-    record: LocalFileRecord,
+    record: LocalFileRecord
   ): Promise<string> {
-    const doc = record.doc ?? "";
-    if (typeof record.md5Checksum === "string") {
+    const doc = record.doc ?? ''
+    if (typeof record.md5Checksum === 'string') {
       // Empty docs intentionally hash to "" and do not need backfill writes.
-      if (record.md5Checksum !== "" || doc === "") {
-        return record.md5Checksum;
+      if (record.md5Checksum !== '' || doc === '') {
+        return record.md5Checksum
       }
     }
 
-    const checksum = checksumForSerializedNotebook(doc);
-    await this.files.update(localUri, { md5Checksum: checksum });
-    return checksum;
+    const checksum = checksumForSerializedNotebook(doc)
+    await this.files.update(localUri, { md5Checksum: checksum })
+    return checksum
   }
 
   private async ensureFolderRecord(
     id: string,
-    name: string,
+    name: string
   ): Promise<LocalFolderRecord> {
-    const existing = await this.folders.get(id);
+    const existing = await this.folders.get(id)
     if (existing) {
-      return existing;
+      return existing
     }
     const record: LocalFolderRecord = {
       id,
       name,
       remoteId: id,
       children: [],
-      lastSynced: "",
-    };
-    await this.folders.put(record);
-    return record;
+      lastSynced: '',
+    }
+    await this.folders.put(record)
+    return record
   }
 
   /**
@@ -979,151 +1119,167 @@ export class LocalNotebooks extends Dexie {
    */
   private deriveDisplayNameFromUri(uri: string): string | null {
     try {
-      const url = new URL(uri);
-      const segments = url.pathname.split("/").filter(Boolean);
+      const url = new URL(uri)
+      const segments = url.pathname.split('/').filter(Boolean)
       if (segments.length > 0) {
-        return decodeURIComponent(segments[segments.length - 1]);
+        return decodeURIComponent(segments[segments.length - 1])
       }
     } catch {
       // Ignore parse failures and fall bacfk to the simple heuristic below.
     }
 
-    const rawSegments = uri.split("/").filter(Boolean);
+    const rawSegments = uri.split('/').filter(Boolean)
     if (rawSegments.length > 0) {
-      return rawSegments[rawSegments.length - 1];
+      return rawSegments[rawSegments.length - 1]
     }
 
-    return null;
+    return null
   }
 
   private async syncFile(localUri: string): Promise<void> {
-    const existingSync = this.inFlightSyncs.get(localUri);
+    const existingSync = this.inFlightSyncs.get(localUri)
     if (existingSync) {
-      return existingSync;
+      return existingSync
     }
 
     const operation = Promise.resolve().then(async () => {
       try {
-        await this.syncFileInner(localUri);
-        await this.files.update(localUri, { lastSyncError: undefined });
+        await this.syncFileInner(localUri)
+        await this.files.update(localUri, { lastSyncError: undefined })
       } catch (error) {
-        await this.files.update(localUri, { lastSyncError: String(error) });
-        throw error;
+        await this.files.update(localUri, { lastSyncError: String(error) })
+        throw error
       }
-    });
-    this.inFlightSyncs.set(localUri, operation);
-    this.notifySync(localUri);
+    })
+    this.inFlightSyncs.set(localUri, operation)
+    this.notifySync(localUri)
 
     const cleanup = () => {
       if (this.inFlightSyncs.get(localUri) !== operation) {
-        return;
+        return
       }
-      this.inFlightSyncs.delete(localUri);
-      this.notifySync(localUri);
-    };
-    void operation.then(cleanup, cleanup);
-    return operation;
+      this.inFlightSyncs.delete(localUri)
+      this.notifySync(localUri)
+    }
+    void operation.then(cleanup, cleanup)
+    return operation
   }
 
   private async syncFileInner(localUri: string): Promise<void> {
-    let record = await this.files.get(localUri);
+    let record = await this.files.get(localUri)
     if (!record) {
-      throw new Error(`Local notebook record not found for ${localUri}`);
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (record.conflict) {
+      appLogger.info('Skipping automatic sync for conflicted notebook', {
+        attrs: {
+          scope: 'storage.drive.sync',
+          code: 'DRIVE_NOTEBOOK_CONFLICT_SYNC_SKIPPED',
+          localUri,
+          remoteUri: record.remoteId,
+        },
+      })
+      return
     }
 
     // Files that do not have a remote counterpart live exclusively in
     // IndexedDB. There is nothing to synchronise for those entries, so we can
     // exit early once we've confirmed the local metadata exists.
-    let completedPendingCreate = false;
+    let completedPendingCreate = false
     if (!record.remoteId) {
       if (!record.parentRemoteIdWhenCreated) {
         throw new Error(
-          `Local notebook ${localUri} is missing remoteId and pending parent`,
-        );
+          `Local notebook ${localUri} is missing remoteId and pending parent`
+        )
       }
-      await this.completePendingDriveCreate(localUri, record);
-      completedPendingCreate = true;
-      const updated = await this.files.get(localUri);
+      await this.completePendingDriveCreate(localUri, record)
+      completedPendingCreate = true
+      const updated = await this.files.get(localUri)
       if (!updated?.remoteId) {
-        throw new Error(`Failed to create Drive file for pending notebook ${localUri}`);
+        throw new Error(
+          `Failed to create Drive file for pending notebook ${localUri}`
+        )
       }
-      record = updated;
+      record = updated
     }
 
     if (isLocalFileUpstream(record.remoteId, localUri)) {
       await this.files.update(localUri, {
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
-      });
-      return;
+      })
+      return
     }
 
     if (isFilesystemUri(record.remoteId)) {
-      await this.syncSerializedNotebookUpstream(localUri, record);
-      return;
+      await this.syncSerializedNotebookUpstream(localUri, record)
+      return
     }
 
     if (!isDriveUri(record.remoteId)) {
       throw new Error(
-        `Unsupported upstream URI ${record.remoteId} for local notebook ${localUri}`,
-      );
+        `Unsupported upstream URI ${record.remoteId} for local notebook ${localUri}`
+      )
     }
 
-    const remoteUri = record.remoteId;
+    const remoteUri = record.remoteId
 
-    let remoteName: string | undefined;
+    let remoteName: string | undefined
     try {
-      const metadata = await this.driveStore.getMetadata(remoteUri);
-      remoteName = metadata?.name;
+      const metadata = await this.driveStore.getMetadata(remoteUri)
+      remoteName = metadata?.name
     } catch (error) {
-      console.error("Failed to fetch remote metadata for", remoteUri, error);
+      console.error('Failed to fetch remote metadata for', remoteUri, error)
     }
     if (remoteName && remoteName !== record.name) {
-      await this.files.update(localUri, { name: remoteName });
+      await this.files.update(localUri, { name: remoteName })
     }
 
     // Fetch the current checksum from Drive. We treat "missing" as an empty
     // string so downstream comparisons remain simple string equality checks.
-    let currentVersion: UpstreamVersion = {};
-    let currentRemoteChecksum = "";
+    let currentVersion: UpstreamVersion = {}
+    let currentRemoteChecksum = ''
     try {
       currentVersion = driveMetadataToUpstreamVersion(
-        await this.driveStore.getVersionMetadata(remoteUri),
-      );
-      currentRemoteChecksum = currentVersion.checksum ?? "";
+        await this.driveStore.getVersionMetadata(remoteUri)
+      )
+      currentRemoteChecksum = currentVersion.checksum ?? ''
     } catch (error) {
       console.error(
-        "Failed to retrieve remote checksum while synchronising",
+        'Failed to retrieve remote checksum while synchronising',
         remoteUri,
-        error,
-      );
-      throw error;
+        error
+      )
+      throw error
     }
 
-    const lastReadChecksum = record.lastRemoteChecksum ?? "";
-    const localDoc = record.doc ?? "";
-    const localChecksum = await this.getOrBackfillLocalChecksum(localUri, record);
-    let synced = false;
+    const lastReadChecksum = record.lastRemoteChecksum ?? ''
+    const localDoc = record.doc ?? ''
+    const localChecksum = await this.getOrBackfillLocalChecksum(
+      localUri,
+      record
+    )
+    let synced = false
 
     // Case 1: The checksum reported by Drive matches the version we last
     // observed. This means no external party has modified the remote file and
     // the local content is authoritative. We can safely push our data back to
     // Drive without risking data loss.
     if (currentRemoteChecksum === lastReadChecksum) {
-      await this.saveLocalDocToDrive(localUri, remoteUri, localDoc);
+      await this.saveLocalDocToDrive(localUri, remoteUri, localDoc)
       const updatedVersion = driveMetadataToUpstreamVersion(
-        await this.driveStore.getVersionMetadata(remoteUri),
-      );
-      const updatedChecksum = updatedVersion.checksum ?? "";
+        await this.driveStore.getVersionMetadata(remoteUri)
+      )
+      const updatedChecksum = updatedVersion.checksum ?? ''
       await this.files.update(localUri, {
         lastRemoteChecksum: updatedChecksum,
         lastUpstreamVersion: updatedVersion,
         md5Checksum: localChecksum,
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
-      });
-      synced = true;
-      return;
+      })
+      synced = true
+      return
     }
 
     // Case 2: We have never read the remote file (the cache holds an empty
@@ -1131,54 +1287,62 @@ export class LocalNotebooks extends Dexie {
     // copy only if the local record has no user-authored content. Otherwise,
     // prefer the local IndexedDB content because overwriting it risks data loss.
     if (!lastReadChecksum && currentRemoteChecksum) {
-      if (completedPendingCreate && serializedNotebookHasUserContent(localDoc)) {
-        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc);
+      if (
+        completedPendingCreate &&
+        serializedNotebookHasUserContent(localDoc)
+      ) {
+        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc)
         const updatedVersion = driveMetadataToUpstreamVersion(
-          await this.driveStore.getVersionMetadata(remoteUri),
-        );
-        const updatedChecksum = updatedVersion.checksum ?? "";
+          await this.driveStore.getVersionMetadata(remoteUri)
+        )
+        const updatedChecksum = updatedVersion.checksum ?? ''
         await this.files.update(localUri, {
           lastRemoteChecksum: updatedChecksum,
           lastUpstreamVersion: updatedVersion,
           md5Checksum: localChecksum,
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
-        });
-        synced = true;
-        return;
+        })
+        synced = true
+        return
       }
 
       if (serializedNotebookHasUserContent(localDoc)) {
         appLogger.warn(
-          "Forking local notebook because Drive exists without a baseline checksum",
+          'Forking local notebook because Drive exists without a baseline checksum',
           {
             attrs: {
-              scope: "storage.drive.sync",
+              scope: 'storage.drive.sync',
               localUri,
               remoteUri,
               remoteChecksum: currentRemoteChecksum,
               localChecksum,
             },
-          },
-        );
-        await this.handleConflict(localUri, record, currentRemoteChecksum);
-        synced = true;
-        return;
+          }
+        )
+        await this.recordConflict(
+          localUri,
+          record,
+          currentVersion,
+          localChecksum
+        )
+        synced = true
+        return
       }
 
-      const remoteNotebook = await this.driveStore.load(remoteUri);
-      const serialized = serializeNotebook(remoteNotebook);
+      const remoteNotebook = await this.driveStore.load(remoteUri)
+      const serialized = serializeNotebook(remoteNotebook)
       logRemoteOverwriteLocalDoc({
         localUri,
         remoteUri,
         localChecksum,
         remoteChecksum: currentRemoteChecksum,
-        reason: "no-local-baseline-checksum",
+        reason: 'no-local-baseline-checksum',
         localDoc,
         remoteDoc: serialized,
         previousUpstreamRevisionId: record.lastUpstreamVersion?.revisionId,
         upstreamRevisionId: currentVersion.revisionId,
-      });
+      })
       await this.files.update(localUri, {
         doc: serialized,
         md5Checksum: checksumForSerializedNotebook(serialized),
@@ -1186,9 +1350,9 @@ export class LocalNotebooks extends Dexie {
         lastUpstreamVersion: currentVersion,
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
-      });
-      synced = true;
-      return;
+      })
+      synced = true
+      return
     }
 
     // Case 3: Drive reports a different checksum than the one we last synced
@@ -1196,19 +1360,19 @@ export class LocalNotebooks extends Dexie {
     // else updated the remote file and we simply need to refresh our cache.
     if (currentRemoteChecksum && currentRemoteChecksum !== lastReadChecksum) {
       if (localChecksum === lastReadChecksum) {
-        const remoteNotebook = await this.driveStore.load(remoteUri);
-        const serialized = serializeNotebook(remoteNotebook);
+        const remoteNotebook = await this.driveStore.load(remoteUri)
+        const serialized = serializeNotebook(remoteNotebook)
         logRemoteOverwriteLocalDoc({
           localUri,
           remoteUri,
           localChecksum,
           remoteChecksum: currentRemoteChecksum,
-          reason: "local-matches-previous-remote-baseline",
+          reason: 'local-matches-previous-remote-baseline',
           localDoc,
           remoteDoc: serialized,
           previousUpstreamRevisionId: record.lastUpstreamVersion?.revisionId,
           upstreamRevisionId: currentVersion.revisionId,
-        });
+        })
         await this.files.update(localUri, {
           doc: serialized,
           md5Checksum: checksumForSerializedNotebook(serialized),
@@ -1216,17 +1380,17 @@ export class LocalNotebooks extends Dexie {
           lastUpstreamVersion: currentVersion,
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
-        });
-        synced = true;
-        return;
+        })
+        synced = true
+        return
       }
 
       // The remote file changed AND we have unapplied local changes (the local
-      // checksum diverges from the shared base). Defer conflict resolution to
-      // `handleConflict`, which will fork a new Drive file so data is not lost.
-      await this.handleConflict(localUri, record, currentRemoteChecksum);
-      synced = true;
-      return;
+      // checksum diverges from the shared base). Record a durable conflict and
+      // wait for the user to choose which version should win.
+      await this.recordConflict(localUri, record, currentVersion, localChecksum)
+      synced = true
+      return
     }
 
     // Case 4: The remote file does not have a checksum (e.g. an empty file).
@@ -1234,28 +1398,28 @@ export class LocalNotebooks extends Dexie {
     // keep the baseline empty.
     if (!currentRemoteChecksum) {
       if (localDoc) {
-        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc);
+        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc)
         const updatedVersion = driveMetadataToUpstreamVersion(
-          await this.driveStore.getVersionMetadata(remoteUri),
-        );
-        const updatedChecksum = updatedVersion.checksum ?? "";
+          await this.driveStore.getVersionMetadata(remoteUri)
+        )
+        const updatedChecksum = updatedVersion.checksum ?? ''
         await this.files.update(localUri, {
           lastRemoteChecksum: updatedChecksum,
           lastUpstreamVersion: updatedVersion,
           md5Checksum: localChecksum,
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
-        });
-        synced = true;
+        })
+        synced = true
       } else if (lastReadChecksum) {
         await this.files.update(localUri, {
-          lastRemoteChecksum: "",
+          lastRemoteChecksum: '',
           lastUpstreamVersion: currentVersion,
           md5Checksum: localChecksum,
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
-        });
-        synced = true;
+        })
+        synced = true
       }
     }
 
@@ -1263,142 +1427,151 @@ export class LocalNotebooks extends Dexie {
       await this.files.update(localUri, {
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
-      });
+      })
     }
   }
 
   private async saveLocalDocToDrive(
     localUri: string,
     remoteUri: string,
-    localDoc: string,
+    localDoc: string
   ): Promise<void> {
     if (!localDoc) {
       await this.driveStore.save(
         remoteUri,
-        create(parser_pb.NotebookSchema, { cells: [] }),
-      );
-      return;
+        create(parser_pb.NotebookSchema, { cells: [] })
+      )
+      return
     }
 
-    const parseResult = parseSerializedNotebook(localDoc);
+    const parseResult = parseSerializedNotebook(localDoc)
     if (parseResult.ok) {
-      await this.driveStore.save(remoteUri, parseResult.notebook);
-      return;
+      await this.driveStore.save(remoteUri, parseResult.notebook)
+      return
     }
 
-    appLogger.warn("Saving raw local notebook JSON because parsing failed", {
+    appLogger.warn('Saving raw local notebook JSON because parsing failed', {
       attrs: {
-        scope: "storage.drive.sync",
+        scope: 'storage.drive.sync',
         localUri,
         remoteUri,
         error: String(parseResult.error),
       },
-    });
-    await this.driveStore.saveContent(remoteUri, localDoc, "application/json");
+    })
+    await this.driveStore.saveContent(remoteUri, localDoc, 'application/json')
   }
 
   private async completePendingDriveCreate(
     localUri: string,
-    record: LocalFileRecord,
+    record: LocalFileRecord
   ): Promise<void> {
-    const parentRemoteUri = record.parentRemoteIdWhenCreated;
+    const parentRemoteUri = record.parentRemoteIdWhenCreated
     if (!parentRemoteUri) {
-      throw new Error(`Missing pending Drive parent for ${localUri}`);
+      throw new Error(`Missing pending Drive parent for ${localUri}`)
     }
     if (!isDriveUri(parentRemoteUri)) {
       throw new Error(
-        `Pending upstream parent is not a Drive folder for ${localUri}: ${parentRemoteUri}`,
-      );
+        `Pending upstream parent is not a Drive folder for ${localUri}: ${parentRemoteUri}`
+      )
     }
 
-    const newFile = await this.driveStore.create(parentRemoteUri, record.name);
-    let version: UpstreamVersion = {};
+    const newFile = await this.driveStore.create(parentRemoteUri, record.name)
+    let version: UpstreamVersion = {}
     try {
       version = driveMetadataToUpstreamVersion(
-        await this.driveStore.getVersionMetadata(newFile.uri),
-      );
+        await this.driveStore.getVersionMetadata(newFile.uri)
+      )
     } catch (error) {
-      appLogger.warn("Failed to record version metadata for new Drive notebook", {
-        attrs: {
-          scope: "storage.drive.sync",
-          localUri,
-          remoteUri: newFile.uri,
-          error: String(error),
-        },
-      });
+      appLogger.warn(
+        'Failed to record version metadata for new Drive notebook',
+        {
+          attrs: {
+            scope: 'storage.drive.sync',
+            localUri,
+            remoteUri: newFile.uri,
+            error: String(error),
+          },
+        }
+      )
     }
-    const currentRecord = await this.files.get(localUri);
-    const localDoc = currentRecord?.doc ?? record.doc ?? "";
-    const hasLocalContent = serializedNotebookHasUserContent(localDoc);
+    const currentRecord = await this.files.get(localUri)
+    const localDoc = currentRecord?.doc ?? record.doc ?? ''
+    const hasLocalContent = serializedNotebookHasUserContent(localDoc)
 
     await this.files.update(localUri, {
       name: newFile.name ?? record.name,
       remoteId: newFile.uri,
       parentRemoteIdWhenCreated: undefined,
-      lastRemoteChecksum: version.checksum ?? "",
+      lastRemoteChecksum: version.checksum ?? '',
       lastUpstreamVersion: version,
-      lastSynced: hasLocalContent ? "" : nowIsoString(),
+      lastSynced: hasLocalContent ? '' : nowIsoString(),
       lastSyncError: undefined,
-    });
+    })
 
-    appLogger.info("Created pending Drive notebook upstream file", {
+    appLogger.info('Created pending Drive notebook upstream file', {
       attrs: {
-        scope: "storage.drive.sync",
+        scope: 'storage.drive.sync',
         localUri,
         parentRemoteUri,
         remoteUri: newFile.uri,
         upstreamChecksum: version.checksum,
         upstreamRevisionId: version.revisionId,
       },
-    });
+    })
 
     if (canDispatchWindowEvents()) {
       window.dispatchEvent(
-        new CustomEvent("local-notebook-updated", {
+        new CustomEvent('local-notebook-updated', {
           detail: {
             uri: localUri,
             name: newFile.name ?? record.name,
             remoteUri: newFile.uri,
           },
-        }),
-      );
+        })
+      )
     }
   }
 
   private resolveSerializedNotebookStore(upstreamUri: string): {
-    load(uri: string): Promise<parser_pb.Notebook>;
-    save(uri: string, notebook: parser_pb.Notebook): Promise<unknown>;
+    load(uri: string): Promise<parser_pb.Notebook>
+    save(uri: string, notebook: parser_pb.Notebook): Promise<unknown>
   } | null {
     if (isFilesystemUri(upstreamUri)) {
-      return this.filesystemStore;
+      return this.filesystemStore
     }
-    return null;
+    return null
   }
 
   private async syncSerializedNotebookUpstream(
     localUri: string,
-    record: LocalFileRecord,
+    record: LocalFileRecord
   ): Promise<void> {
-    const upstreamUri = record.remoteId;
-    const upstreamStore = this.resolveSerializedNotebookStore(upstreamUri);
+    const upstreamUri = record.remoteId
+    const upstreamStore = this.resolveSerializedNotebookStore(upstreamUri)
     if (!upstreamStore) {
-      appLogger.warn("Skipping notebook sync because upstream store is unavailable", {
-        attrs: {
-          scope: "storage.local.sync",
-          localUri,
-          upstreamUri,
-        },
-      });
-      return;
+      appLogger.warn(
+        'Skipping notebook sync because upstream store is unavailable',
+        {
+          attrs: {
+            scope: 'storage.local.sync',
+            localUri,
+            upstreamUri,
+          },
+        }
+      )
+      return
     }
 
-    const localDoc = record.doc ?? "";
-    const localChecksum = await this.getOrBackfillLocalChecksum(localUri, record);
-    const lastRemoteChecksum = record.lastRemoteChecksum ?? "";
+    const localDoc = record.doc ?? ''
+    const localChecksum = await this.getOrBackfillLocalChecksum(
+      localUri,
+      record
+    )
+    const lastRemoteChecksum = record.lastRemoteChecksum ?? ''
 
     if (!localDoc) {
-      const upstreamNotebook = await upstreamStore.load(upstreamUri);
-      const upstreamDoc = serializeNotebook(upstreamNotebook);
+      const upstreamNotebook = await upstreamStore.load(upstreamUri)
+      const upstreamDoc = serializeNotebook(upstreamNotebook)
       await this.files.update(localUri, {
         doc: upstreamDoc,
         md5Checksum: checksumForSerializedNotebook(upstreamDoc),
@@ -1408,13 +1581,13 @@ export class LocalNotebooks extends Dexie {
         },
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
-      });
-      return;
+      })
+      return
     }
 
-    const upstreamNotebook = await upstreamStore.load(upstreamUri);
-    const upstreamDoc = serializeNotebook(upstreamNotebook);
-    const upstreamChecksum = checksumForSerializedNotebook(upstreamDoc);
+    const upstreamNotebook = await upstreamStore.load(upstreamUri)
+    const upstreamDoc = serializeNotebook(upstreamNotebook)
+    const upstreamChecksum = checksumForSerializedNotebook(upstreamDoc)
 
     if (upstreamChecksum !== lastRemoteChecksum) {
       if (localChecksum === lastRemoteChecksum) {
@@ -1423,10 +1596,10 @@ export class LocalNotebooks extends Dexie {
           remoteUri: upstreamUri,
           localChecksum,
           remoteChecksum: upstreamChecksum,
-          reason: "local-matches-previous-upstream-baseline",
+          reason: 'local-matches-previous-upstream-baseline',
           localDoc,
           remoteDoc: upstreamDoc,
-        });
+        })
         await this.files.update(localUri, {
           doc: upstreamDoc,
           md5Checksum: upstreamChecksum,
@@ -1436,37 +1609,40 @@ export class LocalNotebooks extends Dexie {
           },
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
-        });
-        return;
+        })
+        return
       }
 
-      appLogger.warn("Refusing to overwrite changed local and upstream notebooks", {
-        attrs: {
-          scope: "storage.local.sync",
-          localUri,
-          upstreamUri,
-          localChecksum,
-          upstreamChecksum,
-          lastRemoteChecksum,
-        },
-      });
-      return;
+      appLogger.warn(
+        'Refusing to overwrite changed local and upstream notebooks',
+        {
+          attrs: {
+            scope: 'storage.local.sync',
+            localUri,
+            upstreamUri,
+            localChecksum,
+            upstreamChecksum,
+            lastRemoteChecksum,
+          },
+        }
+      )
+      return
     }
 
-    const parseResult = parseSerializedNotebook(localDoc);
+    const parseResult = parseSerializedNotebook(localDoc)
     if (!parseResult.ok) {
-      appLogger.warn("Refusing to sync unparsable local notebook to upstream", {
+      appLogger.warn('Refusing to sync unparsable local notebook to upstream', {
         attrs: {
-          scope: "storage.local.sync",
+          scope: 'storage.local.sync',
           localUri,
           upstreamUri,
           error: String(parseResult.error),
         },
-      });
-      return;
+      })
+      return
     }
 
-    await upstreamStore.save(upstreamUri, parseResult.notebook);
+    await upstreamStore.save(upstreamUri, parseResult.notebook)
     await this.files.update(localUri, {
       lastRemoteChecksum: localChecksum,
       lastUpstreamVersion: {
@@ -1475,223 +1651,177 @@ export class LocalNotebooks extends Dexie {
       md5Checksum: localChecksum,
       lastSynced: nowIsoString(),
       lastSyncError: undefined,
-    });
+    })
   }
 
-  private async handleConflict(
+  private async recordConflict(
     localUri: string,
     record: LocalFileRecord,
-    remoteChecksum: string,
+    upstreamVersion: UpstreamVersion,
+    localChecksum: string
   ): Promise<void> {
     if (!record.remoteId) {
-      throw new Error("Unable to resolve conflict without a remoteId");
+      throw new Error('Unable to resolve conflict without a remoteId')
     }
-
-    const parentFolder = await this.findParentFolder(localUri);
-    const parentRemoteUri = parentFolder?.remoteId;
-    if (!parentRemoteUri) {
+    if (!isDriveUri(record.remoteId)) {
       throw new Error(
-        `Unable to determine parent Drive folder for conflicted notebook ${localUri}`,
-      );
+        `Conflict recording is only supported for Drive-backed notebooks; got ${record.remoteId}`
+      )
     }
 
-    const timestamp = formatTimestamp(new Date());
-    const baseName = stripTimestampSuffix(record.name);
-    const newName = `${baseName}.${timestamp}.json`;
-
-    const newFile = await this.driveStore.create(parentRemoteUri, newName);
-    const localDoc = record.doc ?? "";
-    const parseResult = parseSerializedNotebook(localDoc);
-    if (parseResult.ok) {
-      await this.driveStore.save(newFile.uri, parseResult.notebook);
-    } else {
-      appLogger.warn(
-        "Saving raw local notebook JSON to conflict file because parsing failed",
-        {
-          attrs: {
-            scope: "storage.drive.sync",
-            localUri,
-            newRemoteUri: newFile.uri,
-            error: String(parseResult.error),
-          },
-        },
-      );
-      await this.driveStore.saveContent(
-        newFile.uri,
-        localDoc,
-        "application/json",
-      );
-    }
-
-    let newFileVersion: UpstreamVersion = {};
-    try {
-      newFileVersion = driveMetadataToUpstreamVersion(
-        await this.driveStore.getVersionMetadata(newFile.uri),
-      );
-    } catch (error) {
-      appLogger.warn("Failed to record version metadata for conflict Drive notebook", {
-        attrs: {
-          scope: "storage.drive.sync",
-          localUri,
-          remoteUri: newFile.uri,
-          error: String(error),
-        },
-      });
-    }
+    const upstreamNotebook = await this.driveStore.load(record.remoteId)
+    const upstreamDoc = serializeNotebook(upstreamNotebook)
+    const upstreamChecksum =
+      upstreamVersion.checksum || checksumForSerializedNotebook(upstreamDoc)
 
     await this.files.update(localUri, {
-      name: newName,
-      remoteId: newFile.uri,
-      parentRemoteIdWhenCreated: undefined,
-      lastRemoteChecksum: newFileVersion.checksum ?? "",
-      lastUpstreamVersion: newFileVersion,
-      lastSynced: nowIsoString(),
+      conflict: {
+        detectedAt: nowIsoString(),
+        upstreamChecksum,
+        upstreamVersion,
+        upstreamDoc,
+        localChecksumAtDetection: localChecksum,
+      },
       lastSyncError: undefined,
-    });
+    })
 
-    console.warn("Notebook conflict resolved by creating a new file", {
-      localUri,
-      previousRemote: record.remoteId,
-      newRemote: newFile.uri,
-      previousChecksum: record.lastRemoteChecksum,
-      remoteChecksum,
-    });
-
-    if (canDispatchWindowEvents()) {
-      window.dispatchEvent(
-        new CustomEvent("local-notebook-updated", {
-          detail: {
-            uri: localUri,
-            name: newName,
-            remoteUri: newFile.uri,
-          },
-        }),
-      );
-    }
+    appLogger.warn('Notebook sync conflict recorded', {
+      attrs: {
+        scope: 'storage.drive.sync',
+        code: 'DRIVE_NOTEBOOK_CONFLICT_RECORDED',
+        localUri,
+        remoteUri: record.remoteId,
+        lastRemoteChecksum: record.lastRemoteChecksum,
+        localChecksum,
+        upstreamChecksum,
+        upstreamRevisionId: upstreamVersion.revisionId,
+      },
+    })
+    this.notifySync(localUri)
   }
 
   private async findParentFolder(
-    childUri: string,
+    childUri: string
   ): Promise<LocalFolderRecord | null> {
     const folder = await this.folders
       .filter((folder) => folder.children.includes(childUri))
-      .first();
-    return folder ?? null;
+      .first()
+    return folder ?? null
   }
 
   private async syncFolder(localUri: string): Promise<void> {
-    const record = await this.folders.get(localUri);
+    const record = await this.folders.get(localUri)
     if (!record) {
-      throw new Error(`Local folder not found for ${localUri}`);
+      throw new Error(`Local folder not found for ${localUri}`)
     }
 
     if (!isDriveUri(record.remoteId)) {
       await this.folders.update(localUri, {
         lastSynced: nowIsoString(),
-      });
-      return;
+      })
+      return
     }
 
     try {
-      const metadata = await this.driveStore.getMetadata(record.remoteId);
+      const metadata = await this.driveStore.getMetadata(record.remoteId)
       if (metadata?.name && metadata.name !== record.name) {
-        await this.folders.update(localUri, { name: metadata.name });
+        await this.folders.update(localUri, { name: metadata.name })
       }
     } catch (error) {
       console.error(
-        "Failed to fetch remote folder metadata for",
+        'Failed to fetch remote folder metadata for',
         record.remoteId,
-        error,
-      );
+        error
+      )
     }
 
-    await this.updateFolder(record.remoteId, record.name);
+    await this.updateFolder(record.remoteId, record.name)
     await this.folders.update(localUri, {
       lastSynced: nowIsoString(),
-    });
+    })
   }
 }
 
-export default LocalNotebooks;
+export default LocalNotebooks
 
 function checksumForSerializedNotebook(serialized: string): string {
-  return serialized ? md5(serialized) : "";
+  return serialized ? md5(serialized) : ''
 }
 
 function serializeNotebook(notebook: parser_pb.Notebook): string {
   return toJsonString(
     parser_pb.NotebookSchema,
     notebook,
-    NOTEBOOK_JSON_WRITE_OPTIONS,
-  );
+    NOTEBOOK_JSON_WRITE_OPTIONS
+  )
 }
 
 function deserializeNotebook(json: string): parser_pb.Notebook {
   if (!json) {
-    return create(parser_pb.NotebookSchema, { cells: [] });
+    return create(parser_pb.NotebookSchema, { cells: [] })
   }
-  const parsed = parseSerializedNotebook(json);
+  const parsed = parseSerializedNotebook(json)
   if (parsed.ok) {
-    return parsed.notebook;
+    return parsed.notebook
   }
   console.error(
-    "Falling back to empty notebook due to parse failure",
-    parsed.error,
-  );
-  return create(parser_pb.NotebookSchema, { cells: [] });
+    'Falling back to empty notebook due to parse failure',
+    parsed.error
+  )
+  return create(parser_pb.NotebookSchema, { cells: [] })
 }
 
-function parseSerializedNotebook(json: string):
-  | { ok: true; notebook: parser_pb.Notebook }
-  | { ok: false; error: unknown } {
+function parseSerializedNotebook(
+  json: string
+): { ok: true; notebook: parser_pb.Notebook } | { ok: false; error: unknown } {
   try {
     return {
       ok: true,
       notebook: fromJsonString(parser_pb.NotebookSchema, json, {
         ignoreUnknownFields: true,
       }),
-    };
+    }
   } catch (error) {
-    return { ok: false, error };
+    return { ok: false, error }
   }
 }
 
 function serializedNotebookHasUserContent(json: string): boolean {
   if (!json) {
-    return false;
+    return false
   }
   try {
     const notebook = fromJsonString(parser_pb.NotebookSchema, json, {
       ignoreUnknownFields: true,
-    });
+    })
     return (
       notebook.cells.length > 0 ||
       Object.keys(notebook.metadata ?? {}).length > 0
-    );
+    )
   } catch (error) {
-    appLogger.warn("Preserving unparsable local notebook content", {
+    appLogger.warn('Preserving unparsable local notebook content', {
       attrs: {
-        scope: "storage.drive.sync",
+        scope: 'storage.drive.sync',
         error: String(error),
       },
-    });
-    return true;
+    })
+    return true
   }
 }
 
 function driveMetadataToUpstreamVersion(
-  metadata: DriveVersionMetadata | null,
+  metadata: DriveVersionMetadata | null
 ): UpstreamVersion {
   return {
     checksum: metadata?.md5Checksum,
     revisionId: metadata?.headRevisionId,
-  };
+  }
 }
 
 function syncStateForRecord(
   record: LocalFileRecord,
   status: NotebookSyncStatus,
-  fallbackError?: string,
+  fallbackError?: string
 ): NotebookSyncState {
   return {
     status,
@@ -1700,8 +1830,9 @@ function syncStateForRecord(
     parentRemoteIdWhenCreated: record.parentRemoteIdWhenCreated,
     lastSynced: record.lastSynced || undefined,
     lastUpstreamVersion: record.lastUpstreamVersion,
+    conflict: record.conflict,
     lastError: record.lastSyncError || fallbackError,
-  };
+  }
 }
 
 function logRemoteOverwriteLocalDoc({
@@ -1715,22 +1846,22 @@ function logRemoteOverwriteLocalDoc({
   localDoc,
   remoteDoc,
 }: {
-  localUri: string;
-  remoteUri: string;
-  localChecksum: string;
-  remoteChecksum: string;
-  previousUpstreamRevisionId?: string;
-  upstreamRevisionId?: string;
-  reason: string;
-  localDoc: string;
-  remoteDoc: string;
+  localUri: string
+  remoteUri: string
+  localChecksum: string
+  remoteChecksum: string
+  previousUpstreamRevisionId?: string
+  upstreamRevisionId?: string
+  reason: string
+  localDoc: string
+  remoteDoc: string
 }): void {
   if (localDoc === remoteDoc) {
-    return;
+    return
   }
-  appLogger.warn("Overwriting local notebook content with upstream content", {
+  appLogger.warn('Overwriting local notebook content with upstream content', {
     attrs: {
-      scope: "storage.local.sync",
+      scope: 'storage.local.sync',
       localUri,
       remoteUri,
       localChecksum,
@@ -1741,73 +1872,56 @@ function logRemoteOverwriteLocalDoc({
       localBytes: new TextEncoder().encode(localDoc).byteLength,
       remoteBytes: new TextEncoder().encode(remoteDoc).byteLength,
     },
-  });
-}
-
-function formatTimestamp(date: Date): string {
-  const pad = (value: number) => value.toString().padStart(2, "0");
-  const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
-  const hours = pad(date.getHours());
-  const minutes = pad(date.getMinutes());
-  const seconds = pad(date.getSeconds());
-  return `${year}${month}${day}-${hours}${minutes}${seconds}`;
-}
-
-function stripTimestampSuffix(name: string): string {
-  const match = name.match(/^(.*)\.\d{8}-\d{6}\.json$/);
-  if (match && match[1]) {
-    return match[1];
-  }
-  return name.replace(/\.json$/, "");
+  })
 }
 
 function nowIsoString(): string {
-  return new Date().toISOString();
+  return new Date().toISOString()
 }
 
 function canDispatchWindowEvents(): boolean {
   return (
-    typeof window !== "undefined" &&
-    typeof window.dispatchEvent === "function"
-  );
+    typeof window !== 'undefined' && typeof window.dispatchEvent === 'function'
+  )
 }
 
 function needsSync(lastSynced: string | undefined, maxAgeMs: number): boolean {
   if (!lastSynced) {
-    return true;
+    return true
   }
-  const parsed = Date.parse(lastSynced);
+  const parsed = Date.parse(lastSynced)
   if (Number.isNaN(parsed)) {
-    return true;
+    return true
   }
-  return Date.now() - parsed > maxAgeMs;
+  return Date.now() - parsed > maxAgeMs
 }
 
 function isDriveUri(uri: string | undefined): boolean {
-  return isDriveItemUri(uri);
+  return isDriveItemUri(uri)
 }
 
 function isLocalFileUpstream(
   upstreamUri: string | undefined,
-  localUri?: string,
+  localUri?: string
 ): boolean {
   if (!upstreamUri) {
-    return false;
+    return false
   }
   if (localUri && upstreamUri === localUri) {
-    return true;
+    return true
   }
-  return upstreamUri.startsWith("local://file/");
+  return upstreamUri.startsWith('local://file/')
 }
 
-function publicRemoteUri(record: { id: string; remoteId: string }): string | undefined {
+function publicRemoteUri(record: {
+  id: string
+  remoteId: string
+}): string | undefined {
   return isLocalFileUpstream(record.remoteId, record.id)
     ? undefined
-    : record.remoteId || undefined;
+    : record.remoteId || undefined
 }
 
 function isFilesystemUri(uri: string | undefined): boolean {
-  return uri?.startsWith("fs://") ?? false;
+  return uri?.startsWith('fs://') ?? false
 }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -694,6 +694,55 @@ export class LocalNotebooks extends Dexie {
     this.notifySync(localUri)
   }
 
+  async refreshConflictWithLatestUpstream(
+    localUri: string
+  ): Promise<NotebookConflictState> {
+    if (!localUri.startsWith('local://file/')) {
+      throw new Error(
+        'refreshConflictWithLatestUpstream expects a local://file/ URI'
+      )
+    }
+
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (!record.conflict) {
+      throw new Error(`Local notebook ${localUri} does not have a conflict`)
+    }
+    if (!isDriveUri(record.remoteId)) {
+      throw new Error(
+        `Conflict refresh is only supported for Drive-backed notebooks; got ${record.remoteId}`
+      )
+    }
+
+    const upstreamNotebook = await this.driveStore.load(record.remoteId)
+    const upstreamDoc = serializeNotebook(upstreamNotebook)
+    const upstreamVersion = driveMetadataToUpstreamVersion(
+      await this.driveStore.getVersionMetadata(record.remoteId)
+    )
+    const upstreamChecksum =
+      upstreamVersion.checksum ?? checksumForSerializedNotebook(upstreamDoc)
+    const localChecksum = await this.getOrBackfillLocalChecksum(
+      localUri,
+      record
+    )
+    const conflict: NotebookConflictState = {
+      detectedAt: nowIsoString(),
+      upstreamChecksum,
+      upstreamVersion,
+      upstreamDoc,
+      localChecksumAtDetection: localChecksum,
+    }
+
+    await this.files.update(localUri, {
+      conflict,
+      lastSyncError: undefined,
+    })
+    this.notifySync(localUri)
+    return conflict
+  }
+
   private async persistNotebook(
     uri: string,
     notebook: parser_pb.Notebook

--- a/docs-dev/design/20260530_notebook_conflict_resolution.md
+++ b/docs-dev/design/20260530_notebook_conflict_resolution.md
@@ -1,0 +1,432 @@
+# Notebook Conflict Resolution
+
+Date: 2026-05-30
+
+Builds on:
+
+- `docs-dev/design/20260409_refactor_notebooks.md`
+- `docs-dev/design/20260409_track_drive_versions.md`
+- `docs-dev/design/20260522_notebook_diffs.md`
+- `docs-dev/design/20260526_workspace_document_tabs.md`
+
+## Summary
+
+When a local notebook and its upstream file both changed from the last synced
+baseline, stop automatic sync and show an explicit conflict state.
+
+V0 should not create a timestamped Google Drive copy and silently repoint the
+local notebook at it. That avoids data loss, but it changes the user's backing
+file without consent and makes the resolution path hard to understand.
+
+V0 should instead:
+
+1. Detect the conflict during sync.
+2. Preserve the local notebook and the upstream snapshot that caused the
+   conflict.
+3. Mark the notebook as `conflicted`.
+4. Surface the conflict in the notebook tab sync indicator.
+5. Let the user open a notebook-aware diff tab comparing upstream and local.
+6. Let the user explicitly save the current local notebook back to the original
+   upstream file.
+
+Cell-level resolution tools are follow-up work. In V0, users resolve by editing
+the local notebook manually, reviewing the diff, and then choosing **Save local
+version**.
+
+## Problem
+
+The local mirror protects editing latency and offline recovery, but it creates a
+real conflict case:
+
+```text
+last synced upstream checksum = A
+current local checksum        = B
+current upstream checksum     = C
+
+B != A and C != A
+```
+
+The current Drive sync path detects this condition in
+`LocalNotebooks.syncFileInner(...)`. It resolves the conflict by calling
+`handleConflict(...)`, which creates a new timestamped Drive file containing the
+local version and updates `LocalFileRecord.remoteId` to point at that new file.
+
+That behavior has two problems:
+
+- The user opened and edited one Drive file, but the app silently changes the
+  notebook's upstream file.
+- The user does not get a review step before choosing whether local or upstream
+  content should win.
+
+The app can now render notebook diffs, so the safer V0 is to stop sync, show the
+conflict, and make overwrite an explicit user action.
+
+## Goals
+
+- Preserve both local and upstream content when a conflict is detected.
+- Keep the notebook attached to the original upstream file until the user
+  chooses otherwise.
+- Show a clear conflict signal in the notebook tab.
+- Make the diff reachable from the conflict signal.
+- Support an explicit **Save local version** action that overwrites the original
+  upstream file with the current local notebook.
+- Keep V0 two-way: upstream snapshot versus current local notebook.
+- Reuse the existing notebook diff model and workspace diff tab.
+
+## Non-Goals
+
+- Cell-level accept/reject controls in V0.
+- Automatic merge in V0.
+- Three-way merge in V0.
+- Git conflict UI.
+- Replacing Google Drive revision history with a Runme-owned version history
+  system.
+- Automatically saving a conflict copy to a new Drive file.
+
+## Current Implementation Context
+
+The app-facing persistence path is still:
+
+```text
+NotebookData / editor tabs
+  -> local://file/<id>
+  -> LocalNotebooks / IndexedDB
+  -> optional upstream from LocalFileRecord.remoteId
+```
+
+Relevant current code:
+
+- `app/src/storage/local.ts` owns the local mirror, sync state, and Drive sync.
+- `app/src/storage/drive.ts` reads Drive checksums, revision metadata, and
+  revision contents.
+- `app/src/components/Actions/Actions.tsx` renders the notebook tab sync
+  indicator.
+- `app/src/lib/notebookDiff/*` computes and registers notebook diff documents.
+- `app/src/components/NotebookDiff/NotebookDiffView.tsx` renders the diff tab.
+
+`LocalFileRecord` already stores:
+
+- `doc`: serialized local notebook,
+- `md5Checksum`: checksum of `doc`,
+- `remoteId`: upstream URI,
+- `lastRemoteChecksum`: last synced upstream checksum,
+- `lastUpstreamVersion`: last synced upstream checksum/revision metadata,
+- `lastSyncError`: last sync failure.
+
+`NotebookSyncStatus` currently has:
+
+```ts
+type NotebookSyncStatus =
+  | 'local-only'
+  | 'synced'
+  | 'pending'
+  | 'pending-upstream-create'
+  | 'syncing'
+  | 'error'
+```
+
+Add a first-class conflict state instead of overloading `error`.
+
+## Proposed User Flow
+
+### 1. Conflict Detection
+
+Sync detects a conflict when the upstream checksum changed since the last
+baseline and the local checksum also differs from that baseline.
+
+For Drive-backed files:
+
+```text
+currentRemoteChecksum !== lastRemoteChecksum
+localChecksum !== lastRemoteChecksum
+```
+
+The same state can also occur when the local record has user content but no
+baseline checksum and Drive already has content.
+
+### 2. Sync Stops
+
+The app does not upload local content, download upstream content, or create a
+new Drive file.
+
+The local notebook remains editable. Additional local edits keep updating the
+local mirror, but automatic upstream sync stays blocked while the conflict is
+present.
+
+### 3. Tab Shows Conflict
+
+The notebook tab sync indicator changes from pending/error styling to a
+conflict-specific state.
+
+Recommended presentation:
+
+- color: amber or red-orange,
+- aria label: `Notebook has a sync conflict. Click to review differences.`,
+- click behavior: open the conflict diff tab.
+
+The indicator should not retry sync when the status is `conflicted`. Retrying
+without user intent would rediscover the same conflict.
+
+### 4. Diff Tab Opens
+
+Clicking the conflict indicator opens a workspace document tab using the
+existing notebook diff renderer.
+
+Labels:
+
+- left: `Upstream version`
+- right: `Local version`
+
+The diff should compare the upstream snapshot captured when the conflict was
+detected against the current local notebook. If the user edits the local
+notebook while the diff tab is open, V0 can require reopening the diff to see a
+fresh comparison.
+
+### 5. User Resolves Manually
+
+The user edits the local notebook until it has the desired final content.
+
+V0 does not offer per-cell accept/reject. The diff is a review surface, not an
+editor.
+
+### 6. User Saves Local Version
+
+The diff tab shows a primary **Save local version** button.
+
+Clicking it:
+
+1. Reads the current local notebook.
+2. Writes it to the original upstream file.
+3. Updates `lastRemoteChecksum`, `lastUpstreamVersion`, `md5Checksum`,
+   `lastSynced`, and clears the conflict metadata.
+4. Leaves `remoteId` pointing at the original upstream file.
+5. Updates the tab sync indicator to `synced`.
+
+If the upstream changed again after the conflict snapshot was captured, V0
+should still ask for confirmation before overwriting:
+
+```text
+The upstream file changed again since this conflict was detected.
+Saving local version will replace the latest upstream version.
+```
+
+The first implementation can make this a browser `confirm(...)`. A polished
+dialog can follow.
+
+## Data Model
+
+Add conflict metadata to `LocalFileRecord`.
+
+Illustrative shape:
+
+```ts
+export type NotebookSyncStatus =
+  | 'local-only'
+  | 'synced'
+  | 'pending'
+  | 'pending-upstream-create'
+  | 'syncing'
+  | 'conflicted'
+  | 'error'
+
+export interface NotebookConflictState {
+  detectedAt: string
+  upstreamUri: string
+  localChecksumAtDetection: string
+  baseChecksum?: string
+  baseVersion?: UpstreamVersion
+  upstreamVersion: UpstreamVersion
+  upstreamChecksum: string
+  upstreamDoc: string
+}
+
+export interface LocalFileRecord {
+  // existing fields...
+  conflict?: NotebookConflictState
+}
+```
+
+Persist `upstreamDoc` in IndexedDB so the conflict diff is stable even if Drive
+changes again or auth is temporarily unavailable. This duplicates one notebook
+payload only while a conflict is unresolved. Clear it after the user resolves
+or intentionally discards the conflict.
+
+Use the existing `lastUpstreamVersion` as the base version where possible. It
+is diagnostic metadata, not the merge base content.
+
+## Sync Behavior
+
+Replace `handleConflict(...)` with `recordConflict(...)` for Drive-backed
+notebooks.
+
+Current behavior:
+
+```text
+conflict detected
+  -> create new timestamped Drive file
+  -> save local notebook into that file
+  -> update local record remoteId to new file
+  -> report synced
+```
+
+Proposed behavior:
+
+```text
+conflict detected
+  -> load current upstream notebook
+  -> serialize upstream notebook
+  -> update local record conflict metadata
+  -> keep remoteId unchanged
+  -> report conflicted
+```
+
+`getSyncState(localUri)` should return `conflicted` before `pending` or
+`error` if `record.conflict` exists.
+
+`listDriveBackedFilesNeedingSync()` should not enqueue conflicted files for
+automatic sync. They need a user resolution action, not a retry loop.
+
+`save(localUri, notebook)` should continue to persist local edits while the
+record is conflicted. It should not enqueue upstream sync for conflicted
+records unless we introduce a separate manual resolution method.
+
+Add a new method on `LocalNotebooks`:
+
+```ts
+async resolveConflictWithLocal(localUri: string): Promise<void>
+```
+
+This method performs the explicit overwrite and clears `record.conflict` only
+after the upstream save succeeds and fresh Drive version metadata is recorded.
+
+## Diff Tab Integration
+
+Add a conflict-specific path that creates a `NotebookDiffDocument` from the
+stored conflict snapshot and the current local notebook.
+
+Possible API:
+
+```ts
+async openConflictDiff(localUri: string): Promise<void>
+```
+
+Implementation steps:
+
+1. Read the `LocalFileRecord`.
+2. Parse `record.conflict.upstreamDoc` into the base notebook.
+3. Parse `record.doc` into the compare notebook.
+4. Compute `computeNotebookDiff(baseNotebook, compareNotebook, ...)`.
+5. Register and show the diff document.
+
+Extend `NotebookDiffDocument` with optional action metadata:
+
+```ts
+export interface NotebookDiffDocument {
+  id: string
+  base: { label: string; revisionId?: string }
+  compare: { label: string; revisionId?: string }
+  diff: NotebookDiff
+  resolution?: {
+    kind: 'notebook-sync-conflict'
+    localUri: string
+  }
+}
+```
+
+`NotebookDiffView` can render **Save local version** only when
+`resolution.kind === "notebook-sync-conflict"`.
+
+## UX Details
+
+The tab indicator remains the main entry point because users already look there
+for Drive sync state.
+
+Suggested labels:
+
+- `synced`: `Notebook is synced`
+- `pending`: `Notebook has local changes pending upstream sync. Click to sync now.`
+- `conflicted`: `Notebook has a sync conflict. Click to review differences.`
+- `error`: `Notebook sync failed. Click to retry.`
+
+The diff tab header should include a compact conflict summary:
+
+```text
+This notebook has local changes and upstream changes. Review the diff, edit the
+local notebook if needed, then save the local version to replace upstream.
+```
+
+The button text should be explicit:
+
+- Primary: `Save local version`
+- Secondary follow-up, not V0: `Keep upstream version`
+- Secondary follow-up, not V0: `Save local as copy`
+
+Do not label the V0 action `Resolve` by itself. The action overwrites upstream,
+so the button should say that local content wins.
+
+## Failure Handling
+
+If recording the conflict snapshot fails after detecting a checksum conflict,
+leave the notebook local content untouched and set `lastSyncError`. The app
+should prefer a visible sync error over unsafe upload or download.
+
+If the upstream file is deleted or inaccessible while opening the diff, show a
+diff-tab error with the stored local content and the original Drive URI. The
+stored `upstreamDoc` should usually make this avoidable.
+
+If **Save local version** fails due to auth, network, or Drive permissions, keep
+the conflict state and show the error in the diff tab and tab indicator.
+
+If **Save local version** succeeds but fetching fresh version metadata fails,
+keep the local content saved and set `lastSyncError` so a later sync can
+refresh metadata. Do not restore the old conflict state after a successful
+upstream write.
+
+## Test Plan
+
+Add focused tests around the conflict state transition:
+
+- Drive conflict no longer creates a timestamped file or changes `remoteId`.
+- Drive conflict stores `conflict.upstreamDoc` and returns sync status
+  `conflicted`.
+- `listDriveBackedFilesNeedingSync()` excludes conflicted records.
+- Local edits remain persisted while conflicted.
+- Clicking the tab indicator for `conflicted` opens a diff tab instead of
+  retrying sync.
+- `resolveConflictWithLocal(...)` writes to the original Drive URI, clears
+  conflict metadata, and updates version metadata.
+- If upstream changed again before `resolveConflictWithLocal(...)`, the UI asks
+  for confirmation before overwriting.
+
+## Rollout Plan
+
+1. Add `conflicted` sync status and conflict metadata migration.
+2. Replace Drive `handleConflict(...)` with conflict recording.
+3. Update sync-state queries and tab indicator behavior.
+4. Add conflict diff document creation.
+5. Add **Save local version** to conflict diff tabs.
+6. Remove or quarantine tests that expect automatic conflict copy creation.
+
+## Follow-Up Work
+
+- Add **Keep upstream version**, which replaces local content with the stored
+  upstream snapshot or latest upstream content after confirmation.
+- Add **Save local as copy**, which reintroduces timestamped copy creation as an
+  explicit action.
+- Add cell-level accept local/upstream controls.
+- Add three-way merge using the last synced base content once we persist or can
+  reliably fetch that base.
+- Add a conflict summary in the side panel or Drive status surface for users
+  with multiple conflicted notebooks.
+
+## Open Questions
+
+- Should the conflict snapshot live inline on `LocalFileRecord` or in a
+  separate IndexedDB table keyed by local URI? Inline is simpler for V0; a table
+  is cleaner if we add multiple conflict snapshots or version history.
+- Should local edits while conflicted automatically refresh the open diff tab?
+  V0 can require reopening the diff. Live refresh is nicer but adds subscription
+  complexity to a read-only review surface.
+- Should V0 include **Keep upstream version**? It is useful, but it is also a
+  destructive local overwrite and needs the same confirmation care as **Save
+  local version**.

--- a/docs-dev/design/20260530_notebook_conflict_resolution.md
+++ b/docs-dev/design/20260530_notebook_conflict_resolution.md
@@ -177,10 +177,12 @@ Labels:
 - left: `Upstream version`
 - right: `Local version`
 
-The diff should compare the upstream snapshot captured when the conflict was
-detected against the current local notebook. If the user edits the local
-notebook while the diff tab is open, V0 can require reopening the diff to see a
-fresh comparison.
+The diff should initially compare the upstream snapshot captured when the
+conflict was detected against the current local notebook. The diff tab should
+also provide **Refresh diff** so the user can compare the latest local notebook
+against the current upstream head. Refreshing updates the reviewed upstream
+snapshot used by **Save local version**, so the overwrite warning only appears
+if upstream changes again after the refresh.
 
 ### 5. User Resolves Manually
 
@@ -357,6 +359,7 @@ local notebook if needed, then save the local version to replace upstream.
 
 The button text should be explicit:
 
+- Review: `Refresh diff`
 - Primary: `Save local version`
 - Secondary follow-up, not V0: `Keep upstream version`
 - Secondary follow-up, not V0: `Save local as copy`


### PR DESCRIPTION
## Summary
- Add a design doc for V0 notebook conflict resolution.
- Record Drive-backed notebook conflicts instead of silently creating a new timestamped Drive file.
- Surface conflicted sync state from the notebook tab, open a notebook diff, and add an explicit Save local version action.
- Add focused storage and UI tests for conflict detection, diff entry, and local-wins resolution.

## Verification
- runme run build test
- pnpm -C app exec vitest run
- pnpm -C app exec vitest run src/storage/local.test.ts src/components/NotebookDiff/NotebookDiffView.test.tsx src/components/Actions/Actions.test.tsx
- pnpm exec prettier --check app/src/storage/local.ts app/src/storage/drive.ts app/src/storage/local.test.ts app/src/components/Actions/Actions.tsx app/src/components/Actions/Actions.test.tsx app/src/components/NotebookDiff/NotebookDiffView.tsx app/src/lib/notebookDiff/model.ts app/src/lib/notebookDiff/conflict.ts docs-dev/design/20260530_notebook_conflict_resolution.md
- CDP/in-app Chromium verification: seeded an IndexedDB conflict, confirmed the tab conflict indicator opened the diff tab, and confirmed the Save local version action was present.

Note: pnpm -C app run typecheck still reports existing repository-wide type errors outside these conflict-resolution files.