### PR TITLE
[codex] Add Drive folder creation from explorer

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NotebookStoreItemType } from '../../storage/notebook'
@@ -13,10 +13,36 @@ const mocks = vi.hoisted(() => ({
   isDriveItemUri: vi.fn(),
   openNotebook: vi.fn(),
   showDocument: vi.fn(),
+  addItem: vi.fn(),
+  removeItem: vi.fn(),
+  store: {
+    getMetadata: vi.fn(),
+    createFolder: vi.fn(),
+    sync: vi.fn(),
+  },
+  workspaceItems: [] as string[],
 }))
 
 vi.mock('react-arborist', () => ({
-  Tree: () => <div data-testid="tree" />,
+  Tree: ({ data, children }: any) => (
+    <div data-testid="tree">
+      {(data ?? []).map((item: any) => (
+        <div key={item.id}>
+          {children({
+            node: {
+              data: item,
+              isEditing: false,
+              isOpen: false,
+              handleClick: vi.fn(),
+              toggle: vi.fn(),
+              parent: null,
+            },
+            style: {},
+          })}
+        </div>
+      ))}
+    </div>
+  ),
 }))
 
 vi.mock('./GoogleDrivePickerButton', () => ({
@@ -25,15 +51,15 @@ vi.mock('./GoogleDrivePickerButton', () => ({
 
 vi.mock('../../contexts/WorkspaceContext', () => ({
   useWorkspace: () => ({
-    getItems: () => [],
-    addItem: vi.fn(),
-    removeItem: vi.fn(),
+    getItems: () => mocks.workspaceItems,
+    addItem: mocks.addItem,
+    removeItem: mocks.removeItem,
   }),
 }))
 
 vi.mock('../../contexts/NotebookStoreContext', () => ({
   useNotebookStore: () => ({
-    store: {},
+    store: mocks.store,
   }),
 }))
 
@@ -74,6 +100,10 @@ vi.mock('../../storage/drive', () => ({
   parseDriveItem: mocks.parseDriveItem,
 }))
 
+vi.mock('../../lib/toast', () => ({
+  showToast: vi.fn(),
+}))
+
 describe('WorkspaceExplorer current document handling', () => {
   beforeEach(() => {
     mocks.currentDoc = 'diff://notebook/diff-1'
@@ -91,6 +121,28 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.isDriveItemUri.mockReturnValue(false)
     mocks.openNotebook.mockReset()
     mocks.showDocument.mockReset()
+    mocks.addItem.mockReset()
+    mocks.removeItem.mockReset()
+    mocks.workspaceItems = []
+    mocks.store.getMetadata.mockReset()
+    mocks.store.getMetadata.mockResolvedValue({
+      uri: 'local://folder/local',
+      name: 'Local Notebooks',
+      type: NotebookStoreItemType.Folder,
+      children: [],
+      parents: [],
+    })
+    mocks.store.createFolder.mockReset()
+    mocks.store.createFolder.mockResolvedValue({
+      uri: 'local://folder/new',
+      name: 'Reports',
+      type: NotebookStoreItemType.Folder,
+      children: [],
+      remoteUri: 'https://drive.google.com/drive/folders/new',
+      parents: ['local://folder/drive'],
+    })
+    mocks.store.sync.mockReset()
+    vi.spyOn(window, 'prompt').mockReturnValue('Reports')
   })
 
   it('does not treat notebook diff URIs as Google Drive documents', async () => {
@@ -104,5 +156,39 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(mocks.parseDriveItem).not.toHaveBeenCalled()
     expect(mocks.fetchDriveItemWithParents).not.toHaveBeenCalled()
     expect(mocks.setCurrentDoc).not.toHaveBeenCalledWith(null)
+  })
+
+  it('creates a Google Drive folder from a Drive-backed folder context menu', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    const driveRoot = await screen.findByText('Drive Root')
+    fireEvent.contextMenu(driveRoot)
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'New Google Drive Folder',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.store.createFolder).toHaveBeenCalledWith(
+        'local://folder/drive',
+        'Reports'
+      )
+    })
   })
 })

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -173,6 +173,7 @@ const CONTEXT_MENU_VIEWPORT_PADDING = 8;
 const CONTEXT_MENU_WIDTH = 220;
 const CONTEXT_MENU_VERTICAL_PADDING = 8;
 const CONTEXT_MENU_ITEM_HEIGHT = 38;
+const DEFAULT_DRIVE_FOLDER_NAME = "New Folder";
 
 function getContextMenuItemCount(menu: ContextMenuState): number {
   if (menu.type === NotebookStoreItemType.File) {
@@ -187,6 +188,7 @@ function getContextMenuItemCount(menu: ContextMenuState): number {
     return (
       (menu.uri.startsWith("fs://") ? 0 : 1) +
       1 +
+      (menu.remoteUri ? 1 : 0) +
       (menu.remoteUri ? 2 : 0) +
       (menu.uri === LOCAL_FOLDER_URI ? 0 : 1)
     );
@@ -725,6 +727,43 @@ export function WorkspaceExplorer() {
     [fetchChildren, fsStore, store],
   );
 
+  const handleCreateDriveFolder = useCallback(
+    async (folderUri: string) => {
+      if (!store) {
+        return;
+      }
+
+      const name =
+        typeof window === "undefined"
+          ? DEFAULT_DRIVE_FOLDER_NAME
+          : window.prompt("Folder name", DEFAULT_DRIVE_FOLDER_NAME);
+      if (name === null) {
+        return;
+      }
+
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        return;
+      }
+
+      try {
+        treeRef.current?.open(folderUri);
+        await store.createFolder(folderUri, trimmedName);
+        await fetchChildren(folderUri);
+        setErrorMessage(null);
+        showToast({ message: "Google Drive folder created", tone: "success" });
+      } catch (error) {
+        console.error("Failed to create Google Drive folder", error);
+        setErrorMessage("Unable to create Google Drive folder. Please try again.");
+        showToast({
+          message: "Could not create Google Drive folder",
+          tone: "error",
+        });
+      }
+    },
+    [fetchChildren, store],
+  );
+
   const handleStartRename = useCallback((uri: string) => {
     setContextMenu(null);
     setPendingEditId(uri);
@@ -1199,6 +1238,20 @@ function formatShortTimestamp(date: Date): string {
               >
                 New Document
               </button>
+              {adjustedContextMenu.remoteUri && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setContextMenu(null);
+                    void handleCreateDriveFolder(adjustedContextMenu.uri);
+                  }}
+                >
+                  New Google Drive Folder
+                </button>
+              )}
               {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -84,6 +84,52 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("creates Drive folders with the folder MIME type", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(url.searchParams.get("fields")).toBe("id,name,mimeType,parents");
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          name: "Reports",
+          mimeType: "application/vnd.google-apps.folder",
+          parents: ["parent123"],
+        });
+        return new Response(
+          JSON.stringify({
+            id: "folder123",
+            name: "Reports",
+            mimeType: "application/vnd.google-apps.folder",
+            parents: ["parent123"],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.createFolder(
+      "https://drive.google.com/drive/folders/parent123",
+      "Reports",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      uri: "https://drive.google.com/drive/folders/folder123",
+      name: "Reports",
+      type: NotebookStoreItemType.Folder,
+      children: [],
+      remoteUri: "https://drive.google.com/drive/folders/folder123",
+      parents: ["https://drive.google.com/drive/folders/parent123"],
+    });
+  });
+
   it("renames Drive files through the metadata update API", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -16,6 +16,7 @@ const VERSION_FIELDS = 'md5Checksum,headRevisionId'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
+const DRIVE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
 
 let gapiScriptPromise: Promise<void> | null = null
 let clientPromise: Promise<DriveFilesClient> | null = null
@@ -793,7 +794,7 @@ export class DriveNotebookStore {
     }
     const fileId = file.id
     file = await client.ensureParent(file, id)
-    const isFolder = file.mimeType === 'application/vnd.google-apps.folder'
+    const isFolder = file.mimeType === DRIVE_FOLDER_MIME_TYPE
     return {
       uri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       name: file.name ?? name,
@@ -802,6 +803,37 @@ export class DriveNotebookStore {
         : NotebookStoreItemType.File,
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
+      parents: [parentUri],
+    }
+  }
+
+  async createFolder(
+    parentUri: string,
+    name: string
+  ): Promise<NotebookStoreItem> {
+    const { id, type } = parseDriveItem(parentUri)
+    if (type !== NotebookStoreItemType.Folder) {
+      throw new Error('DriveNotebookStore.createFolder expects a folder URI')
+    }
+    const client = await this.getFilesClient()
+    let folder = await client.create({
+      name,
+      mimeType: DRIVE_FOLDER_MIME_TYPE,
+      parents: [id],
+    })
+
+    if (!folder.id) {
+      throw new Error('Failed to create Google Drive folder')
+    }
+    const folderId = folder.id
+    folder = await client.ensureParent(folder, id)
+    const folderUri = driveFolderUrl(folderId)
+    return {
+      uri: folderUri,
+      name: folder.name ?? name,
+      type: NotebookStoreItemType.Folder,
+      children: [],
+      remoteUri: folderUri,
       parents: [parentUri],
     }
   }
@@ -916,7 +948,7 @@ export class DriveNotebookStore {
     )
 
     return files.map((file) => {
-      const isFolder = file.mimeType === 'application/vnd.google-apps.folder'
+      const isFolder = file.mimeType === DRIVE_FOLDER_MIME_TYPE
       return {
         uri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
         name: file.name ?? 'Untitled item',
@@ -1021,7 +1053,7 @@ export class DriveNotebookStore {
 
     const fileId = file.id ?? id
     const mimeType = file.mimeType
-    const isFolder = mimeType === 'application/vnd.google-apps.folder'
+    const isFolder = mimeType === DRIVE_FOLDER_MIME_TYPE
     return {
       uri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       name: file.name ?? name,
@@ -1074,7 +1106,7 @@ export class DriveNotebookStore {
       mimeType?: string
       parents?: string[]
     }
-    const isFolder = result?.mimeType === 'application/vnd.google-apps.folder'
+    const isFolder = result?.mimeType === DRIVE_FOLDER_MIME_TYPE
     const resolvedType = isFolder
       ? NotebookStoreItemType.Folder
       : NotebookStoreItemType.File
@@ -1132,7 +1164,7 @@ export async function fetchDriveItemWithParents(
       parentId === 'root' ? parentId : driveFolderUrl(parentId)
     )
 
-  const isFolder = meta.mimeType === 'application/vnd.google-apps.folder'
+  const isFolder = meta.mimeType === DRIVE_FOLDER_MIME_TYPE
   const item: NotebookStoreItem = {
     uri: isFolder ? driveFolderUrl(meta.id) : driveFileUrl(meta.id),
     name: meta.name ?? 'Untitled item',
@@ -1154,8 +1186,7 @@ export async function fetchDriveItemWithParents(
       if (!parentMeta.id) {
         continue
       }
-      const parentIsFolder =
-        parentMeta.mimeType === 'application/vnd.google-apps.folder'
+      const parentIsFolder = parentMeta.mimeType === DRIVE_FOLDER_MIME_TYPE
       parents.push({
         uri: parentIsFolder
           ? driveFolderUrl(parentMeta.id)

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -79,6 +79,47 @@ function notebookJson(value: string): string {
 }
 
 describe('LocalNotebooks pending Drive create', () => {
+  it('creates a Drive-backed folder and attaches it locally', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const childRemoteUri = 'https://drive.google.com/drive/folders/child123'
+    const driveStore = {
+      createFolder: vi.fn(async () => ({
+        uri: childRemoteUri,
+        name: 'Reports',
+        type: NotebookStoreItemType.Folder,
+        children: [],
+        remoteUri: childRemoteUri,
+        parents: [parentRemoteUri],
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/drive',
+      name: 'Drive',
+      remoteId: parentRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+
+    const item = await store.createFolder('local://folder/drive', 'Reports')
+
+    expect(driveStore.createFolder).toHaveBeenCalledWith(
+      parentRemoteUri,
+      'Reports'
+    )
+    expect(item.type).toBe(NotebookStoreItemType.Folder)
+    expect(item.remoteUri).toBe(childRemoteUri)
+    const record = await store.folders.get(item.uri)
+    expect(record).toMatchObject({
+      name: 'Reports',
+      remoteId: childRemoteUri,
+      children: [],
+    })
+    expect(
+      (await store.folders.get('local://folder/drive'))?.children
+    ).toContain(item.uri)
+  })
+
   it('persists pending upstream parent when Drive create fails', async () => {
     const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
     const driveStore = {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -936,6 +936,73 @@ export class LocalNotebooks extends Dexie {
     }
   }
 
+  async createFolder(
+    parentUri: string,
+    name: string
+  ): Promise<NotebookStoreItem> {
+    if (!parentUri.startsWith('local://folder/')) {
+      throw new Error('LocalNotebooks.createFolder expects a folder parent URI')
+    }
+
+    const parent = await this.folders.get(parentUri)
+    if (!parent) {
+      throw new Error(`Parent folder not found for ${parentUri}`)
+    }
+    if (!isDriveUri(parent.remoteId)) {
+      throw new Error(
+        'LocalNotebooks.createFolder expects a Drive-backed parent'
+      )
+    }
+
+    const trimmedName = name.trim() || 'New Folder'
+    const remoteFolder = await this.driveStore.createFolder(
+      parent.remoteId,
+      trimmedName
+    )
+    const remoteUri = remoteFolder.remoteUri ?? remoteFolder.uri
+    const existingFolder = await this.folders
+      .where('remoteId')
+      .equals(remoteUri)
+      .first()
+    const folderUri = existingFolder?.id ?? this.generateLocalUri('folder')
+    const folderRecord: LocalFolderRecord = {
+      id: folderUri,
+      name: remoteFolder.name || trimmedName,
+      remoteId: remoteUri,
+      children: existingFolder?.children ?? [],
+      lastSynced: nowIsoString(),
+    }
+
+    await this.folders.put(folderRecord)
+    if (!parent.children.includes(folderUri)) {
+      await this.folders.update(parentUri, {
+        children: [...parent.children, folderUri],
+        lastSynced: nowIsoString(),
+      })
+    }
+
+    if (canDispatchWindowEvents()) {
+      window.dispatchEvent(
+        new CustomEvent('local-notebook-updated', {
+          detail: {
+            uri: folderUri,
+            name: folderRecord.name,
+            remoteUri,
+          },
+        })
+      )
+    }
+
+    return {
+      uri: folderUri,
+      name: folderRecord.name,
+      type: NotebookStoreItemType.Folder,
+      children: [],
+      remoteUri,
+      parents: [parentUri],
+    }
+  }
+
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {
     if (!uri.startsWith('local://file/')) {
       throw new Error('LocalNotebooks.rename expects a file URI')


### PR DESCRIPTION
## Summary
- Add a Drive folder creation API that creates folders with the Google Drive folder MIME type.
- Mirror newly-created Drive folders into the local workspace store and attach them under the selected Drive-backed folder.
- Add a Drive-backed folder context-menu item in Workspace Explorer plus focused tests.

## Validation
- pnpm -C app test --run src/storage/drive.test.ts src/storage/local.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx
- runme run build test
- git diff --check

## Notes
- pnpm -C app run typecheck currently fails on existing app-wide TypeScript errors unrelated to this change.