### PR TITLE
[codex] Reintroduce read-only tabs with deferred rendering

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -21,6 +21,7 @@ const contextMocks = vi.hoisted(() => ({
     uri: string
     title: string
     state?: 'loading' | 'loaded' | 'blocked' | 'error'
+    readOnly?: boolean
   }>,
   currentDoc: null as string | null,
   setCurrentDoc: vi.fn(),
@@ -220,10 +221,10 @@ class StubCellData {
       connect: () => ({ subscribe: () => ({ unsubscribe: () => {} }) }),
     } as any
   }
-  addBefore() {}
-  addAfter() {}
-  remove() {}
-  run() {}
+  addBefore = vi.fn()
+  addAfter = vi.fn()
+  remove = vi.fn()
+  run = vi.fn()
 }
 
 beforeEach(() => {
@@ -279,6 +280,92 @@ describe('Actions tabs', () => {
     expect((scrollViewport as HTMLElement | undefined)?.style.overflowX).toBe(
       'scroll'
     )
+  })
+
+  it('marks read-only notebook tabs and content clearly', () => {
+    const uri = 'local://file/reference.runme.md'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'reference.runme.md',
+        state: 'loaded',
+        readOnly: true,
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      readOnly: true,
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {},
+        cells: [],
+      }),
+    })
+
+    render(<Actions />)
+
+    expect(
+      screen.getAllByLabelText('Read-only notebook').length
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getByTestId('notebook-readonly-banner').textContent
+    ).toContain('Read-only')
+    expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
+  it('defers rendering inactive read-only notebook cells', () => {
+    const activeUri = 'local://file/active.runme.md'
+    const readOnlyUri = 'local://file/reference.runme.md'
+    const readOnlyCell = create(parser_pb.CellSchema, {
+      refId: 'readonly-markdown',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      value: 'expensive readonly content',
+      metadata: {},
+    })
+    const readOnlyCellData = new StubCellData(readOnlyCell)
+    const getReadOnlyCell = vi.fn(() => readOnlyCellData)
+
+    contextMocks.currentDoc = activeUri
+    contextMocks.workspaceDocuments = [
+      { uri: activeUri, title: 'active.runme.md', state: 'loaded' },
+      {
+        uri: readOnlyUri,
+        title: 'reference.runme.md',
+        state: 'loaded',
+        readOnly: true,
+      },
+    ]
+    contextMocks.notebookSnapshots.set(activeUri, {
+      uri: activeUri,
+      loaded: true,
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {},
+        cells: [],
+      }),
+    })
+    contextMocks.notebookSnapshots.set(readOnlyUri, {
+      uri: readOnlyUri,
+      loaded: true,
+      readOnly: true,
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {},
+        cells: [readOnlyCell],
+      }),
+    })
+    contextMocks.getNotebookData.mockImplementation((uri: string) => {
+      if (uri === readOnlyUri) {
+        return { getCell: getReadOnlyCell }
+      }
+      return { getCell: vi.fn() }
+    })
+
+    render(<Actions />)
+
+    expect(screen.getByTestId('notebook-readonly-inactive-state')).toBeTruthy()
+    expect(screen.queryByText('expensive readonly content')).toBeNull()
+    expect(getReadOnlyCell).not.toHaveBeenCalled()
   })
 
   it('falls back from a stale current URI to an open workspace document', async () => {
@@ -677,6 +764,43 @@ describe('Actions tabs', () => {
 })
 
 describe('Action component', () => {
+  it('disables code-cell mutations in read-only mode', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-readonly',
+      kind: parser_pb.CellKind.CODE,
+      languageId: 'bash',
+      outputs: [],
+      metadata: {},
+      value: 'echo hi',
+    })
+    const stub = new StubCellData(cell)
+
+    render(
+      <Action cellData={stub as unknown as CellData} isFirst={false} readOnly />
+    )
+
+    const runButton = screen.getByLabelText('Run code') as HTMLButtonElement
+    const languageSelect = document.querySelector(
+      '.toolbar-select'
+    ) as HTMLSelectElement | null
+
+    expect(runButton.disabled).toBe(true)
+    expect(screen.getByLabelText('Add cell above')).toHaveProperty(
+      'disabled',
+      true
+    )
+    expect(screen.getByLabelText('Add cell below')).toHaveProperty(
+      'disabled',
+      true
+    )
+    fireEvent.click(runButton)
+    expect(stub.run).not.toHaveBeenCalled()
+    expect(stub.update).not.toHaveBeenCalled()
+    expect(stub.addBefore).not.toHaveBeenCalled()
+    expect(stub.addAfter).not.toHaveBeenCalled()
+    expect(languageSelect?.disabled ?? true).toBe(true)
+  })
+
   it('updates CellConsole key when runID changes', async () => {
     const cell = create(parser_pb.CellSchema, {
       refId: 'cell-1',

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -13,7 +13,7 @@ import {
 import { create } from '@bufbuild/protobuf'
 import { Button, ScrollArea, Tabs, Text } from '@radix-ui/themes'
 
-import { XMarkIcon } from '@heroicons/react/20/solid'
+import { LockClosedIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import { MimeType, RunmeMetadataKey, parser_pb } from '../../runme/client'
 import { CellData } from '../../lib/notebookData'
 import { useNotebookContext } from '../../contexts/NotebookContext'
@@ -280,14 +280,34 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
   )
 }
 
+function ReadOnlyTabIndicator() {
+  return (
+    <span
+      className="relative inline-flex h-4 w-4 items-center justify-center text-nb-text-muted"
+      role="img"
+      aria-label="Read-only notebook"
+    >
+      <LockClosedIcon className="h-3.5 w-3.5" aria-hidden="true" />
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-6 z-20 hidden w-max max-w-[220px] -translate-x-1/2 rounded-nb-sm border border-nb-border bg-white px-2 py-1 text-xs font-normal text-nb-text shadow-nb-sm group-hover:inline-block group-focus:inline-block"
+      >
+        Read-only. This notebook is open for editing in another browser tab.
+      </span>
+    </span>
+  )
+}
+
 /** Compact icon-only run button that sits in the cell toolbar.
  *  Shows a spinner while running, otherwise always shows the play icon. */
 function RunActionButton({
   pid,
   onClick,
+  disabled = false,
 }: {
   pid: number | null
   onClick: () => void
+  disabled?: boolean
 }) {
   const isRunning = pid !== null
 
@@ -295,6 +315,7 @@ function RunActionButton({
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       aria-label={isRunning ? 'Running...' : 'Run code'}
       className="icon-btn h-7 w-7"
     >
@@ -573,6 +594,7 @@ export function Action({
   activeFocusRole = 'editor',
   isWindowFocused = false,
   onFocusStateChange,
+  readOnly = false,
 }: {
   cellData: CellData
   docUri?: string
@@ -581,6 +603,7 @@ export function Action({
   activeFocusRole?: CellFocusRole
   isWindowFocused?: boolean
   onFocusStateChange?: (state: NotebookActiveCellState) => void
+  readOnly?: boolean
 }) {
   const { store } = useNotebookStore()
   const { listRunners, defaultRunnerName } = useRunners()
@@ -606,18 +629,27 @@ export function Action({
   const runID = cellData.getRunID()
 
   const handleAddCellBefore = useCallback(() => {
+    if (readOnly) {
+      return
+    }
     cellData.addBefore(parser_pb.CellKind.CODE, cell?.languageId)
-  }, [cell?.languageId, cellData])
+  }, [cell?.languageId, cellData, readOnly])
 
   const handleAddCellAfter = useCallback(() => {
+    if (readOnly) {
+      return
+    }
     cellData.addAfter(parser_pb.CellKind.CODE, cell?.languageId)
-  }, [cell?.languageId, cellData])
+  }, [cell?.languageId, cellData, readOnly])
 
   const updateCellLocal = useCallback(
     (nextCell: parser_pb.Cell) => {
+      if (readOnly) {
+        return
+      }
       cellData.update(nextCell)
     },
-    [cellData]
+    [cellData, readOnly]
   )
 
   const [contextMenu, setContextMenu] = useState<{
@@ -707,8 +739,11 @@ export function Action({
   }, [contextMenu, shareRemoteUri])
 
   const runCode = useCallback(() => {
+    if (readOnly) {
+      return
+    }
     cellData.run()
-  }, [cellData])
+  }, [cellData, readOnly])
 
   const handleContextMenu = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
@@ -762,9 +797,13 @@ export function Action({
   )
 
   const handleRemoveCell = useCallback(() => {
+    if (readOnly) {
+      setContextMenu(null)
+      return
+    }
     cellData.remove()
     setContextMenu(null)
-  }, [cellData])
+  }, [cellData, readOnly])
 
   const handleCopyShareLink = useCallback(async () => {
     if (!shareRemoteUri) {
@@ -901,6 +940,9 @@ export function Action({
   }, [jupyterManager, jupyterRunnerNames, resolvedRunnerName, selectedLanguage])
 
   useEffect(() => {
+    if (readOnly) {
+      return
+    }
     if (
       selectedLanguage === 'javascript' &&
       !isAppKernelRunnerName(initialRunnerName)
@@ -938,7 +980,13 @@ export function Action({
         cellData.clearJupyterKernel()
       }
     }
-  }, [cellData, hasJupyterSelection, initialRunnerName, selectedLanguage])
+  }, [
+    cellData,
+    hasJupyterSelection,
+    initialRunnerName,
+    readOnly,
+    selectedLanguage,
+  ])
 
   const kernelOptions = useMemo(() => {
     if (!showKernelSelector || jupyterRunnerNames.length === 0) {
@@ -996,6 +1044,9 @@ export function Action({
   }, [cell, jupyterManager, resolvedRunnerName])
 
   useEffect(() => {
+    if (readOnly) {
+      return
+    }
     if (selectedLanguage !== 'jupyter') {
       return
     }
@@ -1020,6 +1071,7 @@ export function Action({
     cellData,
     jupyterManager,
     kernelOptions,
+    readOnly,
     selectedKernelKey,
     selectedLanguage,
   ])
@@ -1060,6 +1112,9 @@ export function Action({
   const handleLanguageChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
       if (!cell) {
+        return
+      }
+      if (readOnly) {
         return
       }
       const nextValue = event.target
@@ -1130,7 +1185,7 @@ export function Action({
       setPid(null)
       setExitCode(null)
     },
-    [cell, selectedLanguage, updateCellLocal]
+    [cell, readOnly, selectedLanguage, updateCellLocal]
   )
 
   // Determine if this cell is a markdown cell (either MARKUP kind or CODE with markdown language)
@@ -1171,6 +1226,7 @@ export function Action({
             type="button"
             aria-label="Add cell above"
             className="cell-add-btn h-5 w-5"
+            disabled={readOnly}
             onClick={handleAddCellBefore}
           >
             <PlusIcon width={10} height={10} />
@@ -1179,6 +1235,7 @@ export function Action({
             type="button"
             aria-label="Add cell below"
             className="cell-add-btn h-5 w-5"
+            disabled={readOnly}
             onClick={handleAddCellAfter}
           >
             <PlusIcon width={10} height={10} />
@@ -1194,6 +1251,7 @@ export function Action({
               languageOptions={LANGUAGE_OPTIONS}
               onLanguageChange={handleLanguageChange}
               forceEditRequest={markdownEditRequest}
+              readOnly={readOnly}
               isActiveCell={isActiveCell}
               activeFocusRole={activeFocusRole}
               isWindowFocused={isWindowFocused}
@@ -1204,6 +1262,7 @@ export function Action({
               type="button"
               aria-label="Delete cell"
               className="icon-btn absolute right-2 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+              disabled={readOnly}
               onClick={handleRemoveCell}
             >
               <TrashIcon />
@@ -1234,6 +1293,7 @@ export function Action({
             <button
               type="button"
               className="ctx-menu-item text-red-600"
+              disabled={readOnly}
               onClick={(event) => {
                 event.stopPropagation()
                 handleRemoveCell()
@@ -1263,6 +1323,7 @@ export function Action({
             type="button"
             aria-label="Add cell above"
             className="cell-add-btn h-5 w-5"
+            disabled={readOnly}
             onClick={handleAddCellBefore}
           >
             <PlusIcon width={10} height={10} />
@@ -1271,6 +1332,7 @@ export function Action({
             type="button"
             aria-label="Add cell below"
             className="cell-add-btn h-5 w-5"
+            disabled={readOnly}
             onClick={handleAddCellAfter}
           >
             <PlusIcon width={10} height={10} />
@@ -1285,11 +1347,13 @@ export function Action({
               languageOptions={LANGUAGE_OPTIONS}
               onLanguageChange={handleLanguageChange}
               forceEditRequest={htmlEditRequest}
+              readOnly={readOnly}
             />
             <button
               type="button"
               aria-label="Delete cell"
               className="icon-btn absolute right-2 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+              disabled={readOnly}
               onClick={handleRemoveCell}
             >
               <TrashIcon />
@@ -1320,6 +1384,7 @@ export function Action({
             <button
               type="button"
               className="ctx-menu-item text-red-600"
+              disabled={readOnly}
               onClick={(event) => {
                 event.stopPropagation()
                 handleRemoveCell()
@@ -1354,6 +1419,7 @@ export function Action({
           type="button"
           aria-label="Add cell above"
           className="cell-add-btn h-5 w-5"
+          disabled={readOnly}
           onClick={handleAddCellBefore}
         >
           <PlusIcon width={10} height={10} />
@@ -1362,6 +1428,7 @@ export function Action({
           type="button"
           aria-label="Add cell below"
           className="cell-add-btn h-5 w-5"
+          disabled={readOnly}
           onClick={handleAddCellAfter}
         >
           <PlusIcon width={10} height={10} />
@@ -1384,6 +1451,7 @@ export function Action({
               fontSize={fontSettings.fontSize}
               fontFamily={fontSettings.fontFamily}
               shouldFocus={isActiveCell && isWindowFocused}
+              readOnly={readOnly}
               onChange={(v) => {
                 const updated = create(parser_pb.CellSchema, cell)
                 updated.value = v
@@ -1400,6 +1468,7 @@ export function Action({
                 id={languageSelectId}
                 value={selectedLanguage}
                 onChange={handleLanguageChange}
+                disabled={readOnly}
                 className="toolbar-select"
               >
                 {LANGUAGE_OPTIONS.map((option) => (
@@ -1413,6 +1482,9 @@ export function Action({
                   id={runnerSelectId}
                   value={runnerSelectValue}
                   onChange={(event) => {
+                    if (readOnly) {
+                      return
+                    }
                     const nextName = event.target.value
                     if (isJavascriptLanguage) {
                       const validJsRunner = JAVASCRIPT_RUNNER_OPTIONS.some(
@@ -1433,6 +1505,7 @@ export function Action({
                     }
                     cellData.setRunner(nextName)
                   }}
+                  disabled={readOnly}
                   className="toolbar-select"
                 >
                   {isJavascriptLanguage ? (
@@ -1462,6 +1535,9 @@ export function Action({
                   id={kernelSelectId}
                   value={selectedKernelKey}
                   onChange={(event) => {
+                    if (readOnly) {
+                      return
+                    }
                     const nextKey = event.target.value
                     if (!nextKey) {
                       cellData.clearJupyterKernel()
@@ -1484,6 +1560,7 @@ export function Action({
                       kernelName: option.label,
                     })
                   }}
+                  disabled={readOnly}
                   className="toolbar-select"
                 >
                   <option value="">Select kernel</option>
@@ -1501,11 +1578,16 @@ export function Action({
               )}
             </div>
             <div className="flex items-center gap-1">
-              <RunActionButton pid={pid} onClick={runCode} />
+              <RunActionButton
+                pid={pid}
+                onClick={runCode}
+                disabled={readOnly}
+              />
               <button
                 type="button"
                 aria-label="Delete cell"
                 className="icon-btn h-7 w-7 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+                disabled={readOnly}
                 onClick={handleRemoveCell}
               >
                 <TrashIcon />
@@ -1555,6 +1637,7 @@ export function Action({
           <button
             type="button"
             className="ctx-menu-item text-red-600"
+            disabled={readOnly}
             onClick={(event) => {
               event.stopPropagation()
               handleRemoveCell()
@@ -1572,19 +1655,26 @@ function NotebookTabContent({
   docUri,
   entry,
   activeCell,
+  isSelected,
   isWindowFocused,
   onCellFocus,
 }: {
   docUri: string
   entry: OpenNotebookEntry
   activeCell: NotebookActiveCellState | null
+  isSelected: boolean
   isWindowFocused: boolean
   onCellFocus: (docUri: string, state: NotebookActiveCellState) => void
 }) {
   const { getNotebookData, openNotebook, useNotebookSnapshot } =
     useNotebookContext()
   const notebookSnapshot = useNotebookSnapshot(docUri)
+  const readOnly = Boolean(entry.readOnly || notebookSnapshot?.readOnly)
+  const shouldRenderCells = !readOnly || isSelected
   const cellDatas = useMemo(() => {
+    if (!shouldRenderCells) {
+      return []
+    }
     if (!notebookSnapshot) {
       return []
     }
@@ -1595,7 +1685,19 @@ function NotebookTabContent({
     return (notebookSnapshot.notebook.cells ?? [])
       .map((c) => (c?.refId ? data.getCell(c.refId) : null))
       .filter((c): c is CellData => Boolean(c))
-  }, [getNotebookData, notebookSnapshot])
+  }, [getNotebookData, notebookSnapshot, shouldRenderCells])
+
+  if (readOnly && !isSelected) {
+    return (
+      <div
+        className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center text-sm text-nb-text-muted"
+        data-testid="notebook-readonly-inactive-state"
+      >
+        <LockClosedIcon className="h-4 w-4 text-nb-text-muted" />
+        <span>Read-only notebook content will load when selected.</span>
+      </div>
+    )
+  }
 
   if (entry.state === 'blocked') {
     const ownerText = entry.owner?.ownerStartedAt
@@ -1669,20 +1771,38 @@ function NotebookTabContent({
       {/* Full-width notebook column with horizontal padding for breathing room.
           Cells expand to fill the available width of the tab content area. */}
       <div id="notebook-column" className="w-full py-2 px-8">
+        {readOnly && (
+          <div
+            className="mb-3 flex items-center gap-2 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
+            data-testid="notebook-readonly-banner"
+          >
+            <LockClosedIcon className="h-4 w-4 text-nb-text-muted" />
+            <span>
+              Read-only. This notebook is open for editing in another browser
+              tab.
+            </span>
+          </div>
+        )}
         {cellDatas.length === 0 ? (
           <div
             id="empty-notebook-prompt"
             className="flex flex-col items-center justify-center gap-3 py-16 text-sm text-nb-text-muted"
           >
-            <p>This notebook has no cells yet.</p>
-            <button
-              type="button"
-              className="cell-add-btn h-8 w-8"
-              aria-label="Add first cell"
-              onClick={() => data?.appendCell(parser_pb.CellKind.MARKUP)}
-            >
-              <PlusIcon className="h-5 w-5" />
-            </button>
+            <p>
+              {readOnly
+                ? 'This read-only notebook has no cells.'
+                : 'This notebook has no cells yet.'}
+            </p>
+            {!readOnly && (
+              <button
+                type="button"
+                className="cell-add-btn h-8 w-8"
+                aria-label="Add first cell"
+                onClick={() => data?.appendCell(parser_pb.CellKind.MARKUP)}
+              >
+                <PlusIcon className="h-5 w-5" />
+              </button>
+            )}
           </div>
         ) : (
           <div className="space-y-3">
@@ -1698,21 +1818,23 @@ function NotebookTabContent({
                   activeFocusRole={activeCell?.focusRole ?? 'editor'}
                   isWindowFocused={isWindowFocused}
                   onFocusStateChange={(state) => onCellFocus(docUri, state)}
+                  readOnly={readOnly}
                 />
               )
             })}
-            {/* Add cell button at the bottom of the notebook */}
-            <div className="flex justify-center py-3">
-              <button
-                type="button"
-                className="flex items-center gap-1.5 rounded-full border border-nb-border-strong bg-white px-3 py-1 text-xs text-nb-text-muted transition-colors duration-150 hover:border-nb-accent hover:text-nb-accent hover:bg-nb-accent-muted"
-                aria-label="Add cell at end"
-                onClick={() => data?.appendCell(parser_pb.CellKind.CODE)}
-              >
-                <PlusIcon width={10} height={10} />
-                <span>Add cell</span>
-              </button>
-            </div>
+            {!readOnly && (
+              <div className="flex justify-center py-3">
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-full border border-nb-border-strong bg-white px-3 py-1 text-xs text-nb-text-muted transition-colors duration-150 hover:border-nb-accent hover:text-nb-accent hover:bg-nb-accent-muted"
+                  aria-label="Add cell at end"
+                  onClick={() => data?.appendCell(parser_pb.CellKind.CODE)}
+                >
+                  <PlusIcon width={10} height={10} />
+                  <span>Add cell</span>
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -1779,6 +1901,7 @@ function UnknownDocumentTab({ uri }: { uri: string }) {
 function renderWorkspaceDocument({
   document,
   activeCell,
+  isSelected,
   isWindowFocused,
   onCellFocus,
   onDriveLogin,
@@ -1786,6 +1909,7 @@ function renderWorkspaceDocument({
 }: {
   document: WorkspaceDocument
   activeCell: NotebookActiveCellState | null
+  isSelected: boolean
   isWindowFocused: boolean
   onCellFocus: (docUri: string, state: NotebookActiveCellState) => void
   onDriveLogin: () => void
@@ -1797,6 +1921,7 @@ function renderWorkspaceDocument({
       requestedUri: document.requestedUri ?? document.uri,
       name: document.title,
       state: document.state ?? 'loading',
+      readOnly: document.readOnly,
       errorMessage: document.errorMessage,
       ...(document.owner !== undefined ? { owner: document.owner } : {}),
     }
@@ -1805,6 +1930,7 @@ function renderWorkspaceDocument({
         docUri={document.uri}
         entry={entry}
         activeCell={activeCell}
+        isSelected={isSelected}
         isWindowFocused={isWindowFocused}
         onCellFocus={onCellFocus}
       />
@@ -1853,6 +1979,7 @@ export default function Actions() {
     title: string
     shareableUri: string
     googleDriveUri: string | null
+    readOnly?: boolean
   } | null>(null)
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
   const pendingSelectedTabUriRef = useRef<string | null>(null)
@@ -2120,6 +2247,7 @@ export default function Actions() {
         title,
         shareableUri: docUri,
         googleDriveUri: isGoogleDriveFileUri(docUri) ? docUri : null,
+        readOnly: document?.readOnly,
       })
 
       if (!store || !docUri.startsWith('local://')) {
@@ -2159,6 +2287,10 @@ export default function Actions() {
 
   const handleRenameTab = useCallback(async () => {
     if (!tabContextMenu) {
+      return
+    }
+    if (tabContextMenu.readOnly) {
+      setTabContextMenu(null)
       return
     }
     if (!store) {
@@ -2426,6 +2558,7 @@ export default function Actions() {
                       <span className="max-w-[140px] truncate">
                         {displayName}
                       </span>
+                      {doc.readOnly && <ReadOnlyTabIndicator />}
                     </Tabs.Trigger>
                     {isNotebook && <NotebookSyncIndicator docUri={doc.uri} />}
                     <button
@@ -2458,6 +2591,7 @@ export default function Actions() {
               <button
                 type="button"
                 className="ctx-menu-item"
+                disabled={adjustedTabContextMenu.readOnly}
                 onClick={(event) => {
                   event.stopPropagation()
                   void handleRenameTab()
@@ -2521,6 +2655,7 @@ export default function Actions() {
                   {renderWorkspaceDocument({
                     document: doc,
                     activeCell: activeCellsByDoc[doc.uri] ?? null,
+                    isSelected: resolvedSelectedTabUri === doc.uri,
                     isWindowFocused:
                       isWindowFocused && resolvedSelectedTabUri === doc.uri,
                     onCellFocus: handleCellFocus,

--- a/app/src/components/Actions/HtmlCell.tsx
+++ b/app/src/components/Actions/HtmlCell.tsx
@@ -8,21 +8,22 @@ import {
   useSyncExternalStore,
   type FocusEvent,
   type KeyboardEvent,
-} from "react";
+} from 'react'
 
-import { create } from "@bufbuild/protobuf";
-import { parser_pb } from "../../runme/client";
-import type { CellData } from "../../lib/notebookData";
-import Editor from "./Editor";
-import { fontSettings } from "./CellConsole";
+import { create } from '@bufbuild/protobuf'
+import { parser_pb } from '../../runme/client'
+import type { CellData } from '../../lib/notebookData'
+import Editor from './Editor'
+import { fontSettings } from './CellConsole'
 
 interface HtmlCellProps {
-  cellData: CellData;
-  selectedLanguage: string;
-  languageSelectId: string;
-  languageOptions: readonly { label: string; value: string }[];
-  onLanguageChange: (event: ChangeEvent<HTMLSelectElement>) => void;
-  forceEditRequest?: number;
+  cellData: CellData
+  selectedLanguage: string
+  languageSelectId: string
+  languageOptions: readonly { label: string; value: string }[]
+  onLanguageChange: (event: ChangeEvent<HTMLSelectElement>) => void
+  forceEditRequest?: number
+  readOnly?: boolean
 }
 
 const HtmlCell = memo(
@@ -33,103 +34,114 @@ const HtmlCell = memo(
     languageOptions,
     onLanguageChange,
     forceEditRequest = 0,
+    readOnly = false,
   }: HtmlCellProps) => {
     const cell = useSyncExternalStore(
       useCallback(
         (listener) => cellData.subscribeToContentChange(listener),
-        [cellData],
+        [cellData]
       ),
       useCallback(() => cellData.snapshot, [cellData]),
-      useCallback(() => cellData.snapshot, [cellData]),
-    );
+      useCallback(() => cellData.snapshot, [cellData])
+    )
 
     const [rendered, setRendered] = useState(() => {
-      const value = cell?.value ?? "";
-      return value.trim().length > 0;
-    });
+      const value = cell?.value ?? ''
+      return readOnly || value.trim().length > 0
+    })
 
-    const value = cell?.value ?? "";
-
-    useEffect(() => {
-      if (!value.trim() && rendered) {
-        setRendered(false);
-      }
-    }, [rendered, value]);
+    const value = cell?.value ?? ''
 
     useEffect(() => {
-      if (forceEditRequest > 0) {
-        setRendered(false);
+      if (!readOnly && !value.trim() && rendered) {
+        setRendered(false)
       }
-    }, [forceEditRequest]);
+    }, [readOnly, rendered, value])
+
+    useEffect(() => {
+      if (!readOnly && forceEditRequest > 0) {
+        setRendered(false)
+      }
+    }, [forceEditRequest, readOnly])
 
     const handleRenderedKeyDown = useCallback(
       (event: KeyboardEvent<HTMLDivElement>) => {
         if (event.target !== event.currentTarget) {
-          return;
+          return
         }
-        if (event.key === "Enter" || event.key === " " || event.key === "Escape") {
-          event.preventDefault();
-          setRendered(false);
+        if (readOnly) {
+          return
+        }
+        if (
+          event.key === 'Enter' ||
+          event.key === ' ' ||
+          event.key === 'Escape'
+        ) {
+          event.preventDefault()
+          setRendered(false)
         }
       },
-      [],
-    );
+      [readOnly]
+    )
 
     const handleBlur = useCallback(
       (event: FocusEvent<HTMLDivElement>) => {
         if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
-          return;
+          return
         }
         if (!value.trim()) {
-          return;
+          return
         }
-        setRendered(true);
+        setRendered(true)
       },
-      [value],
-    );
+      [value]
+    )
 
     const handleEditorKeyDown = useCallback(
       (event: KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === "Escape" && value.trim()) {
-          setRendered(true);
+        if (event.key === 'Escape' && value.trim()) {
+          setRendered(true)
         }
       },
-      [value],
-    );
+      [value]
+    )
 
     const handleEditorChange = useCallback(
       (newValue: string) => {
         if (!cell) {
-          return;
+          return
         }
-        const updated = create(parser_pb.CellSchema, cell);
-        updated.value = newValue;
-        cellData.update(updated);
+        if (readOnly) {
+          return
+        }
+        const updated = create(parser_pb.CellSchema, cell)
+        updated.value = newValue
+        cellData.update(updated)
       },
-      [cell, cellData],
-    );
+      [cell, cellData, readOnly]
+    )
 
     const handlePreview = useCallback(() => {
-      if (value.trim()) {
-        setRendered(true);
+      if (!readOnly && value.trim()) {
+        setRendered(true)
       }
-    }, [value]);
+    }, [readOnly, value])
 
     const previewIframe = useMemo(
       () => (
         <iframe
-          title={`html-preview-${cell?.refId ?? "cell"}`}
+          title={`html-preview-${cell?.refId ?? 'cell'}`}
           sandbox=""
           srcDoc={value}
           className="h-[420px] w-full rounded-b-nb-md bg-white"
           data-testid="html-preview-frame"
         />
       ),
-      [cell?.refId, value],
-    );
+      [cell?.refId, value]
+    )
 
     if (!cell) {
-      return null;
+      return null
     }
 
     return (
@@ -153,14 +165,16 @@ const HtmlCell = memo(
               <span className="text-xs font-medium uppercase tracking-wide text-nb-text-faint">
                 HTML preview
               </span>
-              <button
-                type="button"
-                className="rounded border border-nb-border-strong px-2 py-1 text-xs text-nb-text-muted transition-colors hover:border-nb-accent hover:text-nb-accent"
-                onClick={() => setRendered(false)}
-                data-testid="html-edit-button"
-              >
-                Edit HTML
-              </button>
+              {!readOnly && (
+                <button
+                  type="button"
+                  className="rounded border border-nb-border-strong px-2 py-1 text-xs text-nb-text-muted transition-colors hover:border-nb-accent hover:text-nb-accent"
+                  onClick={() => setRendered(false)}
+                  data-testid="html-edit-button"
+                >
+                  Edit HTML
+                </button>
+              )}
             </div>
             {previewIframe}
           </div>
@@ -178,6 +192,7 @@ const HtmlCell = memo(
               language="html"
               fontSize={fontSettings.fontSize}
               fontFamily={fontSettings.fontFamily}
+              readOnly={readOnly}
               onChange={handleEditorChange}
               onEnter={handlePreview}
             />
@@ -187,6 +202,7 @@ const HtmlCell = memo(
                   id={languageSelectId}
                   value={selectedLanguage}
                   onChange={onLanguageChange}
+                  disabled={readOnly}
                   className="toolbar-select"
                 >
                   {languageOptions.map((option) => (
@@ -197,18 +213,21 @@ const HtmlCell = memo(
                 </select>
               </div>
               <div className="text-xs text-nb-text-muted">
-                Press <kbd className="px-1 py-0.5 bg-nb-surface-3 rounded">Esc</kbd>{" "}
+                Press{' '}
+                <kbd className="px-1 py-0.5 bg-nb-surface-3 rounded">Esc</kbd>{' '}
                 or click away to preview
               </div>
             </div>
           </div>
         )}
       </div>
-    );
+    )
   },
-  (prevProps, nextProps) => prevProps.cellData === nextProps.cellData,
-);
+  (prevProps, nextProps) =>
+    prevProps.cellData === nextProps.cellData &&
+    prevProps.readOnly === nextProps.readOnly
+)
 
-HtmlCell.displayName = "HtmlCell";
+HtmlCell.displayName = 'HtmlCell'
 
-export default HtmlCell;
+export default HtmlCell

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -27,17 +27,17 @@ import {
   useState,
   useSyncExternalStore,
   type KeyboardEvent,
-} from "react";
-import ReactMarkdown from "react-markdown";
-import type { Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
+} from 'react'
+import ReactMarkdown from 'react-markdown'
+import type { Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
-import { create } from "@bufbuild/protobuf";
-import { parser_pb } from "../../runme/client";
-import type { CellData } from "../../lib/notebookData";
-import type { CellFocusRole } from "../../lib/notebookActiveCellState";
-import Editor from "./Editor";
-import { fontSettings } from "./CellConsole";
+import { create } from '@bufbuild/protobuf'
+import { parser_pb } from '../../runme/client'
+import type { CellData } from '../../lib/notebookData'
+import type { CellFocusRole } from '../../lib/notebookActiveCellState'
+import Editor from './Editor'
+import { fontSettings } from './CellConsole'
 
 /**
  * Custom markdown components for consistent styling.
@@ -80,7 +80,7 @@ const markdownComponents: Components = {
     </li>
   ),
   code: ({ children, className, ...props }) => {
-    const isInline = !className;
+    const isInline = !className
     if (isInline) {
       return (
         <code
@@ -89,7 +89,7 @@ const markdownComponents: Components = {
         >
           {children}
         </code>
-      );
+      )
     }
     return (
       <code
@@ -98,10 +98,13 @@ const markdownComponents: Components = {
       >
         {children}
       </code>
-    );
+    )
   },
   pre: ({ children, ...props }) => (
-    <pre className="bg-nb-surface-2 p-3 rounded-md overflow-x-auto mb-3" {...props}>
+    <pre
+      className="bg-nb-surface-2 p-3 rounded-md overflow-x-auto mb-3"
+      {...props}
+    >
       {children}
     </pre>
   ),
@@ -148,34 +151,36 @@ const markdownComponents: Components = {
   img: ({ src, alt, ...props }) => (
     <img
       src={src}
-      alt={alt || ""}
+      alt={alt || ''}
       className="max-w-full h-auto rounded-md my-2"
       {...props}
     />
   ),
-};
+}
 
 interface MarkdownCellProps {
   /** The CellData object containing the markdown content and state */
-  cellData: CellData;
+  cellData: CellData
   /** Selected language shown in the footer selector */
-  selectedLanguage: string;
+  selectedLanguage: string
   /** ID for the language selector element */
-  languageSelectId: string;
+  languageSelectId: string
   /** Supported language options for converting markdown/code cells */
-  languageOptions: readonly { label: string; value: string }[];
+  languageOptions: readonly { label: string; value: string }[]
   /** Shared language change handler from parent Action component */
-  onLanguageChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  onLanguageChange: (event: ChangeEvent<HTMLSelectElement>) => void
   /** Incrementing signal to force editor mode after conversion to markdown */
-  forceEditRequest?: number;
+  forceEditRequest?: number
   /** Whether this cell is the persisted active cell for the visible notebook */
-  isActiveCell?: boolean;
+  isActiveCell?: boolean
   /** Which markdown surface was last active for this cell */
-  activeFocusRole?: CellFocusRole;
+  activeFocusRole?: CellFocusRole
   /** Whether the visible browser tab is currently focused */
-  isWindowFocused?: boolean;
+  isWindowFocused?: boolean
   /** Notify parent when markdown focus target changes explicitly */
-  onFocusRoleChange?: (focusRole: CellFocusRole) => void;
+  onFocusRoleChange?: (focusRole: CellFocusRole) => void
+  /** Render and inspect only; editing controls are disabled. */
+  readOnly?: boolean
 }
 
 /**
@@ -196,9 +201,10 @@ const MarkdownCell = memo(
     onLanguageChange,
     forceEditRequest = 0,
     isActiveCell = false,
-    activeFocusRole = "editor",
+    activeFocusRole = 'editor',
     isWindowFocused = false,
     onFocusRoleChange,
+    readOnly = false,
   }: MarkdownCellProps) => {
     // Subscribe to cell data changes using useSyncExternalStore for tearing-safe reads
     const cell = useSyncExternalStore(
@@ -208,93 +214,99 @@ const MarkdownCell = memo(
       ),
       useCallback(() => cellData.snapshot, [cellData]),
       useCallback(() => cellData.snapshot, [cellData])
-    );
+    )
 
     // `rendered` state controls whether we show rendered markdown or the editor
     // Start in rendered mode unless the cell is empty (new cell)
     const [rendered, setRendered] = useState(() => {
-      const value = cell?.value ?? "";
-      if (value.trim() && isActiveCell && activeFocusRole === "editor") {
-        return false;
+      const value = cell?.value ?? ''
+      if (readOnly) {
+        return true
       }
-      return value.trim().length > 0;
-    });
-    const renderedRef = useRef<HTMLDivElement | null>(null);
-    const previousShouldOwnFocusRef = useRef(false);
-    const [editorFocusIntent, setEditorFocusIntent] = useState(false);
-    const [renderedFocusIntent, setRenderedFocusIntent] = useState(false);
+      if (value.trim() && isActiveCell && activeFocusRole === 'editor') {
+        return false
+      }
+      return value.trim().length > 0
+    })
+    const renderedRef = useRef<HTMLDivElement | null>(null)
+    const previousShouldOwnFocusRef = useRef(false)
+    const [editorFocusIntent, setEditorFocusIntent] = useState(false)
+    const [renderedFocusIntent, setRenderedFocusIntent] = useState(false)
 
     // Get the current cell value
-    const value = cell?.value ?? "";
-    const shouldOwnFocus = isActiveCell && isWindowFocused;
-    const tracksActiveCell = Boolean(onFocusRoleChange);
+    const value = cell?.value ?? ''
+    const shouldOwnFocus = isActiveCell && isWindowFocused
+    const tracksActiveCell = Boolean(onFocusRoleChange)
 
     // Enforce invariant: empty cells must be in edit mode.
     // This handles external changes (undo/redo, sync) that clear the value.
     useEffect(() => {
-      if (!value.trim() && rendered) {
-        setRendered(false);
+      if (!readOnly && !value.trim() && rendered) {
+        setRendered(false)
       }
-    }, [value, rendered]);
+    }, [readOnly, value, rendered])
 
     useEffect(() => {
-      if (forceEditRequest > 0) {
-        setRendered(false);
-        setEditorFocusIntent(true);
+      if (!readOnly && forceEditRequest > 0) {
+        setRendered(false)
+        setEditorFocusIntent(true)
       }
-    }, [forceEditRequest]);
+    }, [forceEditRequest, readOnly])
 
     useEffect(() => {
       if (!editorFocusIntent || rendered) {
-        return;
+        return
       }
-      setEditorFocusIntent(false);
-    }, [editorFocusIntent, rendered]);
+      setEditorFocusIntent(false)
+    }, [editorFocusIntent, rendered])
 
     useEffect(() => {
       if (!renderedFocusIntent || !rendered) {
-        return;
+        return
       }
-      renderedRef.current?.focus();
-      setRenderedFocusIntent(false);
-    }, [rendered, renderedFocusIntent]);
+      renderedRef.current?.focus()
+      setRenderedFocusIntent(false)
+    }, [rendered, renderedFocusIntent])
 
     useEffect(() => {
-      const previouslyOwnedFocus = previousShouldOwnFocusRef.current;
-      previousShouldOwnFocusRef.current = shouldOwnFocus;
+      const previouslyOwnedFocus = previousShouldOwnFocusRef.current
+      previousShouldOwnFocusRef.current = shouldOwnFocus
       if (!shouldOwnFocus || previouslyOwnedFocus) {
-        return;
+        return
       }
-      if (activeFocusRole === "editor" || !value.trim()) {
-        setRendered(false);
-        return;
+      if (!readOnly && (activeFocusRole === 'editor' || !value.trim())) {
+        setRendered(false)
+        return
       }
-      setRendered(true);
-      renderedRef.current?.focus();
-    }, [activeFocusRole, shouldOwnFocus, value]);
+      setRendered(true)
+      renderedRef.current?.focus()
+    }, [activeFocusRole, readOnly, shouldOwnFocus, value])
 
     useEffect(() => {
-      if (!shouldOwnFocus || activeFocusRole !== "rendered" || !rendered) {
-        return;
+      if (!shouldOwnFocus || activeFocusRole !== 'rendered' || !rendered) {
+        return
       }
-      renderedRef.current?.focus();
-    }, [activeFocusRole, rendered, shouldOwnFocus]);
+      renderedRef.current?.focus()
+    }, [activeFocusRole, rendered, shouldOwnFocus])
 
     useEffect(() => {
       if (!tracksActiveCell || isActiveCell || rendered || !value.trim()) {
-        return;
+        return
       }
-      setRendered(true);
-    }, [isActiveCell, rendered, tracksActiveCell, value]);
+      setRendered(true)
+    }, [isActiveCell, rendered, tracksActiveCell, value])
 
     /**
      * Handle switching to edit mode when user double-clicks rendered content.
      */
     const handleDoubleClick = useCallback(() => {
-      setRendered(false);
-      setEditorFocusIntent(true);
-      onFocusRoleChange?.("editor");
-    }, [onFocusRoleChange]);
+      if (readOnly) {
+        return
+      }
+      setRendered(false)
+      setEditorFocusIntent(true)
+      onFocusRoleChange?.('editor')
+    }, [onFocusRoleChange, readOnly])
 
     /**
      * Handle keyboard activation on the rendered container for accessibility.
@@ -306,17 +318,20 @@ const MarkdownCell = memo(
       (event: KeyboardEvent<HTMLDivElement>) => {
         // Only handle if the container itself is focused, not nested elements
         if (event.target !== event.currentTarget) {
-          return;
+          return
         }
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          setRendered(false);
-          setEditorFocusIntent(true);
-          onFocusRoleChange?.("editor");
+        if (event.key === 'Enter' || event.key === ' ') {
+          if (readOnly) {
+            return
+          }
+          event.preventDefault()
+          setRendered(false)
+          setEditorFocusIntent(true)
+          onFocusRoleChange?.('editor')
         }
       },
-      [onFocusRoleChange]
-    );
+      [onFocusRoleChange, readOnly]
+    )
 
     /**
      * Handle keyboard events on the editor container.
@@ -324,17 +339,17 @@ const MarkdownCell = memo(
      */
     const handleEditorKeyDown = useCallback(
       (event: KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === "Escape") {
+        if (event.key === 'Escape') {
           // Only render if there's content; empty cells stay in edit mode
           if (value.trim()) {
-            setRendered(true);
-            setRenderedFocusIntent(true);
-            onFocusRoleChange?.("rendered");
+            setRendered(true)
+            setRenderedFocusIntent(true)
+            onFocusRoleChange?.('rendered')
           }
         }
       },
       [onFocusRoleChange, value]
-    );
+    )
 
     /**
      * Handle content changes from the editor.
@@ -342,13 +357,14 @@ const MarkdownCell = memo(
      */
     const handleEditorChange = useCallback(
       (newValue: string) => {
-        if (!cell) return;
-        const updated = create(parser_pb.CellSchema, cell);
-        updated.value = newValue;
-        cellData.update(updated);
+        if (!cell) return
+        if (readOnly) return
+        const updated = create(parser_pb.CellSchema, cell)
+        updated.value = newValue
+        cellData.update(updated)
       },
-      [cell, cellData]
-    );
+      [cell, cellData, readOnly]
+    )
 
     /**
      * Handle "run" action for markdown cells - just renders the markdown.
@@ -356,20 +372,22 @@ const MarkdownCell = memo(
      * renders it and moves to the next cell.
      */
     const handleRun = useCallback(() => {
-      if (value.trim()) {
-        setRendered(true);
-        setRenderedFocusIntent(true);
+      if (!readOnly && value.trim()) {
+        setRendered(true)
+        setRenderedFocusIntent(true)
       }
-    }, [value]);
+    }, [readOnly, value])
 
     // Memoize the rendered markdown to avoid unnecessary re-renders
     const renderedMarkdown = useMemo(() => {
       if (!value.trim()) {
         return (
           <div className="text-nb-text-faint italic py-2">
-            Double-click to edit markdown...
+            {readOnly
+              ? 'This read-only markdown cell is empty.'
+              : 'Double-click to edit markdown...'}
           </div>
-        );
+        )
       }
       return (
         <div className="prose prose-sm max-w-none">
@@ -380,11 +398,11 @@ const MarkdownCell = memo(
             {value}
           </ReactMarkdown>
         </div>
-      );
-    }, [value]);
+      )
+    }, [readOnly, value])
 
     if (!cell) {
-      return null;
+      return null
     }
 
     return (
@@ -403,11 +421,15 @@ const MarkdownCell = memo(
             onKeyDown={handleRenderedKeyDown}
             ref={renderedRef}
             tabIndex={0}
-            role="button"
-            aria-label="Double-click or press Enter to edit markdown"
+            role={readOnly ? undefined : 'button'}
+            aria-label={
+              readOnly
+                ? 'Read-only markdown'
+                : 'Double-click or press Enter to edit markdown'
+            }
             data-testid="markdown-rendered"
             data-cell-focus-role="rendered"
-            onFocus={() => onFocusRoleChange?.("rendered")}
+            onFocus={() => onFocusRoleChange?.('rendered')}
           >
             {renderedMarkdown}
           </div>
@@ -427,11 +449,13 @@ const MarkdownCell = memo(
               fontSize={fontSettings.fontSize}
               fontFamily={fontSettings.fontFamily}
               shouldFocus={
+                !readOnly &&
                 !rendered &&
-                ((shouldOwnFocus && activeFocusRole === "editor") ||
+                ((shouldOwnFocus && activeFocusRole === 'editor') ||
                   editorFocusIntent)
               }
-              onFocus={() => onFocusRoleChange?.("editor")}
+              onFocus={() => onFocusRoleChange?.('editor')}
+              readOnly={readOnly}
               onChange={handleEditorChange}
               onEnter={handleRun}
             />
@@ -441,6 +465,7 @@ const MarkdownCell = memo(
                   id={languageSelectId}
                   value={selectedLanguage}
                   onChange={onLanguageChange}
+                  disabled={readOnly}
                   className="toolbar-select"
                 >
                   {languageOptions.map((option) => (
@@ -451,14 +476,15 @@ const MarkdownCell = memo(
                 </select>
               </div>
               <div className="text-xs text-nb-text-muted">
-                Press <kbd className="px-1 py-0.5 bg-nb-surface-3 rounded">Esc</kbd>{" "}
+                Press{' '}
+                <kbd className="px-1 py-0.5 bg-nb-surface-3 rounded">Esc</kbd>{' '}
                 or run the cell to render
               </div>
             </div>
           </div>
         )}
       </div>
-    );
+    )
   },
   (prevProps, nextProps) => {
     return (
@@ -469,11 +495,12 @@ const MarkdownCell = memo(
       prevProps.isActiveCell === nextProps.isActiveCell &&
       prevProps.activeFocusRole === nextProps.activeFocusRole &&
       prevProps.isWindowFocused === nextProps.isWindowFocused &&
-      prevProps.onFocusRoleChange === nextProps.onFocusRoleChange
-    );
+      prevProps.onFocusRoleChange === nextProps.onFocusRoleChange &&
+      prevProps.readOnly === nextProps.readOnly
+    )
   }
-);
+)
 
-MarkdownCell.displayName = "MarkdownCell";
+MarkdownCell.displayName = 'MarkdownCell'
 
-export default MarkdownCell;
+export default MarkdownCell

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -1,220 +1,246 @@
 // @vitest-environment jsdom
-import { useEffect } from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useEffect } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-type PanelKey = "explorer" | "open-documents" | "chatkit" | null;
+type PanelKey = 'explorer' | 'open-documents' | 'chatkit' | null
 
-let authData: {} | null = null;
-let isDriveSyncing = false;
-let activePanelState: PanelKey = "explorer";
-let currentDocUri: string | null = null;
-let openDocumentsState: { uri: string; title: string; state?: string }[] = [];
-let chatKitMountCount = 0;
-let chatKitUnmountCount = 0;
-const ensureAccessTokenMock = vi.fn(async () => "token");
-const loginWithRedirectMock = vi.fn();
-const logoutMock = vi.fn();
-const togglePanelMock = vi.fn();
-const setCurrentDocMock = vi.fn();
-const closeWorkspaceDocumentMock = vi.fn();
+let authData: {} | null = null
+let isDriveSyncing = false
+let activePanelState: PanelKey = 'explorer'
+let currentDocUri: string | null = null
+let openDocumentsState: {
+  uri: string
+  title: string
+  state?: string
+  readOnly?: boolean
+}[] = []
+let chatKitMountCount = 0
+let chatKitUnmountCount = 0
+const ensureAccessTokenMock = vi.fn(async () => 'token')
+const loginWithRedirectMock = vi.fn()
+const logoutMock = vi.fn()
+const togglePanelMock = vi.fn()
+const setCurrentDocMock = vi.fn()
+const closeWorkspaceDocumentMock = vi.fn()
 
-vi.mock("../../browserAdapter.client", () => ({
+vi.mock('../../browserAdapter.client', () => ({
   useBrowserAuthData: () => authData,
   getBrowserAdapter: () => ({
     loginWithRedirect: loginWithRedirectMock,
     logout: logoutMock,
   }),
-}));
+}))
 
-vi.mock("../../contexts/SidePanelContext", () => ({
+vi.mock('../../contexts/SidePanelContext', () => ({
   useSidePanel: () => ({
     activePanel: activePanelState,
     togglePanel: togglePanelMock,
   }),
-}));
+}))
 
-vi.mock("../../contexts/WorkspaceDocumentContext", () => ({
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
   useWorkspaceDocumentContext: () => ({
     useWorkspaceDocuments: () => openDocumentsState,
     closeWorkspaceDocument: closeWorkspaceDocumentMock,
   }),
-}));
+}))
 
-vi.mock("../../contexts/CurrentDocContext", () => ({
+vi.mock('../../contexts/CurrentDocContext', () => ({
   useCurrentDoc: () => ({
     getCurrentDoc: () => currentDocUri,
     setCurrentDoc: setCurrentDocMock,
   }),
-}));
+}))
 
-vi.mock("../../contexts/GoogleAuthContext", () => ({
+vi.mock('../../contexts/GoogleAuthContext', () => ({
   useGoogleAuth: () => ({
     ensureAccessToken: ensureAccessTokenMock,
     isDriveSyncing,
   }),
-}));
+}))
 
-vi.mock("../ChatKit/ChatKitPanel", () => ({
+vi.mock('../ChatKit/ChatKitPanel', () => ({
   default: () => {
     useEffect(() => {
-      chatKitMountCount += 1;
+      chatKitMountCount += 1
       return () => {
-        chatKitUnmountCount += 1;
-      };
-    }, []);
-    return <div data-testid="chatkit-panel-mock" />;
+        chatKitUnmountCount += 1
+      }
+    }, [])
+    return <div data-testid="chatkit-panel-mock" />
   },
-}));
+}))
 
-vi.mock("../Workspace/WorkspaceExplorer", () => ({
+vi.mock('../Workspace/WorkspaceExplorer', () => ({
   default: () => <div data-testid="workspace-explorer-mock" />,
-}));
+}))
 
-import { SidePanelContent, SidePanelToolbar } from "./SidePanel";
+import { SidePanelContent, SidePanelToolbar } from './SidePanel'
 
-describe("SidePanelToolbar drive status button", () => {
+describe('SidePanelToolbar drive status button', () => {
   beforeEach(() => {
-    authData = null;
-    isDriveSyncing = false;
-    activePanelState = "explorer";
-    currentDocUri = null;
-    openDocumentsState = [];
-    chatKitMountCount = 0;
-    chatKitUnmountCount = 0;
-    ensureAccessTokenMock.mockClear();
-    loginWithRedirectMock.mockClear();
-    logoutMock.mockClear();
-    togglePanelMock.mockClear();
-    setCurrentDocMock.mockClear();
-    closeWorkspaceDocumentMock.mockClear();
-  });
+    authData = null
+    isDriveSyncing = false
+    activePanelState = 'explorer'
+    currentDocUri = null
+    openDocumentsState = []
+    chatKitMountCount = 0
+    chatKitUnmountCount = 0
+    ensureAccessTokenMock.mockClear()
+    loginWithRedirectMock.mockClear()
+    logoutMock.mockClear()
+    togglePanelMock.mockClear()
+    setCurrentDocMock.mockClear()
+    closeWorkspaceDocumentMock.mockClear()
+  })
 
-  it("renders the Drive status button above Login and starts auth when not syncing", async () => {
-    render(<SidePanelToolbar />);
+  it('renders the Drive status button above Login and starts auth when not syncing', async () => {
+    render(<SidePanelToolbar />)
 
-    const driveStatusButton = screen.getByRole("button", {
-      name: "Google Drive status: Not syncing",
-    });
-    const loginButton = screen.getByRole("button", { name: "Login" });
+    const driveStatusButton = screen.getByRole('button', {
+      name: 'Google Drive status: Not syncing',
+    })
+    const loginButton = screen.getByRole('button', { name: 'Login' })
 
     expect(
       driveStatusButton.compareDocumentPosition(loginButton) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
 
     await act(async () => {
-      fireEvent.click(driveStatusButton);
-      await Promise.resolve();
-    });
-    expect(ensureAccessTokenMock).toHaveBeenCalledWith({ interactive: true });
-  });
+      fireEvent.click(driveStatusButton)
+      await Promise.resolve()
+    })
+    expect(ensureAccessTokenMock).toHaveBeenCalledWith({ interactive: true })
+  })
 
-  it("does not start auth when Drive is already syncing", () => {
-    isDriveSyncing = true;
-    render(<SidePanelToolbar />);
+  it('does not start auth when Drive is already syncing', () => {
+    isDriveSyncing = true
+    render(<SidePanelToolbar />)
 
-    const driveStatusButton = screen.getByRole("button", {
-      name: "Google Drive status: Syncing",
-    });
-    fireEvent.click(driveStatusButton);
+    const driveStatusButton = screen.getByRole('button', {
+      name: 'Google Drive status: Syncing',
+    })
+    fireEvent.click(driveStatusButton)
 
-    expect(ensureAccessTokenMock).not.toHaveBeenCalled();
-  });
+    expect(ensureAccessTokenMock).not.toHaveBeenCalled()
+  })
 
-  it("exposes an Open Documents button in the toolbar", () => {
-    render(<SidePanelToolbar />);
+  it('exposes an Open Documents button in the toolbar', () => {
+    render(<SidePanelToolbar />)
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Toggle Open Documents panel" }),
-    );
+      screen.getByRole('button', { name: 'Toggle Open Documents panel' })
+    )
 
-    expect(togglePanelMock).toHaveBeenCalledWith("open-documents");
-  });
-});
+    expect(togglePanelMock).toHaveBeenCalledWith('open-documents')
+  })
+})
 
-describe("SidePanelContent ChatKit persistence", () => {
+describe('SidePanelContent ChatKit persistence', () => {
   beforeEach(() => {
-    activePanelState = "explorer";
-    currentDocUri = null;
-    openDocumentsState = [];
-    chatKitMountCount = 0;
-    chatKitUnmountCount = 0;
-    setCurrentDocMock.mockClear();
-    closeWorkspaceDocumentMock.mockClear();
-  });
+    activePanelState = 'explorer'
+    currentDocUri = null
+    openDocumentsState = []
+    chatKitMountCount = 0
+    chatKitUnmountCount = 0
+    setCurrentDocMock.mockClear()
+    closeWorkspaceDocumentMock.mockClear()
+  })
 
-  it("keeps ChatKit mounted when switching from ChatKit to Explorer and back", () => {
-    activePanelState = "chatkit";
-    const { rerender } = render(<SidePanelContent />);
+  it('keeps ChatKit mounted when switching from ChatKit to Explorer and back', () => {
+    activePanelState = 'chatkit'
+    const { rerender } = render(<SidePanelContent />)
 
-    expect(screen.getByTestId("chatkit-panel-mock")).toBeTruthy();
-    expect(chatKitMountCount).toBe(1);
-    expect(chatKitUnmountCount).toBe(0);
+    expect(screen.getByTestId('chatkit-panel-mock')).toBeTruthy()
+    expect(chatKitMountCount).toBe(1)
+    expect(chatKitUnmountCount).toBe(0)
 
-    activePanelState = "explorer";
-    rerender(<SidePanelContent />);
+    activePanelState = 'explorer'
+    rerender(<SidePanelContent />)
 
-    expect(screen.getByTestId("chatkit-panel-mock")).toBeTruthy();
-    expect(screen.getByTestId("workspace-explorer-mock")).toBeTruthy();
-    expect(chatKitUnmountCount).toBe(0);
+    expect(screen.getByTestId('chatkit-panel-mock')).toBeTruthy()
+    expect(screen.getByTestId('workspace-explorer-mock')).toBeTruthy()
+    expect(chatKitUnmountCount).toBe(0)
 
-    activePanelState = "chatkit";
-    rerender(<SidePanelContent />);
+    activePanelState = 'chatkit'
+    rerender(<SidePanelContent />)
 
-    expect(screen.getByTestId("chatkit-panel-mock")).toBeTruthy();
-    expect(chatKitMountCount).toBe(1);
-    expect(chatKitUnmountCount).toBe(0);
-  });
+    expect(screen.getByTestId('chatkit-panel-mock')).toBeTruthy()
+    expect(chatKitMountCount).toBe(1)
+    expect(chatKitUnmountCount).toBe(0)
+  })
 
-  it("keeps the explorer subtree mounted when the side panel is collapsed", () => {
-    activePanelState = "explorer";
-    const { rerender } = render(<SidePanelContent />);
+  it('keeps the explorer subtree mounted when the side panel is collapsed', () => {
+    activePanelState = 'explorer'
+    const { rerender } = render(<SidePanelContent />)
 
-    expect(screen.getByTestId("workspace-explorer-mock")).toBeTruthy();
+    expect(screen.getByTestId('workspace-explorer-mock')).toBeTruthy()
 
-    activePanelState = null;
-    rerender(<SidePanelContent />);
+    activePanelState = null
+    rerender(<SidePanelContent />)
 
-    expect(screen.getByTestId("workspace-explorer-mock")).toBeTruthy();
-  });
+    expect(screen.getByTestId('workspace-explorer-mock')).toBeTruthy()
+  })
 
-  it("renders the Open Documents panel and routes document actions through shared context state", () => {
-    activePanelState = "open-documents";
-    currentDocUri = "local://file/alpha.json";
+  it('renders the Open Documents panel and routes document actions through shared context state', () => {
+    activePanelState = 'open-documents'
+    currentDocUri = 'local://file/alpha.json'
     openDocumentsState = [
-      { uri: "local://file/alpha.json", title: "alpha.json" },
-      { uri: "diff://notebook/beta", title: "beta diff" },
-    ];
-    closeWorkspaceDocumentMock.mockReturnValue("diff://notebook/beta");
+      { uri: 'local://file/alpha.json', title: 'alpha.json' },
+      { uri: 'diff://notebook/beta', title: 'beta diff' },
+    ]
+    closeWorkspaceDocumentMock.mockReturnValue('diff://notebook/beta')
 
-    render(<SidePanelContent />);
+    render(<SidePanelContent />)
 
-    expect(screen.getByText("Open Documents")).toBeTruthy();
+    expect(screen.getByText('Open Documents')).toBeTruthy()
 
-    fireEvent.click(screen.getByText("beta diff"));
-    expect(setCurrentDocMock).toHaveBeenCalledWith("diff://notebook/beta");
+    fireEvent.click(screen.getByText('beta diff'))
+    expect(setCurrentDocMock).toHaveBeenCalledWith('diff://notebook/beta')
 
-    fireEvent.click(screen.getByRole("button", { name: "Close alpha.json" }));
-    expect(closeWorkspaceDocumentMock).toHaveBeenCalledWith("local://file/alpha.json");
-  });
+    fireEvent.click(screen.getByRole('button', { name: 'Close alpha.json' }))
+    expect(closeWorkspaceDocumentMock).toHaveBeenCalledWith(
+      'local://file/alpha.json'
+    )
+  })
 
-  it("shows blocked notebook status from open entry metadata", () => {
-    activePanelState = "open-documents";
-    currentDocUri = "local://file/blocked";
+  it('shows blocked notebook status from open entry metadata', () => {
+    activePanelState = 'open-documents'
+    currentDocUri = 'local://file/blocked'
     openDocumentsState = [
       {
-        uri: "local://file/blocked",
-        title: "blocked.json",
-        state: "blocked",
+        uri: 'local://file/blocked',
+        title: 'blocked.json',
+        state: 'blocked',
       },
-    ];
+    ]
 
-    render(<SidePanelContent />);
+    render(<SidePanelContent />)
 
-    expect(screen.getByText("blocked.json")).toBeTruthy();
-    expect(screen.getByTestId("open-notebook-status-blocked").textContent).toBe(
-      "Blocked",
-    );
-  });
-});
+    expect(screen.getByText('blocked.json')).toBeTruthy()
+    expect(screen.getByTestId('open-notebook-status-blocked').textContent).toBe(
+      'Blocked'
+    )
+  })
+
+  it('shows read-only notebook status from open entry metadata', () => {
+    currentDocUri = 'local://file/readonly'
+    openDocumentsState = [
+      {
+        uri: 'local://file/readonly',
+        title: 'readonly.json',
+        state: 'loaded',
+        readOnly: true,
+      },
+    ]
+
+    render(<SidePanelContent />)
+
+    expect(screen.getByText('readonly.json')).toBeTruthy()
+    expect(
+      screen.getByTestId('open-notebook-status-readonly').textContent
+    ).toBe('Read-only')
+  })
+})

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -3,47 +3,56 @@ import {
   ChatBubbleLeftRightIcon,
   QueueListIcon,
   UserCircleIcon,
-} from "@heroicons/react/24/outline";
-import { XMarkIcon } from "@heroicons/react/20/solid";
-import { CloudIcon as CloudSolidIcon } from "@heroicons/react/24/solid";
-import { useCallback, useEffect, useState } from "react";
+} from '@heroicons/react/24/outline'
+import { XMarkIcon } from '@heroicons/react/20/solid'
+import { CloudIcon as CloudSolidIcon } from '@heroicons/react/24/solid'
+import { useCallback, useEffect, useState } from 'react'
 
-import ChatKitPanel from "../ChatKit/ChatKitPanel";
-import WorkspaceExplorer from "../Workspace/WorkspaceExplorer";
-import { getBrowserAdapter, useBrowserAuthData } from "../../browserAdapter.client";
-import { useGoogleAuth } from "../../contexts/GoogleAuthContext";
-import { useCurrentDoc } from "../../contexts/CurrentDocContext";
-import { useSidePanel } from "../../contexts/SidePanelContext";
-import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
+import ChatKitPanel from '../ChatKit/ChatKitPanel'
+import WorkspaceExplorer from '../Workspace/WorkspaceExplorer'
+import {
+  getBrowserAdapter,
+  useBrowserAuthData,
+} from '../../browserAdapter.client'
+import { useGoogleAuth } from '../../contexts/GoogleAuthContext'
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useSidePanel } from '../../contexts/SidePanelContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
 import {
   isDriveLinkStatusUri,
   isNotebookDiffUri,
   isNotebookDocumentUri,
-} from "../../lib/workspaceDocuments/workspaceDocumentTypes";
+} from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 
-const sideButtonBase = "group side-btn";
+const sideButtonBase = 'group side-btn'
 
-const sideButtonInactive = "side-btn-inactive";
+const sideButtonInactive = 'side-btn-inactive'
 
-const sideButtonActive = "side-btn-active";
+const sideButtonActive = 'side-btn-active'
 
-const tooltipBase = "side-tooltip";
+const tooltipBase = 'side-tooltip'
 
 function getNotebookDisplayName(uri: string, name?: string): string {
-  return name || uri.split("/").filter(Boolean).pop() || uri;
+  return name || uri.split('/').filter(Boolean).pop() || uri
 }
 
-function getNotebookStatusLabel(state?: string): string | null {
-  if (state === "blocked") {
-    return "Blocked";
+function getNotebookStatusLabel(
+  state?: string,
+  readOnly?: boolean
+): string | null {
+  if (readOnly) {
+    return 'Read-only'
   }
-  if (state === "error") {
-    return "Error";
+  if (state === 'blocked') {
+    return 'Blocked'
   }
-  if (state === "loading" || state === "resolving") {
-    return "Loading";
+  if (state === 'error') {
+    return 'Error'
   }
-  return null;
+  if (state === 'loading' || state === 'resolving') {
+    return 'Loading'
+  }
+  return null
 }
 
 /**
@@ -55,17 +64,17 @@ function getNotebookStatusLabel(state?: string): string | null {
  */
 function OpenDocumentsPanel() {
   const { useWorkspaceDocuments, closeWorkspaceDocument } =
-    useWorkspaceDocumentContext();
-  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc();
-  const openDocuments = useWorkspaceDocuments();
-  const currentDocUri = getCurrentDoc();
+    useWorkspaceDocumentContext()
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
+  const openDocuments = useWorkspaceDocuments()
+  const currentDocUri = getCurrentDoc()
 
   const handleCloseDocument = useCallback(
     (uri: string) => {
-      closeWorkspaceDocument(uri);
+      closeWorkspaceDocument(uri)
     },
-    [closeWorkspaceDocument],
-  );
+    [closeWorkspaceDocument]
+  )
 
   return (
     <div
@@ -80,7 +89,8 @@ function OpenDocumentsPanel() {
           Open Documents
         </p>
         <p className="mt-1 text-sm text-nb-text-muted">
-          {openDocuments.length} {openDocuments.length === 1 ? "document" : "documents"}
+          {openDocuments.length}{' '}
+          {openDocuments.length === 1 ? 'document' : 'documents'}
         </p>
       </div>
       <div
@@ -97,24 +107,27 @@ function OpenDocumentsPanel() {
         ) : (
           <ul id="open-documents-list" className="space-y-1">
             {openDocuments.map((doc) => {
-              const displayName = getNotebookDisplayName(doc.uri, doc.title);
-              const isActive = doc.uri === currentDocUri;
-              const statusLabel = getNotebookStatusLabel(doc.state);
+              const displayName = getNotebookDisplayName(doc.uri, doc.title)
+              const isActive = doc.uri === currentDocUri
+              const statusLabel = getNotebookStatusLabel(
+                doc.state,
+                doc.readOnly
+              )
               const kind = isNotebookDocumentUri(doc.uri)
-                ? "Notebook"
+                ? 'Notebook'
                 : isNotebookDiffUri(doc.uri)
-                  ? "Diff"
+                  ? 'Diff'
                   : isDriveLinkStatusUri(doc.uri)
-                    ? "Status"
-                    : "Document";
+                    ? 'Status'
+                    : 'Document'
               return (
                 <li key={doc.uri}>
                   <div
                     id={`open-document-row-${encodeURIComponent(doc.uri)}`}
                     className={`group flex items-center gap-2 rounded-nb-sm border px-2 py-2 transition-colors ${
                       isActive
-                        ? "border-nb-accent bg-nb-accent-soft text-nb-text"
-                        : "border-transparent bg-transparent text-nb-text-muted hover:border-nb-border hover:bg-white/80 hover:text-nb-text"
+                        ? 'border-nb-accent bg-nb-accent-soft text-nb-text'
+                        : 'border-transparent bg-transparent text-nb-text-muted hover:border-nb-border hover:bg-white/80 hover:text-nb-text'
                     }`}
                   >
                     <button
@@ -129,7 +142,11 @@ function OpenDocumentsPanel() {
                         {statusLabel ? (
                           <span
                             id={`open-notebook-status-${encodeURIComponent(doc.uri)}`}
-                            data-testid={`open-notebook-status-${doc.state}`}
+                            data-testid={
+                              doc.readOnly
+                                ? 'open-notebook-status-readonly'
+                                : `open-notebook-status-${doc.state}`
+                            }
                             className="shrink-0 rounded-nb-xs border border-nb-border bg-white px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-nb-text-muted"
                           >
                             {statusLabel}
@@ -145,8 +162,8 @@ function OpenDocumentsPanel() {
                       className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-nb-xs text-nb-text-faint transition-colors hover:bg-black/5 hover:text-nb-text"
                       aria-label={`Close ${displayName}`}
                       onClick={(event) => {
-                        event.stopPropagation();
-                        handleCloseDocument(doc.uri);
+                        event.stopPropagation()
+                        handleCloseDocument(doc.uri)
                       }}
                       onMouseDown={(event) => event.stopPropagation()}
                     >
@@ -154,38 +171,38 @@ function OpenDocumentsPanel() {
                     </button>
                   </div>
                 </li>
-              );
+              )
             })}
           </ul>
         )}
       </div>
     </div>
-  );
+  )
 }
 
 export function SidePanelToolbar() {
-  const { activePanel, togglePanel } = useSidePanel();
-  const authData = useBrowserAuthData();
-  const browserAdapter = getBrowserAdapter();
-  const { ensureAccessToken, isDriveSyncing } = useGoogleAuth();
-  const [isDriveAuthPending, setIsDriveAuthPending] = useState(false);
+  const { activePanel, togglePanel } = useSidePanel()
+  const authData = useBrowserAuthData()
+  const browserAdapter = getBrowserAdapter()
+  const { ensureAccessToken, isDriveSyncing } = useGoogleAuth()
+  const [isDriveAuthPending, setIsDriveAuthPending] = useState(false)
 
-  const driveStatus = isDriveSyncing ? "Syncing" : "Not syncing";
+  const driveStatus = isDriveSyncing ? 'Syncing' : 'Not syncing'
   const handleDriveStatusClick = useCallback(async () => {
     if (isDriveSyncing || isDriveAuthPending) {
-      return;
+      return
     }
-    setIsDriveAuthPending(true);
+    setIsDriveAuthPending(true)
     try {
-      await ensureAccessToken({ interactive: true });
+      await ensureAccessToken({ interactive: true })
     } catch (error) {
-      if (!String(error).includes("Redirecting to Google OAuth")) {
-        console.error("Failed to start Google Drive auth flow", error);
+      if (!String(error).includes('Redirecting to Google OAuth')) {
+        console.error('Failed to start Google Drive auth flow', error)
       }
     } finally {
-      setIsDriveAuthPending(false);
+      setIsDriveAuthPending(false)
     }
-  }, [ensureAccessToken, isDriveAuthPending, isDriveSyncing]);
+  }, [ensureAccessToken, isDriveAuthPending, isDriveSyncing])
 
   return (
     <div className="flex h-full w-12 flex-col items-center justify-between">
@@ -193,11 +210,11 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
-            activePanel === "explorer" ? sideButtonActive : sideButtonInactive
+            activePanel === 'explorer' ? sideButtonActive : sideButtonInactive
           }`}
-          aria-pressed={activePanel === "explorer"}
+          aria-pressed={activePanel === 'explorer'}
           aria-label="Toggle Explorer panel"
-          onClick={() => togglePanel("explorer")}
+          onClick={() => togglePanel('explorer')}
         >
           <FolderIcon className="h-5 w-5" />
           <span className={tooltipBase}>File Explorer</span>
@@ -205,11 +222,13 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
-            activePanel === "open-documents" ? sideButtonActive : sideButtonInactive
+            activePanel === 'open-documents'
+              ? sideButtonActive
+              : sideButtonInactive
           }`}
-          aria-pressed={activePanel === "open-documents"}
+          aria-pressed={activePanel === 'open-documents'}
           aria-label="Toggle Open Documents panel"
-          onClick={() => togglePanel("open-documents")}
+          onClick={() => togglePanel('open-documents')}
         >
           <QueueListIcon className="h-5 w-5" />
           <span className={tooltipBase}>Open Documents</span>
@@ -217,11 +236,11 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
-            activePanel === "chatkit" ? sideButtonActive : sideButtonInactive
+            activePanel === 'chatkit' ? sideButtonActive : sideButtonInactive
           }`}
-          aria-pressed={activePanel === "chatkit"}
+          aria-pressed={activePanel === 'chatkit'}
           aria-label="Toggle ChatKit panel"
-          onClick={() => togglePanel("chatkit")}
+          onClick={() => togglePanel('chatkit')}
         >
           <ChatBubbleLeftRightIcon className="h-5 w-5" />
           <span className={tooltipBase}>AI Chat</span>
@@ -237,13 +256,13 @@ export function SidePanelToolbar() {
           }`}
           aria-label={`Google Drive status: ${driveStatus}`}
           onClick={() => {
-            void handleDriveStatusClick();
+            void handleDriveStatusClick()
           }}
         >
           <span className="relative inline-flex h-5 w-5 items-center justify-center">
             <CloudSolidIcon
               className={`h-5 w-5 ${
-                isDriveSyncing ? "text-emerald-500" : "text-red-500"
+                isDriveSyncing ? 'text-emerald-500' : 'text-red-500'
               }`}
             />
             {!isDriveSyncing && (
@@ -255,7 +274,7 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${sideButtonInactive}`}
-          aria-label={authData ? "Logout" : "Login"}
+          aria-label={authData ? 'Logout' : 'Login'}
           onClick={() =>
             authData
               ? browserAdapter.logout()
@@ -263,48 +282,48 @@ export function SidePanelToolbar() {
           }
         >
           <UserCircleIcon className="h-5 w-5" />
-          <span className={tooltipBase}>{authData ? "Logout" : "Login"}</span>
+          <span className={tooltipBase}>{authData ? 'Logout' : 'Login'}</span>
         </button>
       </div>
     </div>
-  );
+  )
 }
 
 export function SidePanelContent() {
-  const { activePanel } = useSidePanel();
+  const { activePanel } = useSidePanel()
   const [hasActivatedChatKit, setHasActivatedChatKit] = useState(
-    activePanel === "chatkit",
-  );
-  const shouldRenderChatKit = hasActivatedChatKit || activePanel === "chatkit";
+    activePanel === 'chatkit'
+  )
+  const shouldRenderChatKit = hasActivatedChatKit || activePanel === 'chatkit'
 
   useEffect(() => {
-    if (activePanel === "chatkit") {
-      setHasActivatedChatKit(true);
+    if (activePanel === 'chatkit') {
+      setHasActivatedChatKit(true)
     }
-  }, [activePanel]);
+  }, [activePanel])
 
   return (
     <div className="relative h-full min-h-0 w-full">
       <div
-        className={`h-full min-h-0 w-full ${activePanel === "explorer" ? "flex" : "hidden"}`}
-        aria-hidden={activePanel !== "explorer"}
+        className={`h-full min-h-0 w-full ${activePanel === 'explorer' ? 'flex' : 'hidden'}`}
+        aria-hidden={activePanel !== 'explorer'}
       >
         <WorkspaceExplorer />
       </div>
       <div
-        className={`h-full min-h-0 w-full ${activePanel === "open-documents" ? "flex" : "hidden"}`}
-        aria-hidden={activePanel !== "open-documents"}
+        className={`h-full min-h-0 w-full ${activePanel === 'open-documents' ? 'flex' : 'hidden'}`}
+        aria-hidden={activePanel !== 'open-documents'}
       >
         <OpenDocumentsPanel />
       </div>
       {shouldRenderChatKit ? (
         <div
-          className={`h-full min-h-0 w-full overflow-hidden ${activePanel === "chatkit" ? "flex" : "hidden"}`}
-          aria-hidden={activePanel !== "chatkit"}
+          className={`h-full min-h-0 w-full overflow-hidden ${activePanel === 'chatkit' ? 'flex' : 'hidden'}`}
+          aria-hidden={activePanel !== 'chatkit'}
         >
           <ChatKitPanel />
         </div>
       ) : null}
     </div>
-  );
+  )
 }

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -12,6 +12,7 @@ import {
 import { type NotebookData, type NotebookSnapshot } from "../lib/notebookData";
 import {
   getNotebookDataController,
+  type OpenNotebookOptions,
   type OpenNotebookEntry,
   type OpenNotebookResult,
 } from "../lib/notebookDataController";
@@ -25,7 +26,7 @@ type NotebookContextValue = {
   getNotebookData: (uri: string) => NotebookData | undefined;
   openNotebook: (
     uri: string,
-    options?: { name?: string },
+    options?: OpenNotebookOptions,
   ) => Promise<OpenNotebookResult>;
   useNotebookSnapshot: (uri: string) => NotebookSnapshot | null;
   useNotebookList: () => OpenNotebookEntry[];
@@ -58,7 +59,7 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
   );
 
   const openNotebook = useCallback(
-    (uri: string, options?: { name?: string }) =>
+    (uri: string, options?: OpenNotebookOptions) =>
       controller.openNotebook(uri, options),
     [controller],
   );
@@ -96,7 +97,7 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
   }, [controller]);
 
   const openAndSelectNotebook = useCallback(
-    async (uri: string, options?: { name?: string }) => {
+    async (uri: string, options?: OpenNotebookOptions) => {
       const result = await controller.openNotebook(uri, options);
       setCurrentDoc(result.localUri);
       return result;

--- a/app/src/contexts/WorkspaceDocumentContext.tsx
+++ b/app/src/contexts/WorkspaceDocumentContext.tsx
@@ -57,6 +57,7 @@ export function WorkspaceDocumentProvider({
         title: notebook.name,
         requestedUri: notebook.requestedUri,
         state: notebook.state,
+        readOnly: notebook.readOnly,
         errorMessage: notebook.errorMessage,
         owner: notebook.owner,
       })

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -1,11 +1,47 @@
-import { clone, create } from "@bufbuild/protobuf";
-
+import { clone, create } from '@bufbuild/protobuf'
 import {
-  parser_pb,
-  RunmeMetadataKey,
-  MimeType,
-} from "../contexts/CellContext";
-import { isHtmlLanguageId } from "./cellContent";
+  Heartbeat,
+  Streams,
+  type StreamsLike,
+  genRunID,
+} from '@runmedev/renderers'
+
+import { getBrowserAdapter } from '../browserAdapter.client'
+import { MimeType, RunmeMetadataKey, parser_pb } from '../contexts/CellContext'
+import { isHtmlLanguageId } from './cellContent'
+import {
+  IOPUB_INCOMPLETE_METADATA_KEY,
+  IOPUB_MIME_TYPE,
+  maybeParseIPykernelMessage,
+} from './ipykernel'
+import { appLogger } from './logging/runtime'
+import { buildExecuteRequest } from './runme'
+import type { Runner } from './runner'
+import { createAppJsGlobals } from './runtime/appJsGlobals'
+import {
+  type AppKernelRunnerMode,
+  isAppKernelRunnerName,
+  resolveAppKernelRunnerMode,
+} from './runtime/appKernel'
+import { JSKernel } from './runtime/jsKernel'
+import { buildJupyterChannelsWebSocketURL } from './runtime/jupyterManager'
+import {
+  type NotebooksApiBridgeServer,
+  createHostNotebooksApi,
+  createNotebooksApiBridgeServer,
+} from './runtime/notebooksApiBridge'
+import {
+  type NotebookDataLike,
+  type RunmeConsoleApi,
+  createRunmeConsoleApi,
+} from './runtime/runmeConsole'
+import {
+  DEFAULT_RUNNER_PLACEHOLDER,
+  getRunnersManager,
+} from './runtime/runnersManager'
+import { SandboxJSKernel } from './runtime/sandboxJsKernel'
+import { getClaimedSessionId } from './tabIdentity'
+import { showToast } from './toast'
 
 /**
  * Minimal store interface used by NotebookData for auto-saving.
@@ -13,131 +49,87 @@ import { isHtmlLanguageId } from "./cellContent";
  * in the IndexedDB mirror before any upstream sync runs.
  */
 export interface NotebookSaveStore {
-  save(uri: string, notebook: parser_pb.Notebook): Promise<unknown>;
+  save(uri: string, notebook: parser_pb.Notebook): Promise<unknown>
 }
-import {
-  IOPUB_INCOMPLETE_METADATA_KEY,
-  IOPUB_MIME_TYPE,
-  maybeParseIPykernelMessage,
-} from "./ipykernel";
-import {
-  DEFAULT_RUNNER_PLACEHOLDER,
-  getRunnersManager,
-} from "./runtime/runnersManager";
-import {
-  buildJupyterChannelsWebSocketURL,
-} from "./runtime/jupyterManager";
-import { createAppJsGlobals } from "./runtime/appJsGlobals";
-import {
-  createRunmeConsoleApi,
-  type NotebookDataLike,
-  type RunmeConsoleApi,
-} from "./runtime/runmeConsole";
-import {
-  type NotebooksApiBridgeServer,
-  createHostNotebooksApi,
-  createNotebooksApiBridgeServer,
-} from "./runtime/notebooksApiBridge";
-import { JSKernel } from "./runtime/jsKernel";
-import { SandboxJSKernel } from "./runtime/sandboxJsKernel";
-import {
-  type AppKernelRunnerMode,
-  isAppKernelRunnerName,
-  resolveAppKernelRunnerMode,
-} from "./runtime/appKernel";
-import {
-  Streams,
-  Heartbeat,
-  genRunID,
-  type StreamsLike,
-} from "@runmedev/renderers";
-import { buildExecuteRequest } from "./runme";
-import type { Runner } from "./runner";
-import { getClaimedSessionId } from "./tabIdentity";
-import { showToast } from "./toast";
-import { appLogger } from "./logging/runtime";
-import { getBrowserAdapter } from "../browserAdapter.client";
 
 export type NotebookSnapshot = {
-  readonly uri: string;
-  readonly name: string;
-  readonly notebook: parser_pb.Notebook;
-  readonly loaded: boolean;
-};
+  readonly uri: string
+  readonly name: string
+  readonly notebook: parser_pb.Notebook
+  readonly loaded: boolean
+  readonly readOnly?: boolean
+}
 
-const localTextEncoder = new TextEncoder();
+const localTextEncoder = new TextEncoder()
 
 function encodeCellOutputBytes(text: string): Uint8Array {
-  const encoded = localTextEncoder.encode(text);
+  const encoded = localTextEncoder.encode(text)
   return encoded instanceof Uint8Array
     ? encoded
-    : Uint8Array.from(encoded as ArrayLike<number>);
+    : Uint8Array.from(encoded as ArrayLike<number>)
 }
 
 function createStdTextOutputs(
   stdout: string,
-  stderr: string,
+  stderr: string
 ): parser_pb.CellOutput[] {
   return [
     create(parser_pb.CellOutputSchema, {
       items: [
         create(parser_pb.CellOutputItemSchema, {
           mime: MimeType.VSCodeNotebookStdOut,
-          type: "Buffer",
+          type: 'Buffer',
           data: encodeCellOutputBytes(stdout),
         }),
         create(parser_pb.CellOutputItemSchema, {
           mime: MimeType.VSCodeNotebookStdErr,
-          type: "Buffer",
+          type: 'Buffer',
           data: encodeCellOutputBytes(stderr),
         }),
       ],
     }),
-  ];
+  ]
 }
 
 function createTextOutputItem(
   mime: string,
-  text: string,
+  text: string
 ): parser_pb.CellOutputItem {
   return create(parser_pb.CellOutputItemSchema, {
     mime,
-    type: "Buffer",
+    type: 'Buffer',
     data: encodeCellOutputBytes(text),
-  });
+  })
 }
 
 const JUPYTER_LIMITS = {
   textBytesPerExecution: 16 * 1024 * 1024,
   richBytesPerItem: 10 * 1024 * 1024,
   totalBytesPerExecution: 32 * 1024 * 1024,
-} as const;
+} as const
 
 function decodeBase64ToBytes(value: string): Uint8Array {
   try {
-    const binary = globalThis.atob(value);
-    const bytes = new Uint8Array(binary.length);
+    const binary = globalThis.atob(value)
+    const bytes = new Uint8Array(binary.length)
     for (let i = 0; i < binary.length; i += 1) {
-      bytes[i] = binary.charCodeAt(i);
+      bytes[i] = binary.charCodeAt(i)
     }
-    return bytes;
+    return bytes
   } catch {
-    return new Uint8Array();
+    return new Uint8Array()
   }
 }
 
-type Listener = () => void;
+type Listener = () => void
 
 export type StreamBinder = (args: {
-  refId: string;
-  streams: StreamsLike;
-  getCell: (refId: string) => parser_pb.Cell | null;
-  updateCell: (
-    cell: parser_pb.Cell,
-    options?: { transient?: boolean },
-  ) => void;
-  onClose?: (refId: string) => void;
-}) => { dispose(): void };
+  refId: string
+  streams: StreamsLike
+  getCell: (refId: string) => parser_pb.Cell | null
+  updateCell: (cell: parser_pb.Cell, options?: { transient?: boolean }) => void
+  onClose?: (refId: string) => void
+}) => { dispose(): void }
 
 /**
  * bindStreamsToCell wires a StreamsLike instance to a cell's outputs/metadata.
@@ -156,35 +148,35 @@ export const bindStreamsToCell: StreamBinder = ({
 }) => {
   // Track the most recent error toast so we don't spam the user during
   // repeated reconnect attempts for the same cell run.
-  let lastToastAt = 0;
-  const toastThrottleMs = 3_000;
+  let lastToastAt = 0
+  const toastThrottleMs = 3_000
   /**
    * stdoutBuffer tracks partial lines across chunks so we can parse line-based
    * IOPub messages without losing bytes. We only attempt IOPub detection at
    * the start of the stream or when a newline boundary is reached.
    */
-  let stdoutBuffer = "";
-  const textDecoder = new TextDecoder();
-  const textEncoder = new TextEncoder();
-  let finished = false;
+  let stdoutBuffer = ''
+  const textDecoder = new TextDecoder()
+  const textEncoder = new TextEncoder()
+  let finished = false
 
   const appendBuffer = (mime: MimeType, chunk: Uint8Array) => {
-    const updated = getCell(refId);
-    if (!updated) return;
+    const updated = getCell(refId)
+    if (!updated) return
 
-    const { output, item } = ensureOutputItem(updated, mime);
-    const prev = item.data ?? new Uint8Array();
-    const next = new Uint8Array(prev.length + chunk.length);
-    next.set(prev);
-    next.set(chunk, prev.length);
-    item.data = next;
+    const { output, item } = ensureOutputItem(updated, mime)
+    const prev = item.data ?? new Uint8Array()
+    const next = new Uint8Array(prev.length + chunk.length)
+    next.set(prev)
+    next.set(chunk, prev.length)
+    item.data = next
 
     if (!updated.outputs.includes(output)) {
-      updated.outputs = [...updated.outputs, output];
+      updated.outputs = [...updated.outputs, output]
     }
 
-    updateCell(updated, { transient: true });
-  };
+    updateCell(updated, { transient: true })
+  }
 
   /**
    * ensureOutputItem ensures a cell output item exists for the given mime type.
@@ -197,30 +189,30 @@ export const bindStreamsToCell: StreamBinder = ({
         items: [
           create(parser_pb.CellOutputItemSchema, {
             mime,
-            type: "Buffer",
+            type: 'Buffer',
             data: new Uint8Array(),
           }),
         ],
-      });
+      })
 
     const item =
       existingOutput.items.find((i) => i.mime === mime) ??
       create(parser_pb.CellOutputItemSchema, {
         mime,
-        type: "Buffer",
+        type: 'Buffer',
         data: new Uint8Array(),
-      });
+      })
 
     if (!existingOutput.items.includes(item)) {
-      existingOutput.items = [...existingOutput.items, item];
+      existingOutput.items = [...existingOutput.items, item]
     }
 
     if (!cell.outputs.includes(existingOutput)) {
-      cell.outputs = [...cell.outputs, existingOutput];
+      cell.outputs = [...cell.outputs, existingOutput]
     }
 
-    return { output: existingOutput, item };
-  };
+    return { output: existingOutput, item }
+  }
 
   /**
    * appendIopubLine converts IOPub messages into output items per mime bundle.
@@ -228,48 +220,48 @@ export const bindStreamsToCell: StreamBinder = ({
    */
   const appendIopubLine = (
     line: string,
-    message: ReturnType<typeof maybeParseIPykernelMessage>,
+    message: ReturnType<typeof maybeParseIPykernelMessage>
   ) => {
-    if (!message) return;
+    if (!message) return
 
-    const updated = getCell(refId);
-    if (!updated) return;
+    const updated = getCell(refId)
+    if (!updated) return
 
-    const dataBundle = message.content?.data;
+    const dataBundle = message.content?.data
     const items =
-      dataBundle && typeof dataBundle === "object"
+      dataBundle && typeof dataBundle === 'object'
         ? Object.entries(dataBundle).map(([mime, value]) =>
             create(parser_pb.CellOutputItemSchema, {
               mime,
-              type: "Buffer",
+              type: 'Buffer',
               data: textEncoder.encode(
-                typeof value === "string"
+                typeof value === 'string'
                   ? value
-                  : (JSON.stringify(value) ?? ""),
+                  : (JSON.stringify(value) ?? '')
               ),
               metadata: {
-                [IOPUB_INCOMPLETE_METADATA_KEY]: "true",
+                [IOPUB_INCOMPLETE_METADATA_KEY]: 'true',
               },
-            }),
+            })
           )
         : [
             create(parser_pb.CellOutputItemSchema, {
               mime: IOPUB_MIME_TYPE,
-              type: "Buffer",
+              type: 'Buffer',
               data: textEncoder.encode(line),
               metadata: {
-                [IOPUB_INCOMPLETE_METADATA_KEY]: "true",
+                [IOPUB_INCOMPLETE_METADATA_KEY]: 'true',
               },
             }),
-          ];
+          ]
 
     const output = create(parser_pb.CellOutputSchema, {
       items,
-    });
+    })
 
-    updated.outputs = [...updated.outputs, output];
-    updateCell(updated, { transient: true });
-  };
+    updated.outputs = [...updated.outputs, output]
+    updateCell(updated, { transient: true })
+  }
 
   /**
    * flushStdoutBuffer writes any remaining partial stdout line into the proper
@@ -277,137 +269,137 @@ export const bindStreamsToCell: StreamBinder = ({
    */
   const flushStdoutBuffer = () => {
     if (!stdoutBuffer) {
-      return;
+      return
     }
 
-    const pendingLine = stdoutBuffer;
-    stdoutBuffer = "";
-    const message = maybeParseIPykernelMessage(pendingLine);
+    const pendingLine = stdoutBuffer
+    stdoutBuffer = ''
+    const message = maybeParseIPykernelMessage(pendingLine)
     if (message) {
-      appendIopubLine(pendingLine, message);
+      appendIopubLine(pendingLine, message)
     } else {
       appendBuffer(
         MimeType.VSCodeNotebookStdOut,
-        textEncoder.encode(pendingLine),
-      );
+        textEncoder.encode(pendingLine)
+      )
     }
-  };
+  }
 
   /**
    * appendStdoutChunk parses stdout chunks into lines, detects IOPub messages,
    * and routes them into an IOPub buffer while preserving normal stdout.
    */
   const appendStdoutChunk = (chunk: Uint8Array) => {
-    const chunkText = textDecoder.decode(chunk);
-    const hadBuffer = stdoutBuffer.length > 0;
-    stdoutBuffer += chunkText;
+    const chunkText = textDecoder.decode(chunk)
+    const hadBuffer = stdoutBuffer.length > 0
+    stdoutBuffer += chunkText
 
-    const lines = stdoutBuffer.split("\n");
-    stdoutBuffer = lines.pop() ?? "";
+    const lines = stdoutBuffer.split('\n')
+    stdoutBuffer = lines.pop() ?? ''
 
     if (!hadBuffer && lines.length === 0 && stdoutBuffer) {
       // Stream just started with a partial line; we'll classify it once a newline arrives.
-      return;
+      return
     }
 
     lines.forEach((line) => {
-      const message = maybeParseIPykernelMessage(line);
+      const message = maybeParseIPykernelMessage(line)
       if (message) {
-        appendIopubLine(line, message);
-        return;
+        appendIopubLine(line, message)
+        return
       }
 
       appendBuffer(
         MimeType.VSCodeNotebookStdOut,
-        textEncoder.encode(`${line}\n`),
-      );
-    });
-  };
+        textEncoder.encode(`${line}\n`)
+      )
+    })
+  }
 
   /**
    * finalizeIopubStream marks buffered IOPub output items as complete once the stream ends.
    */
   const finalizeIopubStream = () => {
-    const updated = getCell(refId);
-    if (!updated) return;
+    const updated = getCell(refId)
+    if (!updated) return
 
-    let didUpdate = false;
+    let didUpdate = false
     updated.outputs.forEach((output) => {
       output.items.forEach((item) => {
-        if (item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === "true") {
+        if (item.metadata?.[IOPUB_INCOMPLETE_METADATA_KEY] === 'true') {
           item.metadata = {
             ...(item.metadata ?? {}),
-            [IOPUB_INCOMPLETE_METADATA_KEY]: "false",
-          };
-          didUpdate = true;
+            [IOPUB_INCOMPLETE_METADATA_KEY]: 'false',
+          }
+          didUpdate = true
         }
-      });
-    });
+      })
+    })
 
     if (didUpdate) {
-      updateCell(updated);
+      updateCell(updated)
     }
-  };
+  }
 
   const finish = () => {
     if (finished) {
-      return;
+      return
     }
-    finished = true;
-    onClose?.(refId);
-    streams.close();
-    subs.forEach((s) => s.unsubscribe());
-  };
+    finished = true
+    onClose?.(refId)
+    streams.close()
+    subs.forEach((s) => s.unsubscribe())
+  }
 
   const subs = [
     streams.stdout.subscribe((data) => appendStdoutChunk(data)),
     streams.stderr.subscribe((data) =>
-      appendBuffer(MimeType.VSCodeNotebookStdErr, data),
+      appendBuffer(MimeType.VSCodeNotebookStdErr, data)
     ),
     streams.pid.subscribe((pid) => {
-      const updated = getCell(refId);
-      if (!updated || !updated.metadata) return;
-      updated.metadata[RunmeMetadataKey.Pid] = pid.toString();
-      updateCell(updated, { transient: true });
+      const updated = getCell(refId)
+      if (!updated || !updated.metadata) return
+      updated.metadata[RunmeMetadataKey.Pid] = pid.toString()
+      updateCell(updated, { transient: true })
     }),
     streams.exitCode.subscribe((code) => {
-      const updated = getCell(refId);
-      if (!updated || !updated.metadata) return;
-      updated.metadata[RunmeMetadataKey.ExitCode] = code.toString();
-      delete updated.metadata[RunmeMetadataKey.Pid];
-      updateCell(updated);
-      flushStdoutBuffer();
-      finalizeIopubStream();
-      finish();
+      const updated = getCell(refId)
+      if (!updated || !updated.metadata) return
+      updated.metadata[RunmeMetadataKey.ExitCode] = code.toString()
+      delete updated.metadata[RunmeMetadataKey.Pid]
+      updateCell(updated)
+      flushStdoutBuffer()
+      finalizeIopubStream()
+      finish()
     }),
     streams.mimeType.subscribe(() => {
       // no-op for now
     }),
     streams.errors.subscribe((err) => {
-      console.error("Stream error", err);
-      const now = Date.now();
+      console.error('Stream error', err)
+      const now = Date.now()
       if (now - lastToastAt >= toastThrottleMs) {
-        lastToastAt = now;
+        lastToastAt = now
         showToast({
           message:
-            "Runme backend server is not running. Please start it and try again.",
-          tone: "error",
-        });
+            'Runme backend server is not running. Please start it and try again.',
+          tone: 'error',
+        })
       }
-      flushStdoutBuffer();
-      finalizeIopubStream();
-      finish();
+      flushStdoutBuffer()
+      finalizeIopubStream()
+      finish()
     }),
-  ];
+  ]
 
-  streams.connect(Heartbeat.INITIAL).subscribe();
+  streams.connect(Heartbeat.INITIAL).subscribe()
 
   return {
     dispose() {
-      finish();
+      finish()
     },
-  };
-};
+  }
+}
 
 /**
  * NotebookData keeps an in-memory Notebook proto and provides a tiny subscribe /
@@ -426,27 +418,28 @@ export const bindStreamsToCell: StreamBinder = ({
 //
 //TODO(jlewi): Rename this to NotebookModel as in model-view.
 export class NotebookData {
-  private uri: string;
-  private name: string;
-  private notebook: parser_pb.Notebook;
-  private refToIndex: Map<string, number> = new Map();
-  private listeners: Set<Listener> = new Set();
-  private notebookStore: NotebookSaveStore | null;
-  private sequence = 0;
-  private snapshotCache: NotebookSnapshot;
-  private loaded: boolean;
-  private activeStreams: Map<string, StreamsLike> = new Map();
-  private activeJupyterSockets: Map<string, WebSocket> = new Map();
+  private uri: string
+  private name: string
+  private notebook: parser_pb.Notebook
+  private refToIndex: Map<string, number> = new Map()
+  private listeners: Set<Listener> = new Set()
+  private notebookStore: NotebookSaveStore | null
+  private sequence = 0
+  private snapshotCache: NotebookSnapshot
+  private loaded: boolean
+  private readOnly: boolean
+  private activeStreams: Map<string, StreamsLike> = new Map()
+  private activeJupyterSockets: Map<string, WebSocket> = new Map()
 
-  private refToCellData: Map<string, CellData> = new Map();
+  private refToCellData: Map<string, CellData> = new Map()
   // Debounce auto-save writes so keystrokes don't trigger a full disk write
   // (and in dev, a Vite page reload) on every change.
-  private persistTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly persistDelayMs = 750;
+  private persistTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly persistDelayMs = 750
   private readonly resolveNotebookForAppKernel: (
-    target?: unknown,
-  ) => NotebookDataLike | null;
-  private readonly listNotebooksForAppKernel: () => NotebookDataLike[];
+    target?: unknown
+  ) => NotebookDataLike | null
+  private readonly listNotebooksForAppKernel: () => NotebookDataLike[]
 
   constructor({
     notebook,
@@ -454,74 +447,77 @@ export class NotebookData {
     name,
     notebookStore,
     loaded = false,
+    readOnly = false,
     resolveNotebookForAppKernel,
     listNotebooksForAppKernel,
   }: {
-    notebook: parser_pb.Notebook;
-    uri: string;
-    name: string;
-    notebookStore: NotebookSaveStore | null;
-    loaded?: boolean;
-    resolveNotebookForAppKernel?: (target?: unknown) => NotebookDataLike | null;
-    listNotebooksForAppKernel?: () => NotebookDataLike[];
+    notebook: parser_pb.Notebook
+    uri: string
+    name: string
+    notebookStore: NotebookSaveStore | null
+    loaded?: boolean
+    readOnly?: boolean
+    resolveNotebookForAppKernel?: (target?: unknown) => NotebookDataLike | null
+    listNotebooksForAppKernel?: () => NotebookDataLike[]
   }) {
-    this.uri = uri;
-    this.name = name;
-    this.notebook = clone(parser_pb.NotebookSchema, notebook);
-    this.notebookStore = notebookStore;
-    this.loaded = loaded;
-    this.sequence = this.computeHighestSequence();
-    this.rebuildIndex();
-    this.snapshotCache = this.buildSnapshot();
+    this.uri = uri
+    this.name = name
+    this.notebook = clone(parser_pb.NotebookSchema, notebook)
+    this.notebookStore = notebookStore
+    this.loaded = loaded
+    this.readOnly = readOnly
+    this.sequence = this.computeHighestSequence()
+    this.rebuildIndex()
+    this.snapshotCache = this.buildSnapshot()
     this.resolveNotebookForAppKernel =
       resolveNotebookForAppKernel ??
       ((target?: unknown) => {
         if (!target || this.matchesNotebookTarget(target)) {
-          return this;
+          return this
         }
-        return null;
-      });
+        return null
+      })
     this.listNotebooksForAppKernel =
       listNotebooksForAppKernel ??
       (() => {
-        return [this];
-      });
+        return [this]
+      })
   }
 
   private matchesNotebookTarget(target: unknown): boolean {
-    if (typeof target === "string") {
-      return target === this.getUri();
+    if (typeof target === 'string') {
+      return target === this.getUri()
     }
     if (
-      typeof target === "object" &&
+      typeof target === 'object' &&
       target &&
-      "uri" in target &&
+      'uri' in target &&
       (target as { uri?: string }).uri === this.getUri()
     ) {
-      return true;
+      return true
     }
     if (
-      typeof target === "object" &&
+      typeof target === 'object' &&
       target &&
-      "handle" in target &&
+      'handle' in target &&
       (target as { handle?: { uri?: string } }).handle?.uri === this.getUri()
     ) {
-      return true;
+      return true
     }
-    return false;
+    return false
   }
 
   /** Subscribe to changes. Returns an unsubscribe function. */
   subscribe(listener: Listener): () => void {
-    this.listeners.add(listener);
+    this.listeners.add(listener)
     return () => {
-      this.listeners.delete(listener);
-    };
+      this.listeners.delete(listener)
+    }
   }
 
   /** Current immutable snapshot for rendering. */
   getSnapshot(): NotebookSnapshot {
-    return this.snapshotCache;
+    return this.snapshotCache
   }
 
   /**
@@ -531,16 +527,16 @@ export class NotebookData {
   private validateCells(): void {
     for (const cell of this.notebook.cells) {
       if (!cell.refId) {
-        console.warn("[NotebookData] Cell missing refId", cell);
+        console.warn('[NotebookData] Cell missing refId', cell)
       }
-      const hasOutput = cell.outputs.length > 0;
-      const hasValue = (cell.value ?? "").trim().length > 0;
+      const hasOutput = cell.outputs.length > 0
+      const hasValue = (cell.value ?? '').trim().length > 0
       if (hasOutput && !hasValue) {
         console.warn(
           `[NotebookData] Cell ${cell.refId} has ${cell.outputs.length} output(s) but no input value. ` +
-          `This may indicate a corrupt notebook format.`,
-          { kind: cell.kind, languageId: cell.languageId },
-        );
+            `This may indicate a corrupt notebook format.`,
+          { kind: cell.kind, languageId: cell.languageId }
+        )
       }
     }
   }
@@ -554,195 +550,219 @@ export class NotebookData {
    */
   loadNotebook(
     notebook: parser_pb.Notebook,
-    { persist = true }: { persist?: boolean } = {},
+    { persist = true }: { persist?: boolean } = {}
   ): void {
-    this.notebook = clone(parser_pb.NotebookSchema, notebook);
-    this.rebuildIndex();
-    this.validateCells();
-    this.sequence = this.computeHighestSequence();
-    this.loaded = true;
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    if (persist) {
-      this.schedulePersist();
+    this.notebook = clone(parser_pb.NotebookSchema, notebook)
+    this.rebuildIndex()
+    this.validateCells()
+    this.sequence = this.computeHighestSequence()
+    this.loaded = true
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    if (persist && !this.readOnly) {
+      this.schedulePersist()
     }
   }
 
   updateCell(
     cell: parser_pb.Cell,
-    { transient = false }: { transient?: boolean } = {},
+    { transient = false }: { transient?: boolean } = {}
   ): void {
-    const idx = this.refToIndex.get(cell.refId);
-    const cloned = clone(parser_pb.CellSchema, cell);
+    this.assertWritable()
+    const idx = this.refToIndex.get(cell.refId)
+    const cloned = clone(parser_pb.CellSchema, cell)
     if (idx === undefined) {
-      this.notebook.cells.push(cloned);
-      this.refToIndex.set(cloned.refId, this.notebook.cells.length - 1);
+      this.notebook.cells.push(cloned)
+      this.refToIndex.set(cloned.refId, this.notebook.cells.length - 1)
     } else {
-      this.notebook.cells[idx] = cloned;
+      this.notebook.cells[idx] = cloned
     }
 
-    const existingCellData = this.refToCellData.get(cloned.refId);
+    const existingCellData = this.refToCellData.get(cloned.refId)
     if (existingCellData) {
-      existingCellData.updateCachedSnapshotFromNotebook(cloned);
+      existingCellData.updateCachedSnapshotFromNotebook(cloned)
       // Emit from NotebookData to avoid double-notifying when CellData.update()
       // also routes through here.
-      existingCellData.emitContentChange();
+      existingCellData.emitContentChange()
     }
 
     if (!transient) {
-      this.snapshotCache = this.buildSnapshot();
-      this.emit();
-      this.schedulePersist();
+      this.snapshotCache = this.buildSnapshot()
+      this.emit()
+      this.schedulePersist()
     }
   }
 
   /** Append a new cell to the end of the notebook. */
   appendCell(
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell {
-    const cell = this.createCell(kind, languageId);
-    this.notebook.cells.push(cell);
-    this.rebuildIndex();
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    this.schedulePersist();
-    return cell;
+    this.assertWritable()
+    const cell = this.createCell(kind, languageId)
+    this.notebook.cells.push(cell)
+    this.rebuildIndex()
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
+    return cell
   }
 
   addCellAfter(
     targetRefId: string,
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell | null {
-    const idx = this.refToIndex.get(targetRefId);
+    this.assertWritable()
+    const idx = this.refToIndex.get(targetRefId)
     if (idx === undefined) {
-      return null;
+      return null
     }
-    const cell = this.createCell(kind, languageId);
-    this.notebook.cells.splice(idx + 1, 0, cell);
-    this.rebuildIndex();
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    this.schedulePersist();
-    return cell;
+    const cell = this.createCell(kind, languageId)
+    this.notebook.cells.splice(idx + 1, 0, cell)
+    this.rebuildIndex()
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
+    return cell
   }
 
   addCellBefore(
     targetRefId: string,
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell | null {
-    const idx = this.refToIndex.get(targetRefId);
+    this.assertWritable()
+    const idx = this.refToIndex.get(targetRefId)
     if (idx === undefined) {
-      return null;
+      return null
     }
-    const cell = this.createCell(kind, languageId);
-    this.notebook.cells.splice(idx, 0, cell);
-    this.rebuildIndex();
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    this.schedulePersist();
-    return cell;
+    const cell = this.createCell(kind, languageId)
+    this.notebook.cells.splice(idx, 0, cell)
+    this.rebuildIndex()
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
+    return cell
   }
 
   removeCell(refId: string): void {
-    const idx = this.refToIndex.get(refId);
+    this.assertWritable()
+    const idx = this.refToIndex.get(refId)
     if (idx === undefined) {
-      return;
+      return
     }
-    this.notebook.cells.splice(idx, 1);
-    this.rebuildIndex();
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    this.schedulePersist();
+    this.notebook.cells.splice(idx, 1)
+    this.rebuildIndex()
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
   }
 
   setName(name: string): void {
-    this.name = name;
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    this.schedulePersist();
+    this.assertWritable()
+    this.name = name
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
   }
 
   setUri(uri: string): void {
-    this.uri = uri;
-    this.snapshotCache = this.buildSnapshot();
-    this.emit();
-    this.schedulePersist();
+    this.assertWritable()
+    this.uri = uri
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
   }
 
   setNotebookStore(notebookStore: NotebookSaveStore | null): void {
-    this.notebookStore = notebookStore;
+    this.notebookStore = notebookStore
+  }
+
+  setReadOnly(readOnly: boolean): void {
+    if (this.readOnly === readOnly) {
+      return
+    }
+    this.readOnly = readOnly
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+  }
+
+  isReadOnly(): boolean {
+    return this.readOnly
   }
 
   // Returns the runID if the cell was started successfully.
   // empty string otherwise
   runCodeCell(cell: parser_pb.Cell): string {
+    this.assertWritable()
     if (cell.kind !== parser_pb.CellKind.CODE) {
-      console.warn("Cannot run non-code cell", cell.refId);
-      return "";
+      console.warn('Cannot run non-code cell', cell.refId)
+      return ''
     }
 
-    const normalizedLanguage = (cell.languageId ?? "").trim().toLowerCase();
+    const normalizedLanguage = (cell.languageId ?? '').trim().toLowerCase()
     if (isHtmlLanguageId(normalizedLanguage)) {
-      console.warn("Cannot run HTML content cell", cell.refId);
-      return "";
+      console.warn('Cannot run HTML content cell', cell.refId)
+      return ''
     }
     const requestedRunnerName =
-      (cell.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ?? "";
-    const appKernelMode = resolveAppKernelRunnerMode(requestedRunnerName);
+      (cell.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ?? ''
+    const appKernelMode = resolveAppKernelRunnerMode(requestedRunnerName)
     const useAppKernel =
-      normalizedLanguage === "javascript" || isAppKernelRunnerName(requestedRunnerName);
-    const useJupyterKernel = normalizedLanguage === "jupyter" || normalizedLanguage === "ipython";
-    const runner = useAppKernel ? undefined : this.getRunner(cell);
+      normalizedLanguage === 'javascript' ||
+      isAppKernelRunnerName(requestedRunnerName)
+    const useJupyterKernel =
+      normalizedLanguage === 'jupyter' || normalizedLanguage === 'ipython'
+    const runner = useAppKernel ? undefined : this.getRunner(cell)
     if (!useAppKernel && (!runner || !runner.endpoint)) {
-      console.error("No runner available for cell", cell.refId);
+      console.error('No runner available for cell', cell.refId)
       showToast({
-        message: "Runme backend server is not running. Please start it and try again.",
-        tone: "error",
-      });
-      return "";
+        message:
+          'Runme backend server is not running. Please start it and try again.',
+        tone: 'error',
+      })
+      return ''
     }
 
     // If there is an existing active stream for this cell, close it before
     // starting a new run to avoid leaking sockets.
-    const existing = this.activeStreams.get(cell.refId);
-    existing?.close();
-    this.activeStreams.delete(cell.refId);
-    const existingJupyterSocket = this.activeJupyterSockets.get(cell.refId);
-    existingJupyterSocket?.close();
-    this.activeJupyterSockets.delete(cell.refId);
+    const existing = this.activeStreams.get(cell.refId)
+    existing?.close()
+    this.activeStreams.delete(cell.refId)
+    const existingJupyterSocket = this.activeJupyterSockets.get(cell.refId)
+    existingJupyterSocket?.close()
+    this.activeJupyterSockets.delete(cell.refId)
 
     // Bump sequence and attach to metadata.
-    this.sequence += 1;
-    cell.metadata ??= {};
-    delete cell.metadata[RunmeMetadataKey.ExitCode];
-    delete cell.metadata[RunmeMetadataKey.Pid];
-    cell.metadata[RunmeMetadataKey.Sequence] = this.sequence.toString();
+    this.sequence += 1
+    cell.metadata ??= {}
+    delete cell.metadata[RunmeMetadataKey.ExitCode]
+    delete cell.metadata[RunmeMetadataKey.Pid]
+    cell.metadata[RunmeMetadataKey.Sequence] = this.sequence.toString()
 
     // Clear outputs on each execution start for Jupyter/IPython; for other
     // runners keep terminal output only so reruns don't show stale non-terminal data.
     if (useJupyterKernel) {
-      cell.outputs = [];
+      cell.outputs = []
     } else {
       cell.outputs = cell.outputs.filter((o) =>
-        o.items.some((oi) => oi.mime === MimeType.StatefulRunmeTerminal),
-      );
+        o.items.some((oi) => oi.mime === MimeType.StatefulRunmeTerminal)
+      )
     }
 
-    const runID = genRunID();
-    cell.metadata[RunmeMetadataKey.LastRunID] = runID;
-    this.updateCell(cell);
+    const runID = genRunID()
+    cell.metadata[RunmeMetadataKey.LastRunID] = runID
+    this.updateCell(cell)
 
     if (useAppKernel) {
-      this.runCodeCellWithAppKernel(cell, runID, appKernelMode);
-      return runID;
+      this.runCodeCellWithAppKernel(cell, runID, appKernelMode)
+      return runID
     }
 
     if (useJupyterKernel) {
-      this.runCodeCellWithJupyterKernel(cell, runID, runner!);
-      return runID;
+      this.runCodeCellWithJupyterKernel(cell, runID, runner!)
+      return runID
     }
 
     const streams = this.createAndBindStreams({
@@ -750,77 +770,77 @@ export class NotebookData {
       runID,
       sequence: this.sequence,
       runner: runner!,
-    });
+    })
     if (!streams) {
-      return "";
+      return ''
     }
 
-    const commands = cell.value ? cell.value.split("\n") : [];
+    const commands = cell.value ? cell.value.split('\n') : []
     const execReq = buildExecuteRequest({
       languageId: cell.languageId ?? undefined,
       commands,
-      knownID: streams["knownID"] ?? `cell_${cell.refId}`,
+      knownID: streams['knownID'] ?? `cell_${cell.refId}`,
       runID,
       winsize: undefined,
-    });
-    streams.sendExecuteRequest(execReq as any);
-    return runID;
+    })
+    streams.sendExecuteRequest(execReq as any)
+    return runID
   }
 
   getUri(): string {
-    return this.uri;
+    return this.uri
   }
 
   getName(): string {
-    return this.name;
+    return this.name
   }
 
   getNotebook(): parser_pb.Notebook {
-    return this.notebook;
+    return this.notebook
   }
 
   getCellSnapshot(refId: string): parser_pb.Cell | null {
-    const idx = this.refToIndex.get(refId);
+    const idx = this.refToIndex.get(refId)
     if (idx === undefined || !this.notebook.cells[idx]) {
-      return null;
+      return null
     }
-    return clone(parser_pb.CellSchema, this.notebook.cells[idx]);
+    return clone(parser_pb.CellSchema, this.notebook.cells[idx])
   }
 
   private getCellProto(refId: string): parser_pb.Cell | null {
-    const idx = this.refToIndex.get(refId);
+    const idx = this.refToIndex.get(refId)
     if (idx === undefined || !this.notebook.cells[idx]) {
-      return null;
+      return null
     }
-    return this.notebook.cells[idx];
+    return this.notebook.cells[idx]
   }
 
   getCell(refId: string): CellData | null {
     if (!this.refToIndex.has(refId)) {
-      return null;
+      return null
     }
     // We need getCell to refer to the same CellData instance for a given refId
     // otherwise subscriptions and other changes won't be reflected across the application.
     if (!this.refToCellData.has(refId)) {
-      this.refToCellData.set(refId, new CellData(this, refId));
+      this.refToCellData.set(refId, new CellData(this, refId))
     }
 
-    return this.refToCellData.get(refId)!;
+    return this.refToCellData.get(refId)!
   }
 
   getActiveStream(refId: string): StreamsLike | undefined {
-    const existing = this.activeStreams.get(refId);
-    const cell = this.getCellProto(refId);
-    const metadata = cell?.metadata ?? {};
+    const existing = this.activeStreams.get(refId)
+    const cell = this.getCellProto(refId)
+    const metadata = cell?.metadata ?? {}
     const hasExitCode =
-      typeof metadata[RunmeMetadataKey.ExitCode] === "string" &&
-      metadata[RunmeMetadataKey.ExitCode].length > 0;
+      typeof metadata[RunmeMetadataKey.ExitCode] === 'string' &&
+      metadata[RunmeMetadataKey.ExitCode].length > 0
     if (existing) {
       if (hasExitCode) {
-        this.activeStreams.delete(refId);
-        return undefined;
+        this.activeStreams.delete(refId)
+        return undefined
       }
-      return existing;
+      return existing
     }
 
     // Check if the cell has metadata indicating an active run we can recover.
@@ -828,102 +848,110 @@ export class NotebookData {
     // as an active run.
 
     const hasPid =
-      typeof metadata[RunmeMetadataKey.Pid] === "string" &&
-      metadata[RunmeMetadataKey.Pid].length > 0;
+      typeof metadata[RunmeMetadataKey.Pid] === 'string' &&
+      metadata[RunmeMetadataKey.Pid].length > 0
     const runID =
-      typeof metadata[RunmeMetadataKey.LastRunID] === "string"
+      typeof metadata[RunmeMetadataKey.LastRunID] === 'string'
         ? metadata[RunmeMetadataKey.LastRunID]
-        : "";
+        : ''
 
     if (!cell || !hasPid || hasExitCode || !runID) {
-      return undefined;
+      return undefined
     }
 
-    const runner = this.getRunner(cell);
+    const runner = this.getRunner(cell)
     if (!runner || !runner.endpoint) {
-      console.warn("Cannot recover stream; no runner available", {
+      console.warn('Cannot recover stream; no runner available', {
         refId,
-      });
-      return undefined;
+      })
+      return undefined
     }
-    console.log("Trying to resume streams for cell", { refId, runID });
-    const seqValue = metadata[RunmeMetadataKey.Sequence];
+    console.log('Trying to resume streams for cell', { refId, runID })
+    const seqValue = metadata[RunmeMetadataKey.Sequence]
     const parsedSeq =
-      typeof seqValue === "string" ? Number.parseInt(seqValue, 10) : Number.NaN;
-    const sequence = Number.isNaN(parsedSeq) ? this.sequence : parsedSeq;
+      typeof seqValue === 'string' ? Number.parseInt(seqValue, 10) : Number.NaN
+    const sequence = Number.isNaN(parsedSeq) ? this.sequence : parsedSeq
 
-    return this.createAndBindStreams({ cell, runID, sequence, runner });
+    return this.createAndBindStreams({ cell, runID, sequence, runner })
   }
 
   private createCell(
     kind: parser_pb.CellKind,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell {
-    const isMarkup = kind === parser_pb.CellKind.MARKUP;
-    const normalizedLanguage = languageId?.trim().toLowerCase();
+    const isMarkup = kind === parser_pb.CellKind.MARKUP
+    const normalizedLanguage = languageId?.trim().toLowerCase()
     const resolvedLanguage =
       normalizedLanguage && normalizedLanguage.length > 0
         ? normalizedLanguage
-        : "markdown";
-    const refPrefix = isMarkup ? "markup" : "code";
-    const refID = `${refPrefix}_${crypto.randomUUID().replace(/-/g, "")}`;
+        : 'markdown'
+    const refPrefix = isMarkup ? 'markup' : 'code'
+    const refID = `${refPrefix}_${crypto.randomUUID().replace(/-/g, '')}`
     return create(parser_pb.CellSchema, {
       metadata: {},
       refId: refID,
       languageId: resolvedLanguage,
       role: parser_pb.CellRole.USER,
       kind: isMarkup ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE,
-      value: "",
-    });
+      value: '',
+    })
+  }
+
+  private assertWritable(): void {
+    if (this.readOnly) {
+      throw new Error(
+        `Notebook ${this.uri} is open read-only in this browser tab.`
+      )
+    }
   }
 
   private runCodeCellWithAppKernel(
     cell: parser_pb.Cell,
     runID: string,
-    mode: AppKernelRunnerMode,
+    mode: AppKernelRunnerMode
   ): void {
-    const refId = cell.refId;
-    const languageId = (cell.languageId ?? "").trim().toLowerCase();
-    const source = cell.value ?? "";
+    const refId = cell.refId
+    const languageId = (cell.languageId ?? '').trim().toLowerCase()
+    const source = cell.value ?? ''
     const runmeApi = createRunmeConsoleApi({
       resolveNotebook: () => this,
-    });
+    })
     const notebooksApiBridgeServer = createNotebooksApiBridgeServer({
       notebooksApi: createHostNotebooksApi({
         resolveNotebook: this.resolveNotebookForAppKernel,
         listNotebooks: this.listNotebooksForAppKernel,
       }),
-    });
+    })
 
-    let stdout = "";
-    let stderr = "";
-    let finalExitCode = 0;
+    let stdout = ''
+    let stderr = ''
+    let finalExitCode = 0
 
-    appLogger.info("Starting AppKernel cell execution", {
+    appLogger.info('Starting AppKernel cell execution', {
       attrs: {
-        scope: "appkernel.runner",
+        scope: 'appkernel.runner',
         refId,
         runID,
         languageId,
         mode,
       },
-    });
+    })
 
     const hooks = {
       onStdout: (data: string) => {
-        stdout += data;
+        stdout += data
       },
       onStderr: (data: string) => {
-        stderr += data;
+        stderr += data
       },
       onExit: (code: number) => {
-        finalExitCode = code;
+        finalExitCode = code
       },
-    };
+    }
 
     const runPromise =
-      languageId === "javascript"
-        ? mode === "sandbox"
+      languageId === 'javascript'
+        ? mode === 'sandbox'
           ? new SandboxJSKernel({
               bridge: {
                 call: async (method, args) =>
@@ -931,7 +959,7 @@ export class NotebookData {
                     method,
                     args,
                     runmeApi,
-                    notebooksApiBridgeServer,
+                    notebooksApiBridgeServer
                   ),
               },
               hooks,
@@ -945,59 +973,59 @@ export class NotebookData {
               hooks,
             }).run(source)
         : Promise.resolve().then(() => {
-            appLogger.error("Unsupported AppKernel language", {
+            appLogger.error('Unsupported AppKernel language', {
               attrs: {
-                scope: "appkernel.runner",
+                scope: 'appkernel.runner',
                 refId,
                 runID,
                 languageId,
                 mode,
               },
-            });
-            stderr += "AppKernel only supports javascript cells in v0.\n";
-            finalExitCode = 1;
-          });
+            })
+            stderr += 'AppKernel only supports javascript cells in v0.\n'
+            finalExitCode = 1
+          })
 
     void runPromise
       .catch((error) => {
-        finalExitCode = 1;
-        appLogger.error("AppKernel cell execution failed", {
+        finalExitCode = 1
+        appLogger.error('AppKernel cell execution failed', {
           attrs: {
-            scope: "appkernel.runner",
+            scope: 'appkernel.runner',
             refId,
             runID,
             languageId,
             mode,
             error: String(error),
           },
-        });
-        stderr += `${String(error)}\n`;
+        })
+        stderr += `${String(error)}\n`
       })
       .finally(() => {
-        const updated = this.getCellProto(refId);
+        const updated = this.getCellProto(refId)
         if (!updated) {
-          return;
+          return
         }
         const currentRunID =
-          typeof updated.metadata?.[RunmeMetadataKey.LastRunID] === "string"
+          typeof updated.metadata?.[RunmeMetadataKey.LastRunID] === 'string'
             ? updated.metadata[RunmeMetadataKey.LastRunID]
-            : "";
+            : ''
         if (currentRunID !== runID) {
-          return;
+          return
         }
 
-        updated.metadata ??= {};
-        updated.metadata[RunmeMetadataKey.ExitCode] = `${finalExitCode}`;
-        delete updated.metadata[RunmeMetadataKey.Pid];
+        updated.metadata ??= {}
+        updated.metadata[RunmeMetadataKey.ExitCode] = `${finalExitCode}`
+        delete updated.metadata[RunmeMetadataKey.Pid]
 
         // AppKernel runs are not terminal-stream based. Drop stale terminal MIME
         // outputs from prior remote runs so stdout/stderr are visible in the
         // notebook output renderer.
-        updated.outputs = createStdTextOutputs(stdout, stderr);
-        this.updateCell(updated);
-        appLogger.info("Finished AppKernel cell execution", {
+        updated.outputs = createStdTextOutputs(stdout, stderr)
+        this.updateCell(updated)
+        appLogger.info('Finished AppKernel cell execution', {
           attrs: {
-            scope: "appkernel.runner",
+            scope: 'appkernel.runner',
             refId,
             runID,
             languageId,
@@ -1006,257 +1034,281 @@ export class NotebookData {
             stdoutBytes: stdout.length,
             stderrBytes: stderr.length,
           },
-        });
-      });
+        })
+      })
   }
 
   private async handleSandboxAppKernelCall(
     method: string,
     args: unknown[],
     runmeApi: RunmeConsoleApi,
-    notebooksApiBridgeServer: NotebooksApiBridgeServer,
+    notebooksApiBridgeServer: NotebooksApiBridgeServer
   ): Promise<unknown> {
-    const target = args[0];
+    const target = args[0]
     switch (method) {
-      case "runme.clear":
-        return runmeApi.clear(target);
-      case "runme.clearOutputs":
-        return runmeApi.clearOutputs(target);
-      case "runme.runAll":
-        return runmeApi.runAll(target);
-      case "runme.rerun":
-        return runmeApi.rerun(target);
-      case "runme.help":
-        return runmeApi.help();
-      case "runme.getCurrentNotebook": {
-        const notebook = runmeApi.getCurrentNotebook();
+      case 'runme.clear':
+        return runmeApi.clear(target)
+      case 'runme.clearOutputs':
+        return runmeApi.clearOutputs(target)
+      case 'runme.runAll':
+        return runmeApi.runAll(target)
+      case 'runme.rerun':
+        return runmeApi.rerun(target)
+      case 'runme.help':
+        return runmeApi.help()
+      case 'runme.getCurrentNotebook': {
+        const notebook = runmeApi.getCurrentNotebook()
         if (!notebook) {
-          return null;
+          return null
         }
         return {
           uri: notebook.getUri(),
           name: notebook.getName(),
           cellCount: notebook.getNotebook().cells.length,
-        };
+        }
       }
-      case "app.getSessionId":
-        return getClaimedSessionId();
-      case "app.getSessionID":
-        return getClaimedSessionId();
+      case 'app.getSessionId':
+        return getClaimedSessionId()
+      case 'app.getSessionID':
+        return getClaimedSessionId()
       default:
-        if (method.startsWith("notebooks.")) {
+        if (method.startsWith('notebooks.')) {
           return notebooksApiBridgeServer.handleMessage({
             method,
             args,
-          });
+          })
         }
-        throw new Error(`Unsupported sandbox AppKernel method: ${method}`);
+        throw new Error(`Unsupported sandbox AppKernel method: ${method}`)
     }
   }
 
   private runCodeCellWithJupyterKernel(
     cell: parser_pb.Cell,
     runID: string,
-    runner: Runner,
+    runner: Runner
   ): void {
-    const refId = cell.refId;
-    const source = cell.value ?? "";
+    const refId = cell.refId
+    const source = cell.value ?? ''
     const serverName =
-      (cell.metadata?.[RunmeMetadataKey.JupyterServerName] as string | undefined) ??
-      "";
+      (cell.metadata?.[RunmeMetadataKey.JupyterServerName] as
+        | string
+        | undefined) ?? ''
     const selectedKernelID =
-      (cell.metadata?.[RunmeMetadataKey.JupyterKernelID] as string | undefined) ?? "";
+      (cell.metadata?.[RunmeMetadataKey.JupyterKernelID] as
+        | string
+        | undefined) ?? ''
     const selectedKernelName =
-      (cell.metadata?.[RunmeMetadataKey.JupyterKernelName] as string | undefined) ?? "";
+      (cell.metadata?.[RunmeMetadataKey.JupyterKernelName] as
+        | string
+        | undefined) ?? ''
 
     if (!serverName || !selectedKernelID) {
       showToast({
-        message: "Select a Jupyter kernel before running a Jupyter cell.",
-        tone: "error",
-      });
-      const updated = this.getCellProto(refId);
+        message: 'Select a Jupyter kernel before running a Jupyter cell.',
+        tone: 'error',
+      })
+      const updated = this.getCellProto(refId)
       if (updated) {
-        updated.metadata ??= {};
-        updated.metadata[RunmeMetadataKey.ExitCode] = "1";
-        delete updated.metadata[RunmeMetadataKey.Pid];
+        updated.metadata ??= {}
+        updated.metadata[RunmeMetadataKey.ExitCode] = '1'
+        delete updated.metadata[RunmeMetadataKey.Pid]
         updated.outputs = createStdTextOutputs(
-          "",
-          "Jupyter kernel is not selected for this cell.\n",
-        );
-        this.updateCell(updated);
+          '',
+          'Jupyter kernel is not selected for this cell.\n'
+        )
+        this.updateCell(updated)
       }
-      return;
+      return
     }
 
-    let channelsURL: string;
+    let channelsURL: string
     try {
-      const idToken = getBrowserAdapter().simpleAuth?.idToken?.trim() ?? "";
+      const idToken = getBrowserAdapter().simpleAuth?.idToken?.trim() ?? ''
       channelsURL = buildJupyterChannelsWebSocketURL({
         runnerEndpoint: runner.endpoint,
         serverName,
         kernelId: selectedKernelID,
-        authorization: idToken ? `Bearer ${idToken}` : "",
-      });
+        authorization: idToken ? `Bearer ${idToken}` : '',
+      })
     } catch (error) {
       showToast({
-        message: "Failed to create Jupyter channels URL from runner endpoint.",
-        tone: "error",
-      });
-      const updated = this.getCellProto(refId);
+        message: 'Failed to create Jupyter channels URL from runner endpoint.',
+        tone: 'error',
+      })
+      const updated = this.getCellProto(refId)
       if (updated) {
-        updated.metadata ??= {};
-        updated.metadata[RunmeMetadataKey.ExitCode] = "1";
-        delete updated.metadata[RunmeMetadataKey.Pid];
+        updated.metadata ??= {}
+        updated.metadata[RunmeMetadataKey.ExitCode] = '1'
+        delete updated.metadata[RunmeMetadataKey.Pid]
         updated.outputs = createStdTextOutputs(
-          "",
-          `Invalid runner endpoint for Jupyter: ${runner.endpoint}\n`,
-        );
-        this.updateCell(updated);
+          '',
+          `Invalid runner endpoint for Jupyter: ${runner.endpoint}\n`
+        )
+        this.updateCell(updated)
       }
-      return;
+      return
     }
 
-    const socket = new WebSocket(channelsURL);
-    this.activeJupyterSockets.set(refId, socket);
+    const socket = new WebSocket(channelsURL)
+    this.activeJupyterSockets.set(refId, socket)
 
-    const executeMsgID = crypto.randomUUID().replace(/-/g, "");
-    const sessionID = crypto.randomUUID().replace(/-/g, "");
-    const textDecoder = new TextDecoder();
-    const richOutputs: parser_pb.CellOutput[] = [];
-    let stdoutText = "";
-    let stderrText = "";
-    let textBytes = 0;
-    let totalBytes = 0;
-    let didTruncate = false;
-    let completed = false;
-    let sawExecuteReply = false;
-    let sawIdle = false;
-    let exitCode = 0;
+    const executeMsgID = crypto.randomUUID().replace(/-/g, '')
+    const sessionID = crypto.randomUUID().replace(/-/g, '')
+    const textDecoder = new TextDecoder()
+    const richOutputs: parser_pb.CellOutput[] = []
+    let stdoutText = ''
+    let stderrText = ''
+    let textBytes = 0
+    let totalBytes = 0
+    let didTruncate = false
+    let completed = false
+    let sawExecuteReply = false
+    let sawIdle = false
+    let exitCode = 0
 
     const appendTruncationNotice = () => {
       if (didTruncate) {
-        return;
+        return
       }
-      didTruncate = true;
-      const notice = "[runme] Jupyter output truncated due to v0 output limits.\n";
-      const noticeBytes = encodeCellOutputBytes(notice);
+      didTruncate = true
+      const notice =
+        '[runme] Jupyter output truncated due to v0 output limits.\n'
+      const noticeBytes = encodeCellOutputBytes(notice)
       const allowed = Math.max(
         0,
         Math.min(
           noticeBytes.length,
           JUPYTER_LIMITS.textBytesPerExecution - textBytes,
-          JUPYTER_LIMITS.totalBytesPerExecution - totalBytes,
-        ),
-      );
+          JUPYTER_LIMITS.totalBytesPerExecution - totalBytes
+        )
+      )
       if (allowed <= 0) {
-        return;
+        return
       }
-      stderrText += textDecoder.decode(noticeBytes.slice(0, allowed));
-      textBytes += allowed;
-      totalBytes += allowed;
-    };
+      stderrText += textDecoder.decode(noticeBytes.slice(0, allowed))
+      textBytes += allowed
+      totalBytes += allowed
+    }
 
-    const appendText = (target: "stdout" | "stderr", value: string) => {
+    const appendText = (target: 'stdout' | 'stderr', value: string) => {
       if (!value) {
-        return;
+        return
       }
-      const encoded = encodeCellOutputBytes(value);
+      const encoded = encodeCellOutputBytes(value)
       const allowed = Math.max(
         0,
         Math.min(
           encoded.length,
           JUPYTER_LIMITS.textBytesPerExecution - textBytes,
-          JUPYTER_LIMITS.totalBytesPerExecution - totalBytes,
-        ),
-      );
+          JUPYTER_LIMITS.totalBytesPerExecution - totalBytes
+        )
+      )
       if (allowed <= 0) {
-        appendTruncationNotice();
-        return;
+        appendTruncationNotice()
+        return
       }
-      const chunk = textDecoder.decode(encoded.slice(0, allowed));
-      if (target === "stdout") {
-        stdoutText += chunk;
+      const chunk = textDecoder.decode(encoded.slice(0, allowed))
+      if (target === 'stdout') {
+        stdoutText += chunk
       } else {
-        stderrText += chunk;
+        stderrText += chunk
       }
-      textBytes += allowed;
-      totalBytes += allowed;
+      textBytes += allowed
+      totalBytes += allowed
       if (allowed < encoded.length) {
-        appendTruncationNotice();
+        appendTruncationNotice()
       }
-    };
+    }
 
     const appendRichItem = (mime: string, data: Uint8Array) => {
-      let payload = data;
+      let payload = data
       if (payload.length > JUPYTER_LIMITS.richBytesPerItem) {
-        payload = payload.slice(0, JUPYTER_LIMITS.richBytesPerItem);
-        appendTruncationNotice();
+        payload = payload.slice(0, JUPYTER_LIMITS.richBytesPerItem)
+        appendTruncationNotice()
       }
       const allowed = Math.max(
         0,
-        Math.min(payload.length, JUPYTER_LIMITS.totalBytesPerExecution - totalBytes),
-      );
+        Math.min(
+          payload.length,
+          JUPYTER_LIMITS.totalBytesPerExecution - totalBytes
+        )
+      )
       if (allowed <= 0) {
-        appendTruncationNotice();
-        return;
+        appendTruncationNotice()
+        return
       }
-      const trimmed = payload.slice(0, allowed);
-      totalBytes += trimmed.length;
+      const trimmed = payload.slice(0, allowed)
+      totalBytes += trimmed.length
       if (trimmed.length < payload.length) {
-        appendTruncationNotice();
+        appendTruncationNotice()
       }
       richOutputs.push(
         create(parser_pb.CellOutputSchema, {
           items: [
             create(parser_pb.CellOutputItemSchema, {
               mime,
-              type: "Buffer",
+              type: 'Buffer',
               data: trimmed,
             }),
           ],
-        }),
-      );
-    };
+        })
+      )
+    }
 
     const pushDisplayBundle = (bundle: Record<string, unknown> | undefined) => {
-      if (!bundle || typeof bundle !== "object") {
-        return;
+      if (!bundle || typeof bundle !== 'object') {
+        return
       }
-      if (typeof bundle["text/html"] === "string") {
-        appendRichItem("text/html", encodeCellOutputBytes(bundle["text/html"] as string));
-        return;
+      if (typeof bundle['text/html'] === 'string') {
+        appendRichItem(
+          'text/html',
+          encodeCellOutputBytes(bundle['text/html'] as string)
+        )
+        return
       }
-      if (typeof bundle["image/png"] === "string") {
-        appendRichItem("image/png", decodeBase64ToBytes(bundle["image/png"] as string));
-        return;
+      if (typeof bundle['image/png'] === 'string') {
+        appendRichItem(
+          'image/png',
+          decodeBase64ToBytes(bundle['image/png'] as string)
+        )
+        return
       }
-      if (typeof bundle["image/jpeg"] === "string") {
-        appendRichItem("image/jpeg", decodeBase64ToBytes(bundle["image/jpeg"] as string));
-        return;
+      if (typeof bundle['image/jpeg'] === 'string') {
+        appendRichItem(
+          'image/jpeg',
+          decodeBase64ToBytes(bundle['image/jpeg'] as string)
+        )
+        return
       }
-      if (typeof bundle["image/svg+xml"] === "string") {
-        appendRichItem("image/svg+xml", encodeCellOutputBytes(bundle["image/svg+xml"] as string));
-        return;
+      if (typeof bundle['image/svg+xml'] === 'string') {
+        appendRichItem(
+          'image/svg+xml',
+          encodeCellOutputBytes(bundle['image/svg+xml'] as string)
+        )
+        return
       }
-      if (typeof bundle["text/plain"] === "string") {
-        appendRichItem("text/plain", encodeCellOutputBytes(bundle["text/plain"] as string));
+      if (typeof bundle['text/plain'] === 'string') {
+        appendRichItem(
+          'text/plain',
+          encodeCellOutputBytes(bundle['text/plain'] as string)
+        )
       }
-    };
+    }
 
     const updateCellOutputs = (transient: boolean) => {
-      const updated = this.getCellProto(refId);
+      const updated = this.getCellProto(refId)
       if (!updated) {
-        return false;
+        return false
       }
       const currentRunID =
-        typeof updated.metadata?.[RunmeMetadataKey.LastRunID] === "string"
+        typeof updated.metadata?.[RunmeMetadataKey.LastRunID] === 'string'
           ? updated.metadata[RunmeMetadataKey.LastRunID]
-          : "";
+          : ''
       if (currentRunID !== runID) {
-        return false;
+        return false
       }
 
-      const nextOutputs: parser_pb.CellOutput[] = [];
+      const nextOutputs: parser_pb.CellOutput[] = []
       if (stdoutText.length > 0 || stderrText.length > 0) {
         nextOutputs.push(
           create(parser_pb.CellOutputSchema, {
@@ -1264,51 +1316,51 @@ export class NotebookData {
               createTextOutputItem(MimeType.VSCodeNotebookStdOut, stdoutText),
               createTextOutputItem(MimeType.VSCodeNotebookStdErr, stderrText),
             ],
-          }),
-        );
+          })
+        )
       }
-      nextOutputs.push(...richOutputs);
-      updated.outputs = nextOutputs;
-      this.updateCell(updated, { transient });
-      return true;
-    };
+      nextOutputs.push(...richOutputs)
+      updated.outputs = nextOutputs
+      this.updateCell(updated, { transient })
+      return true
+    }
 
     const markCompleted = (code: number) => {
       if (completed) {
-        return;
+        return
       }
-      completed = true;
-      const updated = this.getCellProto(refId);
+      completed = true
+      const updated = this.getCellProto(refId)
       if (updated) {
         const currentRunID =
-          typeof updated.metadata?.[RunmeMetadataKey.LastRunID] === "string"
+          typeof updated.metadata?.[RunmeMetadataKey.LastRunID] === 'string'
             ? updated.metadata[RunmeMetadataKey.LastRunID]
-            : "";
+            : ''
         if (currentRunID === runID) {
-          updated.metadata ??= {};
-          updated.metadata[RunmeMetadataKey.ExitCode] = `${code}`;
-          delete updated.metadata[RunmeMetadataKey.Pid];
-          this.updateCell(updated);
+          updated.metadata ??= {}
+          updated.metadata[RunmeMetadataKey.ExitCode] = `${code}`
+          delete updated.metadata[RunmeMetadataKey.Pid]
+          this.updateCell(updated)
         }
       }
-      this.activeJupyterSockets.delete(refId);
+      this.activeJupyterSockets.delete(refId)
       try {
-        socket.close();
+        socket.close()
       } catch {
         // no-op
       }
-    };
+    }
 
     socket.onopen = () => {
       const executeRequest = {
-        channel: "shell",
+        channel: 'shell',
         header: {
           msg_id: executeMsgID,
-          username: "runme",
+          username: 'runme',
           session: sessionID,
           date: new Date().toISOString(),
-          msg_type: "execute_request",
-          version: "5.3",
+          msg_type: 'execute_request',
+          version: '5.3',
         },
         parent_header: {},
         metadata: {},
@@ -1320,144 +1372,148 @@ export class NotebookData {
           allow_stdin: false,
           stop_on_error: true,
         },
-      };
-      socket.send(JSON.stringify(executeRequest));
-    };
+      }
+      socket.send(JSON.stringify(executeRequest))
+    }
 
     socket.onmessage = (event) => {
       if (completed) {
-        return;
+        return
       }
-      if (typeof event.data !== "string") {
-        return;
+      if (typeof event.data !== 'string') {
+        return
       }
-      let message: Record<string, any>;
+      let message: Record<string, any>
       try {
-        message = JSON.parse(event.data) as Record<string, any>;
+        message = JSON.parse(event.data) as Record<string, any>
       } catch {
-        return;
+        return
       }
       const msgType =
         (message.msg_type as string | undefined) ??
         (message.header?.msg_type as string | undefined) ??
-        "";
-      const parentMsgID = (message.parent_header?.msg_id as string | undefined) ?? "";
+        ''
+      const parentMsgID =
+        (message.parent_header?.msg_id as string | undefined) ?? ''
       if (parentMsgID && parentMsgID !== executeMsgID) {
-        return;
+        return
       }
 
       switch (msgType) {
-        case "stream": {
-          const streamName = (message.content?.name as string | undefined) ?? "stdout";
-          const text = (message.content?.text as string | undefined) ?? "";
-          appendText(streamName === "stderr" ? "stderr" : "stdout", text);
-          updateCellOutputs(true);
-          break;
+        case 'stream': {
+          const streamName =
+            (message.content?.name as string | undefined) ?? 'stdout'
+          const text = (message.content?.text as string | undefined) ?? ''
+          appendText(streamName === 'stderr' ? 'stderr' : 'stdout', text)
+          updateCellOutputs(true)
+          break
         }
-        case "error": {
+        case 'error': {
           const traceback = Array.isArray(message.content?.traceback)
-            ? (message.content.traceback as string[]).join("\n")
-            : "";
-          const ename = (message.content?.ename as string | undefined) ?? "Error";
-          const evalue = (message.content?.evalue as string | undefined) ?? "";
-          appendText("stderr", `${ename}: ${evalue}\n${traceback}\n`);
-          exitCode = 1;
-          updateCellOutputs(true);
-          break;
+            ? (message.content.traceback as string[]).join('\n')
+            : ''
+          const ename =
+            (message.content?.ename as string | undefined) ?? 'Error'
+          const evalue = (message.content?.evalue as string | undefined) ?? ''
+          appendText('stderr', `${ename}: ${evalue}\n${traceback}\n`)
+          exitCode = 1
+          updateCellOutputs(true)
+          break
         }
-        case "display_data":
-        case "execute_result":
-        case "update_display_data": {
-          const dataBundle = message.content?.data as Record<string, unknown> | undefined;
-          pushDisplayBundle(dataBundle);
-          updateCellOutputs(true);
-          break;
+        case 'display_data':
+        case 'execute_result':
+        case 'update_display_data': {
+          const dataBundle = message.content?.data as
+            | Record<string, unknown>
+            | undefined
+          pushDisplayBundle(dataBundle)
+          updateCellOutputs(true)
+          break
         }
-        case "input_request": {
+        case 'input_request': {
           appendText(
-            "stderr",
-            "Jupyter input_request is not supported in v0. Re-run with non-interactive code.\n",
-          );
-          exitCode = 1;
-          updateCellOutputs(true);
-          break;
+            'stderr',
+            'Jupyter input_request is not supported in v0. Re-run with non-interactive code.\n'
+          )
+          exitCode = 1
+          updateCellOutputs(true)
+          break
         }
-        case "execute_reply": {
-          sawExecuteReply = true;
-          if (message.content?.status && message.content.status !== "ok") {
-            exitCode = 1;
+        case 'execute_reply': {
+          sawExecuteReply = true
+          if (message.content?.status && message.content.status !== 'ok') {
+            exitCode = 1
           }
           if (sawIdle) {
-            updateCellOutputs(false);
-            markCompleted(exitCode);
+            updateCellOutputs(false)
+            markCompleted(exitCode)
           }
-          break;
+          break
         }
-        case "status": {
-          if (message.content?.execution_state === "idle") {
-            sawIdle = true;
+        case 'status': {
+          if (message.content?.execution_state === 'idle') {
+            sawIdle = true
             if (sawExecuteReply) {
-              updateCellOutputs(false);
-              markCompleted(exitCode);
+              updateCellOutputs(false)
+              markCompleted(exitCode)
             }
           }
-          break;
+          break
         }
-        case "clear_output": {
+        case 'clear_output': {
           // v0 behavior: ignore in-band clear_output; we clear at execution start.
-          break;
+          break
         }
         default:
-          break;
+          break
       }
-    };
+    }
 
     socket.onerror = () => {
       if (completed) {
-        return;
+        return
       }
       appendText(
-        "stderr",
-        "Connection lost; output may be incomplete. Re-run the cell.\n",
-      );
-      updateCellOutputs(false);
-      markCompleted(1);
-    };
+        'stderr',
+        'Connection lost; output may be incomplete. Re-run the cell.\n'
+      )
+      updateCellOutputs(false)
+      markCompleted(1)
+    }
 
     socket.onclose = () => {
       if (completed) {
-        return;
+        return
       }
       // Long-running Jupyter executions can be quiet; completion is gated on
       // protocol signals, not "no message for N seconds".
       if (!sawExecuteReply || !sawIdle) {
         appendText(
-          "stderr",
-          "Connection lost; output may be incomplete. Re-run the cell.\n",
-        );
-        updateCellOutputs(false);
-        markCompleted(1);
+          'stderr',
+          'Connection lost; output may be incomplete. Re-run the cell.\n'
+        )
+        updateCellOutputs(false)
+        markCompleted(1)
       }
-    };
+    }
 
-    appLogger.info("Started Jupyter kernel cell execution", {
+    appLogger.info('Started Jupyter kernel cell execution', {
       attrs: {
-        scope: "jupyter.runner",
+        scope: 'jupyter.runner',
         refId,
         runID,
         serverName,
         kernelID: selectedKernelID,
         kernelName: selectedKernelName,
       },
-    });
+    })
   }
 
   private getRunner(cell: parser_pb.Cell): Runner | undefined {
-    const runnerMgr = getRunnersManager();
+    const runnerMgr = getRunnersManager()
     const runnerName =
-      (cell.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ||
-      "";
-    return runnerMgr.getWithFallback(runnerName);
+      (cell.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) || ''
+    return runnerMgr.getWithFallback(runnerName)
   }
 
   private createAndBindStreams({
@@ -1466,10 +1522,10 @@ export class NotebookData {
     sequence,
     runner,
   }: {
-    cell: parser_pb.Cell;
-    runID: string;
-    sequence: number;
-    runner: Runner;
+    cell: parser_pb.Cell
+    runID: string
+    sequence: number
+    runner: Runner
   }): StreamsLike | undefined {
     const streams = new Streams({
       knownID: `cell_${cell.refId}`,
@@ -1480,8 +1536,8 @@ export class NotebookData {
         interceptors: runner.interceptors ?? [],
         autoReconnect: runner.reconnect ?? true,
       },
-    });
-    this.activeStreams.set(cell.refId, streams);
+    })
+    this.activeStreams.set(cell.refId, streams)
 
     bindStreamsToCell({
       refId: cell.refId,
@@ -1489,31 +1545,31 @@ export class NotebookData {
       getCell: (ref) => this.getCellProto(ref),
       updateCell: (next, options) => this.updateCell(next, options),
       onClose: (refId) => {
-        this.activeStreams.delete(refId);
+        this.activeStreams.delete(refId)
       },
-    });
+    })
 
-    return streams;
+    return streams
   }
 
   private rebuildIndex(): void {
-    this.refToIndex.clear();
+    this.refToIndex.clear()
     this.notebook.cells.forEach((cell, index) => {
       if (cell?.refId) {
-        this.refToIndex.set(cell.refId, index);
+        this.refToIndex.set(cell.refId, index)
       }
-    });
+    })
   }
 
   private computeHighestSequence(): number {
     return (this.notebook.cells ?? []).reduce((max, cell) => {
-      const value = cell.metadata?.[RunmeMetadataKey.Sequence];
-      const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
+      const value = cell.metadata?.[RunmeMetadataKey.Sequence]
+      const parsed = value ? Number.parseInt(value, 10) : Number.NaN
       if (Number.isNaN(parsed)) {
-        return max;
+        return max
       }
-      return Math.max(max, parsed);
-    }, 0);
+      return Math.max(max, parsed)
+    }, 0)
   }
 
   private buildSnapshot(): NotebookSnapshot {
@@ -1521,265 +1577,264 @@ export class NotebookData {
       uri: this.uri,
       name: this.name,
       loaded: this.loaded,
+      readOnly: this.readOnly,
       notebook: clone(parser_pb.NotebookSchema, this.notebook),
-    };
+    }
   }
 
   private emit(): void {
     this.listeners.forEach((listener) => {
       try {
-        listener();
+        listener()
       } catch (error) {
-        console.error("NotebookData listener failed", error);
+        console.error('NotebookData listener failed', error)
       }
-    });
+    })
   }
 
   private async persist(): Promise<void> {
-    if (!this.notebookStore) {
-      return;
+    if (this.readOnly || !this.notebookStore) {
+      return
     }
     try {
-      await this.notebookStore.save(this.uri, this.notebook);
+      await this.notebookStore.save(this.uri, this.notebook)
     } catch (error) {
-      console.error("NotebookData failed to persist notebook", {
+      console.error('NotebookData failed to persist notebook', {
         uri: this.uri,
         error,
-      });
+      })
     }
   }
 
   private schedulePersist(): void {
-    if (!this.notebookStore) {
-      return;
+    if (this.readOnly || !this.notebookStore) {
+      return
     }
     if (this.persistTimer) {
-      clearTimeout(this.persistTimer);
+      clearTimeout(this.persistTimer)
     }
     this.persistTimer = setTimeout(() => {
-      this.persistTimer = null;
-      void this.persist();
-    }, this.persistDelayMs);
+      this.persistTimer = null
+      void this.persist()
+    }, this.persistDelayMs)
   }
 }
 
 export class CellData {
-  private listeners: Set<Listener> = new Set();
-  private lastSnapshotKey: string | null = null;
-  private unsubscribeNotebook: (() => void) | null = null;
-  private cachedSnapshot: parser_pb.Cell | null = null;
-  private runIdListeners: Set<(runID: string) => void> = new Set();
+  private listeners: Set<Listener> = new Set()
+  private lastSnapshotKey: string | null = null
+  private unsubscribeNotebook: (() => void) | null = null
+  private cachedSnapshot: parser_pb.Cell | null = null
+  private runIdListeners: Set<(runID: string) => void> = new Set()
 
-  constructor(private readonly notebook: NotebookData, private readonly refId: string) {
+  constructor(
+    private readonly notebook: NotebookData,
+    private readonly refId: string
+  ) {
     // TODO(jlewi): Need to rationalize the design and management of snapshots
-    this.cachedSnapshot = notebook.getCellSnapshot(refId);
+    this.cachedSnapshot = notebook.getCellSnapshot(refId)
   }
 
   subscribe(listener: Listener): () => void {
-    this.listeners.add(listener);
+    this.listeners.add(listener)
     return () => {
-      this.listeners.delete(listener);
-    };
+      this.listeners.delete(listener)
+    }
   }
 
   subscribeToContentChange(listener: Listener): () => void {
-    return this.subscribe(listener);
+    return this.subscribe(listener)
   }
 
   subscribeToRunIDChange(listener: (runID: string) => void): () => void {
-    this.runIdListeners.add(listener);
+    this.runIdListeners.add(listener)
     return () => {
-      this.runIdListeners.delete(listener);
-    };
+      this.runIdListeners.delete(listener)
+    }
   }
 
   private emitRunIDChange(runID: string): void {
     this.runIdListeners.forEach((listener) => {
       try {
-        listener(runID);
+        listener(runID)
       } catch (err) {
-        console.error("CellData runID listener failed", err);
+        console.error('CellData runID listener failed', err)
       }
-    });
+    })
   }
 
   private emit(): void {
     this.listeners.forEach((listener) => {
       try {
-        listener();
+        listener()
       } catch (err) {
-        console.error("CellData listener failed", err);
+        console.error('CellData listener failed', err)
       }
-    });
+    })
   }
 
   emitContentChange(): void {
-    this.emit();
+    this.emit()
   }
 
   updateCachedSnapshotFromNotebook(cell: parser_pb.Cell | null): void {
-    this.cachedSnapshot = cell ? clone(parser_pb.CellSchema, cell) : null;
+    this.cachedSnapshot = cell ? clone(parser_pb.CellSchema, cell) : null
   }
 
   /** Latest cloned snapshot of this cell. */
   get snapshot(): parser_pb.Cell | null {
-    return this.cachedSnapshot;
+    return this.cachedSnapshot
   }
 
   setValue(value: string): void {
-    const cell = this.cachedSnapshot;
-    if (!cell) return;
-    cell.value = value;
-    this.notebook.updateCell(cell);
+    const cell = this.cachedSnapshot
+    if (!cell) return
+    cell.value = value
+    this.notebook.updateCell(cell)
   }
 
   setLanguage(languageId: string): void {
-    const cell = this.cachedSnapshot;
-    if (!cell) return;
-    cell.languageId = languageId;
-    this.notebook.updateCell(cell);
+    const cell = this.cachedSnapshot
+    if (!cell) return
+    cell.languageId = languageId
+    this.notebook.updateCell(cell)
   }
 
   addBefore(
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell | null {
-    return this.notebook.addCellBefore(
-      this.refId,
-      kind,
-      languageId,
-    );
+    return this.notebook.addCellBefore(this.refId, kind, languageId)
   }
 
   addAfter(
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell | null {
-    return this.notebook.addCellAfter(
-      this.refId,
-      kind,
-      languageId,
-    );
+    return this.notebook.addCellAfter(this.refId, kind, languageId)
   }
 
   remove(): void {
-    this.notebook.removeCell(this.refId);
+    this.notebook.removeCell(this.refId)
   }
 
   async run(): Promise<void> {
-    const cell = this.snapshot;
+    const cell = this.snapshot
     if (!cell) {
-      return;
+      return
     }
-    const runID = this.notebook.runCodeCell(cell);
+    const runID = this.notebook.runCodeCell(cell)
     // Update the snapshot after running to pick up any metadata changes.
-    this.cachedSnapshot = this.notebook.getCellSnapshot(this.refId);
-    this.emitRunIDChange(runID ?? "");
+    this.cachedSnapshot = this.notebook.getCellSnapshot(this.refId)
+    this.emitRunIDChange(runID ?? '')
     if (!runID || this.hasRunCompleted(runID)) {
-      return;
+      return
     }
     await new Promise<void>((resolve) => {
       const unsubscribe = this.subscribeToContentChange(() => {
-        this.cachedSnapshot = this.notebook.getCellSnapshot(this.refId);
+        this.cachedSnapshot = this.notebook.getCellSnapshot(this.refId)
         if (this.hasRunCompleted(runID)) {
-          unsubscribe();
-          resolve();
+          unsubscribe()
+          resolve()
         }
-      });
-    });
+      })
+    })
   }
 
   getStreams(): StreamsLike | undefined {
-    return this.notebook.getActiveStream(this.refId);
+    return this.notebook.getActiveStream(this.refId)
   }
 
   getRunID(): string {
-    const snap = this.snapshot;
-    const id = snap?.metadata?.[RunmeMetadataKey.LastRunID];
-    return typeof id === "string" ? id : "";
+    const snap = this.snapshot
+    const id = snap?.metadata?.[RunmeMetadataKey.LastRunID]
+    return typeof id === 'string' ? id : ''
   }
 
   setRunner(name: string): void {
-    const snap = this.snapshot;
-    if (!snap) return;
-    snap.metadata ??= {};
+    const snap = this.snapshot
+    if (!snap) return
+    snap.metadata ??= {}
     if (name === DEFAULT_RUNNER_PLACEHOLDER) {
-      delete (snap.metadata as any)[RunmeMetadataKey.RunnerName];      
+      delete (snap.metadata as any)[RunmeMetadataKey.RunnerName]
     } else {
-      (snap.metadata as any)[RunmeMetadataKey.RunnerName] = name;      
+      ;(snap.metadata as any)[RunmeMetadataKey.RunnerName] = name
     }
-    this.notebook.updateCell(snap);
+    this.notebook.updateCell(snap)
   }
 
   setJupyterKernel(selection: {
-    runnerName?: string;
-    serverName: string;
-    kernelId: string;
-    kernelName: string;
+    runnerName?: string
+    serverName: string
+    kernelId: string
+    kernelName: string
   }): void {
-    const snap = this.snapshot;
-    if (!snap) return;
-    snap.metadata ??= {};
-    (snap.metadata as any)[RunmeMetadataKey.JupyterServerName] =
-      selection.serverName;
-    (snap.metadata as any)[RunmeMetadataKey.JupyterKernelID] =
-      selection.kernelId;
-    (snap.metadata as any)[RunmeMetadataKey.JupyterKernelName] =
-      selection.kernelName;
-    if (selection.runnerName && selection.runnerName !== DEFAULT_RUNNER_PLACEHOLDER) {
-      (snap.metadata as any)[RunmeMetadataKey.RunnerName] = selection.runnerName;
+    const snap = this.snapshot
+    if (!snap) return
+    snap.metadata ??= {}
+    ;(snap.metadata as any)[RunmeMetadataKey.JupyterServerName] =
+      selection.serverName
+    ;(snap.metadata as any)[RunmeMetadataKey.JupyterKernelID] =
+      selection.kernelId
+    ;(snap.metadata as any)[RunmeMetadataKey.JupyterKernelName] =
+      selection.kernelName
+    if (
+      selection.runnerName &&
+      selection.runnerName !== DEFAULT_RUNNER_PLACEHOLDER
+    ) {
+      ;(snap.metadata as any)[RunmeMetadataKey.RunnerName] =
+        selection.runnerName
     }
-    this.notebook.updateCell(snap);
+    this.notebook.updateCell(snap)
   }
 
   clearJupyterKernel(): void {
-    const snap = this.snapshot;
-    if (!snap) return;
-    snap.metadata ??= {};
-    delete (snap.metadata as any)[RunmeMetadataKey.JupyterServerName];
-    delete (snap.metadata as any)[RunmeMetadataKey.JupyterKernelID];
-    delete (snap.metadata as any)[RunmeMetadataKey.JupyterKernelName];
-    this.notebook.updateCell(snap);
+    const snap = this.snapshot
+    if (!snap) return
+    snap.metadata ??= {}
+    delete (snap.metadata as any)[RunmeMetadataKey.JupyterServerName]
+    delete (snap.metadata as any)[RunmeMetadataKey.JupyterKernelID]
+    delete (snap.metadata as any)[RunmeMetadataKey.JupyterKernelName]
+    this.notebook.updateCell(snap)
   }
 
   getJupyterServerName(): string {
-    const value = this.snapshot?.metadata?.[RunmeMetadataKey.JupyterServerName];
-    return typeof value === "string" ? value : "";
+    const value = this.snapshot?.metadata?.[RunmeMetadataKey.JupyterServerName]
+    return typeof value === 'string' ? value : ''
   }
 
   getJupyterKernelID(): string {
-    const value = this.snapshot?.metadata?.[RunmeMetadataKey.JupyterKernelID];
-    return typeof value === "string" ? value : "";
+    const value = this.snapshot?.metadata?.[RunmeMetadataKey.JupyterKernelID]
+    return typeof value === 'string' ? value : ''
   }
 
   getJupyterKernelName(): string {
-    const value = this.snapshot?.metadata?.[RunmeMetadataKey.JupyterKernelName];
-    return typeof value === "string" ? value : "";
+    const value = this.snapshot?.metadata?.[RunmeMetadataKey.JupyterKernelName]
+    return typeof value === 'string' ? value : ''
   }
 
   update(cell: parser_pb.Cell): void {
-    this.cachedSnapshot = clone(parser_pb.CellSchema, cell);
-    this.notebook.updateCell(cell);
+    this.cachedSnapshot = clone(parser_pb.CellSchema, cell)
+    this.notebook.updateCell(cell)
   }
 
   /** Runner name from metadata, validated against known runners; falls back to default placeholder. */
   getRunnerName(): string {
     const requested =
-      this.snapshot?.metadata?.[RunmeMetadataKey.RunnerName] ??
-      null;
+      this.snapshot?.metadata?.[RunmeMetadataKey.RunnerName] ?? null
     if (requested) {
-      return requested;
+      return requested
     }
-    return DEFAULT_RUNNER_PLACEHOLDER;
+    return DEFAULT_RUNNER_PLACEHOLDER
   }
 
   private hasRunCompleted(runID: string): boolean {
-    const snap = this.notebook.getCellSnapshot(this.refId);
+    const snap = this.notebook.getCellSnapshot(this.refId)
     if (!snap) {
-      return true;
+      return true
     }
-    const activeRunID = snap.metadata?.[RunmeMetadataKey.LastRunID];
-    const exitCode = snap.metadata?.[RunmeMetadataKey.ExitCode];
-    return activeRunID !== runID || typeof exitCode === "string";
+    const activeRunID = snap.metadata?.[RunmeMetadataKey.LastRunID]
+    const exitCode = snap.metadata?.[RunmeMetadataKey.ExitCode]
+    return activeRunID !== runID || typeof exitCode === 'string'
   }
 }

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -295,13 +295,25 @@ describe('NotebookDataController', () => {
     ])
   })
 
-  it('restores session open-notebook storage without changing the storage shape', () => {
+  it('restores session open-notebook storage as load intents only', () => {
     window.sessionStorage.setItem(
       'runme/openNotebooks',
       JSON.stringify([
         {
           uri: 'local://file/restored',
+          requestedUri: 'local://file/restored',
           name: 'restored.json',
+          state: 'loaded',
+          readOnly: true,
+          errorMessage: 'stale error',
+          owner: {
+            notebookUri: 'local://file/restored',
+            ownerTabId: 'tab-other',
+            ownerLabel: 'Other tab',
+            ownerUrl: 'http://localhost/',
+            ownerStartedAt: '2026-05-22T12:00:00.000Z',
+            epoch: 'epoch-other',
+          },
           type: 'file',
           children: [],
           parents: [],
@@ -312,7 +324,8 @@ describe('NotebookDataController', () => {
     const controller = getNotebookDataController()
     controller.configureOwnershipManager(createFakeOwnershipManager())
 
-    expect(controller.getOpenNotebooks()).toEqual([
+    const restored = controller.getOpenNotebooks()
+    expect(restored).toEqual([
       expect.objectContaining({
         uri: 'local://file/restored',
         requestedUri: 'local://file/restored',
@@ -320,6 +333,9 @@ describe('NotebookDataController', () => {
         state: 'loading',
       }),
     ])
+    expect(restored[0]).not.toHaveProperty('readOnly')
+    expect(restored[0]).not.toHaveProperty('errorMessage')
+    expect(restored[0]).not.toHaveProperty('owner')
     expect(controller.getNotebookData('local://file/restored')).toBeUndefined()
     controller.configureStores({
       localNotebooks: createFakeLocalNotebooks() as unknown as LocalNotebooks,

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -1,49 +1,50 @@
-import { create } from "@bufbuild/protobuf";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitFor } from '@testing-library/react'
 
-import { parser_pb } from "../contexts/CellContext";
-import type { LocalNotebooks } from "../storage/local";
-import type {
-  AcquireResult,
-  NotebookOwnershipManager,
-} from "./tabCoordination/notebookOwnership";
-import { NotebookStoreItemType } from "../storage/notebook";
+import { parser_pb } from '../contexts/CellContext'
+import type { LocalNotebooks } from '../storage/local'
+import { NotebookStoreItemType } from '../storage/notebook'
 import {
   __resetNotebookDataControllerForTests,
   getNotebookDataController,
-} from "./notebookDataController";
+} from './notebookDataController'
+import type {
+  AcquireResult,
+  NotebookOwnershipManager,
+} from './tabCoordination/notebookOwnership'
 
-vi.mock("@runmedev/renderers", () => ({
+vi.mock('@runmedev/renderers', () => ({
   Streams: class {},
-  Heartbeat: { INITIAL: "INITIAL" },
-  genRunID: () => "run-generated",
-}));
+  Heartbeat: { INITIAL: 'INITIAL' },
+  genRunID: () => 'run-generated',
+}))
 
-function createNotebook(value = ""): parser_pb.Notebook {
+function createNotebook(value = ''): parser_pb.Notebook {
   return create(parser_pb.NotebookSchema, {
     cells: value
       ? [
           create(parser_pb.CellSchema, {
-            refId: "cell-1",
+            refId: 'cell-1',
             value,
           }),
         ]
       : [],
     metadata: {},
-  });
+  })
 }
 
 function createFakeLocalNotebooks() {
   const records = new Map<
     string,
     {
-      id: string;
-      name: string;
-      remoteId: string;
-      notebook: parser_pb.Notebook;
+      id: string
+      name: string
+      remoteId: string
+      notebook: parser_pb.Notebook
     }
-  >();
-  let nextId = 1;
+  >()
+  let nextId = 1
 
   return {
     records,
@@ -51,24 +52,24 @@ function createFakeLocalNotebooks() {
       for (const record of records.values()) {
         if (record.remoteId === remoteUri) {
           if (name) {
-            record.name = name;
+            record.name = name
           }
-          return record.id;
+          return record.id
         }
       }
-      const id = `local://file/${nextId++}`;
+      const id = `local://file/${nextId++}`
       records.set(id, {
         id,
         name: name ?? remoteUri,
         remoteId: remoteUri,
         notebook: createNotebook(),
-      });
-      return id;
+      })
+      return id
     }),
     getMetadata: vi.fn(async (uri: string) => {
-      const record = records.get(uri);
+      const record = records.get(uri)
       if (!record) {
-        return null;
+        return null
       }
       return {
         uri: record.id,
@@ -76,406 +77,470 @@ function createFakeLocalNotebooks() {
         type: NotebookStoreItemType.File,
         children: [],
         parents: [],
-        remoteUri:
-          record.remoteId === record.id ? undefined : record.remoteId,
-      };
+        remoteUri: record.remoteId === record.id ? undefined : record.remoteId,
+      }
     }),
     load: vi.fn(async (uri: string) => {
-      const record = records.get(uri);
+      const record = records.get(uri)
       if (!record) {
-        throw new Error(`Local notebook record not found for ${uri}`);
+        throw new Error(`Local notebook record not found for ${uri}`)
       }
-      return record.notebook;
+      return record.notebook
     }),
     save: vi.fn(),
-  };
+  }
 }
 
 function createFakeOwnershipManager(
-  acquireResult?: AcquireResult,
+  acquireResult?: AcquireResult
 ): NotebookOwnershipManager {
   const fallbackLease = {
-    notebookUri: "local://file/demo",
-    tabId: "tab-test",
-    epoch: "epoch-test",
+    notebookUri: 'local://file/demo',
+    tabId: 'tab-test',
+    epoch: 'epoch-test',
     release: vi.fn(),
     isCurrentOwner: vi.fn(async () => true),
-  };
+  }
   return {
     acquire: vi.fn(async (notebookUri: string) => {
       if (acquireResult) {
-        return acquireResult;
+        return acquireResult
       }
       return {
-        status: "acquired",
+        status: 'acquired',
         lease: {
           ...fallbackLease,
           notebookUri,
         },
-      };
+      }
     }),
     release: vi.fn(),
     getOwner: vi.fn(async () => null),
     subscribe: vi.fn(() => () => {}),
     isCurrentOwner: vi.fn(async () => true),
     dispose: vi.fn(),
-  } as unknown as NotebookOwnershipManager;
+  } as unknown as NotebookOwnershipManager
 }
 
-describe("NotebookDataController", () => {
+describe('NotebookDataController', () => {
   beforeEach(() => {
-    __resetNotebookDataControllerForTests();
-    window.localStorage.clear();
-    window.sessionStorage.clear();
-  });
+    __resetNotebookDataControllerForTests()
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
 
-  it("opens a local notebook and loads NotebookData", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/demo", {
-      id: "local://file/demo",
-      name: "demo.json",
-      remoteId: "local://file/demo",
+  it('opens a local notebook and loads NotebookData', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/demo', {
+      id: 'local://file/demo',
+      name: 'demo.json',
+      remoteId: 'local://file/demo',
       notebook: createNotebook("console.log('demo')"),
-    });
+    })
 
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(createFakeOwnershipManager());
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
-    });
+    })
 
-    const result = await controller.openNotebook("local://file/demo");
+    const result = await controller.openNotebook('local://file/demo')
 
-    expect(result.localUri).toBe("local://file/demo");
+    expect(result.localUri).toBe('local://file/demo')
     expect(controller.getOpenNotebooks()).toEqual([
       expect.objectContaining({
-        uri: "local://file/demo",
-        requestedUri: "local://file/demo",
-        name: "demo.json",
-        state: "loaded",
+        uri: 'local://file/demo',
+        requestedUri: 'local://file/demo',
+        name: 'demo.json',
+        state: 'loaded',
       }),
-    ]);
-    expect(controller.getNotebookData("local://file/demo")?.getSnapshot()).toEqual(
+    ])
+    expect(
+      controller.getNotebookData('local://file/demo')?.getSnapshot()
+    ).toEqual(
       expect.objectContaining({
-        uri: "local://file/demo",
-        name: "demo.json",
+        uri: 'local://file/demo',
+        name: 'demo.json',
         loaded: true,
-      }),
-    );
-  });
+      })
+    )
+  })
 
-  it("resolves a remote URI to a stable local URI before loading", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/existing", {
-      id: "local://file/existing",
-      name: "existing.json",
-      remoteId: "fs://workspace/demo/file/existing.json",
+  it('resolves a remote URI to a stable local URI before loading', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/existing', {
+      id: 'local://file/existing',
+      name: 'existing.json',
+      remoteId: 'fs://workspace/demo/file/existing.json',
       notebook: createNotebook("console.log('existing')"),
-    });
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(createFakeOwnershipManager());
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
-    });
+    })
 
     const result = await controller.openNotebook(
-      "fs://workspace/demo/file/existing.json",
-      { name: "renamed.json" },
-    );
+      'fs://workspace/demo/file/existing.json',
+      { name: 'renamed.json' }
+    )
 
     expect(localStore.addFile).toHaveBeenCalledWith(
-      "fs://workspace/demo/file/existing.json",
-      "renamed.json",
-    );
-    expect(result.localUri).toBe("local://file/existing");
+      'fs://workspace/demo/file/existing.json',
+      'renamed.json'
+    )
+    expect(result.localUri).toBe('local://file/existing')
     expect(controller.getOpenNotebooks()[0]).toEqual(
       expect.objectContaining({
-        uri: "local://file/existing",
-        requestedUri: "fs://workspace/demo/file/existing.json",
-        name: "renamed.json",
-        state: "loaded",
-      }),
-    );
-  });
+        uri: 'local://file/existing',
+        requestedUri: 'fs://workspace/demo/file/existing.json',
+        name: 'renamed.json',
+        state: 'loaded',
+      })
+    )
+  })
 
-  it("updates the open notebook entry when the loaded notebook name changes", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/demo", {
-      id: "local://file/demo",
-      name: "demo.json",
-      remoteId: "local://file/demo",
+  it('updates the open notebook entry when the loaded notebook name changes', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/demo', {
+      id: 'local://file/demo',
+      name: 'demo.json',
+      remoteId: 'local://file/demo',
       notebook: createNotebook("console.log('demo')"),
-    });
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(createFakeOwnershipManager());
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-    await controller.openNotebook("local://file/demo");
+    })
+    await controller.openNotebook('local://file/demo')
 
-    controller.getNotebookData("local://file/demo")?.setName("renamed.json");
+    controller.getNotebookData('local://file/demo')?.setName('renamed.json')
 
     expect(controller.getOpenNotebooks()[0]).toEqual(
       expect.objectContaining({
-        uri: "local://file/demo",
-        name: "renamed.json",
-        state: "loaded",
-      }),
-    );
+        uri: 'local://file/demo',
+        name: 'renamed.json',
+        state: 'loaded',
+      })
+    )
     expect(
-      JSON.parse(window.sessionStorage.getItem("runme/openNotebooks") ?? "[]"),
+      JSON.parse(window.sessionStorage.getItem('runme/openNotebooks') ?? '[]')
     ).toEqual([
       expect.objectContaining({
-        uri: "local://file/demo",
-        name: "renamed.json",
+        uri: 'local://file/demo',
+        name: 'renamed.json',
       }),
-    ]);
-  });
+    ])
+  })
 
-  it("closes a notebook, disposes its model, and returns a fallback URI", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/a", {
-      id: "local://file/a",
-      name: "a.json",
-      remoteId: "local://file/a",
-      notebook: createNotebook("a"),
-    });
-    localStore.records.set("local://file/b", {
-      id: "local://file/b",
-      name: "b.json",
-      remoteId: "local://file/b",
-      notebook: createNotebook("b"),
-    });
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(createFakeOwnershipManager());
+  it('closes a notebook, disposes its model, and returns a fallback URI', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/a', {
+      id: 'local://file/a',
+      name: 'a.json',
+      remoteId: 'local://file/a',
+      notebook: createNotebook('a'),
+    })
+    localStore.records.set('local://file/b', {
+      id: 'local://file/b',
+      name: 'b.json',
+      remoteId: 'local://file/b',
+      notebook: createNotebook('b'),
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-    await controller.openNotebook("local://file/a");
-    await controller.openNotebook("local://file/b");
+    })
+    await controller.openNotebook('local://file/a')
+    await controller.openNotebook('local://file/b')
 
-    const fallback = controller.closeNotebook("local://file/b");
+    const fallback = controller.closeNotebook('local://file/b')
 
-    expect(fallback).toBe("local://file/a");
-    expect(controller.getNotebookData("local://file/b")).toBeUndefined();
+    expect(fallback).toBe('local://file/a')
+    expect(controller.getNotebookData('local://file/b')).toBeUndefined()
     expect(controller.getOpenNotebooks().map((item) => item.uri)).toEqual([
-      "local://file/a",
-    ]);
-  });
+      'local://file/a',
+    ])
+  })
 
-  it("returns null and leaves selection candidates unchanged when closing a stale URI", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/a", {
-      id: "local://file/a",
-      name: "a.json",
-      remoteId: "local://file/a",
-      notebook: createNotebook("a"),
-    });
-    localStore.records.set("local://file/b", {
-      id: "local://file/b",
-      name: "b.json",
-      remoteId: "local://file/b",
-      notebook: createNotebook("b"),
-    });
-    const controller = getNotebookDataController();
+  it('returns null and leaves selection candidates unchanged when closing a stale URI', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/a', {
+      id: 'local://file/a',
+      name: 'a.json',
+      remoteId: 'local://file/a',
+      notebook: createNotebook('a'),
+    })
+    localStore.records.set('local://file/b', {
+      id: 'local://file/b',
+      name: 'b.json',
+      remoteId: 'local://file/b',
+      notebook: createNotebook('b'),
+    })
+    const controller = getNotebookDataController()
     controller.configureStores({
       localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-    await controller.openNotebook("local://file/a");
-    await controller.openNotebook("local://file/b");
+    })
+    await controller.openNotebook('local://file/a')
+    await controller.openNotebook('local://file/b')
 
-    const fallback = controller.closeNotebook("local://file/missing");
+    const fallback = controller.closeNotebook('local://file/missing')
 
-    expect(fallback).toBeNull();
+    expect(fallback).toBeNull()
     expect(controller.getOpenNotebooks().map((item) => item.uri)).toEqual([
-      "local://file/a",
-      "local://file/b",
-    ]);
-  });
+      'local://file/a',
+      'local://file/b',
+    ])
+  })
 
-  it("restores session open-notebook storage without changing the storage shape", () => {
+  it('restores session open-notebook storage without changing the storage shape', () => {
     window.sessionStorage.setItem(
-      "runme/openNotebooks",
+      'runme/openNotebooks',
       JSON.stringify([
         {
-          uri: "local://file/restored",
-          name: "restored.json",
-          type: "file",
+          uri: 'local://file/restored',
+          name: 'restored.json',
+          type: 'file',
           children: [],
           parents: [],
         },
-      ]),
-    );
+      ])
+    )
 
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(createFakeOwnershipManager());
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
 
     expect(controller.getOpenNotebooks()).toEqual([
       expect.objectContaining({
-        uri: "local://file/restored",
-        requestedUri: "local://file/restored",
-        name: "restored.json",
-        state: "loading",
+        uri: 'local://file/restored',
+        requestedUri: 'local://file/restored',
+        name: 'restored.json',
+        state: 'loading',
       }),
-    ]);
-    expect(controller.getNotebookData("local://file/restored")).toBeUndefined();
+    ])
+    expect(controller.getNotebookData('local://file/restored')).toBeUndefined()
     controller.configureStores({
       localNotebooks: createFakeLocalNotebooks() as unknown as LocalNotebooks,
-    });
-    expect(JSON.parse(window.sessionStorage.getItem("runme/openNotebooks") ?? "[]")).toEqual([
-      expect.objectContaining({
-        uri: "local://file/restored",
-        name: "restored.json",
-      }),
-    ]);
-  });
-
-  it("keeps blocked entries metadata-only", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/blocked", {
-      id: "local://file/blocked",
-      name: "blocked.json",
-      remoteId: "local://file/blocked",
-      notebook: createNotebook("blocked"),
-    });
-    const owner = {
-      notebookUri: "local://file/blocked",
-      ownerTabId: "tab-other",
-      ownerLabel: "Other tab",
-      ownerUrl: "http://localhost/",
-      ownerStartedAt: "2026-05-22T12:00:00.000Z",
-      epoch: "epoch-other",
-    };
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(
-      createFakeOwnershipManager({ status: "blocked", owner }),
-    );
-    controller.configureStores({
-      localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-
-    const result = await controller.openNotebook("local://file/blocked");
-
-    expect(result.entry).toEqual(
-      expect.objectContaining({
-        uri: "local://file/blocked",
-        state: "blocked",
-        owner,
-      }),
-    );
-    expect(controller.getNotebookData("local://file/blocked")).toBeUndefined();
-  });
-
-  it("returns unsupported state without creating editable NotebookData", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/unsupported", {
-      id: "local://file/unsupported",
-      name: "unsupported.json",
-      remoteId: "local://file/unsupported",
-      notebook: createNotebook("unsupported"),
-    });
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(
-      createFakeOwnershipManager({
-        status: "unsupported",
-        reason: "web_locks_unavailable",
-      }),
-    );
-    controller.configureStores({
-      localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-
-    const result = await controller.openNotebook("local://file/unsupported");
-
-    expect(result.entry).toEqual(
-      expect.objectContaining({
-        uri: "local://file/unsupported",
-        state: "error",
-      }),
-    );
-    expect(result.entry.errorMessage).toContain("does not support");
-    expect(result.entry.errorMessage).toContain("Web Locks");
-    expect(controller.getNotebookData("local://file/unsupported")).toBeUndefined();
-  });
-
-  it("releases notebook ownership when loading the local notebook fails", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/load-error", {
-      id: "local://file/load-error",
-      name: "load-error.json",
-      remoteId: "local://file/load-error",
-      notebook: createNotebook("load error"),
-    });
-    localStore.load.mockRejectedValueOnce(new Error("load failed"));
-    const release = vi.fn();
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(
-      createFakeOwnershipManager({
-        status: "acquired",
-        lease: {
-          notebookUri: "local://file/load-error",
-          tabId: "tab-test",
-          epoch: "epoch-test",
-          release,
-          isCurrentOwner: vi.fn(async () => true),
-        },
-      }),
-    );
-    controller.configureStores({
-      localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-
-    const result = await controller.openNotebook("local://file/load-error");
-
-    expect(result.entry).toEqual(
-      expect.objectContaining({
-        uri: "local://file/load-error",
-        state: "error",
-      }),
-    );
-    expect(release).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not release an existing loaded notebook when a duplicate open cannot reload", async () => {
-    const localStore = createFakeLocalNotebooks();
-    localStore.records.set("local://file/demo", {
-      id: "local://file/demo",
-      name: "demo.json",
-      remoteId: "local://file/demo",
-      notebook: createNotebook("loaded"),
-    });
-    const release = vi.fn();
-    const controller = getNotebookDataController();
-    controller.configureOwnershipManager(
-      createFakeOwnershipManager({
-        status: "acquired",
-        lease: {
-          notebookUri: "local://file/demo",
-          tabId: "tab-test",
-          epoch: "epoch-test",
-          release,
-          isCurrentOwner: vi.fn(async () => true),
-        },
-      }),
-    );
-    controller.configureStores({
-      localNotebooks: localStore as unknown as LocalNotebooks,
-    });
-
-    await controller.openNotebook("local://file/demo");
-    localStore.load.mockRejectedValueOnce(new Error("load failed"));
-
-    const result = await controller.openNotebook("local://file/demo");
-
-    expect(result.entry).toEqual(
-      expect.objectContaining({
-        uri: "local://file/demo",
-        state: "loaded",
-      }),
-    );
+    })
     expect(
-      controller.getNotebookData("local://file/demo")?.getSnapshot().loaded,
-    ).toBe(true);
-    expect(release).not.toHaveBeenCalled();
-  });
-});
+      JSON.parse(window.sessionStorage.getItem('runme/openNotebooks') ?? '[]')
+    ).toEqual([
+      expect.objectContaining({
+        uri: 'local://file/restored',
+        name: 'restored.json',
+      }),
+    ])
+  })
+
+  it('opens blocked notebooks as read-only', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/blocked', {
+      id: 'local://file/blocked',
+      name: 'blocked.json',
+      remoteId: 'local://file/blocked',
+      notebook: createNotebook('blocked'),
+    })
+    const owner = {
+      notebookUri: 'local://file/blocked',
+      ownerTabId: 'tab-other',
+      ownerLabel: 'Other tab',
+      ownerUrl: 'http://localhost/',
+      ownerStartedAt: '2026-05-22T12:00:00.000Z',
+      epoch: 'epoch-other',
+    }
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: 'blocked', owner })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    const result = await controller.openNotebook('local://file/blocked')
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: 'local://file/blocked',
+        state: 'loaded',
+        readOnly: true,
+        owner,
+      })
+    )
+    const data = controller.getNotebookData('local://file/blocked')
+    expect(data?.isReadOnly()).toBe(true)
+    expect(data?.getSnapshot()).toEqual(
+      expect.objectContaining({
+        uri: 'local://file/blocked',
+        loaded: true,
+        readOnly: true,
+      })
+    )
+  })
+
+  it('restores blocked notebooks without loading read-only content', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/blocked', {
+      id: 'local://file/blocked',
+      name: 'blocked.json',
+      remoteId: 'local://file/blocked',
+      notebook: createNotebook('blocked'),
+    })
+    window.sessionStorage.setItem(
+      'runme/openNotebooks',
+      JSON.stringify([
+        {
+          uri: 'local://file/blocked',
+          requestedUri: 'local://file/blocked',
+          name: 'blocked.json',
+          state: 'loaded',
+        },
+      ])
+    )
+    const owner = {
+      notebookUri: 'local://file/blocked',
+      ownerTabId: 'tab-other',
+      ownerLabel: 'Other tab',
+      ownerUrl: 'http://localhost/',
+      ownerStartedAt: '2026-05-22T12:00:00.000Z',
+      epoch: 'epoch-other',
+    }
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: 'blocked', owner })
+    )
+
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    await waitFor(() => {
+      expect(controller.getOpenNotebooks()[0]).toEqual(
+        expect.objectContaining({
+          uri: 'local://file/blocked',
+          state: 'blocked',
+          readOnly: false,
+          owner,
+        })
+      )
+    })
+    expect(localStore.load).not.toHaveBeenCalled()
+    expect(controller.getNotebookData('local://file/blocked')).toBeUndefined()
+  })
+
+  it('returns unsupported state without creating editable NotebookData', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/unsupported', {
+      id: 'local://file/unsupported',
+      name: 'unsupported.json',
+      remoteId: 'local://file/unsupported',
+      notebook: createNotebook('unsupported'),
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({
+        status: 'unsupported',
+        reason: 'web_locks_unavailable',
+      })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    const result = await controller.openNotebook('local://file/unsupported')
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: 'local://file/unsupported',
+        state: 'error',
+      })
+    )
+    expect(result.entry.errorMessage).toContain('does not support')
+    expect(result.entry.errorMessage).toContain('Web Locks')
+    expect(
+      controller.getNotebookData('local://file/unsupported')
+    ).toBeUndefined()
+  })
+
+  it('releases notebook ownership when loading the local notebook fails', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/load-error', {
+      id: 'local://file/load-error',
+      name: 'load-error.json',
+      remoteId: 'local://file/load-error',
+      notebook: createNotebook('load error'),
+    })
+    localStore.load.mockRejectedValueOnce(new Error('load failed'))
+    const release = vi.fn()
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({
+        status: 'acquired',
+        lease: {
+          notebookUri: 'local://file/load-error',
+          tabId: 'tab-test',
+          epoch: 'epoch-test',
+          release,
+          isCurrentOwner: vi.fn(async () => true),
+        },
+      })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    const result = await controller.openNotebook('local://file/load-error')
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: 'local://file/load-error',
+        state: 'error',
+      })
+    )
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not release an existing loaded notebook when a duplicate open cannot reload', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/demo', {
+      id: 'local://file/demo',
+      name: 'demo.json',
+      remoteId: 'local://file/demo',
+      notebook: createNotebook('loaded'),
+    })
+    const release = vi.fn()
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({
+        status: 'acquired',
+        lease: {
+          notebookUri: 'local://file/demo',
+          tabId: 'tab-test',
+          epoch: 'epoch-test',
+          release,
+          isCurrentOwner: vi.fn(async () => true),
+        },
+      })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    await controller.openNotebook('local://file/demo')
+    localStore.load.mockRejectedValueOnce(new Error('load failed'))
+
+    const result = await controller.openNotebook('local://file/demo')
+
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        uri: 'local://file/demo',
+        state: 'loaded',
+      })
+    )
+    expect(
+      controller.getNotebookData('local://file/demo')?.getSnapshot().loaded
+    ).toBe(true)
+    expect(release).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -1,265 +1,323 @@
-import { create } from "@bufbuild/protobuf";
+import { create } from '@bufbuild/protobuf'
 
-import { parser_pb } from "../contexts/CellContext";
-import { NotebookData, type NotebookSnapshot } from "./notebookData";
-import { appLogger } from "./logging/runtime";
-import type { NotebookDataLike } from "./runtime/runmeConsole";
-import type { LocalNotebooks } from "../storage/local";
-import { getNotebookSessionPersistence } from "./notebookSessionPersistence";
+import { parser_pb } from '../contexts/CellContext'
+import type { LocalNotebooks } from '../storage/local'
+import { appLogger } from './logging/runtime'
+import { NotebookData, type NotebookSnapshot } from './notebookData'
+import { getNotebookSessionPersistence } from './notebookSessionPersistence'
+import type { NotebookDataLike } from './runtime/runmeConsole'
 import {
-  getNotebookOwnershipManager,
   type NotebookLease,
   type NotebookOwnershipManager,
   type NotebookOwnershipRecord,
-} from "./tabCoordination/notebookOwnership";
+  getNotebookOwnershipManager,
+} from './tabCoordination/notebookOwnership'
 
 export type NotebookTabState =
-  | "resolving"
-  | "loading"
-  | "loaded"
-  | "blocked"
-  | "error";
+  | 'resolving'
+  | 'loading'
+  | 'loaded'
+  | 'blocked'
+  | 'error'
 
 export interface OpenNotebookEntry {
-  uri: string;
-  requestedUri: string;
-  name: string;
-  state: NotebookTabState;
-  errorMessage?: string;
-  owner?: NotebookOwnershipRecord | null;
+  uri: string
+  requestedUri: string
+  name: string
+  state: NotebookTabState
+  readOnly?: boolean
+  errorMessage?: string
+  owner?: NotebookOwnershipRecord | null
 }
 
 export interface OpenNotebookResult {
-  localUri: string;
-  entry: OpenNotebookEntry;
+  localUri: string
+  entry: OpenNotebookEntry
+}
+
+export interface OpenNotebookOptions {
+  name?: string
+  loadReadOnly?: boolean
 }
 
 export interface NotebookDataControllerSnapshot {
-  openNotebooks: OpenNotebookEntry[];
+  openNotebooks: OpenNotebookEntry[]
 }
 
 type NotebookDataHandle = {
-  data: NotebookData;
-  unsubscribe: () => void;
-  loaded: boolean;
-};
+  data: NotebookData
+  unsubscribe: () => void
+  loaded: boolean
+}
 
 function createEmptyNotebook(): parser_pb.Notebook {
   return create(parser_pb.NotebookSchema, {
     cells: [],
     metadata: {},
-  });
+  })
 }
 
 function isLocalFileUri(uri: string): boolean {
-  return uri.startsWith("local://file/");
+  return uri.startsWith('local://file/')
 }
 
 function deriveDisplayName(uri: string): string {
   try {
-    const url = new URL(uri);
-    const tail = url.pathname.split("/").filter(Boolean).pop();
+    const url = new URL(uri)
+    const tail = url.pathname.split('/').filter(Boolean).pop()
     if (tail) {
-      return decodeURIComponent(tail);
+      return decodeURIComponent(tail)
     }
   } catch {
     // Fall through to the URI segment heuristic.
   }
-  return uri.split("/").filter(Boolean).pop() ?? uri;
+  return uri.split('/').filter(Boolean).pop() ?? uri
 }
 
 export class NotebookDataController {
-  private static instance: NotebookDataController | null = null;
+  private static instance: NotebookDataController | null = null
 
   static getInstance(): NotebookDataController {
     if (!NotebookDataController.instance) {
-      NotebookDataController.instance = new NotebookDataController();
+      NotebookDataController.instance = new NotebookDataController()
     }
-    return NotebookDataController.instance;
+    return NotebookDataController.instance
   }
 
   static resetForTests(): void {
-    NotebookDataController.instance?.dispose();
-    NotebookDataController.instance = null;
+    NotebookDataController.instance?.dispose()
+    NotebookDataController.instance = null
   }
 
-  private localNotebooks: LocalNotebooks | null = null;
-  private ownershipManager: NotebookOwnershipManager = getNotebookOwnershipManager();
-  private readonly notebooks = new Map<string, NotebookDataHandle>();
-  private readonly leases = new Map<string, NotebookLease>();
-  private openNotebooks: OpenNotebookEntry[] = [];
-  private readonly listeners = new Set<() => void>();
-  private snapshot: NotebookDataControllerSnapshot = { openNotebooks: [] };
-  private restored = false;
+  private localNotebooks: LocalNotebooks | null = null
+  private ownershipManager: NotebookOwnershipManager =
+    getNotebookOwnershipManager()
+  private readonly notebooks = new Map<string, NotebookDataHandle>()
+  private readonly leases = new Map<string, NotebookLease>()
+  private openNotebooks: OpenNotebookEntry[] = []
+  private readonly listeners = new Set<() => void>()
+  private snapshot: NotebookDataControllerSnapshot = { openNotebooks: [] }
+  private restored = false
 
   getSnapshot(): NotebookDataControllerSnapshot {
-    this.ensureRestored();
-    return this.snapshot;
+    this.ensureRestored()
+    return this.snapshot
   }
 
   subscribe(listener: () => void): () => void {
-    this.ensureRestored();
-    this.listeners.add(listener);
+    this.ensureRestored()
+    this.listeners.add(listener)
     return () => {
-      this.listeners.delete(listener);
-    };
+      this.listeners.delete(listener)
+    }
   }
 
   configureStores(options: { localNotebooks: LocalNotebooks | null }): void {
-    this.ensureRestored();
-    this.localNotebooks = options.localNotebooks;
+    this.ensureRestored()
+    this.localNotebooks = options.localNotebooks
     for (const handle of this.notebooks.values()) {
       handle.data.setNotebookStore(
-        this.createOwnedNotebookStore(handle.data.getUri()),
-      );
+        this.createOwnedNotebookStore(handle.data.getUri())
+      )
     }
     if (this.localNotebooks) {
-      void this.loadOpenNotebooks();
+      void this.loadOpenNotebooks()
     }
   }
 
   configureOwnershipManager(manager: NotebookOwnershipManager): void {
-    this.ownershipManager = manager;
+    this.ownershipManager = manager
   }
 
   async openNotebook(
     uri: string,
-    options?: { name?: string },
+    options?: OpenNotebookOptions
   ): Promise<OpenNotebookResult> {
-    this.ensureRestored();
-    const requestedUri = uri.trim();
+    this.ensureRestored()
+    const requestedUri = uri.trim()
     if (!requestedUri) {
-      throw new Error("openNotebook requires a non-empty URI");
+      throw new Error('openNotebook requires a non-empty URI')
     }
 
-    const localUri = await this.resolveLocalUri(requestedUri, options?.name);
-    const name = await this.resolveNotebookName(localUri, options?.name);
+    const localUri = await this.resolveLocalUri(requestedUri, options?.name)
+    const name = await this.resolveNotebookName(localUri, options?.name)
     let entry = this.upsertOpenEntry({
       uri: localUri,
       requestedUri,
       name,
-      state: "loading",
+      state: 'loading',
+      readOnly: false,
       errorMessage: undefined,
       owner: undefined,
-    });
+    })
 
-    const acquireResult = await this.ownershipManager.acquire(localUri);
-    if (acquireResult.status === "unsupported") {
+    const acquireResult = await this.ownershipManager.acquire(localUri)
+    if (acquireResult.status === 'unsupported') {
       entry = this.upsertOpenEntry({
         ...entry,
-        state: "error",
+        state: 'error',
         errorMessage:
-          "This browser does not support safe multi-tab notebook ownership. Use a browser with Web Locks support, or close other Runme tabs before editing.",
-      });
-      return { localUri, entry };
+          'This browser does not support safe multi-tab notebook ownership. Use a browser with Web Locks support, or close other Runme tabs before editing.',
+      })
+      return { localUri, entry }
     }
-    if (acquireResult.status === "blocked") {
+    if (acquireResult.status === 'blocked') {
+      if (options?.loadReadOnly === false) {
+        entry = this.upsertOpenEntry({
+          ...entry,
+          state: 'blocked',
+          readOnly: false,
+          owner: acquireResult.owner,
+          errorMessage: undefined,
+        })
+        return { localUri, entry }
+      }
+      const handle = this.ensureNotebookData({
+        uri: localUri,
+        name,
+        loaded: false,
+        readOnly: true,
+      })
       entry = this.upsertOpenEntry({
         ...entry,
-        state: "blocked",
+        state: 'loading',
+        readOnly: true,
         owner: acquireResult.owner,
         errorMessage: undefined,
-      });
-      return { localUri, entry };
+      })
+      if (this.localNotebooks) {
+        try {
+          const notebook = await this.localNotebooks.load(localUri)
+          handle.data.setNotebookStore(null)
+          handle.data.setReadOnly(true)
+          handle.data.loadNotebook(notebook, { persist: false })
+          handle.loaded = true
+          entry = this.upsertOpenEntry({
+            ...entry,
+            name: await this.resolveNotebookName(localUri, name),
+            state: 'loaded',
+            readOnly: true,
+            owner: acquireResult.owner,
+            errorMessage: undefined,
+          })
+        } catch (error) {
+          entry = this.upsertOpenEntry({
+            ...entry,
+            state: 'error',
+            readOnly: true,
+            owner: acquireResult.owner,
+            errorMessage: `Notebook could not be opened read-only: ${String(error)}`,
+          })
+        }
+      }
+      return { localUri, entry }
     }
-    this.leases.set(localUri, acquireResult.lease);
+    this.leases.set(localUri, acquireResult.lease)
 
     const handle = this.ensureNotebookData({
       uri: localUri,
       name,
       loaded: false,
-    });
+      readOnly: false,
+    })
 
     if (handle.loaded) {
-      handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri));
+      handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
+      handle.data.setReadOnly(false)
       entry = this.upsertOpenEntry({
         ...entry,
         name: handle.data.getName(),
-        state: "loaded",
+        state: 'loaded',
+        readOnly: false,
         errorMessage: undefined,
         owner: undefined,
-      });
-      return { localUri, entry };
+      })
+      return { localUri, entry }
     }
 
     if (this.localNotebooks) {
       try {
-        const notebook = await this.localNotebooks.load(localUri);
-        handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri));
-        handle.data.loadNotebook(notebook, { persist: false });
-        handle.loaded = true;
+        const notebook = await this.localNotebooks.load(localUri)
+        handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
+        handle.data.setReadOnly(false)
+        handle.data.loadNotebook(notebook, { persist: false })
+        handle.loaded = true
         entry = this.upsertOpenEntry({
           ...entry,
           name: await this.resolveNotebookName(localUri, name),
-          state: "loaded",
+          state: 'loaded',
+          readOnly: false,
           errorMessage: undefined,
           owner: undefined,
-        });
+        })
       } catch (error) {
-        this.releaseLease(localUri);
+        this.releaseLease(localUri)
         entry = this.upsertOpenEntry({
           ...entry,
-          state: "error",
+          state: 'error',
           errorMessage: String(error),
-        });
+        })
       }
     }
 
-    return { localUri, entry };
+    return { localUri, entry }
   }
 
   closeNotebook(localUri: string): string | null {
-    this.ensureRestored();
-    const index = this.openNotebooks.findIndex((item) => item.uri === localUri);
+    this.ensureRestored()
+    const index = this.openNotebooks.findIndex((item) => item.uri === localUri)
     if (index === -1) {
-      return null;
+      return null
     }
     const fallback =
       index > 0
-        ? this.openNotebooks[index - 1]?.uri ?? null
-        : this.openNotebooks[index + 1]?.uri ?? null;
-    this.removeNotebook(localUri);
-    return fallback;
+        ? (this.openNotebooks[index - 1]?.uri ?? null)
+        : (this.openNotebooks[index + 1]?.uri ?? null)
+    this.removeNotebook(localUri)
+    return fallback
   }
 
   getNotebookData(localUri: string): NotebookData | undefined {
-    return this.notebooks.get(localUri)?.data;
+    return this.notebooks.get(localUri)?.data
   }
 
   getOpenNotebooks(): OpenNotebookEntry[] {
-    this.ensureRestored();
-    return this.openNotebooks;
+    this.ensureRestored()
+    return this.openNotebooks
   }
 
   getNotebookSnapshot(localUri: string): NotebookSnapshot | null {
-    return this.getNotebookData(localUri)?.getSnapshot() ?? null;
+    return this.getNotebookData(localUri)?.getSnapshot() ?? null
   }
 
   private async resolveLocalUri(uri: string, name?: string): Promise<string> {
     if (isLocalFileUri(uri)) {
-      return uri;
+      return uri
     }
     if (!this.localNotebooks) {
-      throw new Error("Notebook store is not ready");
+      throw new Error('Notebook store is not ready')
     }
-    return this.localNotebooks.addFile(uri, name);
+    return this.localNotebooks.addFile(uri, name)
   }
 
-  private async resolveNotebookName(uri: string, fallbackName?: string): Promise<string> {
+  private async resolveNotebookName(
+    uri: string,
+    fallbackName?: string
+  ): Promise<string> {
     if (fallbackName?.trim()) {
-      return fallbackName;
+      return fallbackName
     }
-    if (this.localNotebooks && uri.startsWith("local://")) {
+    if (this.localNotebooks && uri.startsWith('local://')) {
       try {
-        const metadata = await this.localNotebooks.getMetadata(uri);
+        const metadata = await this.localNotebooks.getMetadata(uri)
         if (metadata?.name) {
-          return metadata.name;
+          return metadata.name
         }
       } catch {
         // Fall back to URI-derived name.
       }
     }
-    return deriveDisplayName(uri);
+    return deriveDisplayName(uri)
   }
 
   private ensureNotebookData({
@@ -267,223 +325,231 @@ export class NotebookDataController {
     name,
     notebook,
     loaded = false,
+    readOnly = false,
   }: {
-    uri: string;
-    name: string;
-    notebook?: parser_pb.Notebook;
-    loaded?: boolean;
+    uri: string
+    name: string
+    notebook?: parser_pb.Notebook
+    loaded?: boolean
+    readOnly?: boolean
   }): NotebookDataHandle {
-    const existing = this.notebooks.get(uri);
+    const existing = this.notebooks.get(uri)
     if (existing) {
-      existing.data.setNotebookStore(this.createOwnedNotebookStore(uri));
-      return existing;
+      existing.data.setNotebookStore(
+        readOnly ? null : this.createOwnedNotebookStore(uri)
+      )
+      existing.data.setReadOnly(readOnly)
+      return existing
     }
 
     const data = new NotebookData({
       uri,
       name,
       notebook: notebook ?? createEmptyNotebook(),
-      notebookStore: this.createOwnedNotebookStore(uri),
+      notebookStore: readOnly ? null : this.createOwnedNotebookStore(uri),
       loaded,
+      readOnly,
       resolveNotebookForAppKernel: (target?: unknown) => {
-        const targetUri = this.resolveTargetUri(target);
+        const targetUri = this.resolveTargetUri(target)
         if (!targetUri) {
-          return this.getOwnedNotebookData(uri);
+          return this.getReadableNotebookData(uri)
         }
-        return this.getOwnedNotebookData(targetUri);
+        return this.getReadableNotebookData(targetUri)
       },
       listNotebooksForAppKernel: () => this.listNotebookDataLike(uri),
-    });
+    })
     const unsubscribe = data.subscribe(() => {
-      this.updateOpenEntryName(data.getUri(), data.getName());
-      this.emit();
-    });
-    const handle = { data, unsubscribe, loaded };
-    this.notebooks.set(uri, handle);
-    this.emit();
-    return handle;
+      this.updateOpenEntryName(data.getUri(), data.getName())
+      this.emit()
+    })
+    const handle = { data, unsubscribe, loaded }
+    this.notebooks.set(uri, handle)
+    this.emit()
+    return handle
   }
 
   private resolveTargetUri(target?: unknown): string | null {
-    if (typeof target === "string" && target.trim() !== "") {
-      return target.trim();
+    if (typeof target === 'string' && target.trim() !== '') {
+      return target.trim()
     }
     if (
-      typeof target === "object" &&
+      typeof target === 'object' &&
       target &&
-      "uri" in target &&
-      typeof (target as { uri?: unknown }).uri === "string" &&
-      (target as { uri: string }).uri.trim() !== ""
+      'uri' in target &&
+      typeof (target as { uri?: unknown }).uri === 'string' &&
+      (target as { uri: string }).uri.trim() !== ''
     ) {
-      return (target as { uri: string }).uri.trim();
+      return (target as { uri: string }).uri.trim()
     }
     if (
-      typeof target === "object" &&
+      typeof target === 'object' &&
       target &&
-      "handle" in target &&
+      'handle' in target &&
       typeof (target as { handle?: { uri?: unknown } }).handle?.uri ===
-        "string" &&
-      (target as { handle: { uri: string } }).handle.uri.trim() !== ""
+        'string' &&
+      (target as { handle: { uri: string } }).handle.uri.trim() !== ''
     ) {
-      return (target as { handle: { uri: string } }).handle.uri.trim();
+      return (target as { handle: { uri: string } }).handle.uri.trim()
     }
-    return null;
+    return null
   }
 
   private listNotebookDataLike(currentUri: string): NotebookDataLike[] {
-    const notebooksByUri = new Map<string, NotebookDataLike>();
+    const notebooksByUri = new Map<string, NotebookDataLike>()
     for (const handle of this.notebooks.values()) {
-      if (!this.leases.has(handle.data.getUri())) {
-        continue;
-      }
-      notebooksByUri.set(handle.data.getUri(), handle.data);
+      notebooksByUri.set(handle.data.getUri(), handle.data)
     }
-    const current = this.getOwnedNotebookData(currentUri);
+    const current = this.getReadableNotebookData(currentUri)
     if (current && !notebooksByUri.has(current.getUri())) {
-      notebooksByUri.set(current.getUri(), current);
+      notebooksByUri.set(current.getUri(), current)
     }
-    return Array.from(notebooksByUri.values());
+    return Array.from(notebooksByUri.values())
   }
 
   private getOwnedNotebookData(uri: string): NotebookData | null {
     if (!this.leases.has(uri)) {
-      return null;
+      return null
     }
-    return this.notebooks.get(uri)?.data ?? null;
+    return this.notebooks.get(uri)?.data ?? null
+  }
+
+  private getReadableNotebookData(uri: string): NotebookData | null {
+    return this.notebooks.get(uri)?.data ?? null
   }
 
   private updateOpenEntryName(uri: string, name: string): void {
-    let changed = false;
+    let changed = false
     this.openNotebooks = this.openNotebooks.map((item) => {
       if (item.uri !== uri || item.name === name) {
-        return item;
+        return item
       }
-      changed = true;
+      changed = true
       return {
         ...item,
         name,
-      };
-    });
+      }
+    })
     if (changed) {
-      this.persist();
+      this.persist()
     }
   }
 
   private upsertOpenEntry(entry: OpenNotebookEntry): OpenNotebookEntry {
-    let changed = false;
+    let changed = false
     const next = this.openNotebooks.map((item) => {
       if (item.uri !== entry.uri) {
-        return item;
+        return item
       }
-      changed = true;
-      return entry;
-    });
-    this.openNotebooks = changed ? next : [...this.openNotebooks, entry];
-    this.emit();
-    this.persist();
-    return entry;
+      changed = true
+      return entry
+    })
+    this.openNotebooks = changed ? next : [...this.openNotebooks, entry]
+    this.emit()
+    this.persist()
+    return entry
   }
 
   private removeNotebook(uri: string): void {
-    this.releaseLease(uri);
-    const handle = this.notebooks.get(uri);
+    this.releaseLease(uri)
+    const handle = this.notebooks.get(uri)
     if (handle) {
-      handle.unsubscribe();
+      handle.unsubscribe()
     }
-    this.notebooks.delete(uri);
-    this.openNotebooks = this.openNotebooks.filter((item) => item.uri !== uri);
-    this.emit();
-    this.persist();
+    this.notebooks.delete(uri)
+    this.openNotebooks = this.openNotebooks.filter((item) => item.uri !== uri)
+    this.emit()
+    this.persist()
   }
 
   private releaseLease(uri: string): void {
-    this.leases.get(uri)?.release();
-    this.leases.delete(uri);
+    this.leases.get(uri)?.release()
+    this.leases.delete(uri)
   }
 
   private async loadOpenNotebooks(): Promise<void> {
     if (!this.localNotebooks) {
-      return;
+      return
     }
-    const restored = [...this.openNotebooks];
+    const restored = [...this.openNotebooks]
     for (const item of restored) {
       if (this.notebooks.get(item.uri)?.loaded) {
-        continue;
+        continue
       }
       void this.openNotebook(item.requestedUri || item.uri, {
         name: item.name,
-      });
+        loadReadOnly: false,
+      })
     }
   }
 
   private ensureRestored(): void {
     if (this.restored) {
-      return;
+      return
     }
-    this.restored = true;
-    this.openNotebooks = getNotebookSessionPersistence().loadOpenNotebooks();
-    this.rebuildSnapshot();
+    this.restored = true
+    this.openNotebooks = getNotebookSessionPersistence().loadOpenNotebooks()
+    this.rebuildSnapshot()
   }
 
   private emit(): void {
-    this.rebuildSnapshot();
+    this.rebuildSnapshot()
     for (const listener of this.listeners) {
       try {
-        listener();
+        listener()
       } catch (error) {
-        appLogger.error("NotebookDataController listener failed", {
-          attrs: { scope: "notebook-session", error },
-        });
+        appLogger.error('NotebookDataController listener failed', {
+          attrs: { scope: 'notebook-session', error },
+        })
       }
     }
   }
 
   private persist(): void {
-    getNotebookSessionPersistence().saveOpenNotebooks(this.openNotebooks);
+    getNotebookSessionPersistence().saveOpenNotebooks(this.openNotebooks)
   }
 
   private rebuildSnapshot(): void {
     this.snapshot = {
       openNotebooks: this.openNotebooks.map((item) => ({ ...item })),
-    };
+    }
   }
 
   private dispose(): void {
     for (const lease of this.leases.values()) {
-      lease.release();
+      lease.release()
     }
-    this.leases.clear();
+    this.leases.clear()
     for (const handle of this.notebooks.values()) {
-      handle.unsubscribe();
+      handle.unsubscribe()
     }
-    this.notebooks.clear();
-    this.openNotebooks = [];
-    this.listeners.clear();
-    this.snapshot = { openNotebooks: [] };
-    this.restored = false;
-    this.localNotebooks = null;
+    this.notebooks.clear()
+    this.openNotebooks = []
+    this.listeners.clear()
+    this.snapshot = { openNotebooks: [] }
+    this.restored = false
+    this.localNotebooks = null
   }
 
   private createOwnedNotebookStore(uri: string) {
     if (!this.localNotebooks) {
-      return null;
+      return null
     }
     return {
       save: async (saveUri: string, notebook: parser_pb.Notebook) => {
-        const lease = this.leases.get(uri);
+        const lease = this.leases.get(uri)
         if (!lease || !(await lease.isCurrentOwner())) {
-          throw new Error(`Notebook ${uri} is not owned by this browser tab.`);
+          throw new Error(`Notebook ${uri} is not owned by this browser tab.`)
         }
-        return this.localNotebooks?.save(saveUri, notebook);
+        return this.localNotebooks?.save(saveUri, notebook)
       },
-    };
+    }
   }
 }
 
 export function getNotebookDataController(): NotebookDataController {
-  return NotebookDataController.getInstance();
+  return NotebookDataController.getInstance()
 }
 
 export function __resetNotebookDataControllerForTests(): void {
-  NotebookDataController.resetForTests();
+  NotebookDataController.resetForTests()
 }

--- a/app/src/lib/notebookSessionPersistence.ts
+++ b/app/src/lib/notebookSessionPersistence.ts
@@ -37,9 +37,7 @@ function normalizeStoredOpenNotebook(item: unknown): OpenNotebookEntry | null {
     uri: candidate.uri,
     requestedUri: candidate.requestedUri ?? candidate.uri,
     name: candidate.name ?? candidate.uri,
-    state: candidate.state ?? "loading",
-    errorMessage: candidate.errorMessage,
-    owner: candidate.owner,
+    state: "loading",
   };
 }
 

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -1,24 +1,23 @@
 // @vitest-environment node
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it, vi } from 'vitest'
 
-import { create } from "@bufbuild/protobuf";
-import { describe, expect, it, vi } from "vitest";
-
-import { RunmeMetadataKey, parser_pb } from "../../contexts/CellContext";
+import { RunmeMetadataKey, parser_pb } from '../../contexts/CellContext'
 import {
+  type NotebookDataLike,
   createNotebooksApi,
   createRunmeConsoleApi,
-  type NotebookDataLike,
-} from "./runmeConsole";
+} from './runmeConsole'
 
 type FakeCellRunner = {
-  run: () => void | Promise<void>;
-  getRunID: () => string;
-  calls: number;
-};
+  run: () => void | Promise<void>
+  getRunID: () => string
+  calls: number
+}
 
 class FakeNotebookData implements NotebookDataLike {
-  private readonly runners = new Map<string, FakeCellRunner>();
-  updates: parser_pb.Cell[] = [];
+  private readonly runners = new Map<string, FakeCellRunner>()
+  updates: parser_pb.Cell[] = []
 
   constructor(
     private readonly uri: string,
@@ -26,116 +25,123 @@ class FakeNotebookData implements NotebookDataLike {
     private readonly notebook: parser_pb.Notebook,
     private readonly failedRunRefIds: Set<string> = new Set(),
     private readonly initialRunIds: Map<string, string> = new Map(),
+    private readonly readOnly = false
   ) {
     for (const cell of notebook.cells ?? []) {
       if (!cell?.refId) {
-        continue;
+        continue
       }
-      let runID = this.initialRunIds.get(cell.refId) ?? "";
+      let runID = this.initialRunIds.get(cell.refId) ?? ''
       const runner: FakeCellRunner = {
         calls: 0,
         run: () => {
-          runner.calls += 1;
+          runner.calls += 1
           if (this.failedRunRefIds.has(cell.refId)) {
-            return;
+            return
           }
-          runID = `run-${cell.refId}-${runner.calls}`;
+          runID = `run-${cell.refId}-${runner.calls}`
         },
         getRunID: () => runID,
-      };
-      this.runners.set(cell.refId, runner);
+      }
+      this.runners.set(cell.refId, runner)
     }
   }
 
   getUri(): string {
-    return this.uri;
+    return this.uri
   }
 
   getName(): string {
-    return this.name;
+    return this.name
   }
 
   getNotebook(): parser_pb.Notebook {
-    return this.notebook;
+    return this.notebook
+  }
+
+  isReadOnly(): boolean {
+    return this.readOnly
   }
 
   updateCell(cell: parser_pb.Cell): void {
-    this.updates.push(cell);
+    this.updates.push(cell)
     this.notebook.cells = (this.notebook.cells ?? []).map((existing) => {
       if (existing.refId !== cell.refId) {
-        return existing;
+        return existing
       }
-      return create(parser_pb.CellSchema, cell);
-    });
+      return create(parser_pb.CellSchema, cell)
+    })
   }
 
   getCell(refId: string): FakeCellRunner | null {
-    return this.runners.get(refId) ?? null;
+    return this.runners.get(refId) ?? null
   }
 
   private createCell(
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell {
-    const refPrefix = kind === parser_pb.CellKind.MARKUP ? "markup" : "cell";
+    const refPrefix = kind === parser_pb.CellKind.MARKUP ? 'markup' : 'cell'
     return create(parser_pb.CellSchema, {
       refId: `${refPrefix}-${Math.random().toString(36).slice(2, 8)}`,
       kind,
       languageId:
-        kind === parser_pb.CellKind.MARKUP ? "markdown" : languageId ?? "javascript",
-      value: "",
+        kind === parser_pb.CellKind.MARKUP
+          ? 'markdown'
+          : (languageId ?? 'javascript'),
+      value: '',
       outputs: [],
       metadata: {},
-    });
+    })
   }
 
   appendCell(
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell {
-    const cell = this.createCell(kind, languageId);
-    this.notebook.cells = [...(this.notebook.cells ?? []), cell];
-    return cell;
+    const cell = this.createCell(kind, languageId)
+    this.notebook.cells = [...(this.notebook.cells ?? []), cell]
+    return cell
   }
 
   addCellAfter(
     targetRefId: string,
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell | null {
-    const cells = this.notebook.cells ?? [];
-    const index = cells.findIndex((cell) => cell.refId === targetRefId);
+    const cells = this.notebook.cells ?? []
+    const index = cells.findIndex((cell) => cell.refId === targetRefId)
     if (index < 0) {
-      return null;
+      return null
     }
-    const cell = this.createCell(kind, languageId);
-    const next = [...cells];
-    next.splice(index + 1, 0, cell);
-    this.notebook.cells = next;
-    return cell;
+    const cell = this.createCell(kind, languageId)
+    const next = [...cells]
+    next.splice(index + 1, 0, cell)
+    this.notebook.cells = next
+    return cell
   }
 
   addCellBefore(
     targetRefId: string,
     kind: parser_pb.CellKind = parser_pb.CellKind.CODE,
-    languageId?: string | null,
+    languageId?: string | null
   ): parser_pb.Cell | null {
-    const cells = this.notebook.cells ?? [];
-    const index = cells.findIndex((cell) => cell.refId === targetRefId);
+    const cells = this.notebook.cells ?? []
+    const index = cells.findIndex((cell) => cell.refId === targetRefId)
     if (index < 0) {
-      return null;
+      return null
     }
-    const cell = this.createCell(kind, languageId);
-    const next = [...cells];
-    next.splice(index, 0, cell);
-    this.notebook.cells = next;
-    return cell;
+    const cell = this.createCell(kind, languageId)
+    const next = [...cells]
+    next.splice(index, 0, cell)
+    this.notebook.cells = next
+    return cell
   }
 
   removeCell(refId: string): void {
     this.notebook.cells = (this.notebook.cells ?? []).filter(
-      (cell) => cell.refId !== refId,
-    );
+      (cell) => cell.refId !== refId
+    )
   }
 }
 
@@ -143,621 +149,713 @@ function codeCell(
   refId: string,
   value: string,
   opts: {
-    languageId?: string;
-    outputs?: parser_pb.CellOutput[];
-    metadata?: Record<string, string>;
-  } = {},
+    languageId?: string
+    outputs?: parser_pb.CellOutput[]
+    metadata?: Record<string, string>
+  } = {}
 ): parser_pb.Cell {
   return create(parser_pb.CellSchema, {
     refId,
     kind: parser_pb.CellKind.CODE,
-    languageId: opts.languageId ?? "bash",
+    languageId: opts.languageId ?? 'bash',
     value,
     outputs: opts.outputs ?? [],
     metadata: opts.metadata ?? {},
-  });
+  })
 }
 
-function codeCellWithBigIntTiming(refId: string, value: string): parser_pb.Cell {
-  const cell = codeCell(refId, value);
-  (cell as any).executionSummary = {
+function codeCellWithBigIntTiming(
+  refId: string,
+  value: string
+): parser_pb.Cell {
+  const cell = codeCell(refId, value)
+  const cellWithTiming = cell as any
+  cellWithTiming.executionSummary = {
     success: true,
     timing: {
       startTime: 1700000000000n,
       endTime: 1700000001000n,
     },
-  };
-  return cell;
+  }
+  return cell
 }
 
-describe("createRunmeConsoleApi", () => {
-  it("returns the current notebook handle", () => {
-    const notebook = create(parser_pb.NotebookSchema, { cells: [] });
-    const model = new FakeNotebookData("local://one", "One", notebook);
-    const resolveNotebook = vi.fn(() => model);
-    const api = createRunmeConsoleApi({ resolveNotebook });
+describe('createRunmeConsoleApi', () => {
+  it('returns the current notebook handle', () => {
+    const notebook = create(parser_pb.NotebookSchema, { cells: [] })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const resolveNotebook = vi.fn(() => model)
+    const api = createRunmeConsoleApi({ resolveNotebook })
 
-    expect(api.getCurrentNotebook()).toBe(model);
-    expect(resolveNotebook).toHaveBeenCalledTimes(1);
-  });
+    expect(api.getCurrentNotebook()).toBe(model)
+    expect(resolveNotebook).toHaveBeenCalledTimes(1)
+  })
 
-  it("clears outputs and run metadata for all matching cells", () => {
+  it('clears outputs and run metadata for all matching cells', () => {
     const output = create(parser_pb.CellOutputSchema, {
       items: [
         create(parser_pb.CellOutputItemSchema, {
-          mime: "text/plain",
-          type: "Buffer",
-          data: new TextEncoder().encode("hello"),
+          mime: 'text/plain',
+          type: 'Buffer',
+          data: new TextEncoder().encode('hello'),
         }),
       ],
-    });
+    })
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
-        codeCell("cell-a", "echo hi", {
+        codeCell('cell-a', 'echo hi', {
           outputs: [output],
           metadata: {
-            [RunmeMetadataKey.LastRunID]: "run-cell-a",
-            [RunmeMetadataKey.Pid]: "42",
-            [RunmeMetadataKey.ExitCode]: "0",
+            [RunmeMetadataKey.LastRunID]: 'run-cell-a',
+            [RunmeMetadataKey.Pid]: '42',
+            [RunmeMetadataKey.ExitCode]: '0',
           },
         }),
-        codeCell("cell-b", "echo bye"),
+        codeCell('cell-b', 'echo bye'),
       ],
-    });
+    })
 
-    const model = new FakeNotebookData("local://one", "Notebook One", notebook);
+    const model = new FakeNotebookData('local://one', 'Notebook One', notebook)
     const api = createRunmeConsoleApi({
       resolveNotebook: () => model,
-    });
+    })
 
-    const message = api.clearOutputs();
+    const message = api.clearOutputs()
 
-    expect(message).toContain("Cleared 1 output item group(s) across 1 cell(s)");
-    const updated = notebook.cells.find((cell) => cell.refId === "cell-a");
-    expect(updated?.outputs).toHaveLength(0);
-    expect(updated?.metadata?.[RunmeMetadataKey.LastRunID]).toBeUndefined();
-    expect(updated?.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
-    expect(updated?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
-    expect(model.updates).toHaveLength(1);
-  });
+    expect(message).toContain('Cleared 1 output item group(s) across 1 cell(s)')
+    const updated = notebook.cells.find((cell) => cell.refId === 'cell-a')
+    expect(updated?.outputs).toHaveLength(0)
+    expect(updated?.metadata?.[RunmeMetadataKey.LastRunID]).toBeUndefined()
+    expect(updated?.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined()
+    expect(updated?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined()
+    expect(model.updates).toHaveLength(1)
+  })
 
-  it("runs all non-empty code cells and reports start failures", () => {
+  it('runs all non-empty code cells and reports start failures', () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
-        codeCell("cell-a", "echo a"),
-        codeCell("cell-b", "   "),
+        codeCell('cell-a', 'echo a'),
+        codeCell('cell-b', '   '),
         create(parser_pb.CellSchema, {
-          refId: "cell-c",
+          refId: 'cell-c',
           kind: parser_pb.CellKind.MARKUP,
-          languageId: "markdown",
-          value: "# title",
+          languageId: 'markdown',
+          value: '# title',
         }),
-        codeCell("cell-d", "echo d"),
+        codeCell('cell-d', 'echo d'),
       ],
-    });
+    })
     const model = new FakeNotebookData(
-      "local://one",
-      "Notebook One",
+      'local://one',
+      'Notebook One',
       notebook,
-      new Set(["cell-d"]),
-    );
+      new Set(['cell-d'])
+    )
     const api = createRunmeConsoleApi({
       resolveNotebook: () => model,
-    });
+    })
 
-    const message = api.runAll();
+    const message = api.runAll()
 
-    expect(message).toContain("Started 1/2 code cell(s)");
-    expect(message).toContain("1 failed to start");
-    expect(model.getCell("cell-a")?.calls).toBe(1);
-    expect(model.getCell("cell-b")?.calls).toBe(0);
-    expect(model.getCell("cell-d")?.calls).toBe(1);
-  });
+    expect(message).toContain('Started 1/2 code cell(s)')
+    expect(message).toContain('1 failed to start')
+    expect(model.getCell('cell-a')?.calls).toBe(1)
+    expect(model.getCell('cell-b')?.calls).toBe(0)
+    expect(model.getCell('cell-d')?.calls).toBe(1)
+  })
 
-  it("supports clear alias", () => {
+  it('supports clear alias', () => {
     const output = create(parser_pb.CellOutputSchema, {
       items: [
         create(parser_pb.CellOutputItemSchema, {
-          mime: "text/plain",
-          type: "Buffer",
-          data: new TextEncoder().encode("hello"),
+          mime: 'text/plain',
+          type: 'Buffer',
+          data: new TextEncoder().encode('hello'),
         }),
       ],
-    });
+    })
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a", { outputs: [output] })],
-    });
-    const model = new FakeNotebookData("local://one", "Notebook One", notebook);
+      cells: [codeCell('cell-a', 'echo a', { outputs: [output] })],
+    })
+    const model = new FakeNotebookData('local://one', 'Notebook One', notebook)
     const api = createRunmeConsoleApi({
       resolveNotebook: () => model,
-    });
+    })
 
-    const clearMessage = api.clear();
-    const runMessage = api.runAll();
+    const clearMessage = api.clear()
+    const runMessage = api.runAll()
 
-    expect(clearMessage).toContain("Cleared 1 output item group(s) across 1 cell(s)");
-    expect(runMessage).toContain("Started 1/1 code cell(s)");
-    expect(model.getCell("cell-a")?.calls).toBe(1);
-  });
+    expect(clearMessage).toContain(
+      'Cleared 1 output item group(s) across 1 cell(s)'
+    )
+    expect(runMessage).toContain('Started 1/1 code cell(s)')
+    expect(model.getCell('cell-a')?.calls).toBe(1)
+  })
 
-  it("skips html content cells in runAll", () => {
+  it('skips html content cells in runAll', () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
-        codeCell("cell-a", "echo a"),
-        codeCell("cell-html", "<div>Hello</div>", { languageId: "html" }),
+        codeCell('cell-a', 'echo a'),
+        codeCell('cell-html', '<div>Hello</div>', { languageId: 'html' }),
       ],
-    });
-    const model = new FakeNotebookData("local://one", "Notebook One", notebook);
+    })
+    const model = new FakeNotebookData('local://one', 'Notebook One', notebook)
     const api = createRunmeConsoleApi({
       resolveNotebook: () => model,
-    });
+    })
 
-    const message = api.runAll();
+    const message = api.runAll()
 
-    expect(message).toContain("Started 1/1 code cell(s)");
-    expect(model.getCell("cell-a")?.calls).toBe(1);
-    expect(model.getCell("cell-html")?.calls).toBe(0);
-  });
+    expect(message).toContain('Started 1/1 code cell(s)')
+    expect(model.getCell('cell-a')?.calls).toBe(1)
+    expect(model.getCell('cell-html')?.calls).toBe(0)
+  })
 
-  it("reruns notebook by clearing outputs before running cells", () => {
+  it('reruns notebook by clearing outputs before running cells', () => {
     const output = create(parser_pb.CellOutputSchema, {
       items: [
         create(parser_pb.CellOutputItemSchema, {
-          mime: "text/plain",
-          type: "Buffer",
-          data: new TextEncoder().encode("hello"),
+          mime: 'text/plain',
+          type: 'Buffer',
+          data: new TextEncoder().encode('hello'),
         }),
       ],
-    });
+    })
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
-        codeCell("cell-a", "echo a", {
+        codeCell('cell-a', 'echo a', {
           outputs: [output],
           metadata: {
-            [RunmeMetadataKey.LastRunID]: "run-cell-a",
+            [RunmeMetadataKey.LastRunID]: 'run-cell-a',
           },
         }),
       ],
-    });
-    const model = new FakeNotebookData("local://one", "Notebook One", notebook);
+    })
+    const model = new FakeNotebookData('local://one', 'Notebook One', notebook)
     const api = createRunmeConsoleApi({
       resolveNotebook: () => model,
-    });
+    })
 
-    const message = api.rerun();
+    const message = api.rerun()
 
-    expect(message).toContain("Cleared 1 output item group(s) across 1 cell(s)");
-    expect(message).toContain("Started 1/1 code cell(s)");
-    expect(notebook.cells[0]?.outputs).toHaveLength(0);
-    expect(model.getCell("cell-a")?.calls).toBe(1);
-  });
+    expect(message).toContain('Cleared 1 output item group(s) across 1 cell(s)')
+    expect(message).toContain('Started 1/1 code cell(s)')
+    expect(notebook.cells[0]?.outputs).toHaveLength(0)
+    expect(model.getCell('cell-a')?.calls).toBe(1)
+  })
 
-  it("treats unchanged stale run IDs as failed starts", () => {
+  it('treats unchanged stale run IDs as failed starts', () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
+      cells: [codeCell('cell-a', 'echo a')],
+    })
     const model = new FakeNotebookData(
-      "local://one",
-      "Notebook One",
+      'local://one',
+      'Notebook One',
       notebook,
-      new Set(["cell-a"]),
-      new Map([["cell-a", "old-run-id"]]),
-    );
+      new Set(['cell-a']),
+      new Map([['cell-a', 'old-run-id']])
+    )
     const api = createRunmeConsoleApi({
       resolveNotebook: () => model,
-    });
+    })
 
-    const message = api.runAll();
+    const message = api.runAll()
 
-    expect(message).toContain("Started 0/1 code cell(s)");
-    expect(message).toContain("1 failed to start");
-  });
+    expect(message).toContain('Started 0/1 code cell(s)')
+    expect(message).toContain('1 failed to start')
+  })
 
-  it("documents notebook/URI helper usage in help text", () => {
-    const notebook = create(parser_pb.NotebookSchema, { cells: [] });
-    const model = new FakeNotebookData("local://one", "One", notebook);
-    const api = createRunmeConsoleApi({
-      resolveNotebook: () => model,
-    });
-
-    const message = api.help();
-
-    expect(message).toContain("runme.clear()");
-    expect(message).toContain("runme.runAll()");
-    expect(message).toContain("runme.rerun()");
-    expect(message).toContain("runme.clear(target)");
-    expect(message).toContain("runme.runAll(target)");
-    expect(message).toContain("runme.rerun(target)");
-  });
-});
-
-describe("createNotebooksApi", () => {
-  it("gets current notebook and returns handle + document", async () => {
+  it('rejects runme mutations for read-only notebooks', () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData(
+      'local://one',
+      'One',
+      notebook,
+      undefined,
+      undefined,
+      true
+    )
+    const api = createRunmeConsoleApi({ resolveNotebook: () => model })
+
+    expect(() => api.clear()).toThrow('open read-only')
+    expect(() => api.runAll()).toThrow('open read-only')
+    expect(() => api.rerun()).toThrow('open read-only')
+  })
+
+  it('documents notebook/URI helper usage in help text', () => {
+    const notebook = create(parser_pb.NotebookSchema, { cells: [] })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const api = createRunmeConsoleApi({
+      resolveNotebook: () => model,
+    })
+
+    const message = api.help()
+
+    expect(message).toContain('runme.clear()')
+    expect(message).toContain('runme.runAll()')
+    expect(message).toContain('runme.rerun()')
+    expect(message).toContain('runme.clear(target)')
+    expect(message).toContain('runme.runAll(target)')
+    expect(message).toContain('runme.rerun(target)')
+  })
+})
+
+describe('createNotebooksApi', () => {
+  it('gets current notebook and returns handle + document', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
-    const document = await api.get();
+    const document = await api.get()
 
-    expect(document.summary.uri).toBe("local://one");
-    expect(document.summary.name).toBe("One");
-    expect(document.handle.uri).toBe("local://one");
-    expect(document.handle.revision.length).toBeGreaterThan(0);
-    expect(document.notebook.cells[0]?.refId).toBe("cell-a");
-  });
+    expect(document.summary.uri).toBe('local://one')
+    expect(document.summary.name).toBe('One')
+    expect(document.handle.uri).toBe('local://one')
+    expect(document.handle.revision.length).toBeGreaterThan(0)
+    expect(document.notebook.cells[0]?.refId).toBe('cell-a')
+  })
 
-  it("returns JSON-safe notebook documents with protobuf BigInt timing fields", async () => {
+  it('returns JSON-safe notebook documents with protobuf BigInt timing fields', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCellWithBigIntTiming("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCellWithBigIntTiming('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
-    const document = await api.get({ uri: "local://one" });
+    const document = await api.get({ uri: 'local://one' })
 
-    expect(JSON.stringify(document)).toContain('"startTime":"1700000000000"');
+    expect(JSON.stringify(document)).toContain('"startTime":"1700000000000"')
     expect(
-      (document.notebook.cells[0] as any).executionSummary.timing.startTime,
-    ).toBe("1700000000000");
-  });
+      (document.notebook.cells[0] as any).executionSummary.timing.startTime
+    ).toBe('1700000000000')
+  })
 
-  it("uses the current notebook when notebooks.get omits target", async () => {
+  it('uses the current notebook when notebooks.get omits target', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const current = new FakeNotebookData("local://current", "Current", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const current = new FakeNotebookData('local://current', 'Current', notebook)
     const resolveNotebook = vi.fn((target?: unknown) => {
       if (target === undefined) {
-        return current;
+        return current
       }
-      return null;
-    });
+      return null
+    })
     const api = createNotebooksApi({
       resolveNotebook,
       listNotebooks: () => [current],
-    });
+    })
 
-    const document = await api.get();
+    const document = await api.get()
 
-    expect(document.handle.uri).toBe("local://current");
-    expect(resolveNotebook).toHaveBeenCalledWith();
-  });
+    expect(document.handle.uri).toBe('local://current')
+    expect(resolveNotebook).toHaveBeenCalledWith()
+  })
 
-  it("lists notebooks with query filters", async () => {
+  it('lists notebooks with query filters', async () => {
     const a = new FakeNotebookData(
-      "local://one",
-      "Notebook One",
-      create(parser_pb.NotebookSchema, { cells: [] }),
-    );
+      'local://one',
+      'Notebook One',
+      create(parser_pb.NotebookSchema, { cells: [] })
+    )
     const b = new FakeNotebookData(
-      "local://two",
-      "Notebook Two",
-      create(parser_pb.NotebookSchema, { cells: [] }),
-    );
+      'local://two',
+      'Notebook Two',
+      create(parser_pb.NotebookSchema, { cells: [] })
+    )
     const api = createNotebooksApi({
       resolveNotebook: () => a,
       listNotebooks: () => [a, b],
-    });
+    })
 
-    const listed = await api.list({ nameContains: "two" });
-    expect(listed).toHaveLength(1);
-    expect(listed[0]?.uri).toBe("local://two");
-  });
+    const listed = await api.list({ nameContains: 'two' })
+    expect(listed).toHaveLength(1)
+    expect(listed[0]?.uri).toBe('local://two')
+  })
 
-  it("applies insert/update/remove mutations", async () => {
+  it('returns read-only notebook documents as cloned readable data', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a"), codeCell("cell-b", "echo b")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData(
+      'local://one',
+      'One',
+      notebook,
+      undefined,
+      undefined,
+      true
+    )
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
+
+    const document = await api.get({ uri: 'local://one' })
+    document.notebook.cells[0]!.value = 'mutated clone'
+
+    expect(document.summary.readOnly).toBe(true)
+    expect(model.getNotebook().cells[0]?.value).toBe('echo a')
+  })
+
+  it('rejects read-only notebook mutations', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData(
+      'local://one',
+      'One',
+      notebook,
+      undefined,
+      undefined,
+      true
+    )
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
+
+    await expect(
+      api.update({
+        target: { uri: 'local://one' },
+        operations: [
+          {
+            op: 'update',
+            refId: 'cell-a',
+            patch: { value: 'echo changed' },
+          },
+        ],
+      })
+    ).rejects.toThrow('open read-only')
+    await expect(
+      api.execute({ target: { uri: 'local://one' }, refIds: ['cell-a'] })
+    ).rejects.toThrow('open read-only')
+  })
+
+  it('applies insert/update/remove mutations', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a'), codeCell('cell-b', 'echo b')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
 
     const updated = await api.update({
-      target: { uri: "local://one" },
+      target: { uri: 'local://one' },
       operations: [
         {
-          op: "insert",
-          at: { afterRefId: "cell-a" },
-          cells: [{ kind: "code", languageId: "javascript", value: "console.log('x')" }],
+          op: 'insert',
+          at: { afterRefId: 'cell-a' },
+          cells: [
+            {
+              kind: 'code',
+              languageId: 'javascript',
+              value: "console.log('x')",
+            },
+          ],
         },
       ],
-    });
-    expect(updated.notebook.cells.length).toBe(3);
+    })
+    expect(updated.notebook.cells.length).toBe(3)
 
     const insertedRefId =
-      updated.notebook.cells.find((cell) => cell.refId !== "cell-a" && cell.refId !== "cell-b")
-        ?.refId ?? "";
+      updated.notebook.cells.find(
+        (cell) => cell.refId !== 'cell-a' && cell.refId !== 'cell-b'
+      )?.refId ?? ''
 
     const afterPatch = await api.update({
       target: { handle: updated.handle },
       operations: [
         {
-          op: "update",
+          op: 'update',
           refId: insertedRefId,
           patch: { value: "console.log('updated')" },
         },
       ],
-    });
-    const inserted = afterPatch.notebook.cells.find((cell) => cell.refId === insertedRefId);
-    expect(inserted?.value).toContain("updated");
+    })
+    const inserted = afterPatch.notebook.cells.find(
+      (cell) => cell.refId === insertedRefId
+    )
+    expect(inserted?.value).toContain('updated')
 
     const afterRemove = await api.update({
       target: { handle: afterPatch.handle },
-      operations: [{ op: "remove", refIds: [insertedRefId] }],
-    });
-    expect(afterRemove.notebook.cells.find((cell) => cell.refId === insertedRefId)).toBeUndefined();
-  });
+      operations: [{ op: 'remove', refIds: [insertedRefId] }],
+    })
+    expect(
+      afterRemove.notebook.cells.find((cell) => cell.refId === insertedRefId)
+    ).toBeUndefined()
+  })
 
-  it("creates inserted markup cells as markup before applying their spec", async () => {
-    const notebook = create(parser_pb.NotebookSchema, { cells: [] });
-    const model = new FakeNotebookData("local://one", "One", notebook);
-    const appendCell = vi.spyOn(model, "appendCell");
+  it('creates inserted markup cells as markup before applying their spec', async () => {
+    const notebook = create(parser_pb.NotebookSchema, { cells: [] })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const appendCell = vi.spyOn(model, 'appendCell')
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
     const updated = await api.update({
-      target: { uri: "local://one" },
+      target: { uri: 'local://one' },
       operations: [
         {
-          op: "insert",
+          op: 'insert',
           at: { index: -1 },
           cells: [
             {
-              kind: "markup",
-              languageId: "markdown",
-              value: "# Terminal-Bench against Responses API",
+              kind: 'markup',
+              languageId: 'markdown',
+              value: '# Terminal-Bench against Responses API',
             },
             {
-              kind: "code",
-              languageId: "bash",
-              value: "set -euo pipefail",
+              kind: 'code',
+              languageId: 'bash',
+              value: 'set -euo pipefail',
             },
             {
-              kind: "markup",
-              languageId: "markdown",
-              value: "## Notes",
+              kind: 'markup',
+              languageId: 'markdown',
+              value: '## Notes',
             },
           ],
         },
       ],
-    });
+    })
 
-    expect(appendCell).toHaveBeenCalledTimes(3);
+    expect(appendCell).toHaveBeenCalledTimes(3)
     expect(appendCell.mock.calls.map((call) => call[0])).toEqual([
       parser_pb.CellKind.MARKUP,
       parser_pb.CellKind.CODE,
       parser_pb.CellKind.MARKUP,
-    ]);
+    ])
     expect(updated.notebook.cells.map((cell) => cell.kind)).toEqual([
       parser_pb.CellKind.MARKUP,
       parser_pb.CellKind.CODE,
       parser_pb.CellKind.MARKUP,
-    ]);
+    ])
     expect(updated.notebook.cells.map((cell) => cell.languageId)).toEqual([
-      "markdown",
-      "bash",
-      "markdown",
-    ]);
+      'markdown',
+      'bash',
+      'markdown',
+    ])
     expect(model.updates.map((cell) => cell.kind)).toEqual([
       parser_pb.CellKind.MARKUP,
       parser_pb.CellKind.CODE,
       parser_pb.CellKind.MARKUP,
-    ]);
-  });
+    ])
+  })
 
-  it("rejects notebooks.update without an explicit target", async () => {
+  it('rejects notebooks.update without an explicit target', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
     await expect(
       api.update({
-        operations: [{ op: "remove", refIds: ["cell-a"] }],
-      }),
-    ).rejects.toThrow(
-      "notebooks.update requires an explicit target notebook.",
-    );
-  });
+        operations: [{ op: 'remove', refIds: ['cell-a'] }],
+      })
+    ).rejects.toThrow('notebooks.update requires an explicit target notebook.')
+  })
 
-  it("returns JSON-safe updated documents with protobuf BigInt timing fields", async () => {
+  it('rejects string notebook targets with an actionable error', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCellWithBigIntTiming("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
+
+    await expect(api.get('local://one' as any)).rejects.toThrow(
+      'Use target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.'
+    )
+  })
+
+  it('rejects unsupported notebooks.update operations with a concrete insert example', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
+
+    await expect(
+      api.update({
+        target: { uri: 'local://one' },
+        operations: [{ op: 'add', path: '/cells/-', value: {} } as any],
+      })
+    ).rejects.toThrow(
+      'Supported ops are "insert", "update", and "remove". To append a cell, use operations: [{ op: "insert", at: { index: -1 }, cells: [{ kind: "code", languageId: "python", value: "print(\\"hello\\")" }] }].'
+    )
+  })
+
+  it('returns JSON-safe updated documents with protobuf BigInt timing fields', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCellWithBigIntTiming('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
 
     const updated = await api.update({
-      target: { uri: "local://one" },
+      target: { uri: 'local://one' },
       operations: [
         {
-          op: "insert",
+          op: 'insert',
           at: { index: -1 },
-          cells: [{ kind: "markup", languageId: "markdown", value: "test" }],
+          cells: [{ kind: 'markup', languageId: 'markdown', value: 'test' }],
         },
       ],
-    });
+    })
 
-    expect(updated.notebook.cells).toHaveLength(2);
-    expect(JSON.stringify(updated)).toContain('"endTime":"1700000001000"');
-  });
+    expect(updated.notebook.cells).toHaveLength(2)
+    expect(JSON.stringify(updated)).toContain('"endTime":"1700000001000"')
+  })
 
-  it("rejects string notebook targets with an actionable error", async () => {
+  it('rolls back inserted cells when applyInsertedCellSpec fails', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    vi.spyOn(model, 'updateCell').mockImplementation(() => {
+      throw new Error('update failed')
+    })
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
-
-    await expect(api.get("local://one" as any)).rejects.toThrow(
-      'Use target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.',
-    );
-  });
-
-  it("rejects unsupported notebooks.update operations with a concrete insert example", async () => {
-    const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
-    const api = createNotebooksApi({
-      resolveNotebook: () => model,
-      listNotebooks: () => [model],
-    });
+    })
 
     await expect(
       api.update({
-        target: { uri: "local://one" },
-        operations: [{ op: "add", path: "/cells/-", value: {} } as any],
-      }),
-    ).rejects.toThrow(
-      'Supported ops are "insert", "update", and "remove". To append a cell, use operations: [{ op: "insert", at: { index: -1 }, cells: [{ kind: "code", languageId: "python", value: "print(\\"hello\\")" }] }].',
-    );
-  });
-
-  it("rolls back inserted cells when applyInsertedCellSpec fails", async () => {
-    const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
-    vi.spyOn(model, "updateCell").mockImplementation(() => {
-      throw new Error("update failed");
-    });
-    const api = createNotebooksApi({
-      resolveNotebook: () => model,
-      listNotebooks: () => [model],
-    });
-
-    await expect(
-      api.update({
-        target: { uri: "local://one" },
+        target: { uri: 'local://one' },
         operations: [
           {
-            op: "insert",
+            op: 'insert',
             at: { index: -1 },
-            cells: [{ kind: "code", languageId: "python", value: "print('hi')" }],
+            cells: [
+              { kind: 'code', languageId: 'python', value: "print('hi')" },
+            ],
           },
         ],
-      }),
-    ).rejects.toThrow("update failed");
+      })
+    ).rejects.toThrow('update failed')
 
-    expect(notebook.cells.map((cell) => cell.refId)).toEqual(["cell-a"]);
-  });
+    expect(notebook.cells.map((cell) => cell.refId)).toEqual(['cell-a'])
+  })
 
-  it("rejects non-array notebooks.update operations", async () => {
+  it('rejects non-array notebooks.update operations', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
     await expect(
       api.update({
-        target: { uri: "local://one" },
-        operations: { op: "insert" } as any,
-      }),
+        target: { uri: 'local://one' },
+        operations: { op: 'insert' } as any,
+      })
     ).rejects.toThrow(
-      'Invalid notebooks.update operations: expected an array of notebook mutations',
-    );
-  });
+      'Invalid notebooks.update operations: expected an array of notebook mutations'
+    )
+  })
 
-  it("awaits asynchronous cell execution in notebooks.execute", async () => {
+  it('awaits asynchronous cell execution in notebooks.execute', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
-    const runner = model.getCell("cell-a");
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const runner = model.getCell('cell-a')
     if (!runner) {
-      throw new Error("expected runner for cell-a");
+      throw new Error('expected runner for cell-a')
     }
 
-    let completed = false;
+    let completed = false
     runner.run = async () => {
-      runner.calls += 1;
+      runner.calls += 1
       await new Promise<void>((resolve) => {
-        setTimeout(resolve, 10);
-      });
-      completed = true;
-    };
+        setTimeout(resolve, 10)
+      })
+      completed = true
+    }
 
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
     await api.execute({
-      target: { uri: "local://one" },
-      refIds: ["cell-a"],
-    });
+      target: { uri: 'local://one' },
+      refIds: ['cell-a'],
+    })
 
-    expect(completed).toBe(true);
-    expect(runner.calls).toBe(1);
-  });
+    expect(completed).toBe(true)
+    expect(runner.calls).toBe(1)
+  })
 
-  it("rejects notebooks.execute for html cells before starting any runs", async () => {
+  it('rejects notebooks.execute for html cells before starting any runs', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [
-        codeCell("cell-a", "echo a"),
-        codeCell("cell-html", "<div>Hello</div>", { languageId: "html" }),
+        codeCell('cell-a', 'echo a'),
+        codeCell('cell-html', '<div>Hello</div>', { languageId: 'html' }),
       ],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
     await expect(
       api.execute({
-        target: { uri: "local://one" },
-        refIds: ["cell-a", "cell-html"],
-      }),
-    ).rejects.toThrow("HTML cells are not runnable: cell-html");
+        target: { uri: 'local://one' },
+        refIds: ['cell-a', 'cell-html'],
+      })
+    ).rejects.toThrow('HTML cells are not runnable: cell-html')
 
-    expect(model.getCell("cell-a")?.calls).toBe(0);
-    expect(model.getCell("cell-html")?.calls).toBe(0);
-  });
+    expect(model.getCell('cell-a')?.calls).toBe(0)
+    expect(model.getCell('cell-html')?.calls).toBe(0)
+  })
 
-  it("rejects notebooks.execute without an explicit target", async () => {
+  it('rejects notebooks.execute without an explicit target', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
-      cells: [codeCell("cell-a", "echo a")],
-    });
-    const model = new FakeNotebookData("local://one", "One", notebook);
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
     const api = createNotebooksApi({
       resolveNotebook: () => model,
       listNotebooks: () => [model],
-    });
+    })
 
     await expect(
       api.execute({
-        refIds: ["cell-a"],
-      }),
-    ).rejects.toThrow(
-      "notebooks.execute requires an explicit target notebook.",
-    );
-  });
-});
+        refIds: ['cell-a'],
+      })
+    ).rejects.toThrow('notebooks.execute requires an explicit target notebook.')
+  })
+})

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -1,785 +1,835 @@
-import { create } from "@bufbuild/protobuf";
-import md5 from "md5";
+import { create } from '@bufbuild/protobuf'
+import md5 from 'md5'
 
-import { RunmeMetadataKey, parser_pb } from "../../runme/client";
-import { isHtmlLanguageId } from "../cellContent";
+import { RunmeMetadataKey, parser_pb } from '../../runme/client'
+import { isHtmlLanguageId } from '../cellContent'
 
 type CellRunnerLike = {
-  run: () => void | Promise<void>;
-  getRunID: () => string;
-};
+  run: () => void | Promise<void>
+  getRunID: () => string
+}
 
-function isRunnableNotebookCodeCell(cell: parser_pb.Cell | null | undefined): boolean {
+function isRunnableNotebookCodeCell(
+  cell: parser_pb.Cell | null | undefined
+): boolean {
   if (!cell || cell.kind !== parser_pb.CellKind.CODE) {
-    return false;
+    return false
   }
-  return !isHtmlLanguageId(cell.languageId);
+  return !isHtmlLanguageId(cell.languageId)
 }
 
 export type NotebookDataLike = {
-  getUri: () => string;
-  getName: () => string;
-  getNotebook: () => parser_pb.Notebook;
-  updateCell: (cell: parser_pb.Cell) => void;
-  getCell: (refId: string) => CellRunnerLike | null;
+  getUri: () => string
+  getName: () => string
+  getNotebook: () => parser_pb.Notebook
+  isReadOnly?: () => boolean
+  updateCell: (cell: parser_pb.Cell) => void
+  getCell: (refId: string) => CellRunnerLike | null
   appendCell?: (
     kind?: parser_pb.CellKind,
-    languageId?: string | null,
-  ) => parser_pb.Cell;
+    languageId?: string | null
+  ) => parser_pb.Cell
   addCellAfter?: (
     targetRefId: string,
     kind?: parser_pb.CellKind,
-    languageId?: string | null,
-  ) => parser_pb.Cell | null;
+    languageId?: string | null
+  ) => parser_pb.Cell | null
   addCellBefore?: (
     targetRefId: string,
     kind?: parser_pb.CellKind,
-    languageId?: string | null,
-  ) => parser_pb.Cell | null;
-  removeCell?: (refId: string) => void;
-};
+    languageId?: string | null
+  ) => parser_pb.Cell | null
+  removeCell?: (refId: string) => void
+}
 
 export type NotebookSummary = {
-  uri: string;
-  name: string;
-  isOpen: boolean;
-  source: "local" | "fs" | "drive";
-};
+  uri: string
+  name: string
+  isOpen: boolean
+  readOnly?: boolean
+  source: 'local' | 'fs' | 'drive'
+}
 
 export type NotebookQuery = {
-  openOnly?: boolean;
-  uriPrefix?: string;
-  nameContains?: string;
-  limit?: number;
-};
+  openOnly?: boolean
+  uriPrefix?: string
+  nameContains?: string
+  limit?: number
+}
 
 export type NotebookHandle = {
-  uri: string;
-  revision: string;
-};
+  uri: string
+  revision: string
+}
 
-export type NotebookTarget = { uri: string } | { handle: NotebookHandle };
+export type NotebookTarget = { uri: string } | { handle: NotebookHandle }
 
 export type NotebookDocument = {
-  summary: NotebookSummary;
-  handle: NotebookHandle;
-  notebook: parser_pb.Notebook;
-};
+  summary: NotebookSummary
+  handle: NotebookHandle
+  notebook: parser_pb.Notebook
+}
 
 export type CellPatch = {
-  value?: string;
-  languageId?: string;
-  metadata?: Record<string, string>;
-  outputs?: parser_pb.CellOutput[];
-};
+  value?: string
+  languageId?: string
+  metadata?: Record<string, string>
+  outputs?: parser_pb.CellOutput[]
+}
 
 export type CellLocation =
   | { index: number }
   | { beforeRefId: string }
-  | { afterRefId: string };
+  | { afterRefId: string }
 
 export type InsertCellSpec = {
-  kind: "code" | "markup";
-  languageId?: string;
-  value?: string;
-  metadata?: Record<string, string>;
-};
+  kind: 'code' | 'markup'
+  languageId?: string
+  value?: string
+  metadata?: Record<string, string>
+}
 
 export type NotebookMutation =
   | {
-      op: "insert";
-      at: CellLocation;
-      cells: InsertCellSpec[];
+      op: 'insert'
+      at: CellLocation
+      cells: InsertCellSpec[]
     }
   | {
-      op: "update";
-      refId: string;
-      patch: CellPatch;
+      op: 'update'
+      refId: string
+      patch: CellPatch
     }
   | {
-      op: "remove";
-      refIds: string[];
-    };
+      op: 'remove'
+      refIds: string[]
+    }
 
-export type NotebookMethod =
-  | "list"
-  | "get"
-  | "update"
-  | "delete"
-  | "execute";
+export type NotebookMethod = 'list' | 'get' | 'update' | 'delete' | 'execute'
 
 export type NotebooksApi = {
-  help: (topic?: NotebookMethod) => Promise<string>;
-  list: (query?: NotebookQuery) => Promise<NotebookSummary[]>;
-  get: (target?: NotebookTarget) => Promise<NotebookDocument>;
+  help: (topic?: NotebookMethod) => Promise<string>
+  list: (query?: NotebookQuery) => Promise<NotebookSummary[]>
+  get: (target?: NotebookTarget) => Promise<NotebookDocument>
   update: (args: {
-    target?: NotebookTarget;
-    expectedRevision?: string;
-    operations: NotebookMutation[];
-    reason?: string;
-  }) => Promise<NotebookDocument>;
-  delete: (target: NotebookTarget) => Promise<void>;
+    target?: NotebookTarget
+    expectedRevision?: string
+    operations: NotebookMutation[]
+    reason?: string
+  }) => Promise<NotebookDocument>
+  delete: (target: NotebookTarget) => Promise<void>
   execute: (args: {
-    target?: NotebookTarget;
-    refIds: string[];
-  }) => Promise<{ handle: NotebookHandle; cells: parser_pb.Cell[] }>;
-};
+    target?: NotebookTarget
+    refIds: string[]
+  }) => Promise<{ handle: NotebookHandle; cells: parser_pb.Cell[] }>
+}
 
 export type RunmeConsoleApi = {
-  getCurrentNotebook: () => NotebookDataLike | null;
-  clear: (target?: unknown) => string;
-  clearOutputs: (target?: unknown) => string;
-  runAll: (target?: unknown) => string;
-  rerun: (target?: unknown) => string;
-  help: () => string;
-};
+  getCurrentNotebook: () => NotebookDataLike | null
+  clear: (target?: unknown) => string
+  clearOutputs: (target?: unknown) => string
+  runAll: (target?: unknown) => string
+  rerun: (target?: unknown) => string
+  help: () => string
+}
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (
-    typeof value === "object" &&
+    typeof value === 'object' &&
     value !== null &&
-    "then" in value &&
-    typeof (value as { then?: unknown }).then === "function"
-  );
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  )
 }
 
-function inferNotebookSource(uri: string): NotebookSummary["source"] {
-  const normalized = (uri ?? "").toLowerCase();
-  if (normalized.startsWith("local://")) {
-    return "local";
+function inferNotebookSource(uri: string): NotebookSummary['source'] {
+  const normalized = (uri ?? '').toLowerCase()
+  if (normalized.startsWith('local://')) {
+    return 'local'
   }
-  if (normalized.startsWith("fs://") || normalized.startsWith("file://")) {
-    return "fs";
+  if (normalized.startsWith('fs://') || normalized.startsWith('file://')) {
+    return 'fs'
   }
-  if (normalized.startsWith("https://drive.google.com/")) {
-    return "drive";
+  if (normalized.startsWith('https://drive.google.com/')) {
+    return 'drive'
   }
-  return "local";
+  return 'local'
 }
 
-export function makeJsonSafe<T>(value: T, seen = new WeakMap<object, unknown>()): T {
-  if (typeof value === "bigint") {
-    return value.toString() as T;
+export function makeJsonSafe<T>(
+  value: T,
+  seen = new WeakMap<object, unknown>()
+): T {
+  if (typeof value === 'bigint') {
+    return value.toString() as T
   }
-  if (value === null || typeof value !== "object") {
-    return value;
+  if (value === null || typeof value !== 'object') {
+    return value
   }
   if (
     value instanceof Date ||
     value instanceof ArrayBuffer ||
     ArrayBuffer.isView(value)
   ) {
-    return value;
+    return value
   }
-  const existing = seen.get(value);
+  const existing = seen.get(value)
   if (existing) {
-    return existing as T;
+    return existing as T
   }
   if (Array.isArray(value)) {
-    const result: unknown[] = [];
-    seen.set(value, result);
+    const result: unknown[] = []
+    seen.set(value, result)
     for (const item of value) {
-      result.push(makeJsonSafe(item, seen));
+      result.push(makeJsonSafe(item, seen))
     }
-    return result as T;
+    return result as T
   }
-  const result: Record<string, unknown> = {};
-  seen.set(value, result);
+  const result: Record<string, unknown> = {}
+  seen.set(value, result)
   for (const [key, item] of Object.entries(value)) {
-    result[key] = makeJsonSafe(item, seen);
+    result[key] = makeJsonSafe(item, seen)
   }
-  return result as T;
+  return result as T
 }
 
 function stringifyJsonSafe(value: unknown): string {
   return JSON.stringify(value, (_key, item) =>
-    typeof item === "bigint" ? item.toString() : item,
-  );
+    typeof item === 'bigint' ? item.toString() : item
+  )
 }
 
 function createRevision(notebook: parser_pb.Notebook): string {
   // Deterministic content hash used for optimistic checks in runtime helpers.
-  return md5(stringifyJsonSafe(notebook));
+  return md5(stringifyJsonSafe(notebook))
 }
 
 function makeHandle(notebook: NotebookDataLike): NotebookHandle {
   return {
     uri: notebook.getUri(),
     revision: createRevision(notebook.getNotebook()),
-  };
+  }
 }
 
 function makeDocument(notebook: NotebookDataLike): NotebookDocument {
-  const handle = makeHandle(notebook);
+  const handle = makeHandle(notebook)
   return {
     summary: {
       uri: notebook.getUri(),
       name: notebook.getName(),
       isOpen: true,
+      readOnly: notebook.isReadOnly?.() ?? false,
       source: inferNotebookSource(notebook.getUri()),
     },
     handle,
     notebook: makeJsonSafe(notebook.getNotebook()),
-  };
+  }
 }
 
 function resolveTargetUri(target?: NotebookTarget): string | null {
   if (target === undefined) {
-    return null;
+    return null
   }
-  if (!target || typeof target !== "object") {
+  if (!target || typeof target !== 'object') {
     throw new Error(
       `Invalid notebook target ${JSON.stringify(target)}. ` +
-        `Use target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.`,
-    );
-  }
-  if ("uri" in target && typeof target.uri === "string" && target.uri.trim() !== "") {
-    return target.uri.trim();
+        `Use target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.`
+    )
   }
   if (
-    "handle" in target &&
-    target.handle &&
-    typeof target.handle.uri === "string" &&
-      target.handle.uri.trim() !== ""
+    'uri' in target &&
+    typeof target.uri === 'string' &&
+    target.uri.trim() !== ''
   ) {
-    return target.handle.uri.trim();
+    return target.uri.trim()
+  }
+  if (
+    'handle' in target &&
+    target.handle &&
+    typeof target.handle.uri === 'string' &&
+    target.handle.uri.trim() !== ''
+  ) {
+    return target.handle.uri.trim()
   }
   throw new Error(
     `Invalid notebook target ${JSON.stringify(target)}. ` +
-      `Use target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.`,
-  );
+      `Use target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.`
+  )
 }
 
-function formatMissingTargetError(method: "update" | "delete" | "execute"): string {
-  if (method === "update") {
+function formatMissingTargetError(
+  method: 'update' | 'delete' | 'execute'
+): string {
+  if (method === 'update') {
     return (
-      "notebooks.update requires an explicit target notebook. " +
-      "Pass target: { handle: doc.handle } after const doc = await notebooks.get(), " +
+      'notebooks.update requires an explicit target notebook. ' +
+      'Pass target: { handle: doc.handle } after const doc = await notebooks.get(), ' +
       'or target: { uri: "local://..." }.'
-    );
+    )
   }
-  if (method === "execute") {
+  if (method === 'execute') {
     return (
-      "notebooks.execute requires an explicit target notebook. " +
-      "Pass target: { handle: doc.handle } after const doc = await notebooks.get(), " +
+      'notebooks.execute requires an explicit target notebook. ' +
+      'Pass target: { handle: doc.handle } after const doc = await notebooks.get(), ' +
       'or target: { uri: "local://..." }.'
-    );
+    )
   }
   return (
-    "notebooks.delete requires an explicit target notebook. " +
+    'notebooks.delete requires an explicit target notebook. ' +
     'Pass target: { uri: "local://..." } or target: { handle: { uri: "local://...", revision: "..." } }.'
-  );
+  )
+}
+
+function assertNotebookWritable(
+  method: 'update' | 'delete' | 'execute' | 'clear' | 'runAll' | 'rerun',
+  notebook: NotebookDataLike
+): void {
+  if (notebook.isReadOnly?.()) {
+    throw new Error(
+      `${method} is not allowed because notebook ${notebook.getUri()} is open read-only in this browser tab.`
+    )
+  }
 }
 
 function resolveInsertIndex(
   notebook: NotebookDataLike,
-  at: CellLocation,
+  at: CellLocation
 ): { beforeRefId?: string; afterRefId?: string; append?: true } {
-  const cells = notebook.getNotebook().cells ?? [];
-  if ("beforeRefId" in at) {
-    return { beforeRefId: at.beforeRefId };
+  const cells = notebook.getNotebook().cells ?? []
+  if ('beforeRefId' in at) {
+    return { beforeRefId: at.beforeRefId }
   }
-  if ("afterRefId" in at) {
-    return { afterRefId: at.afterRefId };
+  if ('afterRefId' in at) {
+    return { afterRefId: at.afterRefId }
   }
-  const rawIndex = at.index;
+  const rawIndex = at.index
   if (!Number.isInteger(rawIndex)) {
-    throw new Error(`Invalid insert index: ${String(rawIndex)}`);
+    throw new Error(`Invalid insert index: ${String(rawIndex)}`)
   }
   if (cells.length === 0) {
-    return { append: true };
+    return { append: true }
   }
-  let normalizedIndex = rawIndex;
+  let normalizedIndex = rawIndex
   if (rawIndex < 0) {
-    normalizedIndex = cells.length + rawIndex + 1;
+    normalizedIndex = cells.length + rawIndex + 1
   }
   if (normalizedIndex <= 0) {
-    return { beforeRefId: cells[0]?.refId };
+    return { beforeRefId: cells[0]?.refId }
   }
   if (normalizedIndex >= cells.length) {
-    return { append: true };
+    return { append: true }
   }
-  return { beforeRefId: cells[normalizedIndex]?.refId };
+  return { beforeRefId: cells[normalizedIndex]?.refId }
 }
 
 function applyInsertedCellSpec(
   notebook: NotebookDataLike,
   inserted: parser_pb.Cell,
-  spec: InsertCellSpec,
+  spec: InsertCellSpec
 ): void {
-  const updated = create(parser_pb.CellSchema, inserted);
+  const updated = create(parser_pb.CellSchema, inserted)
   updated.kind =
-    spec.kind === "markup" ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE;
+    spec.kind === 'markup' ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE
   updated.languageId =
     spec.languageId ??
-    (spec.kind === "markup" ? "markdown" : updated.languageId ?? "javascript");
-  if (typeof spec.value === "string") {
-    updated.value = spec.value;
+    (spec.kind === 'markup' ? 'markdown' : (updated.languageId ?? 'javascript'))
+  if (typeof spec.value === 'string') {
+    updated.value = spec.value
   }
   if (spec.metadata) {
     updated.metadata = {
       ...(updated.metadata ?? {}),
       ...spec.metadata,
-    };
+    }
   }
-  notebook.updateCell(updated);
+  notebook.updateCell(updated)
 }
 
 function appendCellForSpec(
   notebook: NotebookDataLike,
-  spec: InsertCellSpec,
+  spec: InsertCellSpec
 ): parser_pb.Cell {
   const kind =
-    spec.kind === "markup" ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE;
+    spec.kind === 'markup' ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE
   return notebook.appendCell!(
     kind,
-    spec.languageId ?? (spec.kind === "code" ? "javascript" : undefined),
-  );
+    spec.languageId ?? (spec.kind === 'code' ? 'javascript' : undefined)
+  )
 }
 
 function addCellBeforeForSpec(
   notebook: NotebookDataLike,
   targetRefId: string,
-  spec: InsertCellSpec,
+  spec: InsertCellSpec
 ): parser_pb.Cell | null {
   const kind =
-    spec.kind === "markup" ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE;
+    spec.kind === 'markup' ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE
   return notebook.addCellBefore!(
     targetRefId,
     kind,
-    spec.languageId ?? (spec.kind === "code" ? "javascript" : undefined),
-  );
+    spec.languageId ?? (spec.kind === 'code' ? 'javascript' : undefined)
+  )
 }
 
 function addCellAfterForSpec(
   notebook: NotebookDataLike,
   targetRefId: string,
-  spec: InsertCellSpec,
+  spec: InsertCellSpec
 ): parser_pb.Cell | null {
   const kind =
-    spec.kind === "markup" ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE;
+    spec.kind === 'markup' ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE
   return notebook.addCellAfter!(
     targetRefId,
     kind,
-    spec.languageId ?? (spec.kind === "code" ? "javascript" : undefined),
-  );
+    spec.languageId ?? (spec.kind === 'code' ? 'javascript' : undefined)
+  )
 }
 
 function insertCells(
   notebook: NotebookDataLike,
   at: CellLocation,
-  specs: InsertCellSpec[],
+  specs: InsertCellSpec[]
 ): void {
   if (!Array.isArray(specs) || specs.length === 0) {
-    return;
+    return
   }
   if (
-    typeof notebook.appendCell !== "function" ||
-    typeof notebook.addCellBefore !== "function" ||
-    typeof notebook.addCellAfter !== "function" ||
-    typeof notebook.removeCell !== "function"
+    typeof notebook.appendCell !== 'function' ||
+    typeof notebook.addCellBefore !== 'function' ||
+    typeof notebook.addCellAfter !== 'function' ||
+    typeof notebook.removeCell !== 'function'
   ) {
-    throw new Error("Notebook does not support insert operations.");
+    throw new Error('Notebook does not support insert operations.')
   }
 
-  const location = resolveInsertIndex(notebook, at);
-  const insertedRefIds: string[] = [];
+  const location = resolveInsertIndex(notebook, at)
+  const insertedRefIds: string[] = []
   const rollbackInsertedCells = () => {
     for (let i = insertedRefIds.length - 1; i >= 0; i -= 1) {
-      notebook.removeCell!(insertedRefIds[i]!);
+      notebook.removeCell!(insertedRefIds[i]!)
     }
-  };
+  }
 
   try {
     if (location.beforeRefId) {
       for (let i = specs.length - 1; i >= 0; i -= 1) {
-        const spec = specs[i]!;
-        const inserted = addCellBeforeForSpec(notebook, location.beforeRefId, spec);
+        const spec = specs[i]!
+        const inserted = addCellBeforeForSpec(
+          notebook,
+          location.beforeRefId,
+          spec
+        )
         if (!inserted) {
-          throw new Error(`Failed to insert before cell: ${location.beforeRefId}`);
+          throw new Error(
+            `Failed to insert before cell: ${location.beforeRefId}`
+          )
         }
-        insertedRefIds.push(inserted.refId);
-        applyInsertedCellSpec(notebook, inserted, spec);
+        insertedRefIds.push(inserted.refId)
+        applyInsertedCellSpec(notebook, inserted, spec)
       }
-      return;
+      return
     }
 
     if (location.afterRefId) {
-      let anchor = location.afterRefId;
+      let anchor = location.afterRefId
       for (const spec of specs) {
-        const inserted = addCellAfterForSpec(notebook, anchor, spec);
+        const inserted = addCellAfterForSpec(notebook, anchor, spec)
         if (!inserted) {
-          throw new Error(`Failed to insert after cell: ${anchor}`);
+          throw new Error(`Failed to insert after cell: ${anchor}`)
         }
-        insertedRefIds.push(inserted.refId);
-        applyInsertedCellSpec(notebook, inserted, spec);
-        anchor = inserted.refId;
+        insertedRefIds.push(inserted.refId)
+        applyInsertedCellSpec(notebook, inserted, spec)
+        anchor = inserted.refId
       }
-      return;
+      return
     }
 
     for (const spec of specs) {
-      const inserted = appendCellForSpec(notebook, spec);
-      insertedRefIds.push(inserted.refId);
-      applyInsertedCellSpec(notebook, inserted, spec);
+      const inserted = appendCellForSpec(notebook, spec)
+      insertedRefIds.push(inserted.refId)
+      applyInsertedCellSpec(notebook, inserted, spec)
     }
   } catch (error) {
-    rollbackInsertedCells();
-    throw error;
+    rollbackInsertedCells()
+    throw error
   }
 }
 
 function updateCellPatch(
   notebook: NotebookDataLike,
   refId: string,
-  patch: CellPatch,
+  patch: CellPatch
 ): void {
-  const existing = notebook.getNotebook().cells.find((cell) => cell.refId === refId);
+  const existing = notebook
+    .getNotebook()
+    .cells.find((cell) => cell.refId === refId)
   if (!existing) {
-    throw new Error(`Cell not found: ${refId}`);
+    throw new Error(`Cell not found: ${refId}`)
   }
-  const updated = create(parser_pb.CellSchema, existing);
-  if (typeof patch.value === "string") {
-    updated.value = patch.value;
+  const updated = create(parser_pb.CellSchema, existing)
+  if (typeof patch.value === 'string') {
+    updated.value = patch.value
   }
-  if (typeof patch.languageId === "string") {
-    updated.languageId = patch.languageId;
+  if (typeof patch.languageId === 'string') {
+    updated.languageId = patch.languageId
   }
   if (patch.metadata) {
     updated.metadata = {
       ...(updated.metadata ?? {}),
       ...patch.metadata,
-    };
+    }
   }
   if (Array.isArray(patch.outputs)) {
-    updated.outputs = patch.outputs;
+    updated.outputs = patch.outputs
   }
-  notebook.updateCell(updated);
+  notebook.updateCell(updated)
 }
 
-function formatNotebookMutationError(index: number, operation: unknown): string {
+function formatNotebookMutationError(
+  index: number,
+  operation: unknown
+): string {
   const op =
-    operation && typeof operation === "object" && "op" in operation
+    operation && typeof operation === 'object' && 'op' in operation
       ? JSON.stringify((operation as { op?: unknown }).op)
-      : JSON.stringify(operation);
+      : JSON.stringify(operation)
   return (
     `Unsupported notebooks.update operation at operations[${index}]: ${op}. ` +
     `Supported ops are "insert", "update", and "remove". ` +
     `To append a cell, use ` +
     `operations: [{ op: "insert", at: { index: -1 }, cells: [{ kind: "code", languageId: "python", value: "print(\\"hello\\")" }] }].`
-  );
+  )
 }
 
 export function createNotebooksApi({
   resolveNotebook,
   listNotebooks,
 }: {
-  resolveNotebook: (target?: unknown) => NotebookDataLike | null;
-  listNotebooks?: () => NotebookDataLike[];
+  resolveNotebook: (target?: unknown) => NotebookDataLike | null
+  listNotebooks?: () => NotebookDataLike[]
 }): NotebooksApi {
-  const resolveNotebookByTarget = (target?: NotebookTarget): NotebookDataLike => {
-    const uri = resolveTargetUri(target);
-    const resolved = uri ? resolveNotebook(uri) : resolveNotebook();
+  const resolveNotebookByTarget = (
+    target?: NotebookTarget
+  ): NotebookDataLike => {
+    const uri = resolveTargetUri(target)
+    const resolved = uri ? resolveNotebook(uri) : resolveNotebook()
     if (!resolved) {
-      throw new Error("No notebook found for the requested target.");
+      throw new Error('No notebook found for the requested target.')
     }
-    return resolved;
-  };
+    return resolved
+  }
 
   const resolveNotebookByRequiredTarget = (
-    method: "update" | "delete" | "execute",
-    target?: NotebookTarget,
+    method: 'update' | 'delete' | 'execute',
+    target?: NotebookTarget
   ): NotebookDataLike => {
     if (target === undefined) {
-      throw new Error(formatMissingTargetError(method));
+      throw new Error(formatMissingTargetError(method))
     }
-    return resolveNotebookByTarget(target);
-  };
+    return resolveNotebookByTarget(target)
+  }
 
   const listKnownNotebooks = (): NotebookDataLike[] => {
-    const listed = listNotebooks?.() ?? [];
+    const listed = listNotebooks?.() ?? []
     if (listed.length > 0) {
-      return listed;
+      return listed
     }
-    const current = resolveNotebook();
-    return current ? [current] : [];
-  };
+    const current = resolveNotebook()
+    return current ? [current] : []
+  }
 
   const help = async (topic?: NotebookMethod) => {
-    if (topic === "list") {
-      return "notebooks.list(query?: { openOnly?: boolean; uriPrefix?: string; nameContains?: string; limit?: number }): Promise<NotebookSummary[]>";
+    if (topic === 'list') {
+      return 'notebooks.list(query?: { openOnly?: boolean; uriPrefix?: string; nameContains?: string; limit?: number }): Promise<NotebookSummary[]>'
     }
-    if (topic === "get") {
-      return "notebooks.get(target?: { uri } | { handle: { uri, revision } }): Promise<NotebookDocument>. When target is omitted, returns the current notebook selected in the UI.";
+    if (topic === 'get') {
+      return 'notebooks.get(target?: { uri } | { handle: { uri, revision } }): Promise<NotebookDocument>. When target is omitted, returns the current notebook selected in the UI.'
     }
-    if (topic === "update") {
-      return "notebooks.update({ target, expectedRevision?, operations: NotebookMutation[] }): Promise<NotebookDocument>. target is required.";
+    if (topic === 'update') {
+      return 'notebooks.update({ target, expectedRevision?, operations: NotebookMutation[] }): Promise<NotebookDocument>. target is required.'
     }
-    if (topic === "delete") {
-      return "notebooks.delete(target): Promise<void>. target is required.";
+    if (topic === 'delete') {
+      return 'notebooks.delete(target): Promise<void>. target is required.'
     }
-    if (topic === "execute") {
-      return "notebooks.execute({ target, refIds: string[] }): Promise<{ handle, cells }>. target is required.";
+    if (topic === 'execute') {
+      return 'notebooks.execute({ target, refIds: string[] }): Promise<{ handle, cells }>. target is required.'
     }
     return [
-      "Notebook SDK methods:",
-      "- notebooks.list(query?)",
-      "- notebooks.get(target?)              # omitted target = current UI notebook",
-      "- notebooks.update({ target, expectedRevision?, operations })",
-      "- notebooks.delete(target)",
-      "- notebooks.execute({ target, refIds })",
-      "- notebooks.help(topic?)",
-    ].join("\n");
-  };
+      'Notebook SDK methods:',
+      '- notebooks.list(query?)',
+      '- notebooks.get(target?)              # omitted target = current UI notebook',
+      '- notebooks.update({ target, expectedRevision?, operations })',
+      '- notebooks.delete(target)',
+      '- notebooks.execute({ target, refIds })',
+      '- notebooks.help(topic?)',
+    ].join('\n')
+  }
 
   return {
     help,
     list: async (query?: NotebookQuery) => {
-      const all = listKnownNotebooks();
+      const all = listKnownNotebooks()
       let result = all.map((notebook) => ({
         uri: notebook.getUri(),
         name: notebook.getName(),
         isOpen: true,
+        readOnly: notebook.isReadOnly?.() ?? false,
         source: inferNotebookSource(notebook.getUri()),
-      }));
+      }))
       if (query?.uriPrefix) {
-        result = result.filter((item) => item.uri.startsWith(query.uriPrefix!));
+        result = result.filter((item) => item.uri.startsWith(query.uriPrefix!))
       }
       if (query?.nameContains) {
-        const needle = query.nameContains.toLowerCase();
-        result = result.filter((item) => item.name.toLowerCase().includes(needle));
+        const needle = query.nameContains.toLowerCase()
+        result = result.filter((item) =>
+          item.name.toLowerCase().includes(needle)
+        )
       }
-      if (typeof query?.limit === "number" && query.limit >= 0) {
-        result = result.slice(0, query.limit);
+      if (typeof query?.limit === 'number' && query.limit >= 0) {
+        result = result.slice(0, query.limit)
       }
-      return result;
+      return result
     },
     get: async (target?: NotebookTarget) => {
-      const notebook = resolveNotebookByTarget(target);
-      return makeDocument(notebook);
+      const notebook = resolveNotebookByTarget(target)
+      return makeDocument(notebook)
     },
     update: async (args) => {
-      const notebook = resolveNotebookByRequiredTarget("update", args.target);
-      const beforeHandle = makeHandle(notebook);
+      const notebook = resolveNotebookByRequiredTarget('update', args.target)
+      assertNotebookWritable('update', notebook)
+      const beforeHandle = makeHandle(notebook)
       if (
         args.expectedRevision &&
-        args.expectedRevision.trim() !== "" &&
+        args.expectedRevision.trim() !== '' &&
         args.expectedRevision !== beforeHandle.revision
       ) {
         throw new Error(
-          `Revision mismatch: expected ${args.expectedRevision}, actual ${beforeHandle.revision}`,
-        );
+          `Revision mismatch: expected ${args.expectedRevision}, actual ${beforeHandle.revision}`
+        )
       }
 
-      const operations = args.operations ?? [];
+      const operations = args.operations ?? []
       if (!Array.isArray(operations)) {
         throw new Error(
           `Invalid notebooks.update operations: expected an array of notebook mutations, got ${JSON.stringify(
-            operations,
-          )}.`,
-        );
+            operations
+          )}.`
+        )
       }
 
       for (const [index, operation] of operations.entries()) {
-        if (operation.op === "insert") {
-          insertCells(notebook, operation.at, operation.cells);
-          continue;
+        if (operation.op === 'insert') {
+          insertCells(notebook, operation.at, operation.cells)
+          continue
         }
-        if (operation.op === "update") {
-          updateCellPatch(notebook, operation.refId, operation.patch);
-          continue;
+        if (operation.op === 'update') {
+          updateCellPatch(notebook, operation.refId, operation.patch)
+          continue
         }
-        if (operation.op === "remove") {
-          if (typeof notebook.removeCell !== "function") {
-            throw new Error("Notebook does not support remove operations.");
+        if (operation.op === 'remove') {
+          if (typeof notebook.removeCell !== 'function') {
+            throw new Error('Notebook does not support remove operations.')
           }
           for (const refId of operation.refIds ?? []) {
-            notebook.removeCell(refId);
+            notebook.removeCell(refId)
           }
-          continue;
+          continue
         }
-        throw new Error(formatNotebookMutationError(index, operation));
+        throw new Error(formatNotebookMutationError(index, operation))
       }
 
-      return makeDocument(notebook);
+      return makeDocument(notebook)
     },
     delete: async (_target: NotebookTarget) => {
-      resolveNotebookByRequiredTarget("delete", _target);
-      throw new Error("notebooks.delete is not supported in v0 runtime.");
+      const notebook = resolveNotebookByRequiredTarget('delete', _target)
+      assertNotebookWritable('delete', notebook)
+      throw new Error('notebooks.delete is not supported in v0 runtime.')
     },
     execute: async (args) => {
-      const notebook = resolveNotebookByRequiredTarget("execute", args.target);
-      const executedCells: parser_pb.Cell[] = [];
-      const pendingRuns: Array<{ refId: string; runner: CellRunnerLike; cell: parser_pb.Cell }> = [];
+      const notebook = resolveNotebookByRequiredTarget('execute', args.target)
+      assertNotebookWritable('execute', notebook)
+      const executedCells: parser_pb.Cell[] = []
+      const pendingRuns: Array<{
+        refId: string
+        runner: CellRunnerLike
+        cell: parser_pb.Cell
+      }> = []
       for (const refId of args.refIds ?? []) {
-        const cell = notebook.getNotebook().cells.find((candidate) => candidate.refId === refId);
+        const cell = notebook
+          .getNotebook()
+          .cells.find((candidate) => candidate.refId === refId)
         if (!cell) {
-          throw new Error(`Cell not found: ${refId}`);
+          throw new Error(`Cell not found: ${refId}`)
         }
         if (!isRunnableNotebookCodeCell(cell)) {
-          throw new Error(`HTML cells are not runnable: ${refId}`);
+          throw new Error(`HTML cells are not runnable: ${refId}`)
         }
-        const cellRunner = notebook.getCell(refId);
+        const cellRunner = notebook.getCell(refId)
         if (!cellRunner) {
-          throw new Error(`Cell not found: ${refId}`);
+          throw new Error(`Cell not found: ${refId}`)
         }
-        pendingRuns.push({ refId, runner: cellRunner, cell });
+        pendingRuns.push({ refId, runner: cellRunner, cell })
       }
       for (const pending of pendingRuns) {
-        const runResult = pending.runner.run();
+        const runResult = pending.runner.run()
         if (isPromiseLike(runResult)) {
-          await runResult;
+          await runResult
         }
         const cell =
-          notebook.getNotebook().cells.find((candidate) => candidate.refId === pending.refId) ??
-          pending.cell;
+          notebook
+            .getNotebook()
+            .cells.find((candidate) => candidate.refId === pending.refId) ??
+          pending.cell
         if (cell) {
-          executedCells.push(cell);
+          executedCells.push(cell)
         }
       }
       return {
         handle: makeHandle(notebook),
         cells: executedCells,
-      };
+      }
     },
-  };
+  }
 }
 
 function formatNotebookLabel(notebook: NotebookDataLike): string {
-  const name = notebook.getName();
-  const uri = notebook.getUri();
+  const name = notebook.getName()
+  const uri = notebook.getUri()
   if (name && name !== uri) {
-    return `${name} (${uri})`;
+    return `${name} (${uri})`
   }
-  return uri;
+  return uri
 }
 
 function clearCellRunMetadata(cell: parser_pb.Cell): void {
   if (!cell.metadata) {
-    return;
+    return
   }
-  delete cell.metadata[RunmeMetadataKey.LastRunID];
-  delete cell.metadata[RunmeMetadataKey.Pid];
-  delete cell.metadata[RunmeMetadataKey.ExitCode];
+  delete cell.metadata[RunmeMetadataKey.LastRunID]
+  delete cell.metadata[RunmeMetadataKey.Pid]
+  delete cell.metadata[RunmeMetadataKey.ExitCode]
 }
 
 export function createRunmeConsoleApi({
   resolveNotebook,
 }: {
-  resolveNotebook: (target?: unknown) => NotebookDataLike | null;
+  resolveNotebook: (target?: unknown) => NotebookDataLike | null
 }): RunmeConsoleApi {
-  const getCurrentNotebook = () => resolveNotebook();
+  const getCurrentNotebook = () => resolveNotebook()
 
   const clearOutputs = (target?: unknown) => {
-    const notebookData = resolveNotebook(target);
+    const notebookData = resolveNotebook(target)
     if (!notebookData) {
-      return "No active notebook found.";
+      return 'No active notebook found.'
     }
+    assertNotebookWritable('clear', notebookData)
 
-    const notebook = notebookData.getNotebook();
-    const cells = notebook.cells ?? [];
-    let updatedCells = 0;
-    let clearedOutputs = 0;
+    const notebook = notebookData.getNotebook()
+    const cells = notebook.cells ?? []
+    let updatedCells = 0
+    let clearedOutputs = 0
 
     for (const cell of cells) {
       if (!cell?.refId) {
-        continue;
+        continue
       }
-      const hasOutputs = (cell.outputs?.length ?? 0) > 0;
+      const hasOutputs = (cell.outputs?.length ?? 0) > 0
       const hasRunMetadata =
-        typeof cell.metadata?.[RunmeMetadataKey.LastRunID] === "string" ||
-        typeof cell.metadata?.[RunmeMetadataKey.Pid] === "string" ||
-        typeof cell.metadata?.[RunmeMetadataKey.ExitCode] === "string";
+        typeof cell.metadata?.[RunmeMetadataKey.LastRunID] === 'string' ||
+        typeof cell.metadata?.[RunmeMetadataKey.Pid] === 'string' ||
+        typeof cell.metadata?.[RunmeMetadataKey.ExitCode] === 'string'
       if (!hasOutputs && !hasRunMetadata) {
-        continue;
+        continue
       }
 
-      const updatedCell = create(parser_pb.CellSchema, cell);
-      clearedOutputs += updatedCell.outputs.length;
-      updatedCell.outputs = [];
-      clearCellRunMetadata(updatedCell);
-      notebookData.updateCell(updatedCell);
-      updatedCells += 1;
+      const updatedCell = create(parser_pb.CellSchema, cell)
+      clearedOutputs += updatedCell.outputs.length
+      updatedCell.outputs = []
+      clearCellRunMetadata(updatedCell)
+      notebookData.updateCell(updatedCell)
+      updatedCells += 1
     }
 
     if (updatedCells === 0) {
-      return `No cell outputs to clear in ${formatNotebookLabel(notebookData)}.`;
+      return `No cell outputs to clear in ${formatNotebookLabel(notebookData)}.`
     }
 
-    return `Cleared ${clearedOutputs} output item group(s) across ${updatedCells} cell(s) in ${formatNotebookLabel(notebookData)}.`;
-  };
+    return `Cleared ${clearedOutputs} output item group(s) across ${updatedCells} cell(s) in ${formatNotebookLabel(notebookData)}.`
+  }
 
   const runAll = (target?: unknown) => {
-    const notebookData = resolveNotebook(target);
+    const notebookData = resolveNotebook(target)
     if (!notebookData) {
-      return "No active notebook found.";
+      return 'No active notebook found.'
     }
+    assertNotebookWritable('runAll', notebookData)
 
-    const notebook = notebookData.getNotebook();
-    const cells = notebook.cells ?? [];
-    let runnableCells = 0;
-    let started = 0;
-    let failedToStart = 0;
+    const notebook = notebookData.getNotebook()
+    const cells = notebook.cells ?? []
+    let runnableCells = 0
+    let started = 0
+    let failedToStart = 0
 
     for (const cell of cells) {
       if (!cell?.refId || !isRunnableNotebookCodeCell(cell)) {
-        continue;
+        continue
       }
-      if ((cell.value ?? "").trim().length === 0) {
-        continue;
+      if ((cell.value ?? '').trim().length === 0) {
+        continue
       }
-      runnableCells += 1;
+      runnableCells += 1
 
-      const cellData = notebookData.getCell(cell.refId);
+      const cellData = notebookData.getCell(cell.refId)
       if (!cellData) {
-        failedToStart += 1;
-        continue;
+        failedToStart += 1
+        continue
       }
 
-      const previousRunID = cellData.getRunID();
-      cellData.run();
-      const runID = cellData.getRunID();
+      const previousRunID = cellData.getRunID()
+      cellData.run()
+      const runID = cellData.getRunID()
       if (runID && runID !== previousRunID) {
-        started += 1;
+        started += 1
       } else {
-        failedToStart += 1;
+        failedToStart += 1
       }
     }
 
     if (runnableCells === 0) {
-      return `No runnable code cells found in ${formatNotebookLabel(notebookData)}.`;
+      return `No runnable code cells found in ${formatNotebookLabel(notebookData)}.`
     }
 
-    return `Started ${started}/${runnableCells} code cell(s) in ${formatNotebookLabel(notebookData)}.${failedToStart > 0 ? ` ${failedToStart} failed to start.` : ""}`;
-  };
+    return `Started ${started}/${runnableCells} code cell(s) in ${formatNotebookLabel(notebookData)}.${failedToStart > 0 ? ` ${failedToStart} failed to start.` : ''}`
+  }
 
-  const clear = (target?: unknown) => clearOutputs(target);
+  const clear = (target?: unknown) => clearOutputs(target)
   const rerun = (target?: unknown) => {
-    const notebookData = resolveNotebook(target);
+    const notebookData = resolveNotebook(target)
     if (!notebookData) {
-      return "No active notebook found.";
+      return 'No active notebook found.'
     }
+    assertNotebookWritable('rerun', notebookData)
 
-    const clearMessage = clearOutputs(notebookData);
-    const runMessage = runAll(notebookData);
-    return `${clearMessage}\n${runMessage}`;
-  };
+    const clearMessage = clearOutputs(notebookData)
+    const runMessage = runAll(notebookData)
+    return `${clearMessage}\n${runMessage}`
+  }
 
   const help = () =>
     [
-      "runme.clear()                  - Clear outputs in the current visible notebook",
-      "runme.runAll()                 - Run all non-empty code cells in the current visible notebook",
-      "runme.rerun()                  - Clear outputs, then run all cells in the current visible notebook",
-      "runme.getCurrentNotebook()     - Advanced: return notebook handle for scripting",
-      "runme.clearOutputs()           - Alias for runme.clear()",
-      "",
-      "Advanced optional target:",
-      "  runme.clear(target)",
-      "  runme.runAll(target)",
-      "  runme.rerun(target)",
-      "  target can be a notebook handle or notebook URI",
-      "runme.help()                    - Show this help",
-    ].join("\n");
+      'runme.clear()                  - Clear outputs in the current visible notebook',
+      'runme.runAll()                 - Run all non-empty code cells in the current visible notebook',
+      'runme.rerun()                  - Clear outputs, then run all cells in the current visible notebook',
+      'runme.getCurrentNotebook()     - Advanced: return notebook handle for scripting',
+      'runme.clearOutputs()           - Alias for runme.clear()',
+      '',
+      'Advanced optional target:',
+      '  runme.clear(target)',
+      '  runme.runAll(target)',
+      '  runme.rerun(target)',
+      '  target can be a notebook handle or notebook URI',
+      'runme.help()                    - Show this help',
+    ].join('\n')
 
   return {
     getCurrentNotebook,
@@ -788,5 +838,5 @@ export function createRunmeConsoleApi({
     runAll,
     rerun,
     help,
-  };
+  }
 }

--- a/app/src/lib/runtime/useCodeModeExecutor.ts
+++ b/app/src/lib/runtime/useCodeModeExecutor.ts
@@ -18,7 +18,11 @@ type CodeModeNotebookAdapterSource = Pick<
   Partial<
     Pick<
       NotebookDataLike,
-      'appendCell' | 'addCellAfter' | 'addCellBefore' | 'removeCell'
+      | 'appendCell'
+      | 'addCellAfter'
+      | 'addCellBefore'
+      | 'removeCell'
+      | 'isReadOnly'
     >
   >
 
@@ -29,6 +33,7 @@ export function createCodeModeNotebookAdapter(
     getUri: () => data.getUri(),
     getName: () => data.getName(),
     getNotebook: () => data.getNotebook(),
+    isReadOnly: data.isReadOnly?.bind(data),
     updateCell: (cell: parser_pb.Cell) => data.updateCell(cell),
     getCell: (refId: string) => data.getCell(refId),
     appendCell: data.appendCell?.bind(data),

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -149,6 +149,7 @@ export class WorkspaceDocumentController {
       title,
       requestedUri: options?.requestedUri,
       state: options?.state,
+      readOnly: options?.readOnly,
       errorMessage: options?.errorMessage,
       owner: options?.owner,
     }
@@ -161,6 +162,7 @@ export class WorkspaceDocumentController {
         existing?.title === nextDocument.title &&
         existing?.requestedUri === nextDocument.requestedUri &&
         existing?.state === nextDocument.state &&
+        existing?.readOnly === nextDocument.readOnly &&
         existing?.errorMessage === nextDocument.errorMessage &&
         existing?.owner === nextDocument.owner
       ) {

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -1,54 +1,57 @@
-import type { NotebookTabState } from "../notebookDataController";
-import type { NotebookOwnershipRecord } from "../tabCoordination/notebookOwnership";
+import type { NotebookTabState } from '../notebookDataController'
+import type { NotebookOwnershipRecord } from '../tabCoordination/notebookOwnership'
 
-export const DRIVE_LINK_STATUS_DOCUMENT_URI = "status://drive-link";
+export const DRIVE_LINK_STATUS_DOCUMENT_URI = 'status://drive-link'
 
 export interface WorkspaceDocument {
-  uri: string;
-  title: string;
-  requestedUri?: string;
-  state?: NotebookTabState;
-  errorMessage?: string;
-  owner?: NotebookOwnershipRecord | null;
+  uri: string
+  title: string
+  requestedUri?: string
+  state?: NotebookTabState
+  readOnly?: boolean
+  errorMessage?: string
+  owner?: NotebookOwnershipRecord | null
 }
 
 export function getWorkspaceDocumentScheme(uri: string): string {
-  const index = uri.indexOf(":");
-  return index > 0 ? uri.slice(0, index) : "";
+  const index = uri.indexOf(':')
+  return index > 0 ? uri.slice(0, index) : ''
 }
 
-export function isNotebookDocumentUri(uri: string | null | undefined): uri is string {
-  return typeof uri === "string" && uri.startsWith("local://file/");
+export function isNotebookDocumentUri(
+  uri: string | null | undefined
+): uri is string {
+  return typeof uri === 'string' && uri.startsWith('local://file/')
 }
 
 export function isNotebookDiffUri(uri: string | null | undefined): boolean {
-  return typeof uri === "string" && uri.startsWith("diff://notebook/");
+  return typeof uri === 'string' && uri.startsWith('diff://notebook/')
 }
 
 export function isDriveLinkStatusUri(uri: string | null | undefined): boolean {
-  return uri === DRIVE_LINK_STATUS_DOCUMENT_URI;
+  return uri === DRIVE_LINK_STATUS_DOCUMENT_URI
 }
 
 export function isRestorableWorkspaceDocument(uri: string): boolean {
-  return isNotebookDocumentUri(uri);
+  return isNotebookDocumentUri(uri)
 }
 
 export function deriveWorkspaceDocumentTitle(uri: string): string {
-  const documentUri = uri;
+  const documentUri = uri
   if (isDriveLinkStatusUri(documentUri)) {
-    return "Drive Link Status";
+    return 'Drive Link Status'
   }
   if (isNotebookDiffUri(documentUri)) {
-    return "Notebook diff";
+    return 'Notebook diff'
   }
   try {
-    const url = new URL(documentUri);
-    const tail = url.pathname.split("/").filter(Boolean).pop();
+    const url = new URL(documentUri)
+    const tail = url.pathname.split('/').filter(Boolean).pop()
     if (tail) {
-      return decodeURIComponent(tail);
+      return decodeURIComponent(tail)
     }
   } catch {
     // Fall through to the URI segment heuristic.
   }
-  return documentUri.split("/").filter(Boolean).pop() ?? documentUri;
+  return documentUri.split('/').filter(Boolean).pop() ?? documentUri
 }

--- a/docs-dev/design/20260603_readonly_secondary_notebook_tabs.md
+++ b/docs-dev/design/20260603_readonly_secondary_notebook_tabs.md
@@ -1,0 +1,121 @@
+# Read-Only Secondary Notebook Tabs
+
+Date: 2026-06-03
+
+## Summary
+
+Allow a notebook that is already owned by another browser tab to open as a
+read-only notebook in the current tab.
+
+The ownership lock remains the write authority. The owner tab can edit and run
+the notebook. Secondary tabs can load and inspect the notebook, including from
+AppKernel helpers, but cannot mutate cells, outputs, metadata, names, or backing
+storage.
+
+## Current State
+
+`NotebookDataController.openNotebook()` resolves a requested URI to the stable
+`local://file/...` URI and then asks `NotebookOwnershipManager` for an exclusive
+lease.
+
+Before this change, a blocked lease produced an `OpenNotebookEntry` with
+`state: "blocked"` and no `NotebookData` model. That protected the document from
+concurrent writes, but it also prevented useful read scenarios:
+
+- using one notebook as reference while writing another notebook
+- letting Codex read a reference notebook while updating the active notebook
+
+The existing write protections are still the right boundary:
+
+- Web Locks decide which tab owns writes.
+- `NotebookData` persists through a store wrapper that checks the active lease.
+- AppKernel notebook resolution previously exposed only owned notebooks.
+
+## Decision
+
+Blocked ownership becomes read-only access, not a blocked view.
+
+When `NotebookOwnershipManager.acquire(localUri)` returns `blocked`,
+`NotebookDataController` will:
+
+1. create or reuse a `NotebookData` model for `localUri`
+2. mark it `readOnly`
+3. load notebook content from `LocalNotebooks`
+4. publish an open entry with `state: "loaded"` and `readOnly: true`
+5. keep owner metadata for UI explanation
+
+Unsupported Web Locks still fail closed. If the browser cannot safely determine
+ownership, the app must not open an editable or read-only notebook under the
+multi-tab ownership model.
+
+## Read-Only Contract
+
+`OpenNotebookEntry` and `NotebookSnapshot` carry `readOnly`.
+
+`NotebookData` owns the local enforcement:
+
+- read-only notebooks have no save store
+- `updateCell`, `appendCell`, `addCellBefore`, `addCellAfter`, `removeCell`,
+  `setName`, `setUri`, and `runCodeCell` throw
+- persistence is skipped when `readOnly` is true
+- `loadNotebook(..., { persist: false })` remains allowed so the read-only view
+  can hydrate from storage
+
+Runtime APIs expose read-only notebooks for reads:
+
+- `notebooks.list()` includes read-only notebooks with `readOnly: true`
+- `notebooks.get()` returns a cloned notebook document so callers cannot mutate
+  the live model by editing the returned object
+
+Runtime APIs reject read-only mutations:
+
+- `notebooks.update`
+- `notebooks.delete`
+- `notebooks.execute`
+- `runme.clear`
+- `runme.runAll`
+- `runme.rerun`
+
+This lets Codex inspect another open notebook through AppKernel while preventing
+Codex from changing it.
+
+## UI Contract
+
+The tab strip shows a lock icon for read-only notebooks. Hovering the icon shows
+that the notebook is read-only because it is open for editing in another browser
+tab.
+
+The notebook pane also shows a read-only banner. This keeps the mode visible
+after the user starts reading the document and no longer looks at the tab title.
+
+Editing controls are disabled or hidden:
+
+- code, markdown, and HTML editors are read-only
+- add-cell buttons are disabled or hidden
+- delete buttons are disabled
+- run buttons are disabled
+- language, runner, and kernel selectors are disabled
+- markdown and HTML rendered views do not switch into edit mode
+- tab rename is disabled
+
+The sidebar open-documents list labels read-only notebooks as `Read-only`.
+
+## Tradeoffs
+
+Read-only views read from the local notebook mirror. They do not subscribe to
+live in-memory edits from the owner tab. This keeps the change scoped and avoids
+introducing cross-tab document synchronization.
+
+The read-only view may therefore be stale until the owner tab persists changes
+and the secondary tab reloads or reopens the notebook. That is acceptable for
+this change because the goal is safe reference access, not collaborative live
+editing.
+
+## Open Question
+
+Should read-only tabs auto-refresh when the owner tab saves?
+
+The current implementation does not add a refresh protocol. A future change
+could use the existing tab-coordination channel to notify read-only tabs that a
+new local mirror version is available, then offer a manual refresh action or
+safe auto-refresh when the user has no local selection state to preserve.


### PR DESCRIPTION
## Summary

Reintroduces PR #241 on top of the rollback in #244, with additional safeguards for the Chrome Aw Snap regression seen on the hosted `e6ef70b` build.

The fix keeps restored blocked notebooks lightweight by skipping read-only content loading during session restore, and avoids mounting inactive read-only notebook cell trees until the tab is selected.

## Validation

- `pnpm -C app exec vitest run src/lib/notebookDataController.test.ts src/components/Actions/Actions.test.tsx`
- `runme run build test`

## Incident context

The likely app-level failure mode is memory/renderer pressure from #241 restoring many blocked notebooks as loaded read-only tabs and rendering hidden cell trees across restored Chrome tabs. This PR preserves the read-only secondary-tab behavior while removing those eager restore/render paths.

Signed-off-by: Jeremy lewi <jeremy@lewi.us>