### PR TITLE
[codex] Add version information tab

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -14,6 +14,7 @@ import {
   getNotebookDiffDocumentUri,
   registerNotebookDiffDocument,
 } from '../../lib/notebookDiff/registry'
+import { VERSION_INFO_DOCUMENT_URI } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 import Actions, { Action, ActionOutputItems } from './Actions'
 
 const contextMocks = vi.hoisted(() => ({
@@ -760,6 +761,21 @@ describe('Actions tabs', () => {
       expect(diffTab.getAttribute('aria-selected')).toBe('true')
       expect(firstTab.getAttribute('aria-selected')).toBe('false')
     })
+  })
+
+  it('renders the version information workspace document as a tab', () => {
+    contextMocks.currentDoc = VERSION_INFO_DOCUMENT_URI
+    contextMocks.workspaceDocuments = [
+      { uri: VERSION_INFO_DOCUMENT_URI, title: 'Version Information' },
+    ]
+
+    render(<Actions />)
+
+    expect(
+      screen.getByRole('tab', { name: 'Version Information' })
+    ).toBeTruthy()
+    expect(screen.getByText('Release')).toBeTruthy()
+    expect(screen.getByText('version.yaml')).toBeTruthy()
   })
 })
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -61,6 +61,7 @@ import {
   isDriveLinkStatusUri,
   isNotebookDiffUri,
   isNotebookDocumentUri,
+  isVersionInfoUri,
   type WorkspaceDocument,
 } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 import {
@@ -74,6 +75,7 @@ import { NotebookStoreItemType } from '../../storage/notebook'
 import { showToast } from '../../lib/toast'
 import DriveLinkStatusTab from '../DriveLinkStatusTab'
 import { NotebookDiffContent } from '../NotebookDiff/NotebookDiffView'
+import VersionInfoTab from '../VersionInfoTab'
 import React from 'react'
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -1943,6 +1945,10 @@ function renderWorkspaceDocument({
 
   if (isDriveLinkStatusUri(document.uri)) {
     return <DriveLinkStatusTab onLogin={onDriveLogin} onRetry={onDriveRetry} />
+  }
+
+  if (isVersionInfoUri(document.uri)) {
+    return <VersionInfoTab />
   }
 
   return <UnknownDocumentTab uri={document.uri} />

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -22,6 +22,7 @@ const loginWithRedirectMock = vi.fn()
 const logoutMock = vi.fn()
 const togglePanelMock = vi.fn()
 const setCurrentDocMock = vi.fn()
+const showDocumentMock = vi.fn()
 const closeWorkspaceDocumentMock = vi.fn()
 
 vi.mock('../../browserAdapter.client', () => ({
@@ -42,6 +43,7 @@ vi.mock('../../contexts/SidePanelContext', () => ({
 vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
   useWorkspaceDocumentContext: () => ({
     useWorkspaceDocuments: () => openDocumentsState,
+    showDocument: showDocumentMock,
     closeWorkspaceDocument: closeWorkspaceDocumentMock,
   }),
 }))
@@ -92,6 +94,7 @@ describe('SidePanelToolbar drive status button', () => {
     logoutMock.mockClear()
     togglePanelMock.mockClear()
     setCurrentDocMock.mockClear()
+    showDocumentMock.mockClear()
     closeWorkspaceDocumentMock.mockClear()
   })
 
@@ -136,6 +139,19 @@ describe('SidePanelToolbar drive status button', () => {
 
     expect(togglePanelMock).toHaveBeenCalledWith('open-documents')
   })
+
+  it('opens the Version Information document from the toolbar', () => {
+    render(<SidePanelToolbar />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open Version Information' })
+    )
+
+    expect(showDocumentMock).toHaveBeenCalledWith('app://version', {
+      title: 'Version Information',
+    })
+    expect(setCurrentDocMock).toHaveBeenCalledWith('app://version')
+  })
 })
 
 describe('SidePanelContent ChatKit persistence', () => {
@@ -146,6 +162,7 @@ describe('SidePanelContent ChatKit persistence', () => {
     chatKitMountCount = 0
     chatKitUnmountCount = 0
     setCurrentDocMock.mockClear()
+    showDocumentMock.mockClear()
     closeWorkspaceDocumentMock.mockClear()
   })
 
@@ -190,6 +207,7 @@ describe('SidePanelContent ChatKit persistence', () => {
     openDocumentsState = [
       { uri: 'local://file/alpha.json', title: 'alpha.json' },
       { uri: 'diff://notebook/beta', title: 'beta diff' },
+      { uri: 'app://version', title: 'Version Information' },
     ]
     closeWorkspaceDocumentMock.mockReturnValue('diff://notebook/beta')
 
@@ -199,6 +217,7 @@ describe('SidePanelContent ChatKit persistence', () => {
 
     fireEvent.click(screen.getByText('beta diff'))
     expect(setCurrentDocMock).toHaveBeenCalledWith('diff://notebook/beta')
+    expect(screen.getByText('Version · app://version')).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Close alpha.json' }))
     expect(closeWorkspaceDocumentMock).toHaveBeenCalledWith(

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -1,6 +1,7 @@
 import {
   FolderIcon,
   ChatBubbleLeftRightIcon,
+  InformationCircleIcon,
   QueueListIcon,
   UserCircleIcon,
 } from '@heroicons/react/24/outline'
@@ -22,6 +23,8 @@ import {
   isDriveLinkStatusUri,
   isNotebookDiffUri,
   isNotebookDocumentUri,
+  isVersionInfoUri,
+  VERSION_INFO_DOCUMENT_URI,
 } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 
 const sideButtonBase = 'group side-btn'
@@ -119,7 +122,9 @@ function OpenDocumentsPanel() {
                   ? 'Diff'
                   : isDriveLinkStatusUri(doc.uri)
                     ? 'Status'
-                    : 'Document'
+                    : isVersionInfoUri(doc.uri)
+                      ? 'Version'
+                      : 'Document'
               return (
                 <li key={doc.uri}>
                   <div
@@ -185,9 +190,12 @@ export function SidePanelToolbar() {
   const authData = useBrowserAuthData()
   const browserAdapter = getBrowserAdapter()
   const { ensureAccessToken, isDriveSyncing } = useGoogleAuth()
+  const { showDocument } = useWorkspaceDocumentContext()
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
   const [isDriveAuthPending, setIsDriveAuthPending] = useState(false)
 
   const driveStatus = isDriveSyncing ? 'Syncing' : 'Not syncing'
+  const versionInfoSelected = getCurrentDoc() === VERSION_INFO_DOCUMENT_URI
   const handleDriveStatusClick = useCallback(async () => {
     if (isDriveSyncing || isDriveAuthPending) {
       return
@@ -203,6 +211,13 @@ export function SidePanelToolbar() {
       setIsDriveAuthPending(false)
     }
   }, [ensureAccessToken, isDriveAuthPending, isDriveSyncing])
+
+  const handleVersionInfoClick = useCallback(() => {
+    showDocument(VERSION_INFO_DOCUMENT_URI, {
+      title: 'Version Information',
+    })
+    setCurrentDoc(VERSION_INFO_DOCUMENT_URI)
+  }, [setCurrentDoc, showDocument])
 
   return (
     <div className="flex h-full w-12 flex-col items-center justify-between">
@@ -283,6 +298,18 @@ export function SidePanelToolbar() {
         >
           <UserCircleIcon className="h-5 w-5" />
           <span className={tooltipBase}>{authData ? 'Logout' : 'Login'}</span>
+        </button>
+        <button
+          type="button"
+          className={`${sideButtonBase} ${
+            versionInfoSelected ? sideButtonActive : sideButtonInactive
+          }`}
+          aria-pressed={versionInfoSelected}
+          aria-label="Open Version Information"
+          onClick={handleVersionInfoClick}
+        >
+          <InformationCircleIcon className="h-5 w-5" />
+          <span className={tooltipBase}>Version Information</span>
         </button>
       </div>
     </div>

--- a/app/src/components/VersionInfoTab.tsx
+++ b/app/src/components/VersionInfoTab.tsx
@@ -1,0 +1,86 @@
+import { ScrollArea, Text } from '@radix-ui/themes'
+
+import {
+  formatRunmeVersionYaml,
+  hasRunmeVersionInfo,
+  runmeVersionInfo,
+  type RunmeVersionInfo,
+} from '../lib/versionInfo'
+
+const FIELD_LABELS: Array<[keyof RunmeVersionInfo, string]> = [
+  ['buildDate', 'Build Date'],
+  ['webRepo', 'Web Repository'],
+  ['webBranch', 'Web Branch'],
+  ['webCommit', 'Web Commit'],
+  ['codexRepo', 'Codex Repository'],
+  ['codexBranch', 'Codex Branch'],
+  ['codexCommit', 'Codex Commit'],
+  ['bucket', 'Bucket'],
+]
+
+function VersionValue({ value }: { value: string | null }) {
+  if (!value) {
+    return <span className="text-nb-text-faint">Unavailable</span>
+  }
+  return <span className="break-all font-mono text-xs">{value}</span>
+}
+
+export function VersionInfoTab() {
+  const hasVersionInfo = hasRunmeVersionInfo(runmeVersionInfo)
+
+  return (
+    <ScrollArea
+      type="auto"
+      scrollbars="vertical"
+      className="flex-1 p-4"
+      data-testid="version-info-scroll"
+    >
+      <div className="mx-auto flex h-full max-w-3xl flex-col gap-6 text-sm">
+        <div className="space-y-2">
+          <Text size="5" weight="bold" as="p" className="text-nb-text">
+            Version Information
+          </Text>
+          <Text size="2" as="p" className="text-nb-text-muted">
+            These values are baked into the loaded JavaScript bundle at build
+            time and mirror the deployment marker served as version.yaml.
+          </Text>
+        </div>
+
+        {!hasVersionInfo ? (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            Version metadata was not provided for this build.
+          </div>
+        ) : null}
+
+        <div className="rounded-lg border border-nb-border bg-white p-4">
+          <Text size="3" weight="bold" as="p" className="text-nb-text">
+            Release
+          </Text>
+          <dl className="mt-4 grid grid-cols-[minmax(120px,180px)_1fr] gap-x-4 gap-y-3">
+            {FIELD_LABELS.map(([key, label]) => (
+              <div key={key} className="contents">
+                <dt className="text-xs font-semibold uppercase tracking-wide text-nb-text-faint">
+                  {label}
+                </dt>
+                <dd className="min-w-0 text-nb-text">
+                  <VersionValue value={runmeVersionInfo[key]} />
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="rounded-lg border border-nb-border bg-nb-surface-2 p-4">
+          <Text size="3" weight="bold" as="p" className="text-nb-text">
+            version.yaml
+          </Text>
+          <pre className="mt-3 overflow-x-auto whitespace-pre rounded-md bg-gray-900 p-3 text-xs text-gray-100">
+            {formatRunmeVersionYaml(runmeVersionInfo)}
+          </pre>
+        </div>
+      </div>
+    </ScrollArea>
+  )
+}
+
+export default VersionInfoTab

--- a/app/src/lib/versionInfo.test.ts
+++ b/app/src/lib/versionInfo.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatRunmeVersionYaml,
+  hasRunmeVersionInfo,
+  normalizeRunmeVersionInfo,
+} from './versionInfo'
+
+describe('versionInfo', () => {
+  it('normalizes build env into version.yaml fields', () => {
+    const info = normalizeRunmeVersionInfo({
+      VITE_RUNME_VERSION_BUILD_DATE: ' 2026-06-03T12:00:00Z ',
+      VITE_RUNME_VERSION_WEB_REPO: 'runmedev/web',
+      VITE_RUNME_VERSION_WEB_BRANCH: 'main',
+      VITE_RUNME_VERSION_WEB_COMMIT: 'web-sha',
+      VITE_RUNME_VERSION_CODEX_REPO: 'openai/codex',
+      VITE_RUNME_VERSION_CODEX_BRANCH: 'main',
+      VITE_RUNME_VERSION_CODEX_COMMIT: 'codex-sha',
+      VITE_RUNME_VERSION_BUCKET: 'gs://runme-hosted',
+    })
+
+    expect(hasRunmeVersionInfo(info)).toBe(true)
+    expect(formatRunmeVersionYaml(info)).toBe(
+      [
+        'buildDate: 2026-06-03T12:00:00Z',
+        'webRepo: runmedev/web',
+        'webBranch: main',
+        'webCommit: web-sha',
+        'codexRepo: openai/codex',
+        'codexBranch: main',
+        'codexCommit: codex-sha',
+        'bucket: gs://runme-hosted',
+      ].join('\n')
+    )
+  })
+
+  it('treats missing build env as unavailable metadata', () => {
+    const info = normalizeRunmeVersionInfo({})
+
+    expect(hasRunmeVersionInfo(info)).toBe(false)
+    expect(formatRunmeVersionYaml(info)).toContain('webCommit: ')
+  })
+})

--- a/app/src/lib/versionInfo.ts
+++ b/app/src/lib/versionInfo.ts
@@ -1,0 +1,50 @@
+export interface RunmeVersionInfo {
+  buildDate: string | null
+  webRepo: string | null
+  webBranch: string | null
+  webCommit: string | null
+  codexRepo: string | null
+  codexBranch: string | null
+  codexCommit: string | null
+  bucket: string | null
+}
+
+const VERSION_YAML_KEYS: Array<keyof RunmeVersionInfo> = [
+  'buildDate',
+  'webRepo',
+  'webBranch',
+  'webCommit',
+  'codexRepo',
+  'codexBranch',
+  'codexCommit',
+  'bucket',
+]
+
+function normalizeVersionValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function normalizeRunmeVersionInfo(
+  env: Record<string, unknown>
+): RunmeVersionInfo {
+  return {
+    buildDate: normalizeVersionValue(env.VITE_RUNME_VERSION_BUILD_DATE),
+    webRepo: normalizeVersionValue(env.VITE_RUNME_VERSION_WEB_REPO),
+    webBranch: normalizeVersionValue(env.VITE_RUNME_VERSION_WEB_BRANCH),
+    webCommit: normalizeVersionValue(env.VITE_RUNME_VERSION_WEB_COMMIT),
+    codexRepo: normalizeVersionValue(env.VITE_RUNME_VERSION_CODEX_REPO),
+    codexBranch: normalizeVersionValue(env.VITE_RUNME_VERSION_CODEX_BRANCH),
+    codexCommit: normalizeVersionValue(env.VITE_RUNME_VERSION_CODEX_COMMIT),
+    bucket: normalizeVersionValue(env.VITE_RUNME_VERSION_BUCKET),
+  }
+}
+
+export const runmeVersionInfo = normalizeRunmeVersionInfo(import.meta.env)
+
+export function hasRunmeVersionInfo(info: RunmeVersionInfo): boolean {
+  return VERSION_YAML_KEYS.some((key) => Boolean(info[key]))
+}
+
+export function formatRunmeVersionYaml(info: RunmeVersionInfo): string {
+  return VERSION_YAML_KEYS.map((key) => `${key}: ${info[key] ?? ''}`).join('\n')
+}

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -2,6 +2,7 @@ import type { NotebookTabState } from '../notebookDataController'
 import type { NotebookOwnershipRecord } from '../tabCoordination/notebookOwnership'
 
 export const DRIVE_LINK_STATUS_DOCUMENT_URI = 'status://drive-link'
+export const VERSION_INFO_DOCUMENT_URI = 'app://version'
 
 export interface WorkspaceDocument {
   uri: string
@@ -32,6 +33,10 @@ export function isDriveLinkStatusUri(uri: string | null | undefined): boolean {
   return uri === DRIVE_LINK_STATUS_DOCUMENT_URI
 }
 
+export function isVersionInfoUri(uri: string | null | undefined): boolean {
+  return uri === VERSION_INFO_DOCUMENT_URI
+}
+
 export function isRestorableWorkspaceDocument(uri: string): boolean {
   return isNotebookDocumentUri(uri)
 }
@@ -40,6 +45,9 @@ export function deriveWorkspaceDocumentTitle(uri: string): string {
   const documentUri = uri
   if (isDriveLinkStatusUri(documentUri)) {
     return 'Drive Link Status'
+  }
+  if (isVersionInfoUri(documentUri)) {
+    return 'Version Information'
   }
   if (isNotebookDiffUri(documentUri)) {
     return 'Notebook diff'

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_RUNME_VERSION_BUILD_DATE?: string
+  readonly VITE_RUNME_VERSION_WEB_REPO?: string
+  readonly VITE_RUNME_VERSION_WEB_BRANCH?: string
+  readonly VITE_RUNME_VERSION_WEB_COMMIT?: string
+  readonly VITE_RUNME_VERSION_CODEX_REPO?: string
+  readonly VITE_RUNME_VERSION_CODEX_BRANCH?: string
+  readonly VITE_RUNME_VERSION_CODEX_COMMIT?: string
+  readonly VITE_RUNME_VERSION_BUCKET?: string
+}

--- a/releaser/main.go
+++ b/releaser/main.go
@@ -160,7 +160,7 @@ func run(ctx context.Context, cfg config) error {
 		return fmt.Errorf("clone codex repository: %w", err)
 	}
 
-	if err := buildReleasePayload(ctx, webDir, codexDir); err != nil {
+	if err := buildReleasePayload(ctx, webDir, codexDir, version); err != nil {
 		return err
 	}
 
@@ -205,7 +205,7 @@ func run(ctx context.Context, cfg config) error {
 	return nil
 }
 
-func buildReleasePayload(ctx context.Context, webDir, codexDir string) error {
+func buildReleasePayload(ctx context.Context, webDir, codexDir string, version releaseVersion) error {
 	for _, cmdline := range []string{
 		"pnpm install --frozen-lockfile",
 		"pnpm run build:renderers",
@@ -240,11 +240,25 @@ func buildReleasePayload(ctx context.Context, webDir, codexDir string) error {
 		return fmt.Errorf("sync codex wasm assets: %w", err)
 	}
 
-	if err := runShell(ctx, webDir, nil, "pnpm build:app"); err != nil {
+	buildEnv := append(os.Environ(), versionBuildEnv(version)...)
+	if err := runShell(ctx, webDir, buildEnv, "pnpm build:app"); err != nil {
 		return fmt.Errorf("build web app: %w", err)
 	}
 
 	return nil
+}
+
+func versionBuildEnv(version releaseVersion) []string {
+	return []string{
+		"VITE_RUNME_VERSION_BUILD_DATE=" + version.BuildDate,
+		"VITE_RUNME_VERSION_WEB_REPO=" + version.WebRepo,
+		"VITE_RUNME_VERSION_WEB_BRANCH=" + version.WebBranch,
+		"VITE_RUNME_VERSION_WEB_COMMIT=" + version.WebCommit,
+		"VITE_RUNME_VERSION_CODEX_REPO=" + version.CodexRepo,
+		"VITE_RUNME_VERSION_CODEX_BRANCH=" + version.CodexBranch,
+		"VITE_RUNME_VERSION_CODEX_COMMIT=" + version.CodexCommit,
+		"VITE_RUNME_VERSION_BUCKET=" + version.Bucket,
+	}
 }
 
 func activeRustToolchain(ctx context.Context, dir string) (string, error) {

--- a/releaser/main_test.go
+++ b/releaser/main_test.go
@@ -49,6 +49,41 @@ func TestIsMissingVersionMarkerError(t *testing.T) {
 	}
 }
 
+func TestVersionBuildEnv(t *testing.T) {
+	t.Parallel()
+
+	version := releaseVersion{
+		BuildDate:   "2026-06-03T12:00:00Z",
+		WebRepo:     "runmedev/web",
+		WebBranch:   "main",
+		WebCommit:   "web-sha",
+		CodexRepo:   "openai/codex",
+		CodexBranch: "dev/jlewi/wasm",
+		CodexCommit: "codex-sha",
+		Bucket:      "gs://runme-hosted",
+	}
+
+	got := versionBuildEnv(version)
+	want := []string{
+		"VITE_RUNME_VERSION_BUILD_DATE=2026-06-03T12:00:00Z",
+		"VITE_RUNME_VERSION_WEB_REPO=runmedev/web",
+		"VITE_RUNME_VERSION_WEB_BRANCH=main",
+		"VITE_RUNME_VERSION_WEB_COMMIT=web-sha",
+		"VITE_RUNME_VERSION_CODEX_REPO=openai/codex",
+		"VITE_RUNME_VERSION_CODEX_BRANCH=dev/jlewi/wasm",
+		"VITE_RUNME_VERSION_CODEX_COMMIT=codex-sha",
+		"VITE_RUNME_VERSION_BUCKET=gs://runme-hosted",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("versionBuildEnv() returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("versionBuildEnv()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 type errString string
 
 func (e errString) Error() string {


### PR DESCRIPTION
## Summary

- Add a bottom-left navigation item that opens a Version Information workspace document tab.
- Render baked release metadata in the tab using the same fields as `version.yaml`.
- Pass the releaser releaseVersion fields into the Vite app build as `VITE_RUNME_VERSION_*` variables while leaving `version.yaml` unchanged for CD.

## Impact

Users can inspect the version metadata associated with the JavaScript bundle they actually loaded, avoiding drift from a freshly fetched `/version.yaml` when cached client assets are still in use.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run src/components/Actions/Actions.test.tsx src/components/SidePanel/SidePanel.test.tsx src/lib/versionInfo.test.ts`
- `pnpm -C app exec vitest run src/components/SidePanel/SidePanel.test.tsx`
- `go test .` from `releaser/`
- Browser smoke test at `http://localhost:5173/`: confirmed the Version Information toolbar button opens the selected tab and renders the metadata panel.