### PR TITLE
Add notebook reference helpers

### DIFF
--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -915,11 +915,17 @@ export class NotebookData {
     const runmeApi = createRunmeConsoleApi({
       resolveNotebook: () => this,
     })
+    const hostNotebooksApi = createHostNotebooksApi({
+      resolveNotebook: this.resolveNotebookForAppKernel,
+      listNotebooks: this.listNotebooksForAppKernel,
+    })
+    const appGlobals = createAppJsGlobals({
+      runme: runmeApi,
+      resolveNotebook: this.resolveNotebookForAppKernel,
+      listNotebooks: this.listNotebooksForAppKernel,
+    })
     const notebooksApiBridgeServer = createNotebooksApiBridgeServer({
-      notebooksApi: createHostNotebooksApi({
-        resolveNotebook: this.resolveNotebookForAppKernel,
-        listNotebooks: this.listNotebooksForAppKernel,
-      }),
+      notebooksApi: appGlobals.notebooks as typeof hostNotebooksApi,
     })
 
     let stdout = ''
@@ -964,11 +970,7 @@ export class NotebookData {
               hooks,
             }).run(source)
           : new JSKernel({
-              globals: createAppJsGlobals({
-                runme: runmeApi,
-                resolveNotebook: this.resolveNotebookForAppKernel,
-                listNotebooks: this.listNotebooksForAppKernel,
-              }),
+              globals: appGlobals,
               hooks,
             }).run(source)
         : Promise.resolve().then(() => {

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { create } from '@bufbuild/protobuf'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { parser_pb } from '../../runme/client'
+import { appState } from './AppState'
+import { createAppJsGlobals } from './appJsGlobals'
+import type { NotebookDataLike, RunmeConsoleApi } from './runmeConsole'
+
+class FakeNotebookData implements NotebookDataLike {
+  constructor(
+    private readonly uri: string,
+    private readonly name: string
+  ) {}
+
+  getUri(): string {
+    return this.uri
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  getNotebook(): parser_pb.Notebook {
+    return create(parser_pb.NotebookSchema, { cells: [] })
+  }
+
+  updateCell(): void {}
+
+  getCell(): null {
+    return null
+  }
+}
+
+function createRunme(current: NotebookDataLike | null = null): RunmeConsoleApi {
+  return {
+    getCurrentNotebook: () => current,
+    clear: () => '',
+    clearOutputs: () => '',
+    runAll: () => '',
+    rerun: () => '',
+    help: () => '',
+  }
+}
+
+describe('createAppJsGlobals notebook reference helpers', () => {
+  afterEach(() => {
+    appState.setLocalNotebooks(null)
+    appState.setOpenNotebookHandler(null)
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('resolves a local URI to metadata, share URL, and Markdown link', async () => {
+    window.history.replaceState(null, '', '/workspace?ignored=true')
+    appState.setLocalNotebooks({
+      getMetadata: vi.fn(async () => ({
+        uri: 'local://file/local-id',
+        name: 'Team Notes.json',
+        type: 'file',
+        children: [],
+        remoteUri: 'https://drive.google.com/file/d/file123/view',
+        parents: [],
+      })),
+      files: {
+        where: vi.fn(),
+      },
+    } as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const info = await globals.notebooks.resolve('local://file/local-id')
+
+    expect(info).toMatchObject({
+      uri: 'local://file/local-id',
+      localUri: 'local://file/local-id',
+      remoteUri: 'https://drive.google.com/file/d/file123/view',
+      googleDriveUrl: 'https://drive.google.com/file/d/file123/view',
+      title: 'Team Notes.json',
+      shareTarget: 'https://drive.google.com/file/d/file123/view',
+      source: 'drive',
+    })
+    expect(info.shareUrl).toBe(
+      'http://localhost:3000/workspace?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview'
+    )
+    expect(info.markdownLink).toBe(
+      '[Team Notes](http://localhost:3000/workspace?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview)'
+    )
+  })
+
+  it('opens a local URI from a Runme share URL', async () => {
+    const opened = vi.fn()
+    appState.setOpenNotebookHandler(opened)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const info = await globals.notebooks.show(
+      'https://runme.example/?doc=local%3A%2F%2Ffile%2Fopened'
+    )
+
+    expect(opened).toHaveBeenCalledWith('local://file/opened')
+    expect(info.opened).toBe('local://file/opened')
+  })
+
+  it('uses the current notebook when no reference is passed', async () => {
+    window.history.replaceState(null, '', '/')
+    const globals = createAppJsGlobals({
+      runme: createRunme(
+        new FakeNotebookData('local://file/current', 'Current')
+      ),
+    })
+
+    await expect(globals.notebooks.shareUrl()).resolves.toBe(
+      'http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fcurrent'
+    )
+  })
+})

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -4,10 +4,17 @@ import { jwtDecode } from 'jwt-decode'
 import { OidcConfig, oidcConfigManager } from '../../auth/oidcConfig'
 import { parser_pb } from '../../runme/client'
 import {
+  driveFileUrl,
+  driveFolderUrl,
+  isDriveItemUri,
+  parseDriveItem,
+} from '../../storage/drive'
+import {
   FilesystemNotebookStore,
   isFileSystemAccessSupported,
 } from '../../storage/fs'
 import { LOCAL_FOLDER_URI } from '../../storage/local'
+import { NotebookStoreItemType } from '../../storage/notebook'
 import { getAuthData } from '../../token'
 import { agentEndpointManager } from '../agentEndpointManager'
 import { aisreClientManager } from '../aisreClientManager'
@@ -20,6 +27,7 @@ import {
   setAppConfigFromYaml,
   setLocalConfigPreferredOnLoad,
 } from '../appConfig'
+import { driveLinkCoordinator } from '../driveLinkCoordinator'
 import {
   copyDriveNotebookFile,
   createDriveFile,
@@ -39,6 +47,12 @@ import {
 } from '../markdownImport'
 import { createNotebookDiffRuntimeApi } from '../notebookDiff/runtime'
 import type { Runner } from '../runner'
+import {
+  buildNotebookMarkdownLink,
+  buildNotebookShareUrl,
+  getNotebookShareTarget,
+  normalizeNotebookReferenceUri,
+} from '../shareLinks'
 import { getClaimedSessionId } from '../tabIdentity'
 import { appState } from './AppState'
 import type {
@@ -72,6 +86,20 @@ type WorkspaceApi = {
   getItems?: () => string[]
   addItem?: (uri: string) => void
   removeItem?: (uri: string) => void
+}
+
+type NotebookReferenceInfo = {
+  input?: string
+  uri: string
+  localUri?: string
+  remoteUri?: string
+  googleDriveUrl?: string
+  shareTarget: string
+  shareUrl: string
+  markdownLink: string
+  title: string
+  name: string
+  source: 'local' | 'fs' | 'drive' | 'unknown'
 }
 
 type RunnerSync = {
@@ -132,6 +160,32 @@ function defaultEnsureFilesystemStore(): FilesystemNotebookStore | null {
   const store = new FilesystemNotebookStore()
   appState.setFilesystemStore(store)
   return store
+}
+
+function canonicalizeDriveUri(uri: string): string | null {
+  if (!isDriveItemUri(uri)) {
+    return null
+  }
+  const item = parseDriveItem(uri)
+  return item.type === NotebookStoreItemType.Folder
+    ? driveFolderUrl(item.id)
+    : driveFileUrl(item.id)
+}
+
+function deriveTitleFromUri(uri: string): string {
+  try {
+    const parsed = new URL(uri)
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    const tail = segments[segments.length - 1]
+    if (tail) {
+      return decodeURIComponent(tail)
+    }
+  } catch {
+    // Fall through to the URI segment heuristic.
+  }
+
+  const segments = uri.split('/').filter(Boolean)
+  return segments[segments.length - 1] || 'Untitled'
 }
 
 export function createAppJsGlobals({
@@ -479,7 +533,9 @@ export function createAppJsGlobals({
     }
   }) => {
     const doc = await notebooksApi.get(target)
-    const beforeRefIds = new Set((doc.notebook.cells ?? []).map((item) => item.refId))
+    const beforeRefIds = new Set(
+      (doc.notebook.cells ?? []).map((item) => item.refId)
+    )
     const updated = await notebooksApi.update({
       target: { handle: doc.handle },
       expectedRevision: doc.handle.revision,
@@ -496,8 +552,9 @@ export function createAppJsGlobals({
     })
 
     const inserted =
-      (updated.notebook.cells ?? []).find((item) => !beforeRefIds.has(item.refId)) ??
-      null
+      (updated.notebook.cells ?? []).find(
+        (item) => !beforeRefIds.has(item.refId)
+      ) ?? null
     if (!inserted) {
       throw new Error('Failed to identify inserted notebook cell.')
     }
@@ -509,8 +566,9 @@ export function createAppJsGlobals({
       })
       const refreshed = await notebooksApi.get({ handle: executed.handle })
       const executedCell =
-        (refreshed.notebook.cells ?? []).find((item) => item.refId === inserted.refId) ??
-        inserted
+        (refreshed.notebook.cells ?? []).find(
+          (item) => item.refId === inserted.refId
+        ) ?? inserted
       return {
         handle: refreshed.handle,
         cell: executedCell,
@@ -523,6 +581,156 @@ export function createAppJsGlobals({
     }
   }
 
+  const resolveReferenceInput = (reference?: unknown): string => {
+    if (reference === undefined || reference === null) {
+      const current = runme.getCurrentNotebook()
+      if (!current) {
+        throw new Error(
+          'Usage: notebooks.resolve(reference). No current notebook is available.'
+        )
+      }
+      return current.getUri()
+    }
+    if (typeof reference === 'string') {
+      return normalizeNotebookReferenceUri(reference)
+    }
+    if (
+      typeof reference === 'object' &&
+      'uri' in reference &&
+      typeof reference.uri === 'string' &&
+      reference.uri.trim()
+    ) {
+      return normalizeNotebookReferenceUri(reference.uri)
+    }
+    if (
+      typeof reference === 'object' &&
+      'handle' in reference &&
+      reference.handle &&
+      typeof (reference.handle as { uri?: unknown }).uri === 'string' &&
+      (reference.handle as { uri: string }).uri.trim()
+    ) {
+      return normalizeNotebookReferenceUri(
+        (reference.handle as { uri: string }).uri
+      )
+    }
+    throw new Error(
+      'Usage: notebooks.resolve(reference). Reference must be a local URI, Drive URL, Runme share URL, Markdown link, or notebook target.'
+    )
+  }
+
+  const findOpenNotebook = (uri: string): NotebookDataLike | null => {
+    const current = runme.getCurrentNotebook()
+    if (current?.getUri() === uri) {
+      return current
+    }
+    return (
+      listNotebooks?.().find((notebook) => notebook.getUri() === uri) ?? null
+    )
+  }
+
+  const findLocalRecordForRemote = async (remoteUri: string) => {
+    const localStore = appState.localNotebooks
+    if (!localStore) {
+      return null
+    }
+    const canonicalRemoteUri = canonicalizeDriveUri(remoteUri) ?? remoteUri
+    return (
+      (await localStore.files
+        .where('remoteId')
+        .equals(canonicalRemoteUri)
+        .first()) ??
+      (canonicalRemoteUri === remoteUri
+        ? null
+        : await localStore.files.where('remoteId').equals(remoteUri).first())
+    )
+  }
+
+  const resolveNotebookReference = async (
+    reference?: unknown
+  ): Promise<NotebookReferenceInfo> => {
+    const input = typeof reference === 'string' ? reference : undefined
+    const parsedUri = resolveReferenceInput(reference)
+    const driveUri = canonicalizeDriveUri(parsedUri)
+    const uri = driveUri ?? parsedUri
+    const localStore = appState.localNotebooks
+    const openNotebook = findOpenNotebook(uri)
+    let localUri: string | undefined =
+      uri.startsWith('local://') || uri.startsWith('fs://') ? uri : undefined
+    let remoteUri: string | undefined = driveUri ?? undefined
+    let title = openNotebook?.getName() ?? ''
+
+    if (localStore && uri.startsWith('local://')) {
+      const metadata = await localStore.getMetadata(uri)
+      if (metadata) {
+        title = metadata.name || title
+        localUri = metadata.uri
+        remoteUri = metadata.remoteUri?.trim() || remoteUri
+      }
+    } else if (driveUri) {
+      const record = await findLocalRecordForRemote(driveUri)
+      if (record) {
+        title = record.name || title
+        localUri = record.id
+        remoteUri = driveUri
+      } else if (appState.driveNotebookStore) {
+        try {
+          const metadata =
+            await appState.driveNotebookStore.getMetadata(driveUri)
+          title = metadata?.name || title
+        } catch {
+          // Metadata lookup may require auth; the reference is still useful.
+        }
+      }
+    }
+
+    const shareTarget = getNotebookShareTarget(localUri ?? uri, remoteUri)
+    const resolvedTitle =
+      title || deriveTitleFromUri(remoteUri ?? localUri ?? uri)
+    return {
+      input,
+      uri,
+      localUri,
+      remoteUri,
+      googleDriveUrl:
+        remoteUri && isDriveItemUri(remoteUri) ? remoteUri : undefined,
+      shareTarget,
+      shareUrl: buildNotebookShareUrl(shareTarget),
+      markdownLink: buildNotebookMarkdownLink(resolvedTitle, shareTarget),
+      title: resolvedTitle,
+      name: resolvedTitle,
+      source:
+        remoteUri && isDriveItemUri(remoteUri)
+          ? 'drive'
+          : localUri?.startsWith('fs://')
+            ? 'fs'
+            : localUri?.startsWith('local://')
+              ? 'local'
+              : 'unknown',
+    }
+  }
+
+  const showNotebookReference = async (reference?: unknown) => {
+    const info = await resolveNotebookReference(reference)
+    if (info.localUri?.startsWith('local://file/')) {
+      await openNotebookForRuntime(info.localUri)
+      return {
+        ...info,
+        opened: info.localUri,
+      }
+    }
+    if (info.remoteUri && isDriveItemUri(info.remoteUri)) {
+      await driveLinkCoordinator.enqueue(info.remoteUri, 'manual')
+      return {
+        ...info,
+        opened: info.remoteUri,
+        status: 'queued_drive_link_coordination',
+      }
+    }
+    throw new Error(
+      `Unable to show notebook reference ${info.uri}. Expected a local file URI or Drive file URL.`
+    )
+  }
+
   const notebooksHelpers = {
     ...notebooksApi,
     help: async (topic?: string) => {
@@ -532,6 +740,18 @@ export function createAppJsGlobals({
       if (topic === 'appendCell') {
         return 'notebooks.appendCell({ target?, at?, kind, languageId?, value?, metadata?, execute?, reason? }): Promise<{ handle, cell }>. Inserts a cell into the current or targeted notebook. kind must be "code" or "markup".'
       }
+      if (topic === 'resolve') {
+        return 'notebooks.resolve(reference?): Promise<NotebookReferenceInfo>. Accepts a local URI, Drive URL, Runme share URL, Markdown link, or notebook target and returns title, localUri, remoteUri, shareUrl, and markdownLink.'
+      }
+      if (topic === 'show') {
+        return 'notebooks.show(reference?): Promise<NotebookReferenceInfo & { opened | status }>. Opens local notebook references directly and queues Drive references through shared-link coordination.'
+      }
+      if (topic === 'shareUrl') {
+        return 'notebooks.shareUrl(reference?): Promise<string>. Returns the Runme share URL for a local, Drive, share, or Markdown notebook reference.'
+      }
+      if (topic === 'markdownLink' || topic === 'link') {
+        return 'notebooks.markdownLink(reference?): Promise<string>. Returns [title](shareUrl) Markdown for a local, Drive, share, or Markdown notebook reference.'
+      }
       const base = await notebooksApi.help(topic as any)
       if (topic) {
         return base
@@ -540,6 +760,10 @@ export function createAppJsGlobals({
         base,
         '- notebooks.createLocal(name, options?)',
         '- notebooks.appendCell({ target?, at?, kind, languageId?, value?, metadata?, execute?, reason? })',
+        '- notebooks.resolve(reference?)',
+        '- notebooks.show(reference?)',
+        '- notebooks.shareUrl(reference?)',
+        '- notebooks.markdownLink(reference?)',
       ].join('\n')
     },
     createLocal: async (
@@ -574,11 +798,26 @@ export function createAppJsGlobals({
         cell: {
           kind: args.kind,
           languageId:
-            args.languageId ?? (args.kind === 'markup' ? 'markdown' : 'javascript'),
+            args.languageId ??
+            (args.kind === 'markup' ? 'markdown' : 'javascript'),
           value: args?.value ?? '',
           metadata: args?.metadata ?? {},
         },
       })
+    },
+    resolve: resolveNotebookReference,
+    show: showNotebookReference,
+    shareUrl: async (reference?: unknown) => {
+      const info = await resolveNotebookReference(reference)
+      return info.shareUrl
+    },
+    markdownLink: async (reference?: unknown) => {
+      const info = await resolveNotebookReference(reference)
+      return info.markdownLink
+    },
+    link: async (reference?: unknown) => {
+      const info = await resolveNotebookReference(reference)
+      return info.markdownLink
     },
   }
 

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -1,12 +1,13 @@
 import { appLogger } from '../logging/runtime'
+import { createNotebookDiffRuntimeApi } from '../notebookDiff/runtime'
+import { getClaimedSessionId } from '../tabIdentity'
+import { appState } from './AppState'
 import { createAppJsGlobals } from './appJsGlobals'
 import {
   createAppKernelNetworkApi,
   createAppKernelOpfsApi,
 } from './appKernelLowLevelApis'
 import { getCodexTurnEvents, listCodexTurns } from './codexTurns'
-import { createNotebookDiffRuntimeApi } from '../notebookDiff/runtime'
-import { getClaimedSessionId } from '../tabIdentity'
 import { JSKernel } from './jsKernel'
 import {
   type NotebooksApiBridgeServer,
@@ -14,7 +15,6 @@ import {
   createNotebooksApiBridgeServer,
 } from './notebooksApiBridge'
 import { type NotebookDataLike, createRunmeConsoleApi } from './runmeConsole'
-import { appState } from './AppState'
 import {
   CODE_MODE_SANDBOX_ALLOWED_METHODS,
   SandboxJSKernel,
@@ -114,9 +114,6 @@ export function createCodeModeExecutor(options: {
         resolveNotebook,
         listNotebooks,
       })
-      const notebooksApiBridgeServer = createNotebooksApiBridgeServer({
-        notebooksApi: hostNotebooksApi,
-      })
       const notebookDiffApi = createNotebookDiffRuntimeApi({
         notebooksApi: hostNotebooksApi,
         resolveLocalNotebooks: () => appState.localNotebooks,
@@ -157,6 +154,9 @@ export function createCodeModeExecutor(options: {
         listNotebooks,
         opfsApi,
         networkApi,
+      })
+      const notebooksApiBridgeServer = createNotebooksApiBridgeServer({
+        notebooksApi: globals.notebooks as typeof hostNotebooksApi,
       })
 
       const abortController = new AbortController()

--- a/app/src/lib/runtime/notebooksApiBridge.test.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.test.ts
@@ -190,6 +190,27 @@ describe('createNotebooksApiBridgeServer', () => {
     )
   })
 
+  it('delegates notebook reference helper RPCs when provided', async () => {
+    const resolve = vi.fn(async () => ({
+      uri: 'local://file/demo',
+      title: 'demo',
+    }))
+    const bridgeServer = createBridgeServer({
+      resolve,
+    } as Partial<NotebooksApi>)
+
+    await expect(
+      bridgeServer.handleMessage({
+        method: 'notebooks.resolve',
+        args: ['local://file/demo'],
+      })
+    ).resolves.toEqual({
+      uri: 'local://file/demo',
+      title: 'demo',
+    })
+    expect(resolve).toHaveBeenCalledWith('local://file/demo')
+  })
+
   it('returns JSON-safe get and update results for notebooks with BigInt timing fields', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [codeCellWithBigIntTiming()],

--- a/app/src/lib/runtime/notebooksApiBridge.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.ts
@@ -23,7 +23,34 @@ export const SANDBOX_NOTEBOOKS_API_METHODS = [
   'notebooks.update',
   'notebooks.delete',
   'notebooks.execute',
+  'notebooks.resolve',
+  'notebooks.show',
+  'notebooks.shareUrl',
+  'notebooks.markdownLink',
+  'notebooks.link',
 ] as const
+
+type NotebookReferenceApi = {
+  resolve?: (reference?: unknown) => Promise<unknown>
+  show?: (reference?: unknown) => Promise<unknown>
+  shareUrl?: (reference?: unknown) => Promise<string>
+  markdownLink?: (reference?: unknown) => Promise<string>
+  link?: (reference?: unknown) => Promise<string>
+}
+
+function requireReferenceMethod<T extends keyof Required<NotebookReferenceApi>>(
+  notebooksApi: NotebooksApi,
+  method: T
+): Required<NotebookReferenceApi>[T] {
+  const referenceApi = notebooksApi as NotebooksApi & NotebookReferenceApi
+  const callback = referenceApi[method]
+  if (typeof callback !== 'function') {
+    throw new Error(
+      `Unsupported sandbox NotebooksApi method: notebooks.${method}`
+    )
+  }
+  return callback as Required<NotebookReferenceApi>[T]
+}
 
 export function createHostNotebooksApi({
   resolveNotebook,
@@ -86,6 +113,26 @@ export function createNotebooksApiBridgeServer({
                 refIds: [],
               }
             )
+          )
+        case 'notebooks.resolve':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'resolve')(args[0])
+          )
+        case 'notebooks.show':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'show')(args[0])
+          )
+        case 'notebooks.shareUrl':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'shareUrl')(args[0])
+          )
+        case 'notebooks.markdownLink':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'markdownLink')(args[0])
+          )
+        case 'notebooks.link':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'link')(args[0])
           )
         default:
           throw new Error(`Unsupported sandbox NotebooksApi method: ${method}`)

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -258,6 +258,11 @@ function buildSandboxSrcDoc(options: {
           update: (args) => callHost("notebooks.update", [args]),
           delete: (target) => callHost("notebooks.delete", [target]),
           execute: (args) => callHost("notebooks.execute", [args]),
+          resolve: (reference) => callHost("notebooks.resolve", [reference]),
+          show: (reference) => callHost("notebooks.show", [reference]),
+          shareUrl: (reference) => callHost("notebooks.shareUrl", [reference]),
+          markdownLink: (reference) => callHost("notebooks.markdownLink", [reference]),
+          link: (reference) => callHost("notebooks.link", [reference]),
         });
 
         const notebooks = createSandboxNotebooksApiClient(hostCall);
@@ -306,6 +311,10 @@ function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.get([target]) # omitted target = current UI notebook");
           consoleProxy.log("- notebooks.update({ target, expectedRevision?, operations })");
           consoleProxy.log("- notebooks.execute({ target, refIds })");
+          consoleProxy.log("- notebooks.resolve([reference])");
+          consoleProxy.log("- notebooks.show([reference])");
+          consoleProxy.log("- notebooks.shareUrl([reference])");
+          consoleProxy.log("- notebooks.markdownLink([reference])");
           consoleProxy.log("- notebookDiff.listDriveRevisions([target])");
           consoleProxy.log("- notebookDiff.diffDriveRevision({ target?, revisionId, includeOutputs?, includeMetadata? })");
           consoleProxy.log("- notebookDiff.openDiffTab(diff)");

--- a/app/src/lib/shareLinks.test.ts
+++ b/app/src/lib/shareLinks.test.ts
@@ -1,55 +1,116 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest'
 
-import { buildNotebookMarkdownLink, buildNotebookShareUrl } from "./shareLinks";
+import {
+  buildNotebookMarkdownLink,
+  buildNotebookShareBaseUrl,
+  buildNotebookShareUrl,
+  getNotebookShareTarget,
+  normalizeNotebookReferenceUri,
+} from './shareLinks'
 
-describe("buildNotebookShareUrl", () => {
-  it("builds a share URL from the current app location", () => {
+describe('buildNotebookShareUrl', () => {
+  it('builds a share URL from the current app location', () => {
     window.history.replaceState(
       null,
-      "",
-      "/workspace?foo=bar#ignore-this-fragment",
-    );
+      '',
+      '/workspace?foo=bar#ignore-this-fragment'
+    )
 
     expect(
       buildNotebookShareUrl(
-        "https://drive.google.com/file/d/shared-file-123/view",
-      ),
+        'https://drive.google.com/file/d/shared-file-123/view'
+      )
     ).toBe(
-      "http://localhost:3000/workspace?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Fshared-file-123%2Fview",
-    );
-  });
+      'http://localhost:3000/workspace?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Fshared-file-123%2Fview'
+    )
+  })
 
-  it("throws when the remote URI is empty", () => {
-    expect(() => buildNotebookShareUrl("   ")).toThrow(
-      "A remote notebook URI is required to build a share link",
-    );
-  });
-});
+  it('throws when the remote URI is empty', () => {
+    expect(() => buildNotebookShareUrl('   ')).toThrow(
+      'A notebook URI is required to build a share link'
+    )
+  })
+})
 
-describe("buildNotebookMarkdownLink", () => {
-  it("builds markdown with the notebook title and app share URL", () => {
-    window.history.replaceState(null, "", "/");
+describe('buildNotebookShareBaseUrl', () => {
+  it('returns the app path without query params or fragments', () => {
+    window.history.replaceState(null, '', '/workspace?foo=bar#frag')
+
+    expect(buildNotebookShareBaseUrl()).toBe('http://localhost:3000/workspace')
+  })
+})
+
+describe('getNotebookShareTarget', () => {
+  it('prefers the remote URI when one is available', () => {
+    expect(
+      getNotebookShareTarget(
+        'local://file/local-id',
+        'https://drive.google.com/file/d/file123/view'
+      )
+    ).toBe('https://drive.google.com/file/d/file123/view')
+  })
+
+  it('falls back to the local URI for local-only notebooks', () => {
+    expect(getNotebookShareTarget('local://file/local-id')).toBe(
+      'local://file/local-id'
+    )
+  })
+})
+
+describe('buildNotebookMarkdownLink', () => {
+  it('builds markdown with the notebook title and app share URL', () => {
+    window.history.replaceState(null, '', '/')
 
     expect(
       buildNotebookMarkdownLink(
-        "202602a_tb_aws_codex_136.json",
-        "https://drive.google.com/file/d/1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV/view",
-      ),
+        '202602a_tb_aws_codex_136.json',
+        'https://drive.google.com/file/d/1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV/view'
+      )
     ).toBe(
-      "[202602a_tb_aws_codex_136](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV%2Fview)",
-    );
-  });
+      '[202602a_tb_aws_codex_136](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV%2Fview)'
+    )
+  })
 
-  it("escapes markdown link text", () => {
-    window.history.replaceState(null, "", "/");
+  it('escapes markdown link text', () => {
+    window.history.replaceState(null, '', '/')
 
     expect(
       buildNotebookMarkdownLink(
         String.raw`notebook \[draft].json`,
-        "https://drive.google.com/file/d/file123/view",
-      ),
+        'https://drive.google.com/file/d/file123/view'
+      )
     ).toBe(
-      String.raw`[notebook \\[draft\]](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview)`,
-    );
-  });
-});
+      String.raw`[notebook \\[draft\]](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview)`
+    )
+  })
+})
+
+describe('normalizeNotebookReferenceUri', () => {
+  it('returns local URIs unchanged', () => {
+    expect(
+      normalizeNotebookReferenceUri(
+        ' local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018 '
+      )
+    ).toBe('local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018')
+  })
+
+  it('extracts the doc query param from a Runme share URL', () => {
+    expect(
+      normalizeNotebookReferenceUri(
+        'https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F149JKKTgljRiwszwb06Ms74GOYhCOPMNg%2Fview'
+      )
+    ).toBe(
+      'https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view'
+    )
+  })
+
+  it('extracts the href from Markdown links before resolving', () => {
+    expect(
+      normalizeNotebookReferenceUri(
+        '[https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view](https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view)'
+      )
+    ).toBe(
+      'https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view'
+    )
+  })
+})

--- a/app/src/lib/shareLinks.ts
+++ b/app/src/lib/shareLinks.ts
@@ -1,59 +1,119 @@
 function getShareBaseUrl(): URL {
-  if (typeof window === "undefined") {
-    throw new Error("Share links are only available in a browser environment");
+  if (typeof window === 'undefined') {
+    throw new Error('Share links are only available in a browser environment')
   }
 
-  return new URL(window.location.pathname, window.location.origin);
+  return new URL(window.location.pathname, window.location.origin)
+}
+
+function extractMarkdownLinkHref(reference: string): string | null {
+  const trimmed = reference.trim()
+  if (!trimmed.endsWith(')')) {
+    return null
+  }
+
+  const linkStart = trimmed.lastIndexOf('](')
+  if (linkStart < 0 || !trimmed.startsWith('[')) {
+    return null
+  }
+
+  const href = trimmed.slice(linkStart + 2, -1).trim()
+  return href || null
 }
 
 function getNotebookLinkText(name: string): string {
-  const trimmed = name.trim();
-  const withoutJson = trimmed.replace(/\.json$/i, "");
-  return withoutJson || trimmed || "Untitled";
+  const trimmed = name.trim()
+  const withoutJson = trimmed.replace(/\.json$/i, '')
+  return withoutJson || trimmed || 'Untitled'
 }
 
 function escapeMarkdownLinkText(text: string): string {
-  return text.replace(/\\/g, "\\\\").replace(/\]/g, "\\]");
+  return text.replace(/\\/g, '\\\\').replace(/\]/g, '\\]')
 }
 
 export function buildNotebookShareUrl(remoteUri: string): string {
-  const trimmed = remoteUri.trim();
+  const trimmed = remoteUri.trim()
   if (!trimmed) {
-    throw new Error("A remote notebook URI is required to build a share link");
+    throw new Error('A notebook URI is required to build a share link')
   }
 
-  const url = getShareBaseUrl();
-  url.searchParams.set("doc", trimmed);
-  return url.toString();
+  const url = getShareBaseUrl()
+  url.searchParams.set('doc', trimmed)
+  return url.toString()
 }
 
 export function buildNotebookMarkdownLink(
   name: string,
-  remoteUri: string,
+  remoteUri: string
 ): string {
-  const linkText = escapeMarkdownLinkText(getNotebookLinkText(name));
-  return `[${linkText}](${buildNotebookShareUrl(remoteUri)})`;
+  const linkText = escapeMarkdownLinkText(getNotebookLinkText(name))
+  return `[${linkText}](${buildNotebookShareUrl(remoteUri)})`
 }
 
 export async function copyNotebookShareUrl(remoteUri: string): Promise<string> {
-  if (typeof window === "undefined" || !window.navigator?.clipboard?.writeText) {
-    throw new Error("Clipboard access is unavailable in this browser");
+  if (
+    typeof window === 'undefined' ||
+    !window.navigator?.clipboard?.writeText
+  ) {
+    throw new Error('Clipboard access is unavailable in this browser')
   }
 
-  const shareUrl = buildNotebookShareUrl(remoteUri);
-  await window.navigator.clipboard.writeText(shareUrl);
-  return shareUrl;
+  const shareUrl = buildNotebookShareUrl(remoteUri)
+  await window.navigator.clipboard.writeText(shareUrl)
+  return shareUrl
 }
 
 export async function copyNotebookMarkdownLink(
   name: string,
-  remoteUri: string,
+  remoteUri: string
 ): Promise<string> {
-  if (typeof window === "undefined" || !window.navigator?.clipboard?.writeText) {
-    throw new Error("Clipboard access is unavailable in this browser");
+  if (
+    typeof window === 'undefined' ||
+    !window.navigator?.clipboard?.writeText
+  ) {
+    throw new Error('Clipboard access is unavailable in this browser')
   }
 
-  const markdownLink = buildNotebookMarkdownLink(name, remoteUri);
-  await window.navigator.clipboard.writeText(markdownLink);
-  return markdownLink;
+  const markdownLink = buildNotebookMarkdownLink(name, remoteUri)
+  await window.navigator.clipboard.writeText(markdownLink)
+  return markdownLink
+}
+
+export function buildNotebookShareBaseUrl(): string {
+  return getShareBaseUrl().toString()
+}
+
+export function getNotebookShareTarget(
+  localUri: string | undefined,
+  remoteUri?: string | null
+): string {
+  const trimmedRemote = remoteUri?.trim()
+  if (trimmedRemote) {
+    return trimmedRemote
+  }
+  const trimmedLocal = localUri?.trim()
+  if (!trimmedLocal) {
+    throw new Error('A notebook URI is required to build a share target')
+  }
+  return trimmedLocal
+}
+
+export function normalizeNotebookReferenceUri(reference: string): string {
+  const href = extractMarkdownLinkHref(reference) ?? reference
+  const trimmed = href.trim()
+  if (!trimmed) {
+    throw new Error('A notebook reference is required')
+  }
+
+  try {
+    const url = new URL(trimmed)
+    const doc = url.searchParams.get('doc')?.trim()
+    if (doc) {
+      return doc
+    }
+  } catch {
+    // Not a URL; return the trimmed local/fs/Drive reference as-is.
+  }
+
+  return trimmed
 }

--- a/docs/06-sharing-and-opening-drive-links.md
+++ b/docs/06-sharing-and-opening-drive-links.md
@@ -29,9 +29,49 @@ explorer once coordination completes.
 
 The explorer can copy share links for remote items that retain a `remoteUri`.
 
+## App Console helpers
+
+Use these helpers when a human or AI agent has a notebook reference and needs a
+single command from App Console.
+
+```js
+const info = await notebooks.resolve(
+  'local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018'
+)
+console.log(info.title)
+console.log(info.googleDriveUrl)
+console.log(info.markdownLink)
+```
+
+`notebooks.resolve(reference)` accepts:
+
+- `local://file/...` local mirror URIs,
+- Runme share URLs with a `doc=` query parameter,
+- Google Drive file URLs,
+- Markdown links whose destination is one of the supported URL forms.
+
+It returns the display title, `localUri`, `remoteUri`, `shareTarget`,
+`shareUrl`, and `markdownLink`. `shareTarget` is the base reference used in
+Runme share links: the Drive URL when the local notebook has a remote backing
+file, otherwise the local URI.
+
+To open a reference, run:
+
+```js
+await notebooks.show(
+  'https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F149JKKTgljRiwszwb06Ms74GOYhCOPMNg%2Fview'
+)
+```
+
+Local references open directly in a notebook tab. Drive references are queued
+through the shared-link coordinator, which handles auth, local mirroring, and
+opening the resulting local notebook.
+
 ## High-value facts for Codex
 
 - Treat link opening as a coordination flow, not just "navigate to URL."
 - If the user is not authenticated yet, failure may be temporary and recoverable.
 - If the user says "open this shared file," check for Drive-link status or
   coordination progress before concluding the feature is broken.
+- Prefer `await notebooks.markdownLink(reference)` when replacing
+  `local://file/...` text in Markdown with a title and Runme share URL.

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -43,24 +43,39 @@ agent.help()
 Create a local notebook and append cells:
 
 ```js
-const created = await notebooks.createLocal("helloworld")
+const created = await notebooks.createLocal('helloworld')
 await notebooks.appendCell({
   target: { handle: created.handle },
-  kind: "code",
-  languageId: "python",
+  kind: 'code',
+  languageId: 'python',
   value: 'print("hello world")',
 })
 await notebooks.appendCell({
   target: { handle: created.handle },
-  kind: "markup",
-  value: "# Notes",
+  kind: 'markup',
+  value: '# Notes',
 })
+```
+
+Resolve and open notebook references:
+
+```js
+await notebooks.resolve('local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018')
+await notebooks.markdownLink(
+  'local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018'
+)
+await notebooks.show(
+  'https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F149JKKTgljRiwszwb06Ms74GOYhCOPMNg%2Fview'
+)
+await notebooks.show(
+  '[Notebook](https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view)'
+)
 ```
 
 Runner setup:
 
 ```js
-runmeRunners.ensure("default", "ws://localhost:9977/ws", { setDefault: true })
+runmeRunners.ensure('default', 'ws://localhost:9977/ws', { setDefault: true })
 ```
 
 OIDC + Drive setup:
@@ -68,8 +83,8 @@ OIDC + Drive setup:
 ```js
 oidc.setGoogleDefaults()
 oidc.setClientToDrive()
-credentials.google.setClientId("...")
-credentials.google.setClientSecret("...")
+credentials.google.setClientId('...')
+credentials.google.setClientSecret('...')
 ```
 
 App config:
@@ -84,7 +99,7 @@ Harness setup:
 ```js
 app.harness.get()
 app.harness.getDefault()
-app.harness.setDefault("configured-harness-name")
+app.harness.setDefault('configured-harness-name')
 ```
 
 ## High-value facts for Codex
@@ -94,3 +109,8 @@ app.harness.setDefault("configured-harness-name")
 - If a user wants an action that has no visible button, check the App Console before saying the feature is missing.
 - Prefer `notebooks.appendCell({ kind, ... })` for simple inserts before writing
   raw `notebooks.update(...)` mutations by hand.
+- Use `notebooks.resolve(reference)` to turn local URIs, Runme share URLs,
+  Drive URLs, and Markdown links into a title, `localUri`, `remoteUri`,
+  `shareUrl`, and replacement-ready `markdownLink`.
+- Use `notebooks.show(reference)` when Codex needs one command that opens a
+  local notebook tab or hands a Drive reference to shared-link coordination.


### PR DESCRIPTION
## Summary
- add AppConsole notebook reference helpers: `notebooks.resolve`, `notebooks.show`, `notebooks.shareUrl`, and `notebooks.markdownLink`
- support local URIs, Runme share URLs with `doc=`, Drive file URLs, and Markdown links
- document the helper workflow for Codex/humans and route sandbox AppKernel calls through the same helpers

## Verification
- `runme run build test`
- `pnpm -C app exec vitest run src/lib/shareLinks.test.ts src/lib/runtime/appJsGlobals.test.ts src/lib/runtime/notebooksApiBridge.test.ts`

## Notes
- `pnpm -C app run typecheck` still fails on existing repo-wide type errors outside this change, including `src/auth/oidcConfig.ts`, `src/components/Actions/Actions.tsx`, and `src/components/Workspace/WorkspaceExplorer.tsx`.