### PR TITLE
[codex] Fix WebMCP notebook BigInt serialization

### DIFF
--- a/app/src/lib/runtime/notebooksApiBridge.test.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.test.ts
@@ -1,10 +1,129 @@
+import { create } from '@bufbuild/protobuf'
 import { describe, expect, it, vi } from 'vitest'
 
+import { parser_pb } from '../../runme/client'
 import {
-  createNotebooksApiBridgeServer,
   type NotebooksApiBridgeServer,
+  createHostNotebooksApi,
+  createNotebooksApiBridgeServer,
 } from './notebooksApiBridge'
-import type { NotebooksApi } from './runmeConsole'
+import type { NotebookDataLike, NotebooksApi } from './runmeConsole'
+
+class FakeNotebookData implements NotebookDataLike {
+  constructor(
+    private readonly uri: string,
+    private readonly name: string,
+    private readonly notebook: parser_pb.Notebook
+  ) {}
+
+  getUri(): string {
+    return this.uri
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  getNotebook(): parser_pb.Notebook {
+    return this.notebook
+  }
+
+  updateCell(cell: parser_pb.Cell): void {
+    this.notebook.cells = (this.notebook.cells ?? []).map((existing) =>
+      existing.refId === cell.refId
+        ? create(parser_pb.CellSchema, cell)
+        : existing
+    )
+  }
+
+  getCell(): null {
+    return null
+  }
+
+  appendCell(
+    kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
+    languageId?: string | null
+  ): parser_pb.Cell {
+    const cell = this.createCell(kind, languageId)
+    this.notebook.cells = [...(this.notebook.cells ?? []), cell]
+    return cell
+  }
+
+  addCellAfter(
+    targetRefId: string,
+    kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
+    languageId?: string | null
+  ): parser_pb.Cell | null {
+    const cells = this.notebook.cells ?? []
+    const index = cells.findIndex((cell) => cell.refId === targetRefId)
+    if (index < 0) {
+      return null
+    }
+    const cell = this.createCell(kind, languageId)
+    const next = [...cells]
+    next.splice(index + 1, 0, cell)
+    this.notebook.cells = next
+    return cell
+  }
+
+  addCellBefore(
+    targetRefId: string,
+    kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
+    languageId?: string | null
+  ): parser_pb.Cell | null {
+    const cells = this.notebook.cells ?? []
+    const index = cells.findIndex((cell) => cell.refId === targetRefId)
+    if (index < 0) {
+      return null
+    }
+    const cell = this.createCell(kind, languageId)
+    const next = [...cells]
+    next.splice(index, 0, cell)
+    this.notebook.cells = next
+    return cell
+  }
+
+  removeCell(refId: string): void {
+    this.notebook.cells = (this.notebook.cells ?? []).filter(
+      (cell) => cell.refId !== refId
+    )
+  }
+
+  private createCell(
+    kind: parser_pb.CellKind,
+    languageId?: string | null
+  ): parser_pb.Cell {
+    return create(parser_pb.CellSchema, {
+      refId: `cell-${Math.random().toString(36).slice(2, 8)}`,
+      kind,
+      languageId:
+        languageId ??
+        (kind === parser_pb.CellKind.MARKUP ? 'markdown' : 'bash'),
+      value: '',
+      outputs: [],
+      metadata: {},
+    })
+  }
+}
+
+function codeCellWithBigIntTiming(): parser_pb.Cell {
+  const cell = create(parser_pb.CellSchema, {
+    refId: 'cell-a',
+    kind: parser_pb.CellKind.CODE,
+    languageId: 'bash',
+    value: 'echo a',
+    outputs: [],
+    metadata: {},
+  })
+  ;(cell as any).executionSummary = {
+    success: true,
+    timing: {
+      startTime: 1700000000000n,
+      endTime: 1700000001000n,
+    },
+  }
+  return cell
+}
 
 function createBridgeServer(
   overrides: Partial<NotebooksApi> = {}
@@ -66,6 +185,54 @@ describe('createNotebooksApiBridgeServer', () => {
         method: 'notebooks.unknown',
         args: [],
       })
-    ).rejects.toThrow('Unsupported sandbox NotebooksApi method: notebooks.unknown')
+    ).rejects.toThrow(
+      'Unsupported sandbox NotebooksApi method: notebooks.unknown'
+    )
+  })
+
+  it('returns JSON-safe get and update results for notebooks with BigInt timing fields', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCellWithBigIntTiming()],
+    })
+    const model = new FakeNotebookData(
+      'local://file/bigint',
+      'bigint.json',
+      notebook
+    )
+    const bridgeServer = createNotebooksApiBridgeServer({
+      notebooksApi: createHostNotebooksApi({
+        resolveNotebook: (target?: unknown) =>
+          target === undefined || target === 'local://file/bigint'
+            ? model
+            : null,
+        listNotebooks: () => [model],
+      }),
+    })
+
+    const document = await bridgeServer.handleMessage({
+      method: 'notebooks.get',
+      args: [{ uri: 'local://file/bigint' }],
+    })
+    const updated = await bridgeServer.handleMessage({
+      method: 'notebooks.update',
+      args: [
+        {
+          target: { uri: 'local://file/bigint' },
+          operations: [
+            {
+              op: 'insert',
+              at: { index: -1 },
+              cells: [
+                { kind: 'markup', languageId: 'markdown', value: 'test' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(JSON.stringify(document)).toContain('"startTime":"1700000000000"')
+    expect(JSON.stringify(updated)).toContain('"endTime":"1700000001000"')
+    expect((updated as any).notebook.cells).toHaveLength(2)
   })
 })

--- a/app/src/lib/runtime/notebooksApiBridge.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.ts
@@ -4,6 +4,7 @@ import {
   type NotebookTarget,
   type NotebooksApi,
   createNotebooksApi,
+  makeJsonSafe,
 } from './runmeConsole'
 
 export type NotebooksApiBridgeRequest = {
@@ -42,28 +43,49 @@ export function createNotebooksApiBridgeServer({
 }: {
   notebooksApi: NotebooksApi
 }): NotebooksApiBridgeServer {
+  const callJsonSafe = async (callback: () => Promise<unknown>) =>
+    makeJsonSafe(await callback())
+
   return {
     handleMessage: async ({ method, args = [] }) => {
       switch (method) {
         case 'notebooks.help':
-          return notebooksApi.help(args[0] as any)
+          return callJsonSafe(() => notebooksApi.help(args[0] as any))
         case 'notebooks.list':
-          return notebooksApi.list((args[0] as NotebookQuery | undefined) ?? undefined)
+          return callJsonSafe(() =>
+            notebooksApi.list(
+              (args[0] as NotebookQuery | undefined) ?? undefined
+            )
+          )
         case 'notebooks.get':
-          return notebooksApi.get((args[0] as NotebookTarget | undefined) ?? undefined)
+          return callJsonSafe(() =>
+            notebooksApi.get(
+              (args[0] as NotebookTarget | undefined) ?? undefined
+            )
+          )
         case 'notebooks.update':
-          return notebooksApi.update(
-            (args[0] as Parameters<NotebooksApi['update']>[0] | undefined) ?? {
-              operations: [],
-            }
+          return callJsonSafe(() =>
+            notebooksApi.update(
+              (args[0] as
+                | Parameters<NotebooksApi['update']>[0]
+                | undefined) ?? {
+                operations: [],
+              }
+            )
           )
         case 'notebooks.delete':
-          return notebooksApi.delete(args[0] as NotebookTarget)
+          return callJsonSafe(() =>
+            notebooksApi.delete(args[0] as NotebookTarget)
+          )
         case 'notebooks.execute':
-          return notebooksApi.execute(
-            (args[0] as Parameters<NotebooksApi['execute']>[0] | undefined) ?? {
-              refIds: [],
-            }
+          return callJsonSafe(() =>
+            notebooksApi.execute(
+              (args[0] as
+                | Parameters<NotebooksApi['execute']>[0]
+                | undefined) ?? {
+                refIds: [],
+              }
+            )
           )
         default:
           throw new Error(`Unsupported sandbox NotebooksApi method: ${method}`)

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -158,6 +158,18 @@ function codeCell(
   });
 }
 
+function codeCellWithBigIntTiming(refId: string, value: string): parser_pb.Cell {
+  const cell = codeCell(refId, value);
+  (cell as any).executionSummary = {
+    success: true,
+    timing: {
+      startTime: 1700000000000n,
+      endTime: 1700000001000n,
+    },
+  };
+  return cell;
+}
+
 describe("createRunmeConsoleApi", () => {
   it("returns the current notebook handle", () => {
     const notebook = create(parser_pb.NotebookSchema, { cells: [] });
@@ -379,6 +391,24 @@ describe("createNotebooksApi", () => {
     expect(document.notebook.cells[0]?.refId).toBe("cell-a");
   });
 
+  it("returns JSON-safe notebook documents with protobuf BigInt timing fields", async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCellWithBigIntTiming("cell-a", "echo a")],
+    });
+    const model = new FakeNotebookData("local://one", "One", notebook);
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    });
+
+    const document = await api.get({ uri: "local://one" });
+
+    expect(JSON.stringify(document)).toContain('"startTime":"1700000000000"');
+    expect(
+      (document.notebook.cells[0] as any).executionSummary.timing.startTime,
+    ).toBe("1700000000000");
+  });
+
   it("uses the current notebook when notebooks.get omits target", async () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [codeCell("cell-a", "echo a")],
@@ -544,6 +574,31 @@ describe("createNotebooksApi", () => {
     ).rejects.toThrow(
       "notebooks.update requires an explicit target notebook.",
     );
+  });
+
+  it("returns JSON-safe updated documents with protobuf BigInt timing fields", async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCellWithBigIntTiming("cell-a", "echo a")],
+    });
+    const model = new FakeNotebookData("local://one", "One", notebook);
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    });
+
+    const updated = await api.update({
+      target: { uri: "local://one" },
+      operations: [
+        {
+          op: "insert",
+          at: { index: -1 },
+          cells: [{ kind: "markup", languageId: "markdown", value: "test" }],
+        },
+      ],
+    });
+
+    expect(updated.notebook.cells).toHaveLength(2);
+    expect(JSON.stringify(updated)).toContain('"endTime":"1700000001000"');
   });
 
   it("rejects string notebook targets with an actionable error", async () => {

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -157,9 +157,49 @@ function inferNotebookSource(uri: string): NotebookSummary["source"] {
   return "local";
 }
 
+export function makeJsonSafe<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (typeof value === "bigint") {
+    return value.toString() as T;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (
+    value instanceof Date ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value)
+  ) {
+    return value;
+  }
+  const existing = seen.get(value);
+  if (existing) {
+    return existing as T;
+  }
+  if (Array.isArray(value)) {
+    const result: unknown[] = [];
+    seen.set(value, result);
+    for (const item of value) {
+      result.push(makeJsonSafe(item, seen));
+    }
+    return result as T;
+  }
+  const result: Record<string, unknown> = {};
+  seen.set(value, result);
+  for (const [key, item] of Object.entries(value)) {
+    result[key] = makeJsonSafe(item, seen);
+  }
+  return result as T;
+}
+
+function stringifyJsonSafe(value: unknown): string {
+  return JSON.stringify(value, (_key, item) =>
+    typeof item === "bigint" ? item.toString() : item,
+  );
+}
+
 function createRevision(notebook: parser_pb.Notebook): string {
   // Deterministic content hash used for optimistic checks in runtime helpers.
-  return md5(JSON.stringify(notebook));
+  return md5(stringifyJsonSafe(notebook));
 }
 
 function makeHandle(notebook: NotebookDataLike): NotebookHandle {
@@ -179,7 +219,7 @@ function makeDocument(notebook: NotebookDataLike): NotebookDocument {
       source: inferNotebookSource(notebook.getUri()),
     },
     handle,
-    notebook: notebook.getNotebook(),
+    notebook: makeJsonSafe(notebook.getNotebook()),
   };
 }
 


### PR DESCRIPTION
## Summary
- Convert BigInt values in notebook documents to strings before WebMCP notebook RPC results leave the host boundary.
- Use the same BigInt-safe serialization for notebook revision hashes so imported protobuf int64 fields do not break notebooks.get or notebooks.update.
- Add direct API and bridge regression coverage for executionSummary.timing BigInt fields.

## Validation
- pnpm -C app exec vitest run src/lib/runtime/runmeConsole.test.ts src/lib/runtime/notebooksApiBridge.test.ts
- runme run build test