### PR TITLE
[codex] Show Drive loading state for syncing notebooks

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -21,6 +21,7 @@ const contextMocks = vi.hoisted(() => ({
   workspaceDocuments: [] as Array<{
     uri: string
     title: string
+    requestedUri?: string
     state?: 'loading' | 'loaded' | 'blocked' | 'error'
     readOnly?: boolean
   }>,
@@ -31,7 +32,12 @@ const contextMocks = vi.hoisted(() => ({
   getNotebookData: vi.fn(),
   notebookSnapshots: new Map<
     string,
-    { uri: string; loaded: boolean; notebook: parser_pb.Notebook }
+    {
+      uri: string
+      loaded: boolean
+      readOnly?: boolean
+      notebook: parser_pb.Notebook
+    }
   >(),
   notebookStore: null as null | {
     files?: { get: ReturnType<typeof vi.fn> }
@@ -312,6 +318,47 @@ describe('Actions tabs', () => {
     expect(
       screen.getByTestId('notebook-readonly-banner').textContent
     ).toContain('Read-only')
+    expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
+  it('shows Drive syncing state instead of empty notebook prompt', async () => {
+    const uri = 'local://file/drive-syncing.runme.md'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'drive-syncing.runme.md',
+        requestedUri: 'https://drive.google.com/file/d/file123/view',
+        state: 'loaded',
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {},
+        cells: [],
+      }),
+    })
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(),
+      getSyncState: vi.fn(async () => ({
+        status: 'syncing',
+        localUri: uri,
+        remoteId: 'https://drive.google.com/file/d/file123/view',
+      })),
+      rename: vi.fn(),
+      sync: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+
+    render(<Actions />)
+
+    expect(
+      await screen.findByTestId('notebook-drive-loading-state')
+    ).toBeTruthy()
+    expect(screen.getByText('Loading notebook from Google Drive')).toBeTruthy()
+    expect(screen.queryByText('This notebook has no cells yet.')).toBeNull()
     expect(screen.queryByLabelText('Add first cell')).toBeNull()
   })
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -71,7 +71,7 @@ import {
   NOTEBOOK_DIFF_DOCUMENT_CHANGED,
 } from '../../lib/notebookDiff/registry'
 import { openNotebookConflictDiff } from '../../lib/notebookDiff/conflict'
-import { parseDriveItem } from '../../storage/drive'
+import { isDriveItemUri, parseDriveItem } from '../../storage/drive'
 import type { NotebookSyncState } from '../../storage/local'
 import { NotebookStoreItemType } from '../../storage/notebook'
 import { showToast } from '../../lib/toast'
@@ -180,7 +180,7 @@ function syncIndicatorPresentation(state: NotebookSyncState | null): {
   }
 }
 
-function NotebookSyncIndicator({ docUri }: { docUri: string }) {
+function useNotebookSyncState(docUri: string): NotebookSyncState | null {
   const { store } = useNotebookStore()
   const [syncState, setSyncState] = useState<NotebookSyncState | null>(null)
 
@@ -228,6 +228,13 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
       window.removeEventListener('local-notebook-updated', onSyncUpdated)
     }
   }, [docUri, store])
+
+  return syncState
+}
+
+function NotebookSyncIndicator({ docUri }: { docUri: string }) {
+  const { store } = useNotebookStore()
+  const syncState = useNotebookSyncState(docUri)
 
   const presentation = syncIndicatorPresentation(syncState)
   const handleClick = useCallback(
@@ -283,6 +290,31 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
         className={`block h-2.5 w-2.5 rounded-full ${presentation.className}`}
       />
     </button>
+  )
+}
+
+function NotebookDriveLoadingState() {
+  return (
+    <div
+      className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center text-sm text-nb-text-muted"
+      data-testid="notebook-drive-loading-state"
+    >
+      <Text size="3" weight="bold" as="p" className="text-nb-text">
+        Loading notebook from Google Drive
+      </Text>
+      <Text size="2" as="p">
+        Syncing the latest Drive copy before showing cells.
+      </Text>
+    </div>
+  )
+}
+
+function isDriveBackedNotebook(
+  entry: OpenNotebookEntry,
+  syncState: NotebookSyncState | null
+): boolean {
+  return (
+    isDriveItemUri(entry.requestedUri) || isDriveItemUri(syncState?.remoteId)
   )
 }
 
@@ -1675,7 +1707,9 @@ function NotebookTabContent({
   const { getNotebookData, openNotebook, useNotebookSnapshot } =
     useNotebookContext()
   const notebookSnapshot = useNotebookSnapshot(docUri)
+  const syncState = useNotebookSyncState(docUri)
   const readOnly = Boolean(entry.readOnly || notebookSnapshot?.readOnly)
+  const isDriveBacked = isDriveBackedNotebook(entry, syncState)
   const shouldRenderCells = !readOnly || isSelected
   const cellDatas = useMemo(() => {
     if (!shouldRenderCells) {
@@ -1757,6 +1791,9 @@ function NotebookTabContent({
   }
 
   if (!notebookSnapshot || !notebookSnapshot.loaded) {
+    if (isDriveBacked) {
+      return <NotebookDriveLoadingState />
+    }
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-nb-text-muted">
         <span>Loading…</span>
@@ -1765,6 +1802,14 @@ function NotebookTabContent({
   }
 
   const data = getNotebookData(notebookSnapshot.uri)
+
+  if (
+    cellDatas.length === 0 &&
+    isDriveBacked &&
+    syncState?.status === 'syncing'
+  ) {
+    return <NotebookDriveLoadingState />
+  }
 
   return (
     <ScrollArea


### PR DESCRIPTION
## Summary

- Show a Drive-specific loading state while a Drive-backed notebook is still loading or actively syncing.
- Reuse the existing notebook sync-state subscription for both the tab indicator and notebook tab content.
- Add a regression test covering a loaded empty snapshot whose Drive sync state is still `syncing`.

## Why

Drive-backed notebooks can briefly present an empty local snapshot while the latest Drive copy is still being synchronized. Showing "This notebook has no cells yet." in that state is misleading because the notebook may simply not have finished loading from Drive.

## Validation

- `pnpm -C app exec vitest run src/components/Actions/Actions.test.tsx`
- `runme run build test`
- `git diff --check`

## Notes

I also ran `pnpm -C app run typecheck`; it still fails on existing broad app type errors unrelated to this change.
