### PR TITLE
[codex] Store conflict snapshots in OPFS

### DIFF
--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -27,12 +27,14 @@ function parseNotebookJson(
   }
 }
 
-function registerConflictDiffDocument(
+async function registerConflictDiffDocument(
+  store: LocalNotebooks,
   localUri: string,
   record: LocalFileRecord,
   conflict: NotebookConflictState
 ) {
-  const upstreamNotebook = parseNotebookJson(conflict.upstreamDoc, 'upstream')
+  const upstreamDoc = await store.getConflictUpstreamDoc(localUri)
+  const upstreamNotebook = parseNotebookJson(upstreamDoc, 'upstream')
   const localNotebook = parseNotebookJson(record.doc ?? '', 'local')
   return registerNotebookDiffDocument({
     id: `conflict-${encodeURIComponent(localUri)}`,
@@ -66,7 +68,8 @@ export async function openNotebookConflictDiff(
     throw new Error(`Local notebook ${localUri} does not have a conflict`)
   }
 
-  const document = registerConflictDiffDocument(
+  const document = await registerConflictDiffDocument(
+    store,
     localUri,
     record,
     record.conflict
@@ -84,5 +87,5 @@ export async function refreshNotebookConflictDiff(
     throw new Error(`Local notebook record not found for ${localUri}`)
   }
 
-  registerConflictDiffDocument(localUri, record, conflict)
+  await registerConflictDiffDocument(store, localUri, record, conflict)
 }

--- a/app/src/storage/conflictDocs.ts
+++ b/app/src/storage/conflictDocs.ts
@@ -1,0 +1,143 @@
+import md5 from 'md5'
+
+export interface ConflictDocumentRef {
+  storage: 'opfs'
+  path: string
+  sizeBytes: number
+  checksum: string
+}
+
+export interface ConflictDocStorage {
+  write(localUri: string, upstreamDoc: string): Promise<ConflictDocumentRef>
+  read(ref: ConflictDocumentRef): Promise<string>
+  delete(ref: ConflictDocumentRef): Promise<void>
+}
+
+const ROOT_DIR = 'runme'
+const CONFLICT_DIR = 'conflicts'
+const UPSTREAM_DOC_FILE = 'upstream.json'
+
+const textEncoder = new TextEncoder()
+
+function conflictPathForLocalUri(localUri: string): string {
+  return [
+    ROOT_DIR,
+    CONFLICT_DIR,
+    encodeURIComponent(localUri),
+    UPSTREAM_DOC_FILE,
+  ].join('/')
+}
+
+function opfsUnavailableError(): Error {
+  return new Error('Origin private file system is not available')
+}
+
+async function getOpfsRoot(): Promise<FileSystemDirectoryHandle> {
+  const storage = globalThis.navigator?.storage
+  if (!storage?.getDirectory) {
+    throw opfsUnavailableError()
+  }
+  return storage.getDirectory()
+}
+
+async function getDirectory(
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+  options: FileSystemGetDirectoryOptions = {}
+): Promise<FileSystemDirectoryHandle> {
+  let dir = root
+  for (const segment of segments) {
+    dir = await dir.getDirectoryHandle(segment, options)
+  }
+  return dir
+}
+
+export class OpfsConflictDocStorage implements ConflictDocStorage {
+  async write(
+    localUri: string,
+    upstreamDoc: string
+  ): Promise<ConflictDocumentRef> {
+    const path = conflictPathForLocalUri(localUri)
+    const root = await getOpfsRoot()
+    const dir = await getDirectory(
+      root,
+      [ROOT_DIR, CONFLICT_DIR, encodeURIComponent(localUri)],
+      { create: true }
+    )
+    const handle = await dir.getFileHandle(UPSTREAM_DOC_FILE, {
+      create: true,
+    })
+    const writable = await handle.createWritable()
+    await writable.write(upstreamDoc)
+    await writable.close()
+
+    return {
+      storage: 'opfs',
+      path,
+      sizeBytes: textEncoder.encode(upstreamDoc).byteLength,
+      checksum: md5(upstreamDoc),
+    }
+  }
+
+  async read(ref: ConflictDocumentRef): Promise<string> {
+    if (ref.storage !== 'opfs') {
+      throw new Error(`Unsupported conflict document storage: ${ref.storage}`)
+    }
+    const segments = ref.path.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      throw new Error(`Invalid conflict document path: ${ref.path}`)
+    }
+    const root = await getOpfsRoot()
+    const dir = await getDirectory(root, segments.slice(0, -1))
+    const handle = await dir.getFileHandle(segments[segments.length - 1])
+    const file = await handle.getFile()
+    return file.text()
+  }
+
+  async delete(ref: ConflictDocumentRef): Promise<void> {
+    if (ref.storage !== 'opfs') {
+      return
+    }
+    const segments = ref.path.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return
+    }
+    const root = await getOpfsRoot()
+    const dir = await getDirectory(root, segments.slice(0, -1))
+    await dir.removeEntry(segments[segments.length - 1]).catch(() => {})
+  }
+}
+
+export class MemoryConflictDocStorage implements ConflictDocStorage {
+  private readonly docs = new Map<string, string>()
+
+  async write(
+    localUri: string,
+    upstreamDoc: string
+  ): Promise<ConflictDocumentRef> {
+    const path = conflictPathForLocalUri(localUri)
+    this.docs.set(path, upstreamDoc)
+    return {
+      storage: 'opfs',
+      path,
+      sizeBytes: textEncoder.encode(upstreamDoc).byteLength,
+      checksum: md5(upstreamDoc),
+    }
+  }
+
+  async read(ref: ConflictDocumentRef): Promise<string> {
+    const doc = this.docs.get(ref.path)
+    if (doc === undefined) {
+      throw new Error(`Conflict document not found: ${ref.path}`)
+    }
+    return doc
+  }
+
+  async delete(ref: ConflictDocumentRef): Promise<void> {
+    this.docs.delete(ref.path)
+  }
+}
+
+export function createDefaultConflictDocStorage(): ConflictDocStorage {
+  return new OpfsConflictDocStorage()
+}

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -5,6 +5,7 @@ import md5 from 'md5'
 import { describe, expect, it, vi } from 'vitest'
 
 import { MimeType, parser_pb } from '../runme/client'
+import { MemoryConflictDocStorage } from './conflictDocs'
 import LocalNotebooks, {
   type LocalFileRecord,
   type LocalFolderRecord,
@@ -57,6 +58,7 @@ function createTestStore(driveStore: unknown) {
   localStore.syncListeners = new Map()
   localStore.syncSubjects = new Map()
   localStore.markdownSyncSubjects = new Map()
+  localStore.conflictDocStorage = new MemoryConflictDocStorage()
   return localStore as LocalNotebooks
 }
 
@@ -429,7 +431,15 @@ describe('LocalNotebooks Drive conflict resolution', () => {
       },
       localChecksumAtDetection: 'local-checksum',
     })
-    expect(record?.conflict?.upstreamDoc).toBe(
+    expect(record?.conflict?.upstreamDoc).toBeUndefined()
+    expect(record?.conflict?.upstreamDocRef).toMatchObject({
+      storage: 'opfs',
+      sizeBytes: expect.any(Number),
+      checksum: expect.any(String),
+    })
+    await expect(
+      store.getConflictUpstreamDoc('local://file/conflict')
+    ).resolves.toBe(
       toJsonString(
         parser_pb.NotebookSchema,
         upstreamNotebook,
@@ -441,6 +451,9 @@ describe('LocalNotebooks Drive conflict resolution', () => {
     ).resolves.toMatchObject({
       status: 'conflicted',
       remoteId: remoteUri,
+      conflict: {
+        upstreamDocSizeBytes: expect.any(Number),
+      },
     })
     await expect(store.listDriveBackedFilesNeedingSync()).resolves.toEqual([])
     expect(driveStore.create).not.toHaveBeenCalled()
@@ -489,6 +502,66 @@ describe('LocalNotebooks Drive conflict resolution', () => {
     expect(record?.conflict).toBeTruthy()
     expect((store as any).syncSubjects.size).toBe(0)
     expect((store as any).markdownSyncSubjects.size).toBe(0)
+  })
+
+  it('does not expose legacy inline upstreamDoc in passive sync state', async () => {
+    const hugeUpstreamDoc = 'x'.repeat(1024 * 1024)
+    const store = createTestStore({})
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+      conflict: {
+        detectedAt: '2026-05-30T00:00:00.000Z',
+        upstreamChecksum: 'upstream-checksum',
+        upstreamDoc: hugeUpstreamDoc,
+        localChecksumAtDetection: 'local-checksum',
+      },
+    })
+
+    const syncState = await store.getSyncState('local://file/conflict')
+
+    expect(syncState.status).toBe('conflicted')
+    expect(syncState.conflict).toMatchObject({
+      upstreamChecksum: 'upstream-checksum',
+      upstreamDocSizeBytes: hugeUpstreamDoc.length,
+    })
+    expect(JSON.stringify(syncState)).not.toContain(hugeUpstreamDoc)
+  })
+
+  it('migrates a legacy inline upstreamDoc into conflict document storage on demand', async () => {
+    const legacyUpstreamDoc = notebookJson("print('legacy upstream')")
+    const store = createTestStore({})
+    await store.files.put({
+      id: 'local://file/conflict',
+      name: 'notebook.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+      conflict: {
+        detectedAt: '2026-05-30T00:00:00.000Z',
+        upstreamChecksum: 'upstream-checksum',
+        upstreamDoc: legacyUpstreamDoc,
+        localChecksumAtDetection: 'local-checksum',
+      },
+    })
+
+    await expect(
+      store.getConflictUpstreamDoc('local://file/conflict')
+    ).resolves.toBe(legacyUpstreamDoc)
+
+    const record = await store.files.get('local://file/conflict')
+    expect(record?.conflict?.upstreamDoc).toBeUndefined()
+    expect(record?.conflict?.upstreamDocRef).toMatchObject({
+      storage: 'opfs',
+      checksum: md5(legacyUpstreamDoc),
+    })
   })
 
   it('saves the local version to the original Drive URI and clears conflict', async () => {
@@ -640,7 +713,15 @@ describe('LocalNotebooks Drive conflict resolution', () => {
       checksum: md5(upstreamHeadDoc),
       revisionId: 'head-revision',
     })
-    expect(conflict.upstreamDoc).toBe(upstreamHeadDoc)
+    expect(conflict.upstreamDoc).toBeUndefined()
+    expect(conflict.upstreamDocRef).toMatchObject({
+      storage: 'opfs',
+      sizeBytes: expect.any(Number),
+      checksum: md5(upstreamHeadDoc),
+    })
+    await expect(
+      store.getConflictUpstreamDoc('local://file/conflict')
+    ).resolves.toBe(upstreamHeadDoc)
     expect(conflict.localChecksumAtDetection).toBe(md5(record?.doc ?? ''))
     expect(record?.conflict).toEqual(conflict)
   })

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -9,6 +9,11 @@ import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookTo
 import { appState } from '../lib/runtime/AppState'
 import { parser_pb } from '../runme/client'
 import {
+  type ConflictDocStorage,
+  type ConflictDocumentRef,
+  createDefaultConflictDocStorage,
+} from './conflictDocs'
+import {
   DriveNotebookStore,
   type DriveVersionMetadata,
   isDriveItemUri,
@@ -77,7 +82,18 @@ export interface NotebookConflictState {
   detectedAt: string
   upstreamChecksum: string
   upstreamVersion?: UpstreamVersion
-  upstreamDoc: string
+  upstreamDocRef?: ConflictDocumentRef
+  /** @deprecated Legacy inline conflict payload. New records store this in OPFS. */
+  upstreamDoc?: string
+  localChecksumAtDetection: string
+}
+
+export interface NotebookConflictSummary {
+  detectedAt: string
+  upstreamChecksum: string
+  upstreamVersion?: UpstreamVersion
+  upstreamDocRef?: ConflictDocumentRef
+  upstreamDocSizeBytes?: number
   localChecksumAtDetection: string
 }
 
@@ -97,7 +113,7 @@ export interface NotebookSyncState {
   parentRemoteIdWhenCreated?: string
   lastSynced?: string
   lastUpstreamVersion?: UpstreamVersion
-  conflict?: NotebookConflictState
+  conflict?: NotebookConflictSummary
   lastError?: string
 }
 
@@ -159,6 +175,7 @@ export class LocalNotebooks extends Dexie {
 
   private readonly driveStore: DriveNotebookStore
   private filesystemStore: FilesystemNotebookStore | null = null
+  private readonly conflictDocStorage: ConflictDocStorage
 
   private readonly syncSubjects = new Map<string, Subject<void>>()
   private readonly markdownSyncSubjects = new Map<string, Subject<void>>()
@@ -167,7 +184,8 @@ export class LocalNotebooks extends Dexie {
 
   constructor(
     driveStore: DriveNotebookStore,
-    databaseName: string = 'runme-local-notebooks'
+    databaseName: string = 'runme-local-notebooks',
+    conflictDocStorage: ConflictDocStorage = createDefaultConflictDocStorage()
   ) {
     super(databaseName)
 
@@ -256,6 +274,7 @@ export class LocalNotebooks extends Dexie {
     this.folders = this.table('folders')
 
     this.driveStore = driveStore
+    this.conflictDocStorage = conflictDocStorage
 
     void this.ensureFolderRecord(LOCAL_FOLDER_URI, 'Local Notebooks')
   }
@@ -347,13 +366,13 @@ export class LocalNotebooks extends Dexie {
         )
         const changes: Partial<LocalFileRecord> = { name }
         if (checksum !== existingBaseline) {
-          changes.conflict = {
-            detectedAt: nowIsoString(),
+          changes.conflict = await this.createConflictState({
+            localUri: existing.id,
+            upstreamDoc: serialized,
             upstreamChecksum: checksum,
             upstreamVersion: { checksum },
-            upstreamDoc: serialized,
             localChecksumAtDetection: existingChecksum,
-          }
+          })
           changes.lastSyncError = undefined
         }
         await this.files.update(existing.id, changes)
@@ -691,6 +710,7 @@ export class LocalNotebooks extends Dexie {
       lastSynced: nowIsoString(),
       lastSyncError: undefined,
     })
+    await this.deleteConflictDoc(record.conflict)
     this.notifySync(localUri)
   }
 
@@ -727,13 +747,13 @@ export class LocalNotebooks extends Dexie {
       localUri,
       record
     )
-    const conflict: NotebookConflictState = {
-      detectedAt: nowIsoString(),
+    const conflict = await this.createConflictState({
+      localUri,
+      upstreamDoc,
       upstreamChecksum,
       upstreamVersion,
-      upstreamDoc,
       localChecksumAtDetection: localChecksum,
-    }
+    })
 
     await this.files.update(localUri, {
       conflict,
@@ -741,6 +761,39 @@ export class LocalNotebooks extends Dexie {
     })
     this.notifySync(localUri)
     return conflict
+  }
+
+  async getConflictUpstreamDoc(localUri: string): Promise<string> {
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    const conflict = record.conflict
+    if (!conflict) {
+      throw new Error(`Local notebook ${localUri} does not have a conflict`)
+    }
+
+    if (conflict.upstreamDocRef) {
+      return this.getConflictDocStorage().read(conflict.upstreamDocRef)
+    }
+
+    if (typeof conflict.upstreamDoc === 'string') {
+      const legacyDoc = conflict.upstreamDoc
+      const migrated = await this.createConflictState({
+        localUri,
+        upstreamDoc: legacyDoc,
+        upstreamChecksum: conflict.upstreamChecksum,
+        upstreamVersion: conflict.upstreamVersion,
+        localChecksumAtDetection: conflict.localChecksumAtDetection,
+        detectedAt: conflict.detectedAt,
+      })
+      await this.files.update(localUri, { conflict: migrated })
+      return legacyDoc
+    }
+
+    throw new Error(
+      `Conflict upstream document is missing for local notebook ${localUri}`
+    )
   }
 
   private async persistNotebook(
@@ -1722,15 +1775,16 @@ export class LocalNotebooks extends Dexie {
     const upstreamDoc = serializeNotebook(upstreamNotebook)
     const upstreamChecksum =
       upstreamVersion.checksum || checksumForSerializedNotebook(upstreamDoc)
+    const conflict = await this.createConflictState({
+      localUri,
+      upstreamDoc,
+      upstreamChecksum,
+      upstreamVersion,
+      localChecksumAtDetection: localChecksum,
+    })
 
     await this.files.update(localUri, {
-      conflict: {
-        detectedAt: nowIsoString(),
-        upstreamChecksum,
-        upstreamVersion,
-        upstreamDoc,
-        localChecksumAtDetection: localChecksum,
-      },
+      conflict,
       lastSyncError: undefined,
     })
 
@@ -1747,6 +1801,61 @@ export class LocalNotebooks extends Dexie {
       },
     })
     this.notifySync(localUri)
+  }
+
+  private async createConflictState({
+    localUri,
+    upstreamDoc,
+    upstreamChecksum,
+    upstreamVersion,
+    localChecksumAtDetection,
+    detectedAt = nowIsoString(),
+  }: {
+    localUri: string
+    upstreamDoc: string
+    upstreamChecksum: string
+    upstreamVersion?: UpstreamVersion
+    localChecksumAtDetection: string
+    detectedAt?: string
+  }): Promise<NotebookConflictState> {
+    const upstreamDocRef = await this.getConflictDocStorage().write(
+      localUri,
+      upstreamDoc
+    )
+    return {
+      detectedAt,
+      upstreamChecksum,
+      upstreamVersion,
+      upstreamDocRef,
+      localChecksumAtDetection,
+    }
+  }
+
+  private getConflictDocStorage(): ConflictDocStorage {
+    return (
+      (this as unknown as { conflictDocStorage?: ConflictDocStorage })
+        .conflictDocStorage ?? createDefaultConflictDocStorage()
+    )
+  }
+
+  private async deleteConflictDoc(
+    conflict: NotebookConflictState | undefined
+  ): Promise<void> {
+    if (!conflict?.upstreamDocRef) {
+      return
+    }
+    try {
+      await this.getConflictDocStorage().delete(conflict.upstreamDocRef)
+    } catch (error) {
+      appLogger.warn('Failed to delete conflict document from OPFS', {
+        attrs: {
+          scope: 'storage.drive.sync',
+          code: 'DRIVE_NOTEBOOK_CONFLICT_DOC_DELETE_FAILED',
+          path: conflict.upstreamDocRef.path,
+          error: String(error),
+        },
+      })
+    }
   }
 
   private async findParentFolder(
@@ -1879,8 +1988,28 @@ function syncStateForRecord(
     parentRemoteIdWhenCreated: record.parentRemoteIdWhenCreated,
     lastSynced: record.lastSynced || undefined,
     lastUpstreamVersion: record.lastUpstreamVersion,
-    conflict: record.conflict,
+    conflict: summarizeConflictForSync(record.conflict),
     lastError: record.lastSyncError || fallbackError,
+  }
+}
+
+function summarizeConflictForSync(
+  conflict: NotebookConflictState | undefined
+): NotebookConflictSummary | undefined {
+  if (!conflict) {
+    return undefined
+  }
+  return {
+    detectedAt: conflict.detectedAt,
+    upstreamChecksum: conflict.upstreamChecksum,
+    upstreamVersion: conflict.upstreamVersion,
+    upstreamDocRef: conflict.upstreamDocRef,
+    upstreamDocSizeBytes:
+      conflict.upstreamDocRef?.sizeBytes ??
+      (typeof conflict.upstreamDoc === 'string'
+        ? new TextEncoder().encode(conflict.upstreamDoc).byteLength
+        : undefined),
+    localChecksumAtDetection: conflict.localChecksumAtDetection,
   }
 }
 

--- a/docs-dev/design/20260530_notebook_conflict_resolution.md
+++ b/docs-dev/design/20260530_notebook_conflict_resolution.md
@@ -127,6 +127,16 @@ type NotebookSyncStatus =
 
 Add a first-class conflict state instead of overloading `error`.
 
+### 2026-06-04 Storage Amendment
+
+The original V0 data model below stored `conflict.upstreamDoc` inline on
+`LocalFileRecord`. That decision has been superseded by
+`docs-dev/design/20260604_conflict_snapshots_opfs.md`.
+
+Keep the conflict status and lightweight metadata in IndexedDB, but store the
+large upstream snapshot in OPFS and reference it from the record. Passive reads
+such as `getSyncState(...)` must not return the full upstream document.
+
 ## Proposed User Flow
 
 ### 1. Conflict Detection
@@ -248,10 +258,12 @@ export interface LocalFileRecord {
 }
 ```
 
-Persist `upstreamDoc` in IndexedDB so the conflict diff is stable even if Drive
-changes again or auth is temporarily unavailable. This duplicates one notebook
-payload only while a conflict is unresolved. Clear it after the user resolves
-or intentionally discards the conflict.
+Deprecated: the initial design persisted `upstreamDoc` inline in IndexedDB so
+the conflict diff was stable even if Drive changed again or auth was
+temporarily unavailable. That shape caused large conflicted notebooks to make
+the hot `files` record unsafe to load passively. New conflict records should
+store an OPFS document ref instead; see
+`docs-dev/design/20260604_conflict_snapshots_opfs.md`.
 
 Use the existing `lastUpstreamVersion` as the base version where possible. It
 is diagnostic metadata, not the merge base content.

--- a/docs-dev/design/20260604_conflict_snapshots_opfs.md
+++ b/docs-dev/design/20260604_conflict_snapshots_opfs.md
@@ -1,0 +1,314 @@
+# Conflict Snapshot Storage in OPFS
+
+Date: 2026-06-04
+
+Builds on:
+
+- `docs-dev/design/20260530_notebook_conflict_resolution.md`
+- `docs-dev/design/20260409_track_drive_versions.md`
+- `docs-dev/design/20260409_data_migrations.md`
+
+Related:
+
+- Issue: `runmedev/web#249`
+- PR: `runmedev/web#251`
+
+## Summary
+
+Conflict management should store large upstream conflict snapshots in OPFS, not
+inline on the hot IndexedDB `files` record.
+
+IndexedDB remains the source of truth for notebook identity, sync status, and
+conflict metadata. OPFS stores only the large serialized upstream notebook
+document needed to open a conflict diff.
+
+This changes the conflict data model from:
+
+```text
+IndexedDB files record
+  doc: local notebook JSON
+  conflict.upstreamDoc: upstream notebook JSON
+```
+
+to:
+
+```text
+IndexedDB files record
+  doc: local notebook JSON
+  conflict.upstreamDocRef: OPFS pointer + size/checksum metadata
+
+OPFS
+  runme/conflicts/<encoded local URI>/upstream.json
+```
+
+The user-facing conflict flow stays the same: conflict detection stops sync,
+the notebook tab shows `conflicted`, clicking the sync indicator opens the
+upstream-vs-local diff, and **Save local version** resolves the conflict by
+writing local content back to the original upstream file.
+
+## Problem
+
+The original conflict-resolution design stored `conflict.upstreamDoc` inline on
+`LocalFileRecord` in IndexedDB. That was simple and kept the upstream snapshot
+available offline, but it made the `files` record carry two potentially large
+notebook payloads:
+
+- `doc`: current local notebook JSON
+- `conflict.upstreamDoc`: upstream notebook JSON captured at conflict detection
+
+That record is on a hot path:
+
+- `LocalNotebooks.load(uri)` reads the full `files` record before parsing
+  `record.doc`.
+- `LocalNotebooks.getSyncState(uri)` reads the full record to render the sync
+  indicator.
+- `NotebookSyncIndicator` stores the returned sync state in React state.
+
+In the incident that motivated this change, the local notebook document was
+about 11 MB and `conflict.upstreamDoc` was about 11.8 MB. Opening the notebook
+could crash Chrome before the user clicked the sync indicator. Exporting the
+notebook JSON and re-uploading it to Drive opened successfully, which showed the
+notebook JSON itself was not the only trigger. Clearing only the stale
+`record.conflict` snapshot stopped the crash.
+
+The crash did not require `openNotebookConflictDiff()`. Passive page load was
+enough because the app moved the large inline conflict snapshot from IndexedDB
+into JavaScript and then into UI state.
+
+## Goals
+
+- Keep passive notebook load and passive sync-state reads lightweight.
+- Preserve stable conflict diffs when upstream changes after detection.
+- Preserve offline/local conflict review when the snapshot is already local.
+- Keep IndexedDB as the queryable metadata/index layer.
+- Store large conflict document payloads in a storage surface designed for file
+  blobs.
+- Support legacy inline `conflict.upstreamDoc` records without crashing on
+  passive sync-state reads.
+
+## Non-Goals
+
+- Moving the whole notebook store from IndexedDB to OPFS.
+- Changing conflict-resolution semantics or user-facing labels.
+- Adding cell-level conflict resolution.
+- Adding a multi-version history system.
+- Automatically garbage collecting all historical OPFS data in this first
+  change.
+
+## Decision
+
+Use a two-layer model:
+
+1. IndexedDB stores conflict metadata and an optional OPFS reference.
+2. OPFS stores the serialized upstream conflict document.
+
+`LocalFileRecord.conflict` remains the durable marker that the notebook is in a
+conflicted state. It must be small enough to safely return from
+`getSyncState()` and hold in React state.
+
+Illustrative types:
+
+```ts
+export interface ConflictDocumentRef {
+  storage: 'opfs'
+  path: string
+  sizeBytes: number
+  checksum: string
+}
+
+export interface NotebookConflictState {
+  detectedAt: string
+  upstreamChecksum: string
+  upstreamVersion?: UpstreamVersion
+  upstreamDocRef?: ConflictDocumentRef
+
+  // Legacy only. New records should not set this.
+  upstreamDoc?: string
+
+  localChecksumAtDetection: string
+}
+
+export interface NotebookConflictSummary {
+  detectedAt: string
+  upstreamChecksum: string
+  upstreamVersion?: UpstreamVersion
+  upstreamDocRef?: ConflictDocumentRef
+  upstreamDocSizeBytes?: number
+  localChecksumAtDetection: string
+}
+```
+
+`NotebookSyncState` should expose only `NotebookConflictSummary`, not the full
+`NotebookConflictState`.
+
+## Storage Layout
+
+Conflict snapshot files are stored under the origin private file system:
+
+```text
+runme/
+  conflicts/
+    <encodeURIComponent(localUri)>/
+      upstream.json
+```
+
+Example:
+
+```text
+runme/conflicts/local%3A%2F%2Ffile%2F5358eab1-1eb5-4f84-9693-d899baf3e35f/upstream.json
+```
+
+The OPFS path is an implementation detail. IndexedDB should store enough
+metadata to read and validate the snapshot:
+
+- `path`
+- `sizeBytes`
+- `checksum`
+- `storage: "opfs"`
+
+## Write Path
+
+When Drive sync detects a conflict:
+
+1. Load the current upstream notebook from Drive.
+2. Serialize the upstream notebook to JSON.
+3. Write the serialized upstream document to OPFS.
+4. Store conflict metadata plus `upstreamDocRef` on the `files` record.
+5. Leave `remoteId`, `doc`, and local edits unchanged.
+6. Notify sync listeners so the tab indicator shows `conflicted`.
+
+If OPFS write fails, sync should fail visibly instead of uploading, downloading,
+or silently creating a copy. The safe fallback is `lastSyncError`, not inline
+storage of a large payload on the hot record.
+
+## Read Path
+
+Passive reads must not load the conflict document.
+
+`getSyncState(localUri)` should:
+
+1. Read the local `files` record.
+2. Return `status: "conflicted"` if `record.conflict` exists.
+3. Include conflict summary metadata only.
+4. Never include `conflict.upstreamDoc`.
+
+Opening the conflict diff is the explicit read path:
+
+1. Read the local `files` record.
+2. Resolve the upstream snapshot:
+   - if `upstreamDocRef` exists, read OPFS
+   - if legacy `upstreamDoc` exists, migrate it to OPFS and update the record
+   - otherwise show a recoverable missing-snapshot error
+3. Parse upstream and local notebooks.
+4. Compute and display the notebook diff.
+
+## Legacy Inline Records
+
+Existing profiles can already have inline `conflict.upstreamDoc` values. The
+new code must handle them safely.
+
+Passive migration is not required and should be avoided if it would read or
+clone the large document just to render the conflict indicator.
+
+Legacy behavior:
+
+- `getSyncState()` returns a lightweight summary.
+- If `upstreamDoc` is inline, the summary may report
+  `upstreamDocSizeBytes`, but it must not return the document string.
+- `getConflictUpstreamDoc(localUri)` migrates the legacy inline document to
+  OPFS on demand when the user explicitly opens the diff.
+- After successful migration, the IndexedDB record should contain
+  `upstreamDocRef` and no inline `upstreamDoc`.
+
+## Resolution And Cleanup
+
+When the user chooses **Save local version**:
+
+1. Verify the upstream version has not changed since the conflict snapshot, or
+   require force/confirmation if it has changed.
+2. Write the local `doc` to the original upstream file.
+3. Refresh upstream version metadata.
+4. Clear `record.conflict`.
+5. Delete the referenced OPFS conflict snapshot on a best-effort basis.
+
+OPFS deletion failure should not block successful conflict resolution. It should
+be logged as a cleanup warning.
+
+Future cleanup work should garbage collect OPFS conflict directories whose
+local file record no longer exists or no longer points at that conflict ref.
+
+## Failure Handling
+
+### OPFS unavailable while recording conflict
+
+Set `lastSyncError` and leave local content untouched. Do not silently fall back
+to inline `upstreamDoc` for large snapshots, because that reintroduces the
+crash class this design removes.
+
+### OPFS snapshot missing while opening diff
+
+Show an error in the conflict diff path. The user can refresh the conflict
+snapshot from Drive if they still have access, or resolve from local after an
+explicit confirmation path.
+
+### OPFS snapshot checksum mismatch
+
+Treat this as a corrupt local snapshot. Do not compute a diff against it. A
+future implementation can add automatic refresh from Drive when the upstream
+revision still matches.
+
+### Legacy inline snapshot cannot be migrated
+
+Return an actionable error from `openNotebookConflictDiff()`. Do not put the
+large inline document into React sync state.
+
+## Test Plan
+
+Storage tests should cover:
+
+- Recording a Drive conflict writes the upstream document through the conflict
+  document storage abstraction.
+- New `record.conflict` contains `upstreamDocRef` and no `upstreamDoc`.
+- `getConflictUpstreamDoc(localUri)` reads the OPFS-backed document.
+- `getSyncState(localUri)` returns `conflicted` without exposing
+  `upstreamDoc`.
+- Legacy inline `upstreamDoc` is migrated to OPFS on explicit diff open.
+- Resolving a conflict clears IndexedDB conflict metadata and best-effort
+  deletes the OPFS document.
+
+UI/runtime tests should cover:
+
+- The sync indicator can render a conflicted notebook without receiving a large
+  upstream document.
+- Clicking the conflict indicator still opens the diff.
+- Refreshing a conflict diff writes the refreshed upstream snapshot to OPFS.
+
+Manual/browser regression:
+
+1. Seed IndexedDB with a large conflicted local record.
+2. Open the notebook.
+3. Verify the page remains alive and shows the conflicted indicator.
+4. Click the indicator and verify the diff opens or fails recoverably.
+
+## Tradeoffs
+
+OPFS is still origin/profile-local. It is not a sync mechanism and does not make
+conflict snapshots portable across profiles.
+
+The split also introduces a small consistency risk: IndexedDB metadata can point
+at an OPFS file that no longer exists. The conflict diff path must handle this
+as recoverable local-storage corruption.
+
+The benefit is that hot IndexedDB reads stay bounded and predictable. Large
+conflict payloads are loaded only when the user explicitly asks to review the
+conflict.
+
+## Follow-Up Work
+
+- Add OPFS garbage collection for orphaned conflict snapshots.
+- Add snapshot checksum verification on OPFS reads.
+- Add a "refresh upstream snapshot" action for missing or corrupt snapshots.
+- Add a size threshold that shows a lightweight conflict review flow when diff
+  computation itself would be too expensive.
+- Consider moving other cold large payloads out of hot IndexedDB records if
+  similar crash or latency issues appear.


### PR DESCRIPTION
## Summary

- Store large Drive conflict upstream snapshots in OPFS instead of inline on the IndexedDB `files` record.
- Keep IndexedDB conflict state lightweight by storing metadata plus an OPFS document reference.
- Load the upstream conflict document only when the user explicitly opens or refreshes a conflict diff.
- Migrate legacy inline `conflict.upstreamDoc` records on demand when opening a conflict diff.
- Prevent passive sync-state reads from returning large inline conflict documents into React state.

Fixes #249

## Why

We confirmed a Chrome "Aw, Snap!" crash was caused by a conflicted local notebook record that had both:

- `record.doc` around 11 MB
- `record.conflict.upstreamDoc` around 11.8 MB

Opening the notebook caused the app to pull that large IndexedDB record into JS, and the sync indicator could also put the full conflict object into React state just to render the conflicted badge.

This PR keeps the hot IndexedDB record small while preserving conflict diff support through OPFS.

## Validation

- `pnpm -C app exec tsc --noEmit`
- `pnpm -C app exec vitest run src/storage/local.test.ts`
- `pnpm -C app exec vitest run src/storage/local.test.ts src/components/Actions/Actions.test.tsx src/lib/notebookDiff/diff.test.ts`
- `runme run build test`

Notes:

- `pnpm -C app run lint` could not run in this checkout because `eslint` was not installed (`sh: eslint: command not found`).
- `runme run build test` printed the existing `z has been updated; please re-run ./project/z/install` warning, but both build and test tasks exited 0.
