### PR TITLE
Fix ANSI sequences in static stdout output

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -14,7 +14,7 @@ import {
   getNotebookDiffDocumentUri,
   registerNotebookDiffDocument,
 } from '../../lib/notebookDiff/registry'
-import Actions, { Action } from './Actions'
+import Actions, { Action, ActionOutputItems } from './Actions'
 
 const contextMocks = vi.hoisted(() => ({
   workspaceDocuments: [] as Array<{ uri: string; title: string }>,
@@ -665,6 +665,24 @@ describe('Action component', () => {
     expect(
       screen.queryByText(/mime=application\/vnd\.code\.notebook\.stdout/)
     ).toBeNull()
+  })
+
+  it('does not show ANSI control sequences in stdout output items', () => {
+    const stdoutOutput = create(parser_pb.CellOutputSchema, {
+      items: [
+        create(parser_pb.CellOutputItemSchema, {
+          mime: 'application/vnd.code.notebook.stdout',
+          type: 'Buffer',
+          data: new TextEncoder().encode('\x1b[2m\x1b[33m|\x1b[0m\x1b[m ok\n'),
+        }),
+      ],
+    })
+
+    render(<ActionOutputItems outputs={[stdoutOutput]} />)
+
+    const item = screen.getByTestId('cell-output-item')
+    expect(item.textContent).toContain('| ok')
+    expect(item.textContent).not.toContain('\x1b[')
   })
 
   it('shows language selector in markdown edit mode and converts to code language', () => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -47,6 +47,7 @@ import {
   APPKERNEL_SANDBOX_RUNNER_NAME,
   isAppKernelRunnerName,
 } from '../../lib/runtime/appKernel'
+import { stripAnsiControlSequences } from '../../lib/ansi'
 import { getJupyterManager } from '../../lib/runtime/jupyterManager'
 import {
   driveLinkCoordinator,
@@ -330,6 +331,11 @@ type SupportedLanguage =
 
 const outputTextDecoder = new TextDecoder()
 const ALWAYS_SKIP_MIMES = new Set<string>([MimeType.StatefulRunmeTerminal])
+const ANSI_STRIPPED_TEXT_MIMES = new Set<string>([
+  MimeType.VSCodeNotebookStdOut,
+  MimeType.VSCodeNotebookStdErr,
+  'text/plain',
+])
 
 function normalizeBinaryData(
   data?: Uint8Array | ArrayLike<number> | null
@@ -411,6 +417,12 @@ function decodeOutputText(
   }
 }
 
+function formatOutputTextForDisplay(text: string, mime: string): string {
+  return ANSI_STRIPPED_TEXT_MIMES.has(mime)
+    ? stripAnsiControlSequences(text)
+    : text
+}
+
 function uint8ArrayToBase64(
   data?: Uint8Array | ArrayLike<number> | null
 ): string {
@@ -442,7 +454,10 @@ function ActionOutputItemView({
   itemIndex: number
 }) {
   const mime = item.mime || ''
-  const text = decodeOutputText(item.data ?? new Uint8Array())
+  const text = formatOutputTextForDisplay(
+    decodeOutputText(item.data ?? new Uint8Array()),
+    mime
+  )
   const isStreaming = item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === 'true'
   const hasIopubMetadata =
     item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === 'true' ||

--- a/app/src/lib/ansi.ts
+++ b/app/src/lib/ansi.ts
@@ -1,0 +1,20 @@
+const ANSI_OSC_PATTERN = /(?:\x1b\][^\x07]*(?:\x07|\x1b\\))/g
+const ANSI_CSI_PATTERN = /(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g
+const ANSI_CHARSET_PATTERN = /\x1b[()*+\-.\/][0-~]/g
+const ANSI_SINGLE_CHAR_PATTERN = /\x1b[@-Z\\-_]/g
+
+/**
+ * Removes terminal control sequences from text rendered outside an xterm.
+ *
+ * Runme stores stdout/stderr bytes exactly as produced by the process so the
+ * interactive console can interpret color and cursor controls. Static notebook
+ * output uses plain React text nodes, so those same escape bytes need to be
+ * removed instead of displayed as `^[[...` glyphs.
+ */
+export function stripAnsiControlSequences(text: string): string {
+  return text
+    .replace(ANSI_OSC_PATTERN, '')
+    .replace(ANSI_CSI_PATTERN, '')
+    .replace(ANSI_CHARSET_PATTERN, '')
+    .replace(ANSI_SINGLE_CHAR_PATTERN, '')
+}


### PR DESCRIPTION
Fixes #225.

## Summary
- Strip terminal control sequences from static stdout, stderr, and text/plain output rendering
- Preserve raw output bytes for the interactive console path
- Add a regression for ANSI-colored stdout output

## Verification
- pnpm -C app run build
- pnpm -C app exec vitest run src/components/Actions/Actions.test.tsx
- pnpm -C app exec vitest run --reporter=basic
- pnpm run test:run