### PR TITLE
[codex] Add Drive-backed notebook comments

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -121,6 +121,14 @@ vi.mock('../../contexts/CurrentDocContext', () => ({
   }),
 }))
 
+vi.mock('../../contexts/CommentsPanelContext', () => ({
+  useCommentsPanel: () => ({
+    commentsPanelOpen: false,
+    setCommentsPanelOpen: vi.fn(),
+    openCommentsPanel: vi.fn(),
+  }),
+}))
+
 vi.mock('../../lib/notebookDiff/conflict', () => ({
   openNotebookConflictDiff: conflictMocks.openNotebookConflictDiff,
   refreshNotebookConflictDiff: conflictMocks.refreshNotebookConflictDiff,
@@ -1289,5 +1297,153 @@ describe('Action component', () => {
     fireEvent.focus(screen.getByRole('button', { name: 'Delete cell' }))
 
     expect(onFocusStateChange).not.toHaveBeenCalled()
+  })
+
+  it('hides the markdown comment button until hover when the cell has no comments', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-no-comments',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'hello',
+    })
+    const stub = new StubCellData(cell)
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        commentsAvailable
+        commentCount={0}
+      />
+    )
+
+    const commentButton = screen.getByRole('button', { name: 'Add comment' })
+    expect(commentButton.className).toContain('text-nb-accent')
+    expect(commentButton.className).toContain('hover:text-nb-accent')
+    expect(commentButton.className).toContain('opacity-0')
+    expect(commentButton.className).toContain('pointer-events-none')
+    expect(commentButton.className).toContain(
+      'group-hover/cell:pointer-events-auto'
+    )
+    expect(commentButton.className).toContain('group-hover/cell:opacity-100')
+  })
+
+  it('keeps the markdown comment button visible for the focused cell', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-focused',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'hello',
+    })
+    const stub = new StubCellData(cell)
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        isActiveCell
+        isWindowFocused
+        commentsAvailable
+        commentCount={0}
+      />
+    )
+
+    const commentButton = screen.getByRole('button', { name: 'Add comment' })
+    expect(commentButton.className).toContain('opacity-100')
+    expect(commentButton.className).not.toContain('pointer-events-none')
+    expect(commentButton.className).not.toContain('opacity-0')
+  })
+
+  it('keeps a disabled markdown comment button visible for the focused cell when comments are unavailable', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-focused-comments-unavailable',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'hello',
+    })
+    const stub = new StubCellData(cell)
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        isActiveCell
+        isWindowFocused
+        commentCount={0}
+      />
+    )
+
+    const commentButton = screen.getByRole('button', {
+      name: 'Comments unavailable',
+    })
+    expect(commentButton).toHaveProperty('disabled', true)
+    expect(commentButton.className).toContain('text-nb-text-faint')
+    expect(commentButton.className).not.toContain('text-nb-accent')
+    expect(commentButton.className).toContain('opacity-100')
+    expect(commentButton.className).not.toContain('pointer-events-none')
+    expect(commentButton.className).not.toContain('opacity-0')
+  })
+
+  it('keeps the markdown comment button visible when the cell has comments', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-with-comments',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'hello',
+    })
+    const stub = new StubCellData(cell)
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        commentsAvailable
+        commentCount={2}
+      />
+    )
+
+    const commentButton = screen.getByRole('button', {
+      name: '2 open comments',
+    })
+    expect(commentButton.className).toContain('text-nb-accent')
+    expect(commentButton.className).toContain('hover:text-nb-accent')
+    expect(commentButton.className).toContain('opacity-100')
+    expect(commentButton.className).not.toContain('opacity-0')
+  })
+
+  it('starts a comment from the markdown cell context menu', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-context-comment',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'hello',
+    })
+    const stub = new StubCellData(cell)
+    const onStartComment = vi.fn()
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        commentsAvailable
+        onStartComment={onStartComment}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('markdown-action'))
+    fireEvent.click(screen.getByRole('button', { name: 'Add Comment' }))
+
+    expect(onStartComment).toHaveBeenCalledWith('cell-md-context-comment')
+    expect(screen.queryByRole('button', { name: 'Add Comment' })).toBeNull()
   })
 })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -13,7 +13,11 @@ import {
 import { create } from '@bufbuild/protobuf'
 import { Button, ScrollArea, Tabs, Text } from '@radix-ui/themes'
 
-import { LockClosedIcon, XMarkIcon } from '@heroicons/react/20/solid'
+import {
+  ChatBubbleLeftIcon,
+  LockClosedIcon,
+  XMarkIcon,
+} from '@heroicons/react/20/solid'
 import { MimeType, RunmeMetadataKey, parser_pb } from '../../runme/client'
 import { CellData } from '../../lib/notebookData'
 import { useNotebookContext } from '../../contexts/NotebookContext'
@@ -72,15 +76,26 @@ import {
   NOTEBOOK_DIFF_DOCUMENT_CHANGED,
 } from '../../lib/notebookDiff/registry'
 import { openNotebookConflictDiff } from '../../lib/notebookDiff/conflict'
-import { isDriveItemUri, parseDriveItem } from '../../storage/drive'
+import {
+  isDriveItemUri,
+  parseDriveItem,
+  type DriveComment,
+} from '../../storage/drive'
 import type { NotebookSyncState } from '../../storage/local'
 import { NotebookStoreItemType } from '../../storage/notebook'
 import { showToast } from '../../lib/toast'
+import { appState } from '../../lib/runtime/AppState'
+import {
+  createCellCommentAnchor,
+  groupCommentsByCell,
+  toCellCommentThreads,
+} from '../../lib/notebookComments'
 import DriveLinkStatusTab from '../DriveLinkStatusTab'
 import DriveSyncStatusTab from '../DriveSyncStatusTab'
 import RunnerStatusTab from '../RunnerStatusTab'
 import { NotebookDiffContent } from '../NotebookDiff/NotebookDiffView'
 import VersionInfoTab from '../VersionInfoTab'
+import { NotebookCommentsPanel } from '../NotebookCommentsPanel'
 import React from 'react'
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -389,6 +404,39 @@ function RunActionButton({
   )
 }
 
+function CellCommentButton({
+  count,
+  available,
+  onClick,
+  className = '',
+}: {
+  count: number
+  available: boolean
+  onClick: () => void
+  className?: string
+}) {
+  if (!available && count === 0) {
+    return null
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!available}
+      aria-label={count > 0 ? `${count} open comments` : 'Add comment'}
+      title={count > 0 ? `${count} open comments` : 'Add comment'}
+      className={`icon-btn relative ${className}`}
+    >
+      <ChatBubbleLeftIcon className="h-4 w-4" />
+      {count > 0 && (
+        <span className="absolute -right-1 -top-1 min-w-4 rounded-full bg-nb-accent px-1 text-[10px] font-semibold leading-4 text-white">
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}
+
 // Action is an editor and an optional Runme console
 const LANGUAGE_OPTIONS = [
   { label: 'Markdown', value: 'markdown' },
@@ -654,6 +702,9 @@ export function Action({
   isWindowFocused = false,
   onFocusStateChange,
   readOnly = false,
+  commentsAvailable = false,
+  commentCount = 0,
+  onStartComment,
 }: {
   cellData: CellData
   docUri?: string
@@ -663,6 +714,9 @@ export function Action({
   isWindowFocused?: boolean
   onFocusStateChange?: (state: NotebookActiveCellState) => void
   readOnly?: boolean
+  commentsAvailable?: boolean
+  commentCount?: number
+  onStartComment?: (cellId: string) => void
 }) {
   const { store } = useNotebookStore()
   const { listRunners, defaultRunnerName } = useRunners()
@@ -885,6 +939,13 @@ export function Action({
       setContextMenu(null)
     }
   }, [shareRemoteUri])
+
+  const handleStartComment = useCallback(() => {
+    if (!cell?.refId || !onStartComment) {
+      return
+    }
+    onStartComment(cell.refId)
+  }, [cell?.refId, onStartComment])
 
   const sequenceLabel = useMemo(() => {
     if (!cell) {
@@ -1316,6 +1377,12 @@ export function Action({
               isWindowFocused={isWindowFocused}
               onFocusRoleChange={handleMarkdownFocusRoleChange}
             />
+            <CellCommentButton
+              count={commentCount}
+              available={commentsAvailable}
+              onClick={handleStartComment}
+              className="absolute right-10 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+            />
             {/* Trash icon on the right, visible on hover */}
             <button
               type="button"
@@ -1373,6 +1440,7 @@ export function Action({
         className="group/cell relative flex min-w-0"
         onContextMenu={handleContextMenu}
         data-testid="html-action"
+        data-cell-ref-id={cell.refId}
       >
         <div
           id={`html-gutter-${cell.refId}`}
@@ -1407,6 +1475,12 @@ export function Action({
               onLanguageChange={handleLanguageChange}
               forceEditRequest={htmlEditRequest}
               readOnly={readOnly}
+            />
+            <CellCommentButton
+              count={commentCount}
+              available={commentsAvailable}
+              onClick={handleStartComment}
+              className="absolute right-10 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
             />
             <button
               type="button"
@@ -1637,6 +1711,12 @@ export function Action({
               )}
             </div>
             <div className="flex items-center gap-1">
+              <CellCommentButton
+                count={commentCount}
+                available={commentsAvailable}
+                onClick={handleStartComment}
+                className="h-7 w-7"
+              />
               <RunActionButton
                 pid={pid}
                 onClick={runCode}
@@ -1727,6 +1807,7 @@ function NotebookTabContent({
 }) {
   const { getNotebookData, openNotebook, useNotebookSnapshot } =
     useNotebookContext()
+  const { store } = useNotebookStore()
   const notebookSnapshot = useNotebookSnapshot(docUri)
   const syncState = useNotebookSyncState(docUri)
   const readOnly = Boolean(entry.readOnly || notebookSnapshot?.readOnly)
@@ -1747,6 +1828,223 @@ function NotebookTabContent({
       .map((c) => (c?.refId ? data.getCell(c.refId) : null))
       .filter((c): c is CellData => Boolean(c))
   }, [getNotebookData, notebookSnapshot, shouldRenderCells])
+  const [commentsRemoteUri, setCommentsRemoteUri] = useState<string | null>(
+    null
+  )
+  const [commentsStatus, setCommentsStatus] = useState<
+    'loading' | 'available' | 'unavailable' | 'error'
+  >('loading')
+  const [commentsErrorMessage, setCommentsErrorMessage] = useState<
+    string | undefined
+  >()
+  const [comments, setComments] = useState<DriveComment[]>([])
+  const [commentsBusy, setCommentsBusy] = useState(false)
+  const [draftCellId, setDraftCellId] = useState<string | null>(null)
+  const cellLabels = useMemo(() => {
+    const labels = new Map<string, string>()
+    cellDatas.forEach((cellData, index) => {
+      const refId = cellData.snapshot?.refId
+      if (refId) {
+        labels.set(refId, `Cell ${index + 1}`)
+      }
+    })
+    return labels
+  }, [cellDatas])
+  const commentsByCell = useMemo(
+    () => groupCommentsByCell(comments),
+    [comments]
+  )
+  const commentThreads = useMemo(
+    () => toCellCommentThreads(comments),
+    [comments]
+  )
+
+  const selectCommentCell = useCallback((cellId: string) => {
+    const element =
+      document.getElementById(`code-action-${cellId}`) ??
+      document.getElementById(`markdown-action-${cellId}`) ??
+      document.getElementById(`html-action-${cellId}`)
+    element?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  }, [])
+
+  const startCommentDraft = useCallback(
+    (cellId: string) => {
+      setDraftCellId(cellId)
+      selectCommentCell(cellId)
+    },
+    [selectCommentCell]
+  )
+
+  const refreshComments = useCallback(async () => {
+    const driveStore = appState.driveNotebookStore
+    if (!commentsRemoteUri || !driveStore) {
+      setComments([])
+      setCommentsStatus('unavailable')
+      setCommentsErrorMessage(undefined)
+      return
+    }
+
+    setCommentsStatus('loading')
+    setCommentsErrorMessage(undefined)
+    try {
+      const nextComments = await driveStore.listComments(commentsRemoteUri)
+      setComments(nextComments)
+      setCommentsStatus('available')
+    } catch (error) {
+      setComments([])
+      setCommentsStatus('error')
+      setCommentsErrorMessage(String(error))
+    }
+  }, [commentsRemoteUri])
+
+  useEffect(() => {
+    let cancelled = false
+    setDraftCellId(null)
+    setCommentsErrorMessage(undefined)
+
+    void (async () => {
+      if (!notebookSnapshot?.loaded) {
+        if (!cancelled) {
+          setCommentsRemoteUri(null)
+          setCommentsStatus('loading')
+        }
+        return
+      }
+
+      if (isDriveItemUri(docUri)) {
+        if (!cancelled) {
+          setCommentsRemoteUri(docUri)
+        }
+        return
+      }
+
+      if (!store || !docUri.startsWith('local://')) {
+        if (!cancelled) {
+          setCommentsRemoteUri(null)
+        }
+        return
+      }
+
+      try {
+        const metadata = await store.getMetadata(docUri)
+        const remoteUri = metadata?.remoteUri
+        if (!cancelled) {
+          setCommentsRemoteUri(
+            remoteUri && isDriveItemUri(remoteUri) ? remoteUri : null
+          )
+        }
+      } catch {
+        if (!cancelled) {
+          setCommentsRemoteUri(null)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [docUri, notebookSnapshot?.loaded, store])
+
+  useEffect(() => {
+    void refreshComments()
+  }, [refreshComments])
+
+  const handleCreateComment = useCallback(
+    async (cellId: string, content: string) => {
+      const driveStore = appState.driveNotebookStore
+      if (!commentsRemoteUri || !driveStore) {
+        showToast({
+          tone: 'error',
+          message: 'Comments are only available for Google Drive notebooks.',
+        })
+        return
+      }
+      setCommentsBusy(true)
+      try {
+        await driveStore.createComment(
+          commentsRemoteUri,
+          content,
+          createCellCommentAnchor(cellId)
+        )
+        setDraftCellId(null)
+        await refreshComments()
+      } catch (error) {
+        showToast({
+          tone: 'error',
+          message: `Failed to create comment: ${String(error)}`,
+        })
+      } finally {
+        setCommentsBusy(false)
+      }
+    },
+    [commentsRemoteUri, refreshComments]
+  )
+
+  const handleReplyToComment = useCallback(
+    async (commentId: string, content: string) => {
+      const driveStore = appState.driveNotebookStore
+      if (!commentsRemoteUri || !driveStore) {
+        return
+      }
+      setCommentsBusy(true)
+      try {
+        await driveStore.replyToComment(commentsRemoteUri, commentId, content)
+        await refreshComments()
+      } catch (error) {
+        showToast({
+          tone: 'error',
+          message: `Failed to reply to comment: ${String(error)}`,
+        })
+      } finally {
+        setCommentsBusy(false)
+      }
+    },
+    [commentsRemoteUri, refreshComments]
+  )
+
+  const handleResolveComment = useCallback(
+    async (commentId: string) => {
+      const driveStore = appState.driveNotebookStore
+      if (!commentsRemoteUri || !driveStore) {
+        return
+      }
+      setCommentsBusy(true)
+      try {
+        await driveStore.resolveComment(commentsRemoteUri, commentId)
+        await refreshComments()
+      } catch (error) {
+        showToast({
+          tone: 'error',
+          message: `Failed to resolve comment: ${String(error)}`,
+        })
+      } finally {
+        setCommentsBusy(false)
+      }
+    },
+    [commentsRemoteUri, refreshComments]
+  )
+
+  const handleReopenComment = useCallback(
+    async (commentId: string) => {
+      const driveStore = appState.driveNotebookStore
+      if (!commentsRemoteUri || !driveStore) {
+        return
+      }
+      setCommentsBusy(true)
+      try {
+        await driveStore.reopenComment(commentsRemoteUri, commentId)
+        await refreshComments()
+      } catch (error) {
+        showToast({
+          tone: 'error',
+          message: `Failed to reopen comment: ${String(error)}`,
+        })
+      } finally {
+        setCommentsBusy(false)
+      }
+    },
+    [commentsRemoteUri, refreshComments]
+  )
 
   if (readOnly && !isSelected) {
     return (
@@ -1840,85 +2138,106 @@ function NotebookTabContent({
   }
 
   return (
-    <ScrollArea
-      key={`scroll-${docUri}`}
-      type="auto"
-      scrollbars="both"
-      className="flex-1 h-full min-w-0 max-w-full"
-      data-document-id={docUri}
-    >
-      {/* Full-width notebook column with horizontal padding for breathing room.
-          Cells expand to fill the available width of the tab content area. */}
-      <div id="notebook-column" className="w-full py-2 px-8">
-        {readOnly && (
-          <div
-            className="mb-3 flex items-center gap-2 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
-            data-testid="notebook-readonly-banner"
-          >
-            <LockClosedIcon className="h-4 w-4 text-nb-text-muted" />
-            <span>
-              {ownerSessionId
-                ? `Read-only. This notebook is open for editing in session ${ownerSessionId}.`
-                : 'Read-only. This notebook is open for editing in another browser tab.'}
-            </span>
-          </div>
-        )}
-        {cellDatas.length === 0 ? (
-          <div
-            id="empty-notebook-prompt"
-            className="flex flex-col items-center justify-center gap-3 py-16 text-sm text-nb-text-muted"
-          >
-            <p>
-              {readOnly
-                ? 'This read-only notebook has no cells.'
-                : 'This notebook has no cells yet.'}
-            </p>
-            {!readOnly && (
-              <button
-                type="button"
-                className="cell-add-btn h-8 w-8"
-                aria-label="Add first cell"
-                onClick={() => data?.appendCell(parser_pb.CellKind.MARKUP)}
-              >
-                <PlusIcon className="h-5 w-5" />
-              </button>
-            )}
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {cellDatas.map((cellData, index) => {
-              const refId = cellData.snapshot?.refId ?? `cell-${index}`
-              return (
-                <Action
-                  key={`action-${refId}`}
-                  cellData={cellData}
-                  docUri={docUri}
-                  isFirst={index === 0}
-                  isActiveCell={activeCell?.refId === refId}
-                  activeFocusRole={activeCell?.focusRole ?? 'editor'}
-                  isWindowFocused={isWindowFocused}
-                  onFocusStateChange={(state) => onCellFocus(docUri, state)}
-                  readOnly={readOnly}
-                />
-              )
-            })}
-            {!readOnly && (
-              <div className="flex justify-center py-3">
+    <div className="flex h-full min-w-0">
+      <ScrollArea
+        key={`scroll-${docUri}`}
+        type="auto"
+        scrollbars="both"
+        className="h-full min-w-0 max-w-full flex-1"
+        data-document-id={docUri}
+      >
+        {/* Full-width notebook column with horizontal padding for breathing room.
+            Cells expand to fill the available width of the tab content area. */}
+        <div id="notebook-column" className="w-full py-2 px-8">
+          {readOnly && (
+            <div
+              className="mb-3 flex items-center gap-2 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
+              data-testid="notebook-readonly-banner"
+            >
+              <LockClosedIcon className="h-4 w-4 text-nb-text-muted" />
+              <span>
+                {ownerSessionId
+                  ? `Read-only. This notebook is open for editing in session ${ownerSessionId}.`
+                  : 'Read-only. This notebook is open for editing in another browser tab.'}
+              </span>
+            </div>
+          )}
+          {cellDatas.length === 0 ? (
+            <div
+              id="empty-notebook-prompt"
+              className="flex flex-col items-center justify-center gap-3 py-16 text-sm text-nb-text-muted"
+            >
+              <p>
+                {readOnly
+                  ? 'This read-only notebook has no cells.'
+                  : 'This notebook has no cells yet.'}
+              </p>
+              {!readOnly && (
                 <button
                   type="button"
-                  className="flex items-center gap-1.5 rounded-full border border-nb-border-strong bg-white px-3 py-1 text-xs text-nb-text-muted transition-colors duration-150 hover:border-nb-accent hover:text-nb-accent hover:bg-nb-accent-muted"
-                  aria-label="Add cell at end"
-                  onClick={() => data?.appendCell(parser_pb.CellKind.CODE)}
+                  className="cell-add-btn h-8 w-8"
+                  aria-label="Add first cell"
+                  onClick={() => data?.appendCell(parser_pb.CellKind.MARKUP)}
                 >
-                  <PlusIcon width={10} height={10} />
-                  <span>Add cell</span>
+                  <PlusIcon className="h-5 w-5" />
                 </button>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    </ScrollArea>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {cellDatas.map((cellData, index) => {
+                const refId = cellData.snapshot?.refId ?? `cell-${index}`
+                return (
+                  <Action
+                    key={`action-${refId}`}
+                    cellData={cellData}
+                    docUri={docUri}
+                    isFirst={index === 0}
+                    isActiveCell={activeCell?.refId === refId}
+                    activeFocusRole={activeCell?.focusRole ?? 'editor'}
+                    isWindowFocused={isWindowFocused}
+                    onFocusStateChange={(state) => onCellFocus(docUri, state)}
+                    readOnly={readOnly}
+                    commentsAvailable={commentsStatus === 'available'}
+                    commentCount={commentsByCell.get(refId)?.length ?? 0}
+                    onStartComment={startCommentDraft}
+                  />
+                )
+              })}
+              {!readOnly && (
+                <div className="flex justify-center py-3">
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-full border border-nb-border-strong bg-white px-3 py-1 text-xs text-nb-text-muted transition-colors duration-150 hover:border-nb-accent hover:text-nb-accent hover:bg-nb-accent-muted"
+                    aria-label="Add cell at end"
+                    onClick={() => data?.appendCell(parser_pb.CellKind.CODE)}
+                  >
+                    <PlusIcon width={10} height={10} />
+                    <span>Add cell</span>
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+      <NotebookCommentsPanel
+        status={commentsStatus}
+        errorMessage={commentsErrorMessage}
+        threads={commentThreads}
+        cellLabels={cellLabels}
+        draftCellId={draftCellId}
+        busy={commentsBusy}
+        onStartDraft={startCommentDraft}
+        onCancelDraft={() => setDraftCellId(null)}
+        onCreateComment={handleCreateComment}
+        onReply={handleReplyToComment}
+        onResolve={handleResolveComment}
+        onReopen={handleReopenComment}
+        onRefresh={refreshComments}
+        onSelectCell={selectCommentCell}
+      />
+    </div>
   )
 }
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1855,8 +1855,8 @@ function NotebookTabContent({
     [comments]
   )
   const commentThreads = useMemo(
-    () => toCellCommentThreads(comments),
-    [comments]
+    () => toCellCommentThreads(comments, new Set(cellLabels.keys())),
+    [cellLabels, comments]
   )
 
   const selectCommentCell = useCallback((cellId: string) => {
@@ -1914,6 +1914,7 @@ function NotebookTabContent({
       if (isDriveItemUri(docUri)) {
         if (!cancelled) {
           setCommentsRemoteUri(docUri)
+          setCommentsStatus('loading')
         }
         return
       }
@@ -1921,6 +1922,8 @@ function NotebookTabContent({
       if (!store || !docUri.startsWith('local://')) {
         if (!cancelled) {
           setCommentsRemoteUri(null)
+          setComments([])
+          setCommentsStatus('unavailable')
         }
         return
       }
@@ -1929,13 +1932,20 @@ function NotebookTabContent({
         const metadata = await store.getMetadata(docUri)
         const remoteUri = metadata?.remoteUri
         if (!cancelled) {
-          setCommentsRemoteUri(
-            remoteUri && isDriveItemUri(remoteUri) ? remoteUri : null
-          )
+          if (remoteUri && isDriveItemUri(remoteUri)) {
+            setCommentsRemoteUri(remoteUri)
+            setCommentsStatus('loading')
+          } else {
+            setCommentsRemoteUri(null)
+            setComments([])
+            setCommentsStatus('unavailable')
+          }
         }
       } catch {
         if (!cancelled) {
           setCommentsRemoteUri(null)
+          setComments([])
+          setCommentsStatus('unavailable')
         }
       }
     })()

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -49,6 +49,7 @@ import { PlayIcon, PlusIcon, SpinnerIcon, TrashIcon } from './icons'
 //import { useRun } from "../../lib/useRun.js";
 import { useCurrentDoc } from '../../contexts/CurrentDocContext'
 import { useRunners } from '../../contexts/RunnersContext'
+import { useCommentsPanel } from '../../contexts/CommentsPanelContext'
 import { DEFAULT_RUNNER_PLACEHOLDER } from '../../lib/runtime/runnersManager'
 import {
   APPKERNEL_RUNNER_NAME,
@@ -415,17 +416,24 @@ function CellCommentButton({
   onClick: () => void
   className?: string
 }) {
-  if (!available && count === 0) {
-    return null
-  }
+  const label =
+    count > 0
+      ? `${count} open comments`
+      : available
+        ? 'Add comment'
+        : 'Comments unavailable'
+  const stateClass = available
+    ? 'text-nb-accent hover:bg-nb-accent-muted hover:text-nb-accent focus-visible:bg-nb-accent-muted focus-visible:text-nb-accent'
+    : 'text-nb-text-faint'
+
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={!available}
-      aria-label={count > 0 ? `${count} open comments` : 'Add comment'}
-      title={count > 0 ? `${count} open comments` : 'Add comment'}
-      className={`icon-btn relative ${className}`}
+      aria-label={label}
+      title={label}
+      className={`icon-btn disabled:cursor-not-allowed disabled:opacity-100 ${stateClass} ${className}`}
     >
       <ChatBubbleLeftIcon className="h-4 w-4" />
       {count > 0 && (
@@ -839,7 +847,7 @@ export function Action({
     }
 
     const menuWidth = 200
-    const menuHeight = shareRemoteUri ? 88 : 48
+    const menuHeight = shareRemoteUri ? 128 : 88
     const left = Math.max(
       0,
       Math.min(contextMenu.x, window.innerWidth - menuWidth)
@@ -942,9 +950,11 @@ export function Action({
 
   const handleStartComment = useCallback(() => {
     if (!cell?.refId || !onStartComment) {
+      setContextMenu(null)
       return
     }
     onStartComment(cell.refId)
+    setContextMenu(null)
   }, [cell?.refId, onStartComment])
 
   const sequenceLabel = useMemo(() => {
@@ -1325,6 +1335,11 @@ export function Action({
     return null
   }
 
+  const cellCommentVisibilityClass =
+    commentCount > 0 || (isActiveCell && isWindowFocused)
+      ? 'opacity-100'
+      : 'pointer-events-none opacity-0 transition-opacity duration-150 group-hover/cell:pointer-events-auto group-hover/cell:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100'
+
   // Render markdown cells with in-place rendering (Jupyter-style)
   // No run button, no output area - just the markdown rendered in-place
   if (isMarkdownCell) {
@@ -1381,7 +1396,7 @@ export function Action({
               count={commentCount}
               available={commentsAvailable}
               onClick={handleStartComment}
-              className="absolute right-10 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+              className={`absolute right-10 top-2 h-6 w-6 ${cellCommentVisibilityClass}`}
             />
             {/* Trash icon on the right, visible on hover */}
             <button
@@ -1416,6 +1431,17 @@ export function Action({
                 Copy Share Link
               </button>
             )}
+            <button
+              type="button"
+              className="ctx-menu-item"
+              disabled={!commentsAvailable}
+              onClick={(event) => {
+                event.stopPropagation()
+                handleStartComment()
+              }}
+            >
+              Add Comment
+            </button>
             <button
               type="button"
               className="ctx-menu-item text-red-600"
@@ -1480,7 +1506,7 @@ export function Action({
               count={commentCount}
               available={commentsAvailable}
               onClick={handleStartComment}
-              className="absolute right-10 top-2 h-6 w-6 opacity-0 transition-opacity duration-150 group-hover/cell:opacity-100"
+              className={`absolute right-10 top-2 h-6 w-6 ${cellCommentVisibilityClass}`}
             />
             <button
               type="button"
@@ -1514,6 +1540,17 @@ export function Action({
                 Copy Share Link
               </button>
             )}
+            <button
+              type="button"
+              className="ctx-menu-item"
+              disabled={!commentsAvailable}
+              onClick={(event) => {
+                event.stopPropagation()
+                handleStartComment()
+              }}
+            >
+              Add Comment
+            </button>
             <button
               type="button"
               className="ctx-menu-item text-red-600"
@@ -1715,7 +1752,7 @@ export function Action({
                 count={commentCount}
                 available={commentsAvailable}
                 onClick={handleStartComment}
-                className="h-7 w-7"
+                className={`relative h-7 w-7 ${cellCommentVisibilityClass}`}
               />
               <RunActionButton
                 pid={pid}
@@ -1775,6 +1812,17 @@ export function Action({
           )}
           <button
             type="button"
+            className="ctx-menu-item"
+            disabled={!commentsAvailable}
+            onClick={(event) => {
+              event.stopPropagation()
+              handleStartComment()
+            }}
+          >
+            Add Comment
+          </button>
+          <button
+            type="button"
             className="ctx-menu-item text-red-600"
             disabled={readOnly}
             onClick={(event) => {
@@ -1812,6 +1860,8 @@ function NotebookTabContent({
   const syncState = useNotebookSyncState(docUri)
   const readOnly = Boolean(entry.readOnly || notebookSnapshot?.readOnly)
   const isDriveBacked = isDriveBackedNotebook(entry, syncState)
+  const { commentsPanelOpen, openCommentsPanel, setCommentsPanelOpen } =
+    useCommentsPanel()
   const shouldRenderCells = !readOnly || isSelected
   const cellDatas = useMemo(() => {
     if (!shouldRenderCells) {
@@ -1864,15 +1914,23 @@ function NotebookTabContent({
       document.getElementById(`code-action-${cellId}`) ??
       document.getElementById(`markdown-action-${cellId}`) ??
       document.getElementById(`html-action-${cellId}`)
+    const focusRole = element?.id.startsWith('markdown-action-')
+      ? 'rendered'
+      : 'editor'
+    const nextState = createNotebookActiveCellState(cellId, focusRole)
+    if (nextState) {
+      onCellFocus(docUri, nextState)
+    }
     element?.scrollIntoView({ block: 'center', behavior: 'smooth' })
-  }, [])
+  }, [docUri, onCellFocus])
 
   const startCommentDraft = useCallback(
     (cellId: string) => {
+      openCommentsPanel()
       setDraftCellId(cellId)
       selectCommentCell(cellId)
     },
-    [selectCommentCell]
+    [openCommentsPanel, selectCommentCell]
   )
 
   const refreshComments = useCallback(async () => {
@@ -2231,22 +2289,25 @@ function NotebookTabContent({
           )}
         </div>
       </ScrollArea>
-      <NotebookCommentsPanel
-        status={commentsStatus}
-        errorMessage={commentsErrorMessage}
-        threads={commentThreads}
-        cellLabels={cellLabels}
-        draftCellId={draftCellId}
-        busy={commentsBusy}
-        onStartDraft={startCommentDraft}
-        onCancelDraft={() => setDraftCellId(null)}
-        onCreateComment={handleCreateComment}
-        onReply={handleReplyToComment}
-        onResolve={handleResolveComment}
-        onReopen={handleReopenComment}
-        onRefresh={refreshComments}
-        onSelectCell={selectCommentCell}
-      />
+      {commentsPanelOpen && (
+        <NotebookCommentsPanel
+          status={commentsStatus}
+          errorMessage={commentsErrorMessage}
+          threads={commentThreads}
+          cellLabels={cellLabels}
+          activeCellId={activeCell?.refId ?? null}
+          draftCellId={draftCellId}
+          busy={commentsBusy}
+          onCancelDraft={() => setDraftCellId(null)}
+          onCreateComment={handleCreateComment}
+          onReply={handleReplyToComment}
+          onResolve={handleResolveComment}
+          onReopen={handleReopenComment}
+          onRefresh={refreshComments}
+          onHide={() => setCommentsPanelOpen(false)}
+          onSelectCell={selectCommentCell}
+        />
+      )}
     </div>
   )
 }

--- a/app/src/components/BottomPane/BottomPane.test.tsx
+++ b/app/src/components/BottomPane/BottomPane.test.tsx
@@ -15,10 +15,19 @@ vi.mock("../Logs/LogsPane", () => ({
 }));
 
 import BottomPane from "./BottomPane";
+import { BottomPaneProvider } from "../../contexts/BottomPaneContext";
+
+function renderBottomPane() {
+  return render(
+    <BottomPaneProvider>
+      <BottomPane />
+    </BottomPaneProvider>
+  );
+}
 
 describe("BottomPane", () => {
   it("uses a single tab bar and highlights the selected tab", () => {
-    render(<BottomPane />);
+    renderBottomPane();
 
     const consoleTab = screen.getByRole("tab", { name: "App Console" });
     const logsTab = screen.getByRole("tab", { name: "Logs" });

--- a/app/src/components/BottomPane/BottomPane.tsx
+++ b/app/src/components/BottomPane/BottomPane.tsx
@@ -1,40 +1,17 @@
-import { useEffect, useState } from "react";
 import * as Tabs from "@radix-ui/react-tabs";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 
 import AppConsole from "../AppConsole/AppConsole";
 import LogsPane from "../Logs/LogsPane";
-
-const STORAGE_KEY = "runme.bottomPaneCollapsed";
-const LEGACY_STORAGE_KEY = "aisre.bottomPaneCollapsed";
+import { useBottomPane } from "../../contexts/BottomPaneContext";
 
 /**
  * BottomPane groups debugging surfaces into tabs so the App Console and the
  * new Logs panel share the same page area (similar to VS Code output panels).
  */
 export default function BottomPane() {
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-    try {
-      const stored =
-        localStorage.getItem(STORAGE_KEY) ??
-        localStorage.getItem(LEGACY_STORAGE_KEY);
-      return stored === "true";
-    } catch {
-      return false;
-    }
-  });
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, collapsed ? "true" : "false");
-      localStorage.removeItem(LEGACY_STORAGE_KEY);
-    } catch {
-      // Non-critical preference persistence.
-    }
-  }, [collapsed]);
+  const { activeTab, collapsed, setActiveTab, toggleCollapsed } =
+    useBottomPane();
 
   return (
     <div
@@ -46,7 +23,10 @@ export default function BottomPane() {
     >
       <Tabs.Root
         id="bottom-pane-tabs"
-        defaultValue="console"
+        value={activeTab}
+        onValueChange={(value) =>
+          setActiveTab(value === "logs" ? "logs" : "console")
+        }
         className="flex h-full min-h-0 flex-col"
       >
         <div
@@ -75,11 +55,17 @@ export default function BottomPane() {
           <button
             id="bottom-pane-collapse-toggle"
             type="button"
-            aria-label={collapsed ? "Expand bottom pane" : "Collapse bottom pane"}
+            aria-label={
+              collapsed ? "Expand bottom pane" : "Collapse bottom pane"
+            }
             className="inline-flex h-8 w-8 items-center justify-center rounded bg-black/0 text-[12.6px] font-mono font-medium text-white hover:bg-black/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/80"
-            onClick={() => setCollapsed((prev) => !prev)}
+            onClick={toggleCollapsed}
           >
-            {collapsed ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
+            {collapsed ? (
+              <ChevronUpIcon className="h-4 w-4" />
+            ) : (
+              <ChevronDownIcon className="h-4 w-4" />
+            )}
           </button>
         </div>
 

--- a/app/src/components/MainPage/MainPage.tsx
+++ b/app/src/components/MainPage/MainPage.tsx
@@ -2,6 +2,8 @@ import Actions from "../Actions/Actions";
 import BottomPane from "../BottomPane/BottomPane";
 import { SidePanelContent, SidePanelToolbar } from "../SidePanel/SidePanel";
 import { useSidePanel } from "../../contexts/SidePanelContext";
+import { BottomPaneProvider } from "../../contexts/BottomPaneContext";
+import { CommentsPanelProvider } from "../../contexts/CommentsPanelContext";
 import { CurrentDocInitializer } from "../CurrentDocInitializer";
 
 const SIDE_PANEL_WIDTH = 360;
@@ -12,39 +14,48 @@ export default function MainPage() {
   const sidePanelVisible = Boolean(activePanel);
 
   return (
-    <div id="main-page" className="flex h-screen w-screen bg-nb-bg">
-      <CurrentDocInitializer />
-      <div className="flex h-full min-h-0 w-full">
-        <div
-          id="toolbar-column"
-          className="flex h-full flex-col bg-nb-surface border-r border-nb-border"
-          style={{ width: TOOLBAR_WIDTH }}
-        >
-          <SidePanelToolbar />
-        </div>
-        <div
-          id="sidepanel-column"
-          className={`h-full transition-[width] duration-200 ease-in-out overflow-hidden bg-nb-surface ${sidePanelVisible ? 'border-r border-nb-border' : ''}`}
-          style={{
-            width: sidePanelVisible ? SIDE_PANEL_WIDTH : 0,
-          }}
-        >
-          <SidePanelContent />
-        </div>
-        <div
-          id="content-area"
-          className={`flex h-full flex-1 min-w-0 flex-col gap-2 ${
-            sidePanelVisible ? "py-2 pr-2 pl-0" : "p-2"
-          }`}
-        >
-          <div id="notebook-pane" className="flex-1 min-h-0 overflow-hidden rounded-nb-md border border-nb-border-strong bg-white">
-            <Actions />
+    <BottomPaneProvider>
+      <CommentsPanelProvider>
+        <div id="main-page" className="flex h-screen w-screen bg-nb-bg">
+          <CurrentDocInitializer />
+          <div className="flex h-full min-h-0 w-full">
+            <div
+              id="toolbar-column"
+              className="flex h-full flex-col bg-nb-surface border-r border-nb-border"
+              style={{ width: TOOLBAR_WIDTH }}
+            >
+              <SidePanelToolbar />
+            </div>
+            <div
+              id="sidepanel-column"
+              className={`h-full transition-[width] duration-200 ease-in-out overflow-hidden bg-nb-surface ${
+                sidePanelVisible ? "border-r border-nb-border" : ""
+              }`}
+              style={{
+                width: sidePanelVisible ? SIDE_PANEL_WIDTH : 0,
+              }}
+            >
+              <SidePanelContent />
+            </div>
+            <div
+              id="content-area"
+              className={`flex h-full flex-1 min-w-0 flex-col gap-2 ${
+                sidePanelVisible ? "py-2 pr-2 pl-0" : "p-2"
+              }`}
+            >
+              <div
+                id="notebook-pane"
+                className="flex-1 min-h-0 overflow-hidden rounded-nb-md border border-nb-border-strong bg-white"
+              >
+                <Actions />
+              </div>
+              <div id="bottom-pane-container">
+                <BottomPane />
+              </div>
+            </div>
           </div>
-          <div id="bottom-pane-container">
-            <BottomPane />
-          </div>
         </div>
-      </div>
-    </div>
+      </CommentsPanelProvider>
+    </BottomPaneProvider>
   );
 }

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment jsdom
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CellCommentThread } from '../lib/notebookComments'
+import { createCellCommentAnchor } from '../lib/notebookComments'
+import { NotebookCommentsPanel } from './NotebookCommentsPanel'
+
+const noopAsync = vi.fn(async () => undefined)
+const noop = vi.fn()
+
+function renderPanel(overrides = {}) {
+  const props = {
+    status: 'available' as const,
+    threads: [],
+    cellLabels: new Map<string, string>(),
+    activeCellId: null,
+    draftCellId: null,
+    busy: false,
+    onCancelDraft: noop,
+    onCreateComment: noopAsync,
+    onReply: noopAsync,
+    onResolve: noopAsync,
+    onReopen: noopAsync,
+    onRefresh: noop,
+    onHide: noop,
+    onSelectCell: noop,
+    ...overrides,
+  }
+
+  const view = render(<NotebookCommentsPanel {...props} />)
+
+  return { ...props, ...view }
+}
+
+describe('NotebookCommentsPanel', () => {
+  it('calls onHide from the header hide button', () => {
+    const onHide = vi.fn()
+
+    renderPanel({ onHide })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
+
+    expect(onHide).toHaveBeenCalledTimes(1)
+  })
+
+  it('orders anchored threads by cell order instead of modification time', () => {
+    const threads: CellCommentThread[] = [
+      thread('comment on cell two', 'cell-2', {
+        id: 'comment-2',
+        createdTime: '2026-06-14T10:00:00Z',
+        modifiedTime: '2026-06-14T10:00:00Z',
+      }),
+      thread('comment on cell one', 'cell-1', {
+        id: 'comment-1',
+        createdTime: '2026-06-14T11:00:00Z',
+        modifiedTime: '2026-06-14T12:00:00Z',
+      }),
+    ]
+
+    renderPanel({
+      threads,
+      cellLabels: new Map([
+        ['cell-1', 'Cell 1'],
+        ['cell-2', 'Cell 2'],
+      ]),
+    })
+
+    const text = document.body.textContent ?? ''
+    expect(text.indexOf('comment on cell one')).toBeLessThan(
+      text.indexOf('comment on cell two')
+    )
+  })
+
+  it('orders a draft comment by the target cell instead of pinning it first', () => {
+    renderPanel({
+      threads: [
+        thread('comment on cell three', 'cell-3', { id: 'comment-3' }),
+        thread('comment on cell one', 'cell-1', { id: 'comment-1' }),
+      ],
+      draftCellId: 'cell-2',
+      cellLabels: new Map([
+        ['cell-1', 'Cell 1'],
+        ['cell-2', 'Cell 2'],
+        ['cell-3', 'Cell 3'],
+      ]),
+    })
+
+    const text = document.body.textContent ?? ''
+    expect(text.indexOf('comment on cell one')).toBeLessThan(
+      text.indexOf('New comment on Cell 2')
+    )
+    expect(text.indexOf('New comment on Cell 2')).toBeLessThan(
+      text.indexOf('comment on cell three')
+    )
+  })
+
+  it('marks the draft comment active when its cell has focus', () => {
+    renderPanel({
+      draftCellId: 'cell-2',
+      activeCellId: 'cell-2',
+      cellLabels: new Map([['cell-2', 'Cell 2']]),
+    })
+
+    const draft = screen.getByText('New comment on Cell 2').closest('article')
+
+    expect(draft).not.toBeNull()
+    expect(draft?.getAttribute('aria-current')).toBe('true')
+  })
+
+  it('groups multiple top-level comments on the same cell into one thread card', () => {
+    renderPanel({
+      threads: [
+        thread('first comment on cell four', 'cell-4', { id: 'comment-1' }),
+        thread('second comment on cell four', 'cell-4', { id: 'comment-2' }),
+      ],
+      draftCellId: 'cell-4',
+      activeCellId: 'cell-4',
+      cellLabels: new Map([['cell-4', 'Cell 4']]),
+    })
+
+    const articles = document.querySelectorAll(
+      '[data-comment-panel-item="thread"]'
+    )
+    const article = articles[0] as HTMLElement
+
+    expect(articles).toHaveLength(1)
+    expect(within(article).getByText('first comment on cell four')).toBeTruthy()
+    expect(
+      within(article).getByText('second comment on cell four')
+    ).toBeTruthy()
+    expect(within(article).getByText('New comment on Cell 4')).toBeTruthy()
+    expect(article.querySelectorAll('[data-comment-message]')).toHaveLength(2)
+  })
+
+  it('only shows reply and resolve controls on the active thread', () => {
+    const threads: CellCommentThread[] = [
+      thread('inactive thread', 'cell-1', { id: 'comment-1' }),
+      thread('active thread', 'cell-2', { id: 'comment-2' }),
+    ]
+
+    renderPanel({
+      threads,
+      activeCellId: 'cell-2',
+      cellLabels: new Map([
+        ['cell-1', 'Cell 1'],
+        ['cell-2', 'Cell 2'],
+      ]),
+    })
+
+    const inactiveArticle = screen.getByText('inactive thread').closest('article')
+    const activeArticle = screen.getByText('active thread').closest('article')
+
+    expect(inactiveArticle).not.toBeNull()
+    expect(activeArticle).not.toBeNull()
+    expect(
+      within(inactiveArticle as HTMLElement).queryByRole('button', {
+        name: 'Resolve',
+      })
+    ).toBeNull()
+    expect(
+      within(inactiveArticle as HTMLElement).queryByRole('button', {
+        name: 'Reply',
+      })
+    ).toBeNull()
+    expect(
+      within(activeArticle as HTMLElement).getByRole('button', {
+        name: 'Resolve',
+      })
+    ).toBeTruthy()
+    expect(
+      within(activeArticle as HTMLElement).getByRole('button', {
+        name: 'Reply',
+      })
+    ).toBeTruthy()
+    expect(within(activeArticle as HTMLElement).getByText('Active')).toBeTruthy()
+  })
+
+  it('moves the active thread when the focused cell changes', async () => {
+    const threads: CellCommentThread[] = [
+      thread('first thread', 'cell-1', { id: 'comment-1' }),
+      thread('second thread', 'cell-2', { id: 'comment-2' }),
+    ]
+    const cellLabels = new Map([
+      ['cell-1', 'Cell 1'],
+      ['cell-2', 'Cell 2'],
+    ])
+
+    const view = renderPanel({
+      threads,
+      cellLabels,
+      activeCellId: 'cell-1',
+    })
+
+    view.rerender(
+      <NotebookCommentsPanel
+        {...view}
+        threads={threads}
+        cellLabels={cellLabels}
+        activeCellId="cell-2"
+      />
+    )
+
+    await waitFor(() => {
+      const firstArticle = screen.getByText('first thread').closest('article')
+      const secondArticle = screen.getByText('second thread').closest('article')
+
+      expect(firstArticle).not.toBeNull()
+      expect(secondArticle).not.toBeNull()
+      expect(
+        within(firstArticle as HTMLElement).queryByRole('button', {
+          name: 'Reply',
+        })
+      ).toBeNull()
+      expect(
+        within(secondArticle as HTMLElement).getByRole('button', {
+          name: 'Reply',
+        })
+      ).toBeTruthy()
+    })
+  })
+
+  it('selects the owning cell when a comment thread is clicked', () => {
+    const onSelectCell = vi.fn()
+
+    renderPanel({
+      threads: [thread('cell one thread', 'cell-1', { id: 'comment-1' })],
+      cellLabels: new Map([['cell-1', 'Cell 1']]),
+      onSelectCell,
+    })
+
+    fireEvent.click(screen.getByText('cell one thread').closest('article')!)
+
+    expect(onSelectCell).toHaveBeenCalledWith('cell-1')
+  })
+
+  it('does not treat textarea space key presses as thread selection', () => {
+    const onSelectCell = vi.fn()
+    const threads: CellCommentThread[] = [
+      thread('active thread', 'cell-1', { id: 'comment-1' }),
+    ]
+
+    renderPanel({
+      threads,
+      activeCellId: 'cell-1',
+      cellLabels: new Map([['cell-1', 'Cell 1']]),
+      onSelectCell,
+    })
+
+    const textarea = screen.getByPlaceholderText('Reply or add others with @')
+    fireEvent.keyDown(textarea, { key: ' ' })
+
+    expect(onSelectCell).not.toHaveBeenCalled()
+  })
+})
+
+function thread(
+  content: string,
+  cellId: string,
+  overrides: Partial<CellCommentThread['comment']> = {}
+): CellCommentThread {
+  return {
+    cellId,
+    orphaned: false,
+    comment: {
+      id: overrides.id,
+      content,
+      createdTime: overrides.createdTime ?? '2026-06-14T10:00:00Z',
+      modifiedTime: overrides.modifiedTime ?? '2026-06-14T10:00:00Z',
+      anchor: createCellCommentAnchor(cellId),
+      author: { displayName: 'Tester' },
+      resolved: false,
+      replies: [],
+      ...overrides,
+    },
+  }
+}

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react'
+
+import type { CellCommentThread } from '../lib/notebookComments'
+
+type CommentsStatus = 'loading' | 'available' | 'unavailable' | 'error'
+
+export function NotebookCommentsPanel({
+  status,
+  errorMessage,
+  threads,
+  cellLabels,
+  draftCellId,
+  busy,
+  onStartDraft,
+  onCancelDraft,
+  onCreateComment,
+  onReply,
+  onResolve,
+  onReopen,
+  onRefresh,
+  onSelectCell,
+}: {
+  status: CommentsStatus
+  errorMessage?: string
+  threads: CellCommentThread[]
+  cellLabels: Map<string, string>
+  draftCellId: string | null
+  busy: boolean
+  onStartDraft: (cellId: string) => void
+  onCancelDraft: () => void
+  onCreateComment: (cellId: string, content: string) => Promise<void>
+  onReply: (commentId: string, content: string) => Promise<void>
+  onResolve: (commentId: string) => Promise<void>
+  onReopen: (commentId: string) => Promise<void>
+  onRefresh: () => void
+  onSelectCell: (cellId: string) => void
+}) {
+  const [draft, setDraft] = useState('')
+  const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({})
+
+  const sortedThreads = [...threads].sort((a, b) => {
+    const aResolved = a.comment.resolved ? 1 : 0
+    const bResolved = b.comment.resolved ? 1 : 0
+    if (aResolved !== bResolved) {
+      return aResolved - bResolved
+    }
+    return (
+      b.comment.modifiedTime ??
+      b.comment.createdTime ??
+      ''
+    ).localeCompare(a.comment.modifiedTime ?? a.comment.createdTime ?? '')
+  })
+
+  return (
+    <aside
+      className="hidden h-full w-[340px] shrink-0 border-l border-nb-border bg-nb-surface-1 lg:flex lg:flex-col"
+      aria-label="Notebook comments"
+    >
+      <div className="flex items-center justify-between border-b border-nb-border px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold text-nb-text">Comments</h2>
+          <p className="text-xs text-nb-text-muted">
+            Google Drive comment threads
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
+          onClick={onRefresh}
+          disabled={busy || status !== 'available'}
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+        {status === 'loading' && (
+          <p className="text-sm text-nb-text-muted">Loading comments...</p>
+        )}
+        {status === 'unavailable' && (
+          <div className="rounded-nb-sm border border-dashed border-nb-border bg-white p-3 text-sm text-nb-text-muted">
+            Comments are available for notebooks saved in Google Drive.
+          </div>
+        )}
+        {status === 'error' && (
+          <div className="rounded-nb-sm border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {errorMessage ?? 'Could not load comments from Google Drive.'}
+          </div>
+        )}
+        {status === 'available' && draftCellId && (
+          <form
+            className="mb-3 rounded-nb-sm border border-nb-border bg-white p-3"
+            onSubmit={(event) => {
+              event.preventDefault()
+              const content = draft.trim()
+              if (!content) {
+                return
+              }
+              void onCreateComment(draftCellId, content).then(() => {
+                setDraft('')
+              })
+            }}
+          >
+            <label className="block text-xs font-medium text-nb-text-muted">
+              New comment on {cellLabels.get(draftCellId) ?? 'cell'}
+            </label>
+            <textarea
+              className="mt-2 h-24 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-sm text-nb-text outline-none focus:border-nb-accent"
+              value={draft}
+              disabled={busy}
+              onChange={(event) => setDraft(event.target.value)}
+              autoFocus
+            />
+            <div className="mt-2 flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-nb-sm px-2 py-1 text-xs text-nb-text-muted hover:bg-nb-surface-2"
+                onClick={() => {
+                  setDraft('')
+                  onCancelDraft()
+                }}
+                disabled={busy}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+                disabled={busy || !draft.trim()}
+              >
+                Comment
+              </button>
+            </div>
+          </form>
+        )}
+        {status === 'available' &&
+          sortedThreads.length === 0 &&
+          !draftCellId && (
+            <div className="rounded-nb-sm border border-dashed border-nb-border bg-white p-3 text-sm text-nb-text-muted">
+              No comments yet. Use a cell comment button to start a thread.
+            </div>
+          )}
+        {status === 'available' && sortedThreads.length > 0 && (
+          <div className="space-y-3">
+            {sortedThreads.map(({ comment, cellId }) => {
+              const commentId = comment.id ?? ''
+              const replyDraft = replyDrafts[commentId] ?? ''
+              return (
+                <article
+                  key={commentId || `${comment.createdTime}-${comment.content}`}
+                  className="rounded-nb-sm border border-nb-border bg-white p-3 shadow-sm"
+                >
+                  <div className="mb-2 flex items-start justify-between gap-2">
+                    <div>
+                      <div className="text-xs font-medium text-nb-text">
+                        {comment.author?.displayName ?? 'Commenter'}
+                      </div>
+                      <div className="text-[11px] text-nb-text-faint">
+                        {formatDriveTime(
+                          comment.modifiedTime ?? comment.createdTime
+                        )}
+                      </div>
+                    </div>
+                    <span className="rounded-full bg-nb-surface-2 px-2 py-0.5 text-[11px] text-nb-text-muted">
+                      {comment.resolved ? 'Resolved' : 'Open'}
+                    </span>
+                  </div>
+                  {cellId ? (
+                    <button
+                      type="button"
+                      className="mb-2 text-left text-xs font-medium text-nb-accent hover:underline"
+                      onClick={() => onSelectCell(cellId)}
+                    >
+                      {cellLabels.get(cellId) ?? 'Cell'}
+                    </button>
+                  ) : (
+                    <div className="mb-2 text-xs text-nb-text-faint">
+                      Unanchored comment
+                    </div>
+                  )}
+                  <p className="whitespace-pre-wrap text-sm text-nb-text">
+                    {comment.content ?? ''}
+                  </p>
+                  {(comment.replies ?? []).filter((reply) => !reply.deleted)
+                    .length > 0 && (
+                    <div className="mt-3 space-y-2 border-l border-nb-border pl-3">
+                      {(comment.replies ?? [])
+                        .filter((reply) => !reply.deleted)
+                        .map((reply) => (
+                          <div
+                            key={
+                              reply.id ??
+                              `${reply.createdTime}-${reply.content}`
+                            }
+                          >
+                            <div className="text-[11px] font-medium text-nb-text-muted">
+                              {reply.author?.displayName ?? 'Reply'}
+                              {reply.action ? ` - ${reply.action}` : ''}
+                            </div>
+                            {reply.content && (
+                              <p className="whitespace-pre-wrap text-xs text-nb-text">
+                                {reply.content}
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                    </div>
+                  )}
+                  {commentId && (
+                    <div className="mt-3 space-y-2">
+                      {!comment.resolved && (
+                        <>
+                          <textarea
+                            className="h-16 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-xs text-nb-text outline-none focus:border-nb-accent"
+                            placeholder="Reply"
+                            value={replyDraft}
+                            disabled={busy}
+                            onChange={(event) =>
+                              setReplyDrafts((current) => ({
+                                ...current,
+                                [commentId]: event.target.value,
+                              }))
+                            }
+                          />
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              className="rounded-nb-sm px-2 py-1 text-xs text-nb-text-muted hover:bg-nb-surface-2"
+                              disabled={busy}
+                              onClick={() => {
+                                void onResolve(commentId)
+                              }}
+                            >
+                              Resolve
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+                              disabled={busy || !replyDraft.trim()}
+                              onClick={() => {
+                                const content = replyDraft.trim()
+                                if (!content) {
+                                  return
+                                }
+                                void onReply(commentId, content).then(() => {
+                                  setReplyDrafts((current) => ({
+                                    ...current,
+                                    [commentId]: '',
+                                  }))
+                                })
+                              }}
+                            >
+                              Reply
+                            </button>
+                          </div>
+                        </>
+                      )}
+                      {comment.resolved && (
+                        <button
+                          type="button"
+                          className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
+                          disabled={busy}
+                          onClick={() => {
+                            void onReopen(commentId)
+                          }}
+                        >
+                          Reopen
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </article>
+              )
+            })}
+          </div>
+        )}
+        {status === 'available' && !draftCellId && cellLabels.size > 0 && (
+          <div className="mt-4 border-t border-nb-border pt-3">
+            <label className="block text-xs font-medium text-nb-text-muted">
+              Start a new thread
+            </label>
+            <select
+              className="mt-2 w-full rounded-nb-sm border border-nb-border bg-white px-2 py-1 text-sm text-nb-text"
+              defaultValue=""
+              onChange={(event) => {
+                if (!event.target.value) {
+                  return
+                }
+                onStartDraft(event.target.value)
+                event.target.value = ''
+              }}
+            >
+              <option value="">Select a cell</option>
+              {[...cellLabels.entries()].map(([cellId, label]) => (
+                <option key={cellId} value={cellId}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function formatDriveTime(value?: string): string {
+  if (!value) {
+    return ''
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return date.toLocaleString()
+}

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import type { CellCommentThread } from '../lib/notebookComments'
 
 type CommentsStatus = 'loading' | 'available' | 'unavailable' | 'error'
+type CommentsFilter = 'open' | 'resolved' | 'all'
 
 export function NotebookCommentsPanel({
   status,
@@ -35,42 +36,79 @@ export function NotebookCommentsPanel({
   onRefresh: () => void
   onSelectCell: (cellId: string) => void
 }) {
+  const [filter, setFilter] = useState<CommentsFilter>('open')
   const [draft, setDraft] = useState('')
   const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({})
 
-  const sortedThreads = [...threads].sort((a, b) => {
-    const aResolved = a.comment.resolved ? 1 : 0
-    const bResolved = b.comment.resolved ? 1 : 0
-    if (aResolved !== bResolved) {
-      return aResolved - bResolved
+  const sortedThreads = useMemo(
+    () => sortCommentThreads(threads, cellLabels, filter),
+    [cellLabels, filter, threads]
+  )
+  const counts = useMemo(
+    () => ({
+      open: threads.filter((thread) => !thread.comment.resolved).length,
+      resolved: threads.filter((thread) => thread.comment.resolved).length,
+      all: threads.length,
+    }),
+    [threads]
+  )
+
+  const submitDraft = () => {
+    if (!draftCellId) {
+      return
     }
-    return (
-      b.comment.modifiedTime ??
-      b.comment.createdTime ??
-      ''
-    ).localeCompare(a.comment.modifiedTime ?? a.comment.createdTime ?? '')
-  })
+    const content = draft.trim()
+    if (!content) {
+      return
+    }
+    void onCreateComment(draftCellId, content).then(() => {
+      setDraft('')
+    })
+  }
 
   return (
     <aside
       className="hidden h-full w-[340px] shrink-0 border-l border-nb-border bg-nb-surface-1 lg:flex lg:flex-col"
       aria-label="Notebook comments"
     >
-      <div className="flex items-center justify-between border-b border-nb-border px-4 py-3">
-        <div>
-          <h2 className="text-sm font-semibold text-nb-text">Comments</h2>
-          <p className="text-xs text-nb-text-muted">
-            Google Drive comment threads
-          </p>
+      <div className="border-b border-nb-border px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-nb-text">Comments</h2>
+            <p className="text-xs text-nb-text-muted">
+              Google Drive comment threads
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
+            onClick={onRefresh}
+            disabled={busy || status !== 'available'}
+          >
+            Refresh
+          </button>
         </div>
-        <button
-          type="button"
-          className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
-          onClick={onRefresh}
-          disabled={busy || status !== 'available'}
-        >
-          Refresh
-        </button>
+        {status === 'available' && (
+          <div
+            className="mt-3 grid grid-cols-3 rounded-nb-sm border border-nb-border bg-white p-0.5"
+            aria-label="Comment filter"
+          >
+            {(['open', 'resolved', 'all'] as CommentsFilter[]).map((item) => (
+              <button
+                key={item}
+                type="button"
+                className={`rounded-[5px] px-2 py-1 text-xs capitalize ${
+                  filter === item
+                    ? 'bg-nb-accent text-white'
+                    : 'text-nb-text-muted hover:bg-nb-surface-2 hover:text-nb-text'
+                }`}
+                onClick={() => setFilter(item)}
+              >
+                {item} {counts[item]}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
@@ -79,7 +117,11 @@ export function NotebookCommentsPanel({
         )}
         {status === 'unavailable' && (
           <div className="rounded-nb-sm border border-dashed border-nb-border bg-white p-3 text-sm text-nb-text-muted">
-            Comments are available for notebooks saved in Google Drive.
+            <p>Comments are available for notebooks saved in Google Drive.</p>
+            <p className="mt-2 text-xs">
+              Save this notebook to Drive, then reopen the Drive-backed copy to
+              enable cell comments.
+            </p>
           </div>
         )}
         {status === 'error' && (
@@ -92,13 +134,7 @@ export function NotebookCommentsPanel({
             className="mb-3 rounded-nb-sm border border-nb-border bg-white p-3"
             onSubmit={(event) => {
               event.preventDefault()
-              const content = draft.trim()
-              if (!content) {
-                return
-              }
-              void onCreateComment(draftCellId, content).then(() => {
-                setDraft('')
-              })
+              submitDraft()
             }}
           >
             <label className="block text-xs font-medium text-nb-text-muted">
@@ -109,6 +145,12 @@ export function NotebookCommentsPanel({
               value={draft}
               disabled={busy}
               onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                  event.preventDefault()
+                  submitDraft()
+                }
+              }}
               autoFocus
             />
             <div className="mt-2 flex justify-end gap-2">
@@ -137,12 +179,14 @@ export function NotebookCommentsPanel({
           sortedThreads.length === 0 &&
           !draftCellId && (
             <div className="rounded-nb-sm border border-dashed border-nb-border bg-white p-3 text-sm text-nb-text-muted">
-              No comments yet. Use a cell comment button to start a thread.
+              {threads.length === 0
+                ? 'No comments yet. Use a cell comment button to start a thread.'
+                : `No ${filter} comments.`}
             </div>
           )}
         {status === 'available' && sortedThreads.length > 0 && (
           <div className="space-y-3">
-            {sortedThreads.map(({ comment, cellId }) => {
+            {sortedThreads.map(({ comment, cellId, orphaned }) => {
               const commentId = comment.id ?? ''
               const replyDraft = replyDrafts[commentId] ?? ''
               return (
@@ -165,7 +209,7 @@ export function NotebookCommentsPanel({
                       {comment.resolved ? 'Resolved' : 'Open'}
                     </span>
                   </div>
-                  {cellId ? (
+                  {cellId && !orphaned ? (
                     <button
                       type="button"
                       className="mb-2 text-left text-xs font-medium text-nb-accent hover:underline"
@@ -173,9 +217,13 @@ export function NotebookCommentsPanel({
                     >
                       {cellLabels.get(cellId) ?? 'Cell'}
                     </button>
+                  ) : cellId && orphaned ? (
+                    <div className="mb-2 text-xs font-medium text-nb-text-faint">
+                      Deleted cell
+                    </div>
                   ) : (
                     <div className="mb-2 text-xs text-nb-text-faint">
-                      Unanchored comment
+                      Document-level comment
                     </div>
                   )}
                   <p className="whitespace-pre-wrap text-sm text-nb-text">
@@ -221,6 +269,23 @@ export function NotebookCommentsPanel({
                                 [commentId]: event.target.value,
                               }))
                             }
+                            onKeyDown={(event) => {
+                              if (
+                                (event.metaKey || event.ctrlKey) &&
+                                event.key === 'Enter'
+                              ) {
+                                event.preventDefault()
+                                const content = replyDraft.trim()
+                                if (content) {
+                                  void onReply(commentId, content).then(() => {
+                                    setReplyDrafts((current) => ({
+                                      ...current,
+                                      [commentId]: '',
+                                    }))
+                                  })
+                                }
+                              }
+                            }}
                           />
                           <div className="flex justify-end gap-2">
                             <button
@@ -302,6 +367,62 @@ export function NotebookCommentsPanel({
       </div>
     </aside>
   )
+}
+
+function sortCommentThreads(
+  threads: CellCommentThread[],
+  cellLabels: Map<string, string>,
+  filter: CommentsFilter
+): CellCommentThread[] {
+  return threads
+    .filter((thread) => {
+      if (filter === 'all') {
+        return true
+      }
+      return filter === 'resolved'
+        ? Boolean(thread.comment.resolved)
+        : !thread.comment.resolved
+    })
+    .sort((a, b) => {
+      const aGroup = threadGroup(a)
+      const bGroup = threadGroup(b)
+      if (aGroup !== bGroup) {
+        return aGroup - bGroup
+      }
+
+      const aIndex = a.cellId ? cellIndex(cellLabels, a.cellId) : Infinity
+      const bIndex = b.cellId ? cellIndex(cellLabels, b.cellId) : Infinity
+      if (aIndex !== bIndex) {
+        return aIndex - bIndex
+      }
+
+      return (
+        b.comment.modifiedTime ??
+        b.comment.createdTime ??
+        ''
+      ).localeCompare(a.comment.modifiedTime ?? a.comment.createdTime ?? '')
+    })
+}
+
+function threadGroup(thread: CellCommentThread): number {
+  if (thread.cellId && !thread.orphaned) {
+    return 0
+  }
+  if (thread.orphaned) {
+    return 1
+  }
+  return 2
+}
+
+function cellIndex(cellLabels: Map<string, string>, cellId: string): number {
+  let index = 0
+  for (const [knownCellId] of cellLabels) {
+    if (knownCellId === cellId) {
+      return index
+    }
+    index += 1
+  }
+  return Infinity
 }
 
 function formatDriveTime(value?: string): string {

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -1,48 +1,63 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { CellCommentThread } from '../lib/notebookComments'
 
 type CommentsStatus = 'loading' | 'available' | 'unavailable' | 'error'
 type CommentsFilter = 'open' | 'resolved' | 'all'
+type CommentsPanelItem = {
+  type: 'thread'
+  key: string
+  cellId: string | null
+  orphaned: boolean
+  threads: CellCommentThread[]
+  draftCellId?: string
+}
 
 export function NotebookCommentsPanel({
   status,
   errorMessage,
   threads,
   cellLabels,
+  activeCellId,
   draftCellId,
   busy,
-  onStartDraft,
   onCancelDraft,
   onCreateComment,
   onReply,
   onResolve,
   onReopen,
   onRefresh,
+  onHide,
   onSelectCell,
 }: {
   status: CommentsStatus
   errorMessage?: string
   threads: CellCommentThread[]
   cellLabels: Map<string, string>
+  activeCellId?: string | null
   draftCellId: string | null
   busy: boolean
-  onStartDraft: (cellId: string) => void
   onCancelDraft: () => void
   onCreateComment: (cellId: string, content: string) => Promise<void>
   onReply: (commentId: string, content: string) => Promise<void>
   onResolve: (commentId: string) => Promise<void>
   onReopen: (commentId: string) => Promise<void>
   onRefresh: () => void
+  onHide: () => void
   onSelectCell: (cellId: string) => void
 }) {
   const [filter, setFilter] = useState<CommentsFilter>('open')
   const [draft, setDraft] = useState('')
   const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({})
+  const [activeThreadKey, setActiveThreadKey] = useState<string | null>(null)
 
   const sortedThreads = useMemo(
     () => sortCommentThreads(threads, cellLabels, filter),
     [cellLabels, filter, threads]
+  )
+  const panelItems = useMemo(
+    () => sortCommentPanelItems(sortedThreads, cellLabels, draftCellId),
+    [cellLabels, draftCellId, sortedThreads]
   )
   const counts = useMemo(
     () => ({
@@ -52,6 +67,29 @@ export function NotebookCommentsPanel({
     }),
     [threads]
   )
+  const activeCellThreadKey = useMemo(() => {
+    if (!activeCellId) {
+      return null
+    }
+    const activeItem = panelItems.find(
+      (item) => item.cellId === activeCellId && !item.orphaned
+    )
+    return activeItem?.key ?? null
+  }, [activeCellId, panelItems])
+
+  useEffect(() => {
+    const visibleKeys = new Set(panelItems.map((item) => item.key))
+    const firstThreadKey = panelItems[0]?.key ?? null
+    const nextActiveThreadKey =
+      activeCellThreadKey ??
+      (activeThreadKey && visibleKeys.has(activeThreadKey)
+        ? activeThreadKey
+        : firstThreadKey)
+
+    if (nextActiveThreadKey !== activeThreadKey) {
+      setActiveThreadKey(nextActiveThreadKey)
+    }
+  }, [activeCellThreadKey, activeThreadKey, panelItems])
 
   const submitDraft = () => {
     if (!draftCellId) {
@@ -61,14 +99,50 @@ export function NotebookCommentsPanel({
     if (!content) {
       return
     }
-    void onCreateComment(draftCellId, content).then(() => {
-      setDraft('')
+    const targetCommentId = findReplyTargetCommentId(
+      sortedThreads.filter(
+        (thread) => thread.cellId === draftCellId && !thread.orphaned
+      )
+    )
+    const submit = targetCommentId
+      ? onReply(targetCommentId, content).then(onCancelDraft)
+      : onCreateComment(draftCellId, content)
+    void submit.then(() => setDraft(''))
+  }
+
+  const submitThreadReply = (item: CommentsPanelItem) => {
+    const content = (replyDrafts[item.key] ?? '').trim()
+    if (!content) {
+      return
+    }
+    const targetCommentId = findReplyTargetCommentId(item.threads)
+    const submit = targetCommentId
+      ? onReply(targetCommentId, content)
+      : item.cellId && !item.orphaned
+        ? onCreateComment(item.cellId, content)
+        : Promise.resolve()
+    void submit.then(() => {
+      setReplyDrafts((current) => ({ ...current, [item.key]: '' }))
     })
+  }
+
+  const resolveThread = (item: CommentsPanelItem) => {
+    const commentIds = item.threads
+      .filter((thread) => !thread.comment.resolved && thread.comment.id)
+      .map((thread) => thread.comment.id as string)
+    void Promise.all(commentIds.map((commentId) => onResolve(commentId)))
+  }
+
+  const reopenThread = (item: CommentsPanelItem) => {
+    const commentIds = item.threads
+      .filter((thread) => thread.comment.resolved && thread.comment.id)
+      .map((thread) => thread.comment.id as string)
+    void Promise.all(commentIds.map((commentId) => onReopen(commentId)))
   }
 
   return (
     <aside
-      className="hidden h-full w-[340px] shrink-0 border-l border-nb-border bg-nb-surface-1 lg:flex lg:flex-col"
+      className="flex h-full w-[340px] shrink-0 flex-col border-l border-nb-border bg-nb-surface-1"
       aria-label="Notebook comments"
     >
       <div className="border-b border-nb-border px-4 py-3">
@@ -79,14 +153,23 @@ export function NotebookCommentsPanel({
               Google Drive comment threads
             </p>
           </div>
-          <button
-            type="button"
-            className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
-            onClick={onRefresh}
-            disabled={busy || status !== 'available'}
-          >
-            Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
+              onClick={onRefresh}
+              disabled={busy || status !== 'available'}
+            >
+              Refresh
+            </button>
+            <button
+              type="button"
+              className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
+              onClick={onHide}
+            >
+              Hide
+            </button>
+          </div>
         </div>
         {status === 'available' && (
           <div
@@ -129,52 +212,6 @@ export function NotebookCommentsPanel({
             {errorMessage ?? 'Could not load comments from Google Drive.'}
           </div>
         )}
-        {status === 'available' && draftCellId && (
-          <form
-            className="mb-3 rounded-nb-sm border border-nb-border bg-white p-3"
-            onSubmit={(event) => {
-              event.preventDefault()
-              submitDraft()
-            }}
-          >
-            <label className="block text-xs font-medium text-nb-text-muted">
-              New comment on {cellLabels.get(draftCellId) ?? 'cell'}
-            </label>
-            <textarea
-              className="mt-2 h-24 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-sm text-nb-text outline-none focus:border-nb-accent"
-              value={draft}
-              disabled={busy}
-              onChange={(event) => setDraft(event.target.value)}
-              onKeyDown={(event) => {
-                if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-                  event.preventDefault()
-                  submitDraft()
-                }
-              }}
-              autoFocus
-            />
-            <div className="mt-2 flex justify-end gap-2">
-              <button
-                type="button"
-                className="rounded-nb-sm px-2 py-1 text-xs text-nb-text-muted hover:bg-nb-surface-2"
-                onClick={() => {
-                  setDraft('')
-                  onCancelDraft()
-                }}
-                disabled={busy}
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
-                disabled={busy || !draft.trim()}
-              >
-                Comment
-              </button>
-            </div>
-          </form>
-        )}
         {status === 'available' &&
           sortedThreads.length === 0 &&
           !draftCellId && (
@@ -184,154 +221,224 @@ export function NotebookCommentsPanel({
                 : `No ${filter} comments.`}
             </div>
           )}
-        {status === 'available' && sortedThreads.length > 0 && (
+        {status === 'available' && panelItems.length > 0 && (
           <div className="space-y-3">
-            {sortedThreads.map(({ comment, cellId, orphaned }) => {
-              const commentId = comment.id ?? ''
-              const replyDraft = replyDrafts[commentId] ?? ''
+            {panelItems.map((item) => {
+              const openThreads = item.threads.filter(
+                (thread) => !thread.comment.resolved
+              )
+              const resolvedThreads = item.threads.filter(
+                (thread) => thread.comment.resolved
+              )
+              const isActiveThread =
+                activeThreadKey === item.key ||
+                Boolean(
+                  activeCellId &&
+                    activeCellId === item.cellId &&
+                    !item.orphaned
+                )
+              const isActiveCell = Boolean(
+                activeCellId && item.cellId === activeCellId && !item.orphaned
+              )
+              const canEditThread = isActiveThread && !item.draftCellId
+              const replyDraft = replyDrafts[item.key] ?? ''
+
               return (
                 <article
-                  key={commentId || `${comment.createdTime}-${comment.content}`}
-                  className="rounded-nb-sm border border-nb-border bg-white p-3 shadow-sm"
+                  key={item.key}
+                  role="button"
+                  tabIndex={0}
+                  aria-current={isActiveThread ? 'true' : undefined}
+                  data-comment-cell-id={item.cellId ?? undefined}
+                  data-comment-panel-item="thread"
+                  className={`relative rounded-nb-sm border bg-white p-3 text-left transition-all ${
+                    isActiveThread
+                      ? 'border-nb-accent shadow-nb-lg ring-1 ring-nb-accent/20'
+                      : 'border-nb-border shadow-sm hover:border-nb-border-strong'
+                  }`}
+                  onClick={() => {
+                    setActiveThreadKey(item.key)
+                    if (item.cellId && !item.orphaned) {
+                      onSelectCell(item.cellId)
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (isInteractiveTarget(event.target)) {
+                      return
+                    }
+                    if (event.key !== 'Enter' && event.key !== ' ') {
+                      return
+                    }
+                    event.preventDefault()
+                    setActiveThreadKey(item.key)
+                    if (item.cellId && !item.orphaned) {
+                      onSelectCell(item.cellId)
+                    }
+                  }}
                 >
-                  <div className="mb-2 flex items-start justify-between gap-2">
-                    <div>
-                      <div className="text-xs font-medium text-nb-text">
-                        {comment.author?.displayName ?? 'Commenter'}
-                      </div>
-                      <div className="text-[11px] text-nb-text-faint">
-                        {formatDriveTime(
-                          comment.modifiedTime ?? comment.createdTime
-                        )}
-                      </div>
-                    </div>
-                    <span className="rounded-full bg-nb-surface-2 px-2 py-0.5 text-[11px] text-nb-text-muted">
-                      {comment.resolved ? 'Resolved' : 'Open'}
-                    </span>
-                  </div>
-                  {cellId && !orphaned ? (
-                    <button
-                      type="button"
-                      className="mb-2 text-left text-xs font-medium text-nb-accent hover:underline"
-                      onClick={() => onSelectCell(cellId)}
-                    >
-                      {cellLabels.get(cellId) ?? 'Cell'}
-                    </button>
-                  ) : cellId && orphaned ? (
-                    <div className="mb-2 text-xs font-medium text-nb-text-faint">
-                      Deleted cell
-                    </div>
-                  ) : (
-                    <div className="mb-2 text-xs text-nb-text-faint">
-                      Document-level comment
-                    </div>
+                  {isActiveThread && (
+                    <div className="absolute bottom-3 left-0 top-3 w-1 rounded-r-full bg-nb-accent" />
                   )}
-                  <p className="whitespace-pre-wrap text-sm text-nb-text">
-                    {comment.content ?? ''}
-                  </p>
-                  {(comment.replies ?? []).filter((reply) => !reply.deleted)
-                    .length > 0 && (
-                    <div className="mt-3 space-y-2 border-l border-nb-border pl-3">
-                      {(comment.replies ?? [])
-                        .filter((reply) => !reply.deleted)
-                        .map((reply) => (
-                          <div
-                            key={
-                              reply.id ??
-                              `${reply.createdTime}-${reply.content}`
-                            }
-                          >
-                            <div className="text-[11px] font-medium text-nb-text-muted">
-                              {reply.author?.displayName ?? 'Reply'}
-                              {reply.action ? ` - ${reply.action}` : ''}
-                            </div>
-                            {reply.content && (
-                              <p className="whitespace-pre-wrap text-xs text-nb-text">
-                                {reply.content}
-                              </p>
-                            )}
-                          </div>
-                        ))}
-                    </div>
-                  )}
-                  {commentId && (
-                    <div className="mt-3 space-y-2">
-                      {!comment.resolved && (
-                        <>
-                          <textarea
-                            className="h-16 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-xs text-nb-text outline-none focus:border-nb-accent"
-                            placeholder="Reply"
-                            value={replyDraft}
-                            disabled={busy}
-                            onChange={(event) =>
-                              setReplyDrafts((current) => ({
-                                ...current,
-                                [commentId]: event.target.value,
-                              }))
-                            }
-                            onKeyDown={(event) => {
-                              if (
-                                (event.metaKey || event.ctrlKey) &&
-                                event.key === 'Enter'
-                              ) {
-                                event.preventDefault()
-                                const content = replyDraft.trim()
-                                if (content) {
-                                  void onReply(commentId, content).then(() => {
-                                    setReplyDrafts((current) => ({
-                                      ...current,
-                                      [commentId]: '',
-                                    }))
-                                  })
-                                }
-                              }
-                            }}
-                          />
-                          <div className="flex justify-end gap-2">
-                            <button
-                              type="button"
-                              className="rounded-nb-sm px-2 py-1 text-xs text-nb-text-muted hover:bg-nb-surface-2"
-                              disabled={busy}
-                              onClick={() => {
-                                void onResolve(commentId)
-                              }}
-                            >
-                              Resolve
-                            </button>
-                            <button
-                              type="button"
-                              className="rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
-                              disabled={busy || !replyDraft.trim()}
-                              onClick={() => {
-                                const content = replyDraft.trim()
-                                if (!content) {
-                                  return
-                                }
-                                void onReply(commentId, content).then(() => {
-                                  setReplyDrafts((current) => ({
-                                    ...current,
-                                    [commentId]: '',
-                                  }))
-                                })
-                              }}
-                            >
-                              Reply
-                            </button>
-                          </div>
-                        </>
+
+                  <div className="mb-3 flex items-start justify-between gap-2">
+                    <ThreadLocation
+                      item={item}
+                      cellLabels={cellLabels}
+                      isActiveCell={isActiveCell}
+                      onSelectCell={() => {
+                        if (item.cellId && !item.orphaned) {
+                          setActiveThreadKey(item.key)
+                          onSelectCell(item.cellId)
+                        }
+                      }}
+                    />
+                    <div className="flex items-center gap-1">
+                      {isActiveThread && (
+                        <span className="rounded-full bg-nb-accent-soft px-2 py-0.5 text-[11px] font-medium text-nb-accent">
+                          Active
+                        </span>
                       )}
-                      {comment.resolved && (
+                      <span className="rounded-full bg-nb-surface-2 px-2 py-0.5 text-[11px] text-nb-text-muted">
+                        {openThreads.length > 0
+                          ? `Open ${openThreads.length}`
+                          : `Resolved ${resolvedThreads.length}`}
+                      </span>
+                    </div>
+                  </div>
+
+                  {item.threads.length > 0 && (
+                    <div className="space-y-3">
+                      {item.threads.map((thread, index) => (
+                        <CommentMessage
+                          key={getThreadKey(thread)}
+                          thread={thread}
+                          showStatus={item.threads.length > 1}
+                          separated={index > 0}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  {item.draftCellId && (
+                    <form
+                      aria-current={isActiveThread ? 'true' : undefined}
+                      data-comment-panel-item="draft"
+                      className="mt-3 border-t border-nb-border pt-3"
+                      onSubmit={(event) => {
+                        event.preventDefault()
+                        submitDraft()
+                      }}
+                    >
+                      <label className="block text-xs font-medium text-nb-text-muted">
+                        New comment on{' '}
+                        {cellLabels.get(item.draftCellId) ?? 'cell'}
+                      </label>
+                      <textarea
+                        className="mt-2 h-24 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-sm text-nb-text outline-none focus:border-nb-accent"
+                        value={draft}
+                        disabled={busy}
+                        onChange={(event) => setDraft(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (
+                            (event.metaKey || event.ctrlKey) &&
+                            event.key === 'Enter'
+                          ) {
+                            event.preventDefault()
+                            submitDraft()
+                          }
+                        }}
+                        autoFocus
+                      />
+                      <div className="mt-2 flex justify-end gap-2">
                         <button
                           type="button"
-                          className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
-                          disabled={busy}
+                          className="rounded-nb-sm px-2 py-1 text-xs text-nb-text-muted hover:bg-nb-surface-2"
                           onClick={() => {
-                            void onReopen(commentId)
+                            setDraft('')
+                            onCancelDraft()
                           }}
+                          disabled={busy}
                         >
-                          Reopen
+                          Cancel
                         </button>
+                        <button
+                          type="submit"
+                          className="rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+                          disabled={busy || !draft.trim()}
+                        >
+                          Comment
+                        </button>
+                      </div>
+                    </form>
+                  )}
+
+                  {canEditThread && (
+                    <div className="mt-3 space-y-2 border-t border-nb-border pt-3">
+                      {openThreads.length > 0 && (
+                        <textarea
+                          className="h-16 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-xs text-nb-text outline-none focus:border-nb-accent"
+                          placeholder="Reply or add others with @"
+                          value={replyDraft}
+                          disabled={busy}
+                          onChange={(event) =>
+                            setReplyDrafts((current) => ({
+                              ...current,
+                              [item.key]: event.target.value,
+                            }))
+                          }
+                          onKeyDown={(event) => {
+                            if (
+                              (event.metaKey || event.ctrlKey) &&
+                              event.key === 'Enter'
+                            ) {
+                              event.preventDefault()
+                              submitThreadReply(item)
+                            }
+                          }}
+                        />
                       )}
+                      <div className="flex justify-end gap-2">
+                        {openThreads.length > 0 && (
+                          <button
+                            type="button"
+                            className="rounded-nb-sm px-2 py-1 text-xs text-nb-text-muted hover:bg-nb-surface-2"
+                            disabled={busy}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              resolveThread(item)
+                            }}
+                          >
+                            Resolve
+                          </button>
+                        )}
+                        {openThreads.length > 0 && (
+                          <button
+                            type="button"
+                            className="rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+                            disabled={busy || !replyDraft.trim()}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              submitThreadReply(item)
+                            }}
+                          >
+                            Reply
+                          </button>
+                        )}
+                        {openThreads.length === 0 &&
+                          resolvedThreads.length > 0 && (
+                            <button
+                              type="button"
+                              className="rounded-nb-sm border border-nb-border px-2 py-1 text-xs text-nb-text-muted hover:border-nb-accent hover:text-nb-accent"
+                              disabled={busy}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                reopenThread(item)
+                              }}
+                            >
+                              Reopen
+                            </button>
+                          )}
+                      </div>
                     </div>
                   )}
                 </article>
@@ -339,33 +446,106 @@ export function NotebookCommentsPanel({
             })}
           </div>
         )}
-        {status === 'available' && !draftCellId && cellLabels.size > 0 && (
-          <div className="mt-4 border-t border-nb-border pt-3">
-            <label className="block text-xs font-medium text-nb-text-muted">
-              Start a new thread
-            </label>
-            <select
-              className="mt-2 w-full rounded-nb-sm border border-nb-border bg-white px-2 py-1 text-sm text-nb-text"
-              defaultValue=""
-              onChange={(event) => {
-                if (!event.target.value) {
-                  return
-                }
-                onStartDraft(event.target.value)
-                event.target.value = ''
-              }}
-            >
-              <option value="">Select a cell</option>
-              {[...cellLabels.entries()].map(([cellId, label]) => (
-                <option key={cellId} value={cellId}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
       </div>
     </aside>
+  )
+}
+
+function ThreadLocation({
+  item,
+  cellLabels,
+  isActiveCell,
+  onSelectCell,
+}: {
+  item: CommentsPanelItem
+  cellLabels: Map<string, string>
+  isActiveCell: boolean
+  onSelectCell: () => void
+}) {
+  if (item.cellId && !item.orphaned) {
+    return (
+      <button
+        type="button"
+        className={`rounded-full px-2 py-0.5 text-left text-xs font-medium ${
+          isActiveCell
+            ? 'bg-nb-accent-soft text-nb-accent'
+            : 'text-nb-accent hover:bg-nb-accent-muted'
+        }`}
+        onClick={(event) => {
+          event.stopPropagation()
+          onSelectCell()
+        }}
+      >
+        {cellLabels.get(item.cellId) ?? 'Cell'}
+      </button>
+    )
+  }
+  if (item.cellId && item.orphaned) {
+    return (
+      <div className="text-xs font-medium text-nb-text-faint">
+        Deleted cell
+      </div>
+    )
+  }
+  return (
+    <div className="text-xs text-nb-text-faint">Document-level comment</div>
+  )
+}
+
+function CommentMessage({
+  thread,
+  showStatus,
+  separated,
+}: {
+  thread: CellCommentThread
+  showStatus: boolean
+  separated: boolean
+}) {
+  const { comment } = thread
+  return (
+    <div
+      className={separated ? 'border-t border-nb-border pt-3' : ''}
+      data-comment-message
+    >
+      <div className="mb-1 flex items-start justify-between gap-2">
+        <div>
+          <div className="text-xs font-medium text-nb-text">
+            {comment.author?.displayName ?? 'Commenter'}
+          </div>
+          <div className="text-[11px] text-nb-text-faint">
+            {formatDriveTime(comment.modifiedTime ?? comment.createdTime)}
+          </div>
+        </div>
+        {showStatus && (
+          <span className="rounded-full bg-nb-surface-2 px-2 py-0.5 text-[11px] text-nb-text-muted">
+            {comment.resolved ? 'Resolved' : 'Open'}
+          </span>
+        )}
+      </div>
+      <p className="whitespace-pre-wrap text-sm text-nb-text">
+        {comment.content ?? ''}
+      </p>
+      {(comment.replies ?? []).filter((reply) => !reply.deleted).length >
+        0 && (
+        <div className="mt-3 space-y-2 border-l border-nb-border pl-3">
+          {(comment.replies ?? [])
+            .filter((reply) => !reply.deleted)
+            .map((reply) => (
+              <div key={reply.id ?? `${reply.createdTime}-${reply.content}`}>
+                <div className="text-[11px] font-medium text-nb-text-muted">
+                  {reply.author?.displayName ?? 'Reply'}
+                  {reply.action ? ` - ${reply.action}` : ''}
+                </div>
+                {reply.content && (
+                  <p className="whitespace-pre-wrap text-xs text-nb-text">
+                    {reply.content}
+                  </p>
+                )}
+              </div>
+            ))}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -375,33 +555,115 @@ function sortCommentThreads(
   filter: CommentsFilter
 ): CellCommentThread[] {
   return threads
+    .map((thread, originalIndex) => ({ thread, originalIndex }))
     .filter((thread) => {
+      const comment = thread.thread.comment
       if (filter === 'all') {
         return true
       }
       return filter === 'resolved'
-        ? Boolean(thread.comment.resolved)
-        : !thread.comment.resolved
+        ? Boolean(comment.resolved)
+        : !comment.resolved
     })
     .sort((a, b) => {
-      const aGroup = threadGroup(a)
-      const bGroup = threadGroup(b)
+      const aGroup = threadGroup(a.thread)
+      const bGroup = threadGroup(b.thread)
       if (aGroup !== bGroup) {
         return aGroup - bGroup
       }
 
-      const aIndex = a.cellId ? cellIndex(cellLabels, a.cellId) : Infinity
-      const bIndex = b.cellId ? cellIndex(cellLabels, b.cellId) : Infinity
+      const aIndex = a.thread.cellId
+        ? cellIndex(cellLabels, a.thread.cellId)
+        : Infinity
+      const bIndex = b.thread.cellId
+        ? cellIndex(cellLabels, b.thread.cellId)
+        : Infinity
       if (aIndex !== bIndex) {
         return aIndex - bIndex
       }
 
-      return (
-        b.comment.modifiedTime ??
-        b.comment.createdTime ??
-        ''
-      ).localeCompare(a.comment.modifiedTime ?? a.comment.createdTime ?? '')
+      const aCreated = a.thread.comment.createdTime ?? ''
+      const bCreated = b.thread.comment.createdTime ?? ''
+      if (aCreated !== bCreated) {
+        return aCreated.localeCompare(bCreated)
+      }
+
+      return a.originalIndex - b.originalIndex
     })
+    .map(({ thread }) => thread)
+}
+
+function sortCommentPanelItems(
+  sortedThreads: CellCommentThread[],
+  cellLabels: Map<string, string>,
+  draftCellId: string | null
+): CommentsPanelItem[] {
+  const items: CommentsPanelItem[] = []
+  const itemsByCell = new Map<string, CommentsPanelItem>()
+
+  sortedThreads.forEach((thread) => {
+    if (thread.cellId && !thread.orphaned) {
+      const key = getCellThreadKey(thread.cellId)
+      let item = itemsByCell.get(key)
+      if (!item) {
+        item = {
+          type: 'thread',
+          key,
+          cellId: thread.cellId,
+          orphaned: false,
+          threads: [],
+        }
+        itemsByCell.set(key, item)
+        items.push(item)
+      }
+      item.threads.push(thread)
+      return
+    }
+
+    items.push({
+      type: 'thread',
+      key: `thread:${getThreadKey(thread)}`,
+      cellId: thread.cellId,
+      orphaned: thread.orphaned,
+      threads: [thread],
+    })
+  })
+
+  if (!draftCellId) {
+    return items
+  }
+
+  const draftKey = getCellThreadKey(draftCellId)
+  const existingItem = itemsByCell.get(draftKey)
+  if (existingItem) {
+    existingItem.draftCellId = draftCellId
+    return items
+  }
+
+  const draftIndex = cellIndex(cellLabels, draftCellId)
+  const draftItem: CommentsPanelItem = {
+    type: 'thread',
+    key: draftKey,
+    cellId: draftCellId,
+    orphaned: false,
+    threads: [],
+    draftCellId,
+  }
+  const insertionIndex = items.findIndex((item) => {
+    if (!item.cellId || item.orphaned) {
+      return true
+    }
+    return cellIndex(cellLabels, item.cellId) > draftIndex
+  })
+
+  if (insertionIndex === -1) {
+    return [...items, draftItem]
+  }
+  return [
+    ...items.slice(0, insertionIndex),
+    draftItem,
+    ...items.slice(insertionIndex),
+  ]
 }
 
 function threadGroup(thread: CellCommentThread): number {
@@ -423,6 +685,45 @@ function cellIndex(cellLabels: Map<string, string>, cellId: string): number {
     index += 1
   }
   return Infinity
+}
+
+function getCellThreadKey(cellId: string): string {
+  return `cell:${cellId}`
+}
+
+function getThreadKey(thread: CellCommentThread): string {
+  return (
+    thread.comment.id ??
+    [
+      thread.cellId ?? 'document',
+      thread.comment.createdTime ?? '',
+      thread.comment.content ?? '',
+    ].join(':')
+  )
+}
+
+function findReplyTargetCommentId(
+  threads: CellCommentThread[]
+): string | null {
+  const openThreads = threads.filter(
+    (thread) => !thread.comment.resolved && thread.comment.id
+  )
+  const candidates = openThreads.length > 0 ? openThreads : threads
+  const [target] = [...candidates].sort((a, b) =>
+    (b.comment.createdTime ?? '').localeCompare(a.comment.createdTime ?? '')
+  )
+  return target?.comment.id ?? null
+}
+
+function isInteractiveTarget(target: EventTarget): boolean {
+  return (
+    target instanceof Element &&
+    Boolean(
+      target.closest(
+        'button, textarea, input, select, a, [contenteditable="true"]'
+      )
+    )
+  )
 }
 
 function formatDriveTime(value?: string): string {

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -8,6 +8,8 @@ type PanelKey = 'explorer' | 'open-documents' | 'chatkit' | null
 let authData: {} | null = null
 let isDriveSyncing = false
 let activePanelState: PanelKey = 'explorer'
+let commandsPanelOpen = false
+let commentsPanelOpen = false
 let currentDocUri: string | null = null
 let openDocumentsState: {
   uri: string
@@ -27,6 +29,8 @@ const startGoogleDriveOAuthMock = vi.fn(async () => ({
 const loginWithRedirectMock = vi.fn()
 const logoutMock = vi.fn()
 const togglePanelMock = vi.fn()
+const toggleCommandsPanelMock = vi.fn()
+const toggleCommentsPanelMock = vi.fn()
 const setCurrentDocMock = vi.fn()
 const showDocumentMock = vi.fn()
 const closeWorkspaceDocumentMock = vi.fn()
@@ -43,6 +47,20 @@ vi.mock('../../contexts/SidePanelContext', () => ({
   useSidePanel: () => ({
     activePanel: activePanelState,
     togglePanel: togglePanelMock,
+  }),
+}))
+
+vi.mock('../../contexts/BottomPaneContext', () => ({
+  useBottomPane: () => ({
+    commandsPanelOpen,
+    toggleCommandsPanel: toggleCommandsPanelMock,
+  }),
+}))
+
+vi.mock('../../contexts/CommentsPanelContext', () => ({
+  useCommentsPanel: () => ({
+    commentsPanelOpen,
+    toggleCommentsPanel: toggleCommentsPanelMock,
   }),
 }))
 
@@ -99,6 +117,8 @@ describe('SidePanelToolbar drive status button', () => {
     authData = null
     isDriveSyncing = false
     activePanelState = 'explorer'
+    commandsPanelOpen = false
+    commentsPanelOpen = false
     currentDocUri = null
     openDocumentsState = []
     runnersState = []
@@ -109,6 +129,8 @@ describe('SidePanelToolbar drive status button', () => {
     loginWithRedirectMock.mockClear()
     logoutMock.mockClear()
     togglePanelMock.mockClear()
+    toggleCommandsPanelMock.mockClear()
+    toggleCommentsPanelMock.mockClear()
     setCurrentDocMock.mockClear()
     showDocumentMock.mockClear()
     closeWorkspaceDocumentMock.mockClear()
@@ -201,6 +223,35 @@ describe('SidePanelToolbar drive status button', () => {
     )
 
     expect(togglePanelMock).toHaveBeenCalledWith('open-documents')
+  })
+
+  it('exposes a Commands button in the toolbar', () => {
+    render(<SidePanelToolbar />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle Commands panel' })
+    )
+
+    expect(toggleCommandsPanelMock).toHaveBeenCalled()
+  })
+
+  it('exposes a Comments button above Commands in the toolbar', () => {
+    render(<SidePanelToolbar />)
+
+    const commentsButton = screen.getByRole('button', {
+      name: 'Toggle Comments panel',
+    })
+    const commandsButton = screen.getByRole('button', {
+      name: 'Toggle Commands panel',
+    })
+
+    expect(
+      commentsButton.compareDocumentPosition(commandsButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+
+    fireEvent.click(commentsButton)
+    expect(toggleCommentsPanelMock).toHaveBeenCalled()
   })
 
   it('opens the Version Information document from the toolbar', () => {

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -1,4 +1,6 @@
 import {
+  ChatBubbleLeftIcon,
+  CommandLineIcon,
   FolderIcon,
   ChatBubbleLeftRightIcon,
   InformationCircleIcon,
@@ -27,6 +29,8 @@ import { useGoogleAuth } from '../../contexts/GoogleAuthContext'
 import { useCurrentDoc } from '../../contexts/CurrentDocContext'
 import { useRunners } from '../../contexts/RunnersContext'
 import { useSidePanel } from '../../contexts/SidePanelContext'
+import { useBottomPane } from '../../contexts/BottomPaneContext'
+import { useCommentsPanel } from '../../contexts/CommentsPanelContext'
 import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
 import {
   isDriveLinkStatusUri,
@@ -204,6 +208,8 @@ function OpenDocumentsPanel() {
 
 export function SidePanelToolbar() {
   const { activePanel, togglePanel } = useSidePanel()
+  const { commandsPanelOpen, toggleCommandsPanel } = useBottomPane()
+  const { commentsPanelOpen, toggleCommentsPanel } = useCommentsPanel()
   const { showDocument } = useWorkspaceDocumentContext()
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
   const authData = useBrowserAuthData()
@@ -351,6 +357,30 @@ export function SidePanelToolbar() {
         >
           <ChatBubbleLeftRightIcon className="h-5 w-5" />
           <span className={tooltipBase}>AI Chat</span>
+        </button>
+        <button
+          type="button"
+          className={`${sideButtonBase} ${
+            commentsPanelOpen ? sideButtonActive : sideButtonInactive
+          }`}
+          aria-pressed={commentsPanelOpen}
+          aria-label="Toggle Comments panel"
+          onClick={toggleCommentsPanel}
+        >
+          <ChatBubbleLeftIcon className="h-5 w-5" />
+          <span className={tooltipBase}>Comments</span>
+        </button>
+        <button
+          type="button"
+          className={`${sideButtonBase} ${
+            commandsPanelOpen ? sideButtonActive : sideButtonInactive
+          }`}
+          aria-pressed={commandsPanelOpen}
+          aria-label="Toggle Commands panel"
+          onClick={toggleCommandsPanel}
+        >
+          <CommandLineIcon className="h-5 w-5" />
+          <span className={tooltipBase}>Commands</span>
         </button>
       </div>
       <div className="flex flex-col items-center gap-2 pb-2">

--- a/app/src/contexts/BottomPaneContext.tsx
+++ b/app/src/contexts/BottomPaneContext.tsx
@@ -1,0 +1,91 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+export type BottomPaneTab = 'console' | 'logs'
+
+interface BottomPaneContextValue {
+  activeTab: BottomPaneTab
+  collapsed: boolean
+  commandsPanelOpen: boolean
+  setActiveTab: (tab: BottomPaneTab) => void
+  setCollapsed: (collapsed: boolean) => void
+  toggleCollapsed: () => void
+  toggleCommandsPanel: () => void
+}
+
+const STORAGE_KEY = 'runme.bottomPaneCollapsed'
+const LEGACY_STORAGE_KEY = 'aisre.bottomPaneCollapsed'
+
+const BottomPaneContext = createContext<BottomPaneContextValue | undefined>(
+  undefined
+)
+
+export function BottomPaneProvider({ children }: { children: ReactNode }) {
+  const [activeTab, setActiveTab] = useState<BottomPaneTab>('console')
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+    try {
+      const stored =
+        localStorage.getItem(STORAGE_KEY) ??
+        localStorage.getItem(LEGACY_STORAGE_KEY)
+      return stored === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, collapsed ? 'true' : 'false')
+      localStorage.removeItem(LEGACY_STORAGE_KEY)
+    } catch {
+      // Non-critical preference persistence.
+    }
+  }, [collapsed])
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed((prev) => !prev)
+  }, [])
+
+  const toggleCommandsPanel = useCallback(() => {
+    const shouldCollapse = activeTab === 'console' && !collapsed
+    setActiveTab('console')
+    setCollapsed(shouldCollapse)
+  }, [activeTab, collapsed])
+
+  const value = useMemo(
+    () => ({
+      activeTab,
+      collapsed,
+      commandsPanelOpen: activeTab === 'console' && !collapsed,
+      setActiveTab,
+      setCollapsed,
+      toggleCollapsed,
+      toggleCommandsPanel,
+    }),
+    [activeTab, collapsed, toggleCollapsed, toggleCommandsPanel]
+  )
+
+  return (
+    <BottomPaneContext.Provider value={value}>
+      {children}
+    </BottomPaneContext.Provider>
+  )
+}
+
+export function useBottomPane() {
+  const ctx = useContext(BottomPaneContext)
+  if (!ctx) {
+    throw new Error('useBottomPane must be used within a BottomPaneProvider')
+  }
+  return ctx
+}

--- a/app/src/contexts/CommentsPanelContext.tsx
+++ b/app/src/contexts/CommentsPanelContext.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+interface CommentsPanelContextValue {
+  commentsPanelOpen: boolean
+  setCommentsPanelOpen: (open: boolean) => void
+  openCommentsPanel: () => void
+  toggleCommentsPanel: () => void
+}
+
+const STORAGE_KEY = 'runme.commentsPanel.open'
+
+const CommentsPanelContext = createContext<
+  CommentsPanelContextValue | undefined
+>(undefined)
+
+export function CommentsPanelProvider({ children }: { children: ReactNode }) {
+  const [commentsPanelOpen, setCommentsPanelOpen] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, commentsPanelOpen ? 'true' : 'false')
+    } catch {
+      // Non-critical preference persistence.
+    }
+  }, [commentsPanelOpen])
+
+  const openCommentsPanel = useCallback(() => {
+    setCommentsPanelOpen(true)
+  }, [])
+
+  const toggleCommentsPanel = useCallback(() => {
+    setCommentsPanelOpen((open) => !open)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      commentsPanelOpen,
+      setCommentsPanelOpen,
+      openCommentsPanel,
+      toggleCommentsPanel,
+    }),
+    [commentsPanelOpen, openCommentsPanel, toggleCommentsPanel]
+  )
+
+  return (
+    <CommentsPanelContext.Provider value={value}>
+      {children}
+    </CommentsPanelContext.Provider>
+  )
+}
+
+export function useCommentsPanel() {
+  const ctx = useContext(CommentsPanelContext)
+  if (!ctx) {
+    throw new Error(
+      'useCommentsPanel must be used within a CommentsPanelProvider'
+    )
+  }
+  return ctx
+}

--- a/app/src/lib/notebookComments.test.ts
+++ b/app/src/lib/notebookComments.test.ts
@@ -4,6 +4,7 @@ import {
   createCellCommentAnchor,
   groupCommentsByCell,
   parseCellCommentAnchor,
+  toCellCommentThreads,
 } from './notebookComments'
 
 describe('notebook comment anchors', () => {
@@ -11,8 +12,23 @@ describe('notebook comment anchors', () => {
     const anchor = createCellCommentAnchor('cell-123')
 
     expect(parseCellCommentAnchor(anchor)).toEqual({
-      kind: 'cell',
+      type: 'cell',
       cellId: 'cell-123',
+      cellIdKind: 'runme-ref-id',
+    })
+  })
+
+  it('parses legacy cell anchors written by earlier local builds', () => {
+    expect(
+      parseCellCommentAnchor(
+        JSON.stringify({
+          runme: { version: 1, kind: 'cell', cellId: 'cell-legacy' },
+        })
+      )
+    ).toEqual({
+      type: 'cell',
+      cellId: 'cell-legacy',
+      cellIdKind: 'runme-ref-id',
     })
   })
 
@@ -25,6 +41,24 @@ describe('notebook comment anchors', () => {
         JSON.stringify({ runme: { version: 2, kind: 'cell', cellId: 'c1' } })
       )
     ).toBeNull()
+  })
+
+  it('marks anchored comments as orphaned when the cell is missing', () => {
+    const [thread] = toCellCommentThreads(
+      [
+        {
+          id: 'comment-1',
+          anchor: createCellCommentAnchor('cell-1'),
+          content: 'open',
+        },
+      ],
+      new Set(['cell-2'])
+    )
+
+    expect(thread).toMatchObject({
+      cellId: 'cell-1',
+      orphaned: true,
+    })
   })
 
   it('groups only unresolved cell comments', () => {

--- a/app/src/lib/notebookComments.test.ts
+++ b/app/src/lib/notebookComments.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createCellCommentAnchor,
+  groupCommentsByCell,
+  parseCellCommentAnchor,
+} from './notebookComments'
+
+describe('notebook comment anchors', () => {
+  it('round-trips cell anchors', () => {
+    const anchor = createCellCommentAnchor('cell-123')
+
+    expect(parseCellCommentAnchor(anchor)).toEqual({
+      kind: 'cell',
+      cellId: 'cell-123',
+    })
+  })
+
+  it('rejects invalid or non-runme anchors', () => {
+    expect(parseCellCommentAnchor(null)).toBeNull()
+    expect(parseCellCommentAnchor('not-json')).toBeNull()
+    expect(parseCellCommentAnchor(JSON.stringify({}))).toBeNull()
+    expect(
+      parseCellCommentAnchor(
+        JSON.stringify({ runme: { version: 2, kind: 'cell', cellId: 'c1' } })
+      )
+    ).toBeNull()
+  })
+
+  it('groups only unresolved cell comments', () => {
+    const grouped = groupCommentsByCell([
+      {
+        id: 'comment-1',
+        anchor: createCellCommentAnchor('cell-1'),
+        content: 'open',
+      },
+      {
+        id: 'comment-2',
+        anchor: createCellCommentAnchor('cell-1'),
+        resolved: true,
+        content: 'resolved',
+      },
+      {
+        id: 'comment-3',
+        content: 'unanchored',
+      },
+    ])
+
+    expect(grouped.get('cell-1')?.map((comment) => comment.id)).toEqual([
+      'comment-1',
+    ])
+  })
+})

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -3,29 +3,34 @@ import type { DriveComment } from '../storage/drive'
 const RUNME_COMMENT_ANCHOR_VERSION = 1
 
 export type CellCommentAnchor = {
-  kind: 'cell'
+  type: 'cell'
   cellId: string
+  cellIdKind: 'runme-ref-id' | 'ipynb-cell-id'
 }
 
 type RunmeCommentAnchorPayload = {
   runme?: {
     version?: number
+    type?: string
     kind?: string
     cellId?: string
+    cellIdKind?: string
   }
 }
 
 export type CellCommentThread = {
   comment: DriveComment
   cellId: string | null
+  orphaned: boolean
 }
 
 export function createCellCommentAnchor(cellId: string): string {
   return JSON.stringify({
     runme: {
       version: RUNME_COMMENT_ANCHOR_VERSION,
-      kind: 'cell',
+      type: 'cell',
       cellId,
+      cellIdKind: 'runme-ref-id',
     },
   })
 }
@@ -39,18 +44,22 @@ export function parseCellCommentAnchor(
 
   try {
     const parsed = JSON.parse(anchor) as RunmeCommentAnchorPayload
+    const anchorType = parsed.runme?.type ?? parsed.runme?.kind
+    const cellIdKind = parsed.runme?.cellIdKind ?? 'runme-ref-id'
     if (
       parsed.runme?.version !== RUNME_COMMENT_ANCHOR_VERSION ||
-      parsed.runme.kind !== 'cell' ||
+      anchorType !== 'cell' ||
       typeof parsed.runme.cellId !== 'string' ||
-      !parsed.runme.cellId.trim()
+      !parsed.runme.cellId.trim() ||
+      (cellIdKind !== 'runme-ref-id' && cellIdKind !== 'ipynb-cell-id')
     ) {
       return null
     }
 
     return {
-      kind: 'cell',
+      type: 'cell',
       cellId: parsed.runme.cellId,
+      cellIdKind,
     }
   } catch {
     return null
@@ -77,12 +86,21 @@ export function groupCommentsByCell(
 }
 
 export function toCellCommentThreads(
-  comments: DriveComment[]
+  comments: DriveComment[],
+  knownCellIds: Set<string> = new Set()
 ): CellCommentThread[] {
   return comments
     .filter((comment) => !comment.deleted)
-    .map((comment) => ({
-      comment,
-      cellId: parseCellCommentAnchor(comment.anchor)?.cellId ?? null,
-    }))
+    .map((comment) => {
+      const anchor = parseCellCommentAnchor(comment.anchor)
+      return {
+        comment,
+        cellId: anchor?.cellId ?? null,
+        orphaned: Boolean(
+          anchor?.cellId &&
+            knownCellIds.size > 0 &&
+            !knownCellIds.has(anchor.cellId)
+        ),
+      }
+    })
 }

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -1,0 +1,88 @@
+import type { DriveComment } from '../storage/drive'
+
+const RUNME_COMMENT_ANCHOR_VERSION = 1
+
+export type CellCommentAnchor = {
+  kind: 'cell'
+  cellId: string
+}
+
+type RunmeCommentAnchorPayload = {
+  runme?: {
+    version?: number
+    kind?: string
+    cellId?: string
+  }
+}
+
+export type CellCommentThread = {
+  comment: DriveComment
+  cellId: string | null
+}
+
+export function createCellCommentAnchor(cellId: string): string {
+  return JSON.stringify({
+    runme: {
+      version: RUNME_COMMENT_ANCHOR_VERSION,
+      kind: 'cell',
+      cellId,
+    },
+  })
+}
+
+export function parseCellCommentAnchor(
+  anchor?: string | null
+): CellCommentAnchor | null {
+  if (!anchor) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(anchor) as RunmeCommentAnchorPayload
+    if (
+      parsed.runme?.version !== RUNME_COMMENT_ANCHOR_VERSION ||
+      parsed.runme.kind !== 'cell' ||
+      typeof parsed.runme.cellId !== 'string' ||
+      !parsed.runme.cellId.trim()
+    ) {
+      return null
+    }
+
+    return {
+      kind: 'cell',
+      cellId: parsed.runme.cellId,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function groupCommentsByCell(
+  comments: DriveComment[]
+): Map<string, DriveComment[]> {
+  const byCell = new Map<string, DriveComment[]>()
+  comments.forEach((comment) => {
+    if (comment.deleted || comment.resolved) {
+      return
+    }
+    const anchor = parseCellCommentAnchor(comment.anchor)
+    if (!anchor) {
+      return
+    }
+    const existing = byCell.get(anchor.cellId) ?? []
+    existing.push(comment)
+    byCell.set(anchor.cellId, existing)
+  })
+  return byCell
+}
+
+export function toCellCommentThreads(
+  comments: DriveComment[]
+): CellCommentThread[] {
+  return comments
+    .filter((comment) => !comment.deleted)
+    .map((comment) => ({
+      comment,
+      cellId: parseCellCommentAnchor(comment.anchor)?.cellId ?? null,
+    }))
+}

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -1,6 +1,13 @@
+import { googleClientManager } from '../googleClientManager'
 import { appLogger } from '../logging/runtime'
 import { createNotebookDiffRuntimeApi } from '../notebookDiff/runtime'
 import { getClaimedSessionId } from '../tabIdentity'
+import {
+  createDriveFile,
+  listDriveFolderItems,
+  saveNotebookAsDriveCopy,
+  updateDriveFileBytes,
+} from '../driveTransfer'
 import { appState } from './AppState'
 import { createAppJsGlobals } from './appJsGlobals'
 import {
@@ -27,6 +34,7 @@ const DEFAULT_TIMEOUT_MS = 15_000
 const DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024
 const DEFAULT_MAX_CODE_BYTES = 64 * 1024
 const OUTPUT_TRUNCATED_SUFFIX = '\n[output truncated]\n'
+const LOCAL_SERVICE_ACCOUNT_KEY_ENDPOINT = '/__runme-dev/service-account-key'
 
 export type CodeModeExecutionError = Error & { output: string }
 export type CodeModeExecutionHooks = {
@@ -47,6 +55,40 @@ export function getCodeModeErrorOutput(error: unknown): string {
   }
   const output = (error as { output?: unknown }).output
   return typeof output === 'string' ? output : ''
+}
+
+async function readServiceAccountJsonFromLocalPath(
+  keyPath: string
+): Promise<{ name: string; text: string }> {
+  const trimmedPath = keyPath.trim()
+  if (!trimmedPath) {
+    throw new Error('Google service account key path is required.')
+  }
+  const url = new URL(
+    LOCAL_SERVICE_ACCOUNT_KEY_ENDPOINT,
+    window.location.origin
+  )
+  url.searchParams.set('path', trimmedPath)
+  const response = await fetch(url.toString(), { cache: 'no-store' })
+  const responseText = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read service account key from local dev server (${response.status}): ${responseText}`
+    )
+  }
+  const parsed = JSON.parse(responseText) as {
+    name?: string
+    text?: string
+  }
+  if (!parsed.text) {
+    throw new Error(
+      'Local dev server did not return service account JSON text.'
+    )
+  }
+  return {
+    name: parsed.name || trimmedPath.split('/').pop() || 'service-account.json',
+    text: parsed.text,
+  }
 }
 
 export type CodeModeExecutor = {
@@ -187,6 +229,7 @@ export function createCodeModeExecutor(options: {
                     runmeApi,
                     opfsApi,
                     networkApi,
+                    globals,
                     notebooksApiBridgeServer,
                     notebookDiffApi,
                   }),
@@ -268,6 +311,7 @@ async function handleSandboxAppKernelBridgeCall({
   runmeApi,
   opfsApi,
   networkApi,
+  globals,
   notebooksApiBridgeServer,
   notebookDiffApi,
 }: {
@@ -276,6 +320,7 @@ async function handleSandboxAppKernelBridgeCall({
   runmeApi: ReturnType<typeof createRunmeConsoleApi>
   opfsApi: ReturnType<typeof createAppKernelOpfsApi>
   networkApi: ReturnType<typeof createAppKernelNetworkApi>
+  globals: ReturnType<typeof createAppJsGlobals>
   notebooksApiBridgeServer: NotebooksApiBridgeServer
   notebookDiffApi: ReturnType<typeof createNotebookDiffRuntimeApi>
 }): Promise<unknown> {
@@ -375,6 +420,58 @@ async function handleSandboxAppKernelBridgeCall({
         ...(result.accessToken ? { accessToken: '<redacted>' } : {}),
       }
     }
+    case 'credentials.google.setServiceAccountFromFilePath': {
+      const selection = await readServiceAccountJsonFromLocalPath(
+        String(args[0] ?? '')
+      )
+      const config = googleClientManager.setOAuthClientFromJson(selection.text)
+      if (config.authFlow !== 'service_account') {
+        throw new Error(
+          `Selected JSON file (${selection.name}) did not contain Google service account credentials.`
+        )
+      }
+      return {
+        authFlow: config.authFlow,
+        authUxMode: config.authUxMode,
+        clientId: config.clientId,
+        serviceAccount: config.serviceAccount
+          ? {
+              clientEmail: config.serviceAccount.clientEmail,
+              privateKeyId: config.serviceAccount.privateKeyId,
+              tokenUri: config.serviceAccount.tokenUri,
+              subject: config.serviceAccount.subject,
+              scopes: config.serviceAccount.scopes,
+            }
+          : undefined,
+      }
+    }
+    case 'drive.list':
+      return listDriveFolderItems(String(args[0] ?? ''))
+    case 'drive.create':
+      return createDriveFile(String(args[0] ?? ''), String(args[1] ?? ''))
+    case 'drive.update': {
+      const bytesArg = args[1]
+      const bytes =
+        bytesArg instanceof Uint8Array
+          ? bytesArg
+          : Array.isArray(bytesArg)
+            ? new Uint8Array(bytesArg)
+            : bytesArg instanceof ArrayBuffer
+              ? new Uint8Array(bytesArg)
+              : new Uint8Array()
+      return updateDriveFileBytes(String(args[0] ?? ''), bytes)
+    }
+    case 'drive.saveAsCurrentNotebook': {
+      const notebook = runmeApi.getCurrentNotebook()
+      if (!notebook) {
+        throw new Error('No active notebook handle available.')
+      }
+      return saveNotebookAsDriveCopy(
+        notebook.getNotebook(),
+        String(args[0] ?? ''),
+        String(args[1] ?? '')
+      )
+    }
     case 'notebookDiff.listDriveRevisions':
       return notebookDiffApi.listDriveRevisions(args[0] as any)
     case 'notebookDiff.diffDriveRevision':
@@ -392,6 +489,12 @@ async function handleSandboxAppKernelBridgeCall({
     case 'notebookDiff.help':
       return notebookDiffApi.help()
     default:
+      if (method === 'notebooks.createLocal') {
+        return (globals.notebooks as any).createLocal(args[0], args[1])
+      }
+      if (method === 'notebooks.appendCell') {
+        return (globals.notebooks as any).appendCell(args[0])
+      }
       if (method.startsWith('notebooks.')) {
         return notebooksApiBridgeServer.handleMessage({
           method,

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -13,7 +13,10 @@ type Scenario =
   | 'lowLevel'
   | 'codex'
   | 'app'
+  | 'credentials'
   | 'drive'
+  | 'driveSave'
+  | 'notebooksCreate'
 
 class MockSandboxPort {
   onmessage: ((event: MessageEvent<any>) => void) | null = null
@@ -73,12 +76,45 @@ class MockSandboxPort {
           method: 'app.getSessionID',
           args: [],
         })
+      } else if (this.scenario === 'credentials') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'credentials.google.setServiceAccountFromFilePath',
+          args: ['/tmp/service-account.json'],
+        })
       } else if (this.scenario === 'drive') {
         this.emit({
           type: 'host-call',
           callId: 1,
           method: 'drive.authorize',
           args: [{ mode: 'new_tab' }],
+        })
+      } else if (this.scenario === 'driveSave') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'drive.saveAsCurrentNotebook',
+          args: ['root', 'Comments demo.ipynb'],
+        })
+      } else if (this.scenario === 'notebooksCreate') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'notebooks.createLocal',
+          args: ['Comments demo.ipynb', undefined],
+        })
+        this.emit({
+          type: 'host-call',
+          callId: 2,
+          method: 'notebooks.appendCell',
+          args: [
+            {
+              target: { handle: { uri: 'local://file/comments-demo', revision: '1' } },
+              kind: 'markup',
+              value: '# Comments demo',
+            },
+          ],
         })
       } else if (this.scenario === 'hang') {
         this.emit({ type: 'stdout', data: 'started\n' })
@@ -105,6 +141,34 @@ class MockSandboxPort {
         return
       }
       if (this.scenario === 'drive' && this.hostResults.has(1)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'driveSave' && this.hostResults.has(1)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (
+        this.scenario === 'notebooksCreate' &&
+        this.hostResults.has(1) &&
+        this.hostResults.has(2)
+      ) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(2) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'credentials' && this.hostResults.has(1)) {
         this.emit({
           type: 'stdout',
           data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
@@ -489,6 +553,156 @@ describe('SandboxJSKernel', () => {
     ])
     expect(stdout).toContain('"status":"started"')
     expect(stdout).toContain('"mode":"new_tab"')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports Google service account helper through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'credentials.google.setServiceAccountFromFilePath') {
+        return {
+          authFlow: 'service_account',
+          serviceAccount: {
+            clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+          },
+        }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('credentials'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      "console.log(await credentials.google.setServiceAccountFromFilePath('/tmp/service-account.json'));"
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith(
+      'credentials.google.setServiceAccountFromFilePath',
+      ['/tmp/service-account.json']
+    )
+    expect(stdout).toContain('"authFlow":"service_account"')
+    expect(stdout).toContain('runme-drive-test@example.iam.gserviceaccount.com')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports saving the current notebook to Drive through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'drive.saveAsCurrentNotebook') {
+        return {
+          fileId: 'drive-file-1',
+          fileName: 'Comments demo.ipynb',
+          remoteUri: 'https://drive.google.com/file/d/drive-file-1/view',
+          localUri: 'local://drive-file-1',
+        }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(new MockSandboxPort('driveSave'), {
+      bridge: { call: bridgeCall },
+      hooks: {
+        onStdout: (data) => {
+          stdout += data
+        },
+        onStderr: (data) => {
+          stderr += data
+        },
+        onExit: (code) => {
+          exitCode = code
+        },
+      },
+    })
+
+    await kernel.run(
+      "console.log(await drive.saveAsCurrentNotebook('root', 'Comments demo.ipynb'));"
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('drive.saveAsCurrentNotebook', [
+      'root',
+      'Comments demo.ipynb',
+    ])
+    expect(stdout).toContain('"fileId":"drive-file-1"')
+    expect(stdout).toContain('Comments demo.ipynb')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports local notebook creation helpers through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'notebooks.createLocal') {
+        return {
+          handle: { uri: 'local://file/comments-demo', revision: '1' },
+        }
+      }
+      if (method === 'notebooks.appendCell') {
+        return {
+          handle: { uri: 'local://file/comments-demo', revision: '2' },
+          cell: { refId: 'cell-comments-demo', value: '# Comments demo' },
+        }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('notebooksCreate'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      "const created = await notebooks.createLocal('Comments demo.ipynb'); console.log(await notebooks.appendCell({ target: { handle: created.handle }, kind: 'markup', value: '# Comments demo' }));"
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('notebooks.createLocal', [
+      'Comments demo.ipynb',
+      undefined,
+    ])
+    expect(bridgeCall).toHaveBeenCalledWith('notebooks.appendCell', [
+      {
+        target: { handle: { uri: 'local://file/comments-demo', revision: '1' } },
+        kind: 'markup',
+        value: '# Comments demo',
+      },
+    ])
+    expect(stdout).toContain('cell-comments-demo')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
   })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -52,9 +52,16 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'app.getSessionId',
   'app.getSessionID',
   'app.startGoogleDriveOAuth',
+  'credentials.google.setServiceAccountFromFilePath',
   'drive.authorize',
   'drive.refreshAuth',
+  'drive.list',
+  'drive.create',
+  'drive.update',
+  'drive.saveAsCurrentNotebook',
   ...SANDBOX_NOTEBOOKS_API_METHODS,
+  'notebooks.createLocal',
+  'notebooks.appendCell',
 ]
 
 const LOW_LEVEL_SANDBOX_ALLOWED_METHODS = [
@@ -265,6 +272,8 @@ function buildSandboxSrcDoc(options: {
           update: (args) => callHost("notebooks.update", [args]),
           delete: (target) => callHost("notebooks.delete", [target]),
           execute: (args) => callHost("notebooks.execute", [args]),
+          createLocal: (name, options) => callHost("notebooks.createLocal", [name, options]),
+          appendCell: (args) => callHost("notebooks.appendCell", [args]),
           resolve: (reference) => callHost("notebooks.resolve", [reference]),
           show: (reference) => callHost("notebooks.show", [reference]),
           shareUrl: (reference) => callHost("notebooks.shareUrl", [reference]),
@@ -307,12 +316,27 @@ function buildSandboxSrcDoc(options: {
           getSessionID: () => hostCall("app.getSessionID", []),
           startGoogleDriveOAuth: (options) => hostCall("app.startGoogleDriveOAuth", [options]),
         };
+        const credentials = {
+          google: {
+            setServiceAccountFromFilePath: (path) =>
+              hostCall("credentials.google.setServiceAccountFromFilePath", [path]),
+          },
+        };
         const drive = {
           authorize: (options) => hostCall("drive.authorize", [options]),
           refreshAuth: (options) => hostCall("drive.refreshAuth", [options]),
+          list: (folder) => hostCall("drive.list", [folder]),
+          create: (folder, name) => hostCall("drive.create", [folder, name]),
+          update: (idOrUri, bytes) => hostCall("drive.update", [idOrUri, bytes]),
+          saveAsCurrentNotebook: (folder, name) =>
+            hostCall("drive.saveAsCurrentNotebook", [folder, name]),
           help: () => {
             consoleProxy.log("drive.authorize({ mode?, prompt? })");
             consoleProxy.log("drive.refreshAuth({ mode?, prompt? })");
+            consoleProxy.log("drive.list(folderIdOrUri)");
+            consoleProxy.log("drive.create(folderIdOrUri, name)");
+            consoleProxy.log("drive.update(fileIdOrUri, bytes)");
+            consoleProxy.log("drive.saveAsCurrentNotebook(folderIdOrUri, name)");
           },
         };
 
@@ -331,6 +355,8 @@ function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.get([target]) # omitted target = current UI notebook");
           consoleProxy.log("- notebooks.update({ target, expectedRevision?, operations })");
           consoleProxy.log("- notebooks.execute({ target, refIds })");
+          consoleProxy.log("- notebooks.createLocal(name, options?)");
+          consoleProxy.log("- notebooks.appendCell({ target?, at?, kind, languageId?, value?, metadata?, execute?, reason? })");
           consoleProxy.log("- notebooks.resolve([reference])");
           consoleProxy.log("- notebooks.show([reference])");
           consoleProxy.log("- notebooks.shareUrl([reference])");
@@ -348,7 +374,9 @@ function buildSandboxSrcDoc(options: {
           consoleProxy.log("- await app.getSessionId()");
           consoleProxy.log("- await app.getSessionID()");
           consoleProxy.log("- await app.startGoogleDriveOAuth({ mode?, prompt? })");
+          consoleProxy.log("- await credentials.google.setServiceAccountFromFilePath(path)");
           consoleProxy.log("- await drive.authorize({ mode?, prompt? })");
+          consoleProxy.log("- await drive.saveAsCurrentNotebook(folderIdOrUri, fileName)");
           consoleProxy.log("- help()");
         };
 
@@ -364,11 +392,12 @@ function buildSandboxSrcDoc(options: {
               "notebookDiff",
               "codex",
               "app",
+              "credentials",
               "drive",
               "help",
               '"use strict"; return (async () => {\\n' + code + '\\n})();',
             );
-            await runner(consoleProxy, runme, opfs, net, notebooks, notebookDiff, codex, app, drive, help);
+            await runner(consoleProxy, runme, opfs, net, notebooks, notebookDiff, codex, app, credentials, drive, help);
           } catch (error) {
             exitCode = 1;
             post({ type: "stderr", data: String(error) + "\\n" });

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -296,4 +296,107 @@ describe("DriveNotebookStore", () => {
       new URL(String(fetchMock.mock.calls[1][0])).searchParams.get("pageToken"),
     ).toBe("next-page");
   });
+
+  it("paginates Drive comments", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/file123/comments");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(url.searchParams.get("includeDeleted")).toBe("false");
+        const pageToken = url.searchParams.get("pageToken");
+        const body = pageToken
+          ? { comments: [{ id: "comment-2", content: "second" }] }
+          : {
+              comments: [{ id: "comment-1", content: "first" }],
+              nextPageToken: "next-page",
+            };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const comments = await store.listComments(
+      "https://drive.google.com/file/d/file123/view",
+    );
+
+    expect(comments.map((comment) => comment.id)).toEqual([
+      "comment-1",
+      "comment-2",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      new URL(String(fetchMock.mock.calls[1][0])).searchParams.get("pageToken"),
+    ).toBe("next-page");
+  });
+
+  it("creates anchored Drive comments", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/file123/comments");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          content: "Please check this",
+          anchor: "{\"runme\":{\"kind\":\"cell\",\"cellId\":\"cell-1\"}}",
+        });
+        return new Response(
+          JSON.stringify({
+            id: "comment-1",
+            content: "Please check this",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const comment = await store.createComment(
+      "https://drive.google.com/file/d/file123/view",
+      " Please check this ",
+      "{\"runme\":{\"kind\":\"cell\",\"cellId\":\"cell-1\"}}",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(comment.id).toBe("comment-1");
+  });
+
+  it("resolves Drive comments through replies", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe(
+          "/drive/v3/files/file123/comments/comment-1/replies",
+        );
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          action: "resolve",
+        });
+        return new Response(JSON.stringify({ id: "reply-1", action: "resolve" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const reply = await store.resolveComment(
+      "https://drive.google.com/file/d/file123/view",
+      "comment-1",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(reply.action).toBe("resolve");
+  });
 });

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -170,7 +170,7 @@ type DriveCommentListResponse = {
 }
 
 const DRIVE_COMMENT_FIELDS =
-  'id,createdTime,modifiedTime,resolved,anchor,author(displayName,photoLink,me),deleted,htmlContent,content,mentionedEmailAddresses,assigneeEmailAddress,replies(id,createdTime,modifiedTime,action,author(displayName,photoLink,me),deleted,htmlContent,content)'
+  'id,createdTime,modifiedTime,resolved,anchor,author(displayName,photoLink,me),deleted,htmlContent,content,replies(id,createdTime,modifiedTime,action,author(displayName,photoLink,me),deleted,htmlContent,content)'
 const DRIVE_COMMENT_LIST_FIELDS = `nextPageToken,comments(${DRIVE_COMMENT_FIELDS})`
 
 class GapiDriveFilesClient implements DriveFilesClient {
@@ -182,6 +182,62 @@ class GapiDriveFilesClient implements DriveFilesClient {
     this.files = this.gapi.client.drive.files
     this.drives = this.gapi.client.drive.drives
     this.revisions = this.gapi.client.drive.revisions
+  }
+
+  private buildUrl(path: string, params?: Record<string, unknown>): string {
+    const url = new URL(path.replace(/^\//, ''), 'https://www.googleapis.com/')
+    for (const [key, value] of Object.entries(params ?? {})) {
+      if (value === undefined || value === null || value === '') {
+        continue
+      }
+      url.searchParams.set(key, String(value))
+    }
+    return url.toString()
+  }
+
+  private async request(
+    method: string,
+    path: string,
+    options: {
+      params?: Record<string, unknown>
+      body?: string
+      contentType?: string
+      expectText?: boolean
+    } = {}
+  ): Promise<{ body?: string; result?: unknown }> {
+    const token = this.gapi.client.getToken?.()?.access_token ?? ''
+    if (!token) {
+      throw new Error('Google Drive request requires an access token')
+    }
+    const response = await fetch(this.buildUrl(path, options.params), {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(options.body !== undefined
+          ? {
+              'Content-Type': options.contentType ?? 'application/json',
+            }
+          : {}),
+      },
+      body: options.body,
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => '')
+      throw new Error(
+        `Drive request failed (${response.status} ${response.statusText}): ${errorBody}`
+      )
+    }
+
+    if (options.expectText) {
+      return { body: await response.text() }
+    }
+
+    const text = await response.text()
+    if (!text) {
+      return { result: undefined }
+    }
+    return { result: JSON.parse(text) }
   }
 
   // setContent uploads content to a Google Drive file using a media upload.
@@ -197,23 +253,29 @@ class GapiDriveFilesClient implements DriveFilesClient {
     content: string,
     mimeType?: string
   ): Promise<void> {
-    const encoder = new TextEncoder()
-    const byteLength = encoder.encode(content).byteLength
-    await this.gapi.client.request({
-      path: `https://www.googleapis.com/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
+    const token = this.gapi.client.getToken?.()?.access_token ?? ''
+    if (!token) {
+      throw new Error('Google Drive upload requires an access token')
+    }
+    const url = new URL(
+      `https://www.googleapis.com/upload/drive/v3/files/${encodeURIComponent(fileId)}`
+    )
+    url.searchParams.set('uploadType', 'media')
+    url.searchParams.set('supportsAllDrives', 'true')
+    const response = await fetch(url.toString(), {
       method: 'PATCH',
-      params: {
-        uploadType: 'media',
-        // If we don't set this we get a 404 because the file isn't in "My Drive."
-        supportsAllDrives: 'true',
-      },
       headers: {
-        Authorization: `Bearer ${this.gapi.client.getToken?.()?.access_token ?? ''}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': mimeType ?? 'application/octet-stream',
-        'Content-Length': String(byteLength),
       },
       body: content,
     })
+    if (!response.ok) {
+      const message = await response.text().catch(() => '')
+      throw new Error(
+        `Google Drive media upload failed (${response.status}): ${message}`
+      )
+    }
   }
 
   private buildResource(doc: DriveDoc): Record<string, unknown> {
@@ -316,15 +378,13 @@ class GapiDriveFilesClient implements DriveFilesClient {
     request: Record<string, unknown>
   ): Promise<DriveCommentListResponse> {
     const fileId = String(request.fileId ?? '')
-    return this.gapi.client.request({
-      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}/comments`,
-      method: 'GET',
-      params: Object.fromEntries(
-        Object.entries(request)
-          .filter(([key]) => key !== 'fileId')
-          .map(([key, value]) => [key, String(value)])
-      ),
-    }) as Promise<DriveCommentListResponse>
+    const params = { ...request }
+    delete params.fileId
+    return this.request(
+      'GET',
+      `/drive/v3/files/${encodeURIComponent(fileId)}/comments`,
+      { params }
+    ) as Promise<DriveCommentListResponse>
   }
 
   createComment(request: {
@@ -332,18 +392,17 @@ class GapiDriveFilesClient implements DriveFilesClient {
     resource: Record<string, unknown>
     fields?: string
   }): Promise<{ result?: unknown }> {
-    return this.gapi.client.request({
-      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(request.fileId)}/comments`,
-      method: 'POST',
-      params: {
-        fields: request.fields ?? DRIVE_COMMENT_FIELDS,
-        supportsAllDrives: 'true',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(request.resource),
-    })
+    return this.request(
+      'POST',
+      `/drive/v3/files/${encodeURIComponent(request.fileId)}/comments`,
+      {
+        params: {
+          fields: request.fields ?? DRIVE_COMMENT_FIELDS,
+          supportsAllDrives: 'true',
+        },
+        body: JSON.stringify(request.resource),
+      }
+    )
   }
 
   updateComment(request: {
@@ -352,18 +411,17 @@ class GapiDriveFilesClient implements DriveFilesClient {
     resource: Record<string, unknown>
     fields?: string
   }): Promise<{ result?: unknown }> {
-    return this.gapi.client.request({
-      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}`,
-      method: 'PATCH',
-      params: {
-        fields: request.fields ?? DRIVE_COMMENT_FIELDS,
-        supportsAllDrives: 'true',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(request.resource),
-    })
+    return this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}`,
+      {
+        params: {
+          fields: request.fields ?? DRIVE_COMMENT_FIELDS,
+          supportsAllDrives: 'true',
+        },
+        body: JSON.stringify(request.resource),
+      }
+    )
   }
 
   createReply(request: {
@@ -372,20 +430,19 @@ class GapiDriveFilesClient implements DriveFilesClient {
     resource: Record<string, unknown>
     fields?: string
   }): Promise<{ result?: unknown }> {
-    return this.gapi.client.request({
-      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}/replies`,
-      method: 'POST',
-      params: {
-        fields:
-          request.fields ??
-          `id,action,createdTime,modifiedTime,author(displayName,photoLink,me),deleted,htmlContent,content`,
-        supportsAllDrives: 'true',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(request.resource),
-    })
+    return this.request(
+      'POST',
+      `/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}/replies`,
+      {
+        params: {
+          fields:
+            request.fields ??
+            `id,action,createdTime,modifiedTime,author(displayName,photoLink,me),deleted,htmlContent,content`,
+          supportsAllDrives: 'true',
+        },
+        body: JSON.stringify(request.resource),
+      }
+    )
   }
 
   async ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc> {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -105,8 +105,73 @@ interface DriveFilesClient {
   getRevision(
     request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }>
+  listComments(
+    request: Record<string, unknown>
+  ): Promise<DriveCommentListResponse>
+  createComment(request: {
+    fileId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }>
+  updateComment(request: {
+    fileId: string
+    commentId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }>
+  createReply(request: {
+    fileId: string
+    commentId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }>
   ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc>
 }
+
+export type DriveUser = {
+  displayName?: string
+  photoLink?: string
+  me?: boolean
+}
+
+export type DriveReply = {
+  id?: string
+  kind?: string
+  createdTime?: string
+  modifiedTime?: string
+  action?: string
+  author?: DriveUser
+  deleted?: boolean
+  htmlContent?: string
+  content?: string
+}
+
+export type DriveComment = {
+  id?: string
+  kind?: string
+  createdTime?: string
+  modifiedTime?: string
+  resolved?: boolean
+  anchor?: string
+  author?: DriveUser
+  deleted?: boolean
+  htmlContent?: string
+  content?: string
+  mentionedEmailAddresses?: string[]
+  assigneeEmailAddress?: string
+  replies?: DriveReply[]
+}
+
+type DriveCommentListResponse = {
+  result?: {
+    comments?: DriveComment[]
+    nextPageToken?: string
+  }
+}
+
+const DRIVE_COMMENT_FIELDS =
+  'id,createdTime,modifiedTime,resolved,anchor,author(displayName,photoLink,me),deleted,htmlContent,content,mentionedEmailAddresses,assigneeEmailAddress,replies(id,createdTime,modifiedTime,action,author(displayName,photoLink,me),deleted,htmlContent,content)'
+const DRIVE_COMMENT_LIST_FIELDS = `nextPageToken,comments(${DRIVE_COMMENT_FIELDS})`
 
 class GapiDriveFilesClient implements DriveFilesClient {
   private readonly files: GapiDriveFileMethods
@@ -245,6 +310,82 @@ class GapiDriveFilesClient implements DriveFilesClient {
       body?: string
       result?: unknown
     }>
+  }
+
+  listComments(
+    request: Record<string, unknown>
+  ): Promise<DriveCommentListResponse> {
+    const fileId = String(request.fileId ?? '')
+    return this.gapi.client.request({
+      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}/comments`,
+      method: 'GET',
+      params: Object.fromEntries(
+        Object.entries(request)
+          .filter(([key]) => key !== 'fileId')
+          .map(([key, value]) => [key, String(value)])
+      ),
+    }) as Promise<DriveCommentListResponse>
+  }
+
+  createComment(request: {
+    fileId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }> {
+    return this.gapi.client.request({
+      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(request.fileId)}/comments`,
+      method: 'POST',
+      params: {
+        fields: request.fields ?? DRIVE_COMMENT_FIELDS,
+        supportsAllDrives: 'true',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request.resource),
+    })
+  }
+
+  updateComment(request: {
+    fileId: string
+    commentId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }> {
+    return this.gapi.client.request({
+      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}`,
+      method: 'PATCH',
+      params: {
+        fields: request.fields ?? DRIVE_COMMENT_FIELDS,
+        supportsAllDrives: 'true',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request.resource),
+    })
+  }
+
+  createReply(request: {
+    fileId: string
+    commentId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }> {
+    return this.gapi.client.request({
+      path: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}/replies`,
+      method: 'POST',
+      params: {
+        fields:
+          request.fields ??
+          `id,action,createdTime,modifiedTime,author(displayName,photoLink,me),deleted,htmlContent,content`,
+        supportsAllDrives: 'true',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request.resource),
+    })
   }
 
   async ensureParent(file: DriveDoc, parentId?: string): Promise<DriveDoc> {
@@ -456,6 +597,77 @@ class FetchDriveFilesClient implements DriveFilesClient {
       {
         params: request,
         expectText: request.alt === 'media',
+      }
+    )
+  }
+
+  listComments(
+    request: Record<string, unknown>
+  ): Promise<DriveCommentListResponse> {
+    const fileId = String(request.fileId ?? '')
+    const params = { ...request }
+    delete params.fileId
+    return this.request(
+      'GET',
+      `/drive/v3/files/${encodeURIComponent(fileId)}/comments`,
+      { params }
+    ) as Promise<DriveCommentListResponse>
+  }
+
+  createComment(request: {
+    fileId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }> {
+    return this.request(
+      'POST',
+      `/drive/v3/files/${encodeURIComponent(request.fileId)}/comments`,
+      {
+        params: {
+          fields: request.fields ?? DRIVE_COMMENT_FIELDS,
+          supportsAllDrives: 'true',
+        },
+        body: JSON.stringify(request.resource),
+      }
+    )
+  }
+
+  updateComment(request: {
+    fileId: string
+    commentId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }> {
+    return this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}`,
+      {
+        params: {
+          fields: request.fields ?? DRIVE_COMMENT_FIELDS,
+          supportsAllDrives: 'true',
+        },
+        body: JSON.stringify(request.resource),
+      }
+    )
+  }
+
+  createReply(request: {
+    fileId: string
+    commentId: string
+    resource: Record<string, unknown>
+    fields?: string
+  }): Promise<{ result?: unknown }> {
+    return this.request(
+      'POST',
+      `/drive/v3/files/${encodeURIComponent(request.fileId)}/comments/${encodeURIComponent(request.commentId)}/replies`,
+      {
+        params: {
+          fields:
+            request.fields ??
+            'id,action,createdTime,modifiedTime,author(displayName,photoLink,me),deleted,htmlContent,content',
+          supportsAllDrives: 'true',
+        },
+        body: JSON.stringify(request.resource),
       }
     )
   }
@@ -995,6 +1207,120 @@ export class DriveNotebookStore {
         parents: [],
       }
     })
+  }
+
+  async listComments(uri: string): Promise<DriveComment[]> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.listComments expects a file URI')
+    }
+    const client = await this.getFilesClient()
+    const comments: DriveComment[] = []
+    let pageToken: string | undefined
+
+    do {
+      const response = await client.listComments({
+        fileId: id,
+        supportsAllDrives: true,
+        includeDeleted: false,
+        fields: DRIVE_COMMENT_LIST_FIELDS,
+        ...(pageToken ? { pageToken } : {}),
+      })
+      comments.push(...(response.result?.comments ?? []))
+      pageToken = optionalString(response.result?.nextPageToken)
+    } while (pageToken)
+
+    return comments
+  }
+
+  async createComment(
+    uri: string,
+    content: string,
+    anchor?: string
+  ): Promise<DriveComment> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.createComment expects a file URI')
+    }
+    const trimmedContent = content.trim()
+    if (!trimmedContent) {
+      throw new Error('DriveNotebookStore.createComment requires content')
+    }
+    const client = await this.getFilesClient()
+    const response = await client.createComment({
+      fileId: id,
+      resource: {
+        content: trimmedContent,
+        ...(anchor ? { anchor } : {}),
+      },
+      fields: DRIVE_COMMENT_FIELDS,
+    })
+    return (response.result ?? {}) as DriveComment
+  }
+
+  async replyToComment(
+    uri: string,
+    commentId: string,
+    content: string
+  ): Promise<DriveReply> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.replyToComment expects a file URI')
+    }
+    const trimmedContent = content.trim()
+    if (!commentId.trim()) {
+      throw new Error('DriveNotebookStore.replyToComment requires a comment id')
+    }
+    if (!trimmedContent) {
+      throw new Error('DriveNotebookStore.replyToComment requires content')
+    }
+    const client = await this.getFilesClient()
+    const response = await client.createReply({
+      fileId: id,
+      commentId: commentId.trim(),
+      resource: {
+        content: trimmedContent,
+      },
+    })
+    return (response.result ?? {}) as DriveReply
+  }
+
+  async resolveComment(uri: string, commentId: string): Promise<DriveReply> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.resolveComment expects a file URI')
+    }
+    if (!commentId.trim()) {
+      throw new Error('DriveNotebookStore.resolveComment requires a comment id')
+    }
+    const client = await this.getFilesClient()
+    const response = await client.createReply({
+      fileId: id,
+      commentId: commentId.trim(),
+      resource: {
+        action: 'resolve',
+      },
+    })
+    return (response.result ?? {}) as DriveReply
+  }
+
+  async reopenComment(uri: string, commentId: string): Promise<DriveReply> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.reopenComment expects a file URI')
+    }
+    if (!commentId.trim()) {
+      throw new Error('DriveNotebookStore.reopenComment requires a comment id')
+    }
+    const client = await this.getFilesClient()
+    const response = await client.createReply({
+      fileId: id,
+      commentId: commentId.trim(),
+      resource: {
+        action: 'reopen',
+      },
+    })
+    return (response.result ?? {}) as DriveReply
   }
 
   async getType(uri: string): Promise<NotebookStoreItemType> {

--- a/docs-dev/design/20260611_notebook_comments.md
+++ b/docs-dev/design/20260611_notebook_comments.md
@@ -10,40 +10,48 @@ Builds on:
 
 ## Summary
 
-Add cell-level comment threads to notebooks.
+Add cell-level comment threads to Google Drive-backed notebooks.
 
-V0 should store comments inside the notebook document, under notebook metadata,
-not in an auxiliary file and not as a new cell field. Each thread should anchor
-to a stable cell id. Replies, resolution state, author metadata, and agent
-dispatch state should live with the thread.
+V0 should use the Google Drive Comments API as the canonical comment store.
+Comments should be enabled only when the current notebook has a Google Drive
+upstream file. Local-only and filesystem-backed notebooks should show comments
+as unavailable until they are saved to Drive.
 
-This gives Runme a Google Docs/Colab-like review surface while preserving
-Jupyter `.ipynb` compatibility. Jupyter's notebook format does not define a
-standard comments or annotations model. It does define stable cell ids and
-allows arbitrary JSON metadata at the notebook, cell, and output levels. Those
-two facts are the compatibility path.
+Each Drive comment should anchor to a Runme cell id using an app-defined Drive
+comment anchor. Replies, resolution state, author identity, and edit/delete
+permissions should come from Drive. Runme should keep only transient UI state
+and optional local caches, not full comment threads inside the notebook file.
+
+This trades portable `.ipynb` comments for Google-native collaboration. That is
+the right V0 tradeoff because sharing and commenting are primarily Drive
+workflows in Runme. The Google Workspace Events API also gives us a path to
+comment/reply notifications, external automation, and agent triggers without
+polling notebook files.
 
 ## Goals
 
-- Let users add comments to notebook cells.
-- Show open and resolved comment threads in a notebook sidebar.
+- Let users add comments to cells in Google Drive-backed notebooks.
+- Show open and resolved Drive comment threads in a notebook sidebar.
 - Show per-cell comment affordances in the notebook body.
-- Support replies and resolve/reopen actions.
-- Persist comments with local, Drive-backed, and filesystem-backed notebooks.
-- Preserve comments when a Drive-backed notebook is shared or copied.
-- Preserve `.ipynb` compatibility for native notebook support.
+- Support replies and resolve/reopen actions through Drive.
+- Use Google identity, permissions, authorship, and timestamps for comments.
+- Disable comment creation for non-Drive notebooks with a clear save-to-Drive
+  path.
+- Subscribe to Drive comment and reply events for agent and notification
+  workflows when backend infrastructure is available.
 - Emit structured events when a comment mentions an agent, such as
   `@codex run this cell`.
 
 ## Non-Goals
 
+- Comments on local-only or filesystem-backed notebooks in V0.
 - Text-range comments inside a cell in V0.
+- Portable `.ipynb` comments in V0.
 - Multiplayer live cursors or live collaborative editing.
-- Google Drive Comments API parity in V0.
-- A separate permissions model for comments.
+- A separate Runme permissions model for comments.
 - Suggested edits.
 - Emoji reactions.
-- Email notifications.
+- Offline comment creation.
 
 ## Prior Art
 
@@ -69,8 +77,7 @@ Design implications:
 - Resolved comments should remain available.
 - Mentions should be parsed from comment text and treated as actionable
   structured data, not only display text.
-- V0 can skip assignment and notifications while keeping room in the model for
-  them.
+- V0 should use Google identity rather than inventing a parallel author model.
 
 ### Google Drive Comments API
 
@@ -80,10 +87,10 @@ JSON strings. Replies are attached to a comment. A comment is resolved by
 posting a reply with an action, and the comment resource then exposes
 `resolved: true`.
 
-Drive's anchor model is useful, but it is not a drop-in storage backend for
-Runme V0. Google Workspace editor apps treat custom anchored comments as
-unanchored, and Drive warns that anchors are immutable and their position across
-document revisions is not guaranteed.
+The API returns author, timestamps, deleted/resolved state, plain text content,
+HTML content for display, quoted file content, mentioned email addresses, and
+assignee email address. Some fields, including mentioned email addresses and
+assignee email address, are output-only.
 
 Sources:
 
@@ -92,11 +99,37 @@ Sources:
 
 Design implications:
 
-- Model comments as threads with replies and resolved state.
-- Keep anchors immutable after thread creation.
-- Use cell ids rather than line offsets for V0 anchors.
-- Consider Drive comments later for Drive-backed sharing, but do not make them
-  the canonical V0 store.
+- Use Drive comments as the V0 source of truth for Drive-backed notebooks.
+- Store the Runme cell anchor in the Drive `anchor` JSON string.
+- Treat Drive's author, timestamp, reply, resolved, deleted, and permission
+  behavior as canonical.
+- Test whether API-created `@email` comments trigger Google-native mention
+  notifications before relying on them for product-critical alerts.
+- Do not depend on Google Workspace editors to render Runme anchors. Google
+  documents that Workspace editor apps treat custom anchored comments as
+  unanchored.
+
+### Google Workspace Events API
+
+Google Workspace Events supports Drive comment and reply events. Apps can
+subscribe to Drive files or shared drives and receive events through Cloud
+Pub/Sub. Supported Drive event types include comment created, edited, resolved,
+reopened, deleted, and reply created, edited, and deleted.
+
+Sources:
+
+- <https://developers.google.com/workspace/events/guides/events-drive>
+- <https://developers.google.com/workspace/drive/api/guides/events-overview>
+
+Design implications:
+
+- Drive comments unlock server-side notification and automation workflows.
+- Agent triggers should use Workspace Events when a backend subscription is
+  available.
+- Browser-only V0 can still dispatch local events for comments created in the
+  current tab, but cross-user triggers require Workspace Events or polling.
+- Subscription lifecycle, Pub/Sub setup, OAuth scopes, and renewal handling are
+  backend work, not React component work.
 
 ### Google Colab
 
@@ -111,10 +144,10 @@ Sources:
 
 Design implications:
 
-- Colab is strong product prior art for comments as notebook content.
+- Colab is strong product prior art for Drive-first notebook comments.
 - Colab is not public implementation prior art for a reusable comments schema.
-- The most compatible interpretation is that notebook comments can live inside
-  `.ipynb` metadata while remaining associated with notebook cells.
+- Runme can make the same product choice: comments are part of the Drive
+  collaboration surface, not necessarily portable notebook content.
 
 ### Jupyter `.ipynb`
 
@@ -140,11 +173,11 @@ Sources:
 
 Design implications:
 
-- Do not add a new top-level field or a new cell field for comments in
-  `.ipynb`.
-- Use notebook metadata with a Runme namespace for compatibility.
-- Use `.ipynb` cell `id` as the anchor when present.
-- Map Runme `refId` to `.ipynb` cell `id` when importing/exporting.
+- `.ipynb` does not force a comments storage decision.
+- Use stable cell ids for Drive comment anchors.
+- Do not add a new top-level `.ipynb` field or new cell field for V0 comments.
+- If portable comments become a requirement later, use namespaced metadata as an
+  export/cache format.
 
 ## Current Runme Context
 
@@ -157,99 +190,126 @@ NotebookData / editor tabs
   -> optional upstream from LocalFileRecord.remoteId
 ```
 
-`NotebookData` owns one in-memory `parser_pb.Notebook`. React views render
-immutable snapshots. Mutations should go through `NotebookData` and `CellData`,
-then autosave through the local mirror.
+Drive-backed editor tabs still use a local mirror. The local record points to
+the upstream Drive file through `remoteId` / `remoteUri`.
 
-Cells already have stable `refId` values and `metadata`. The AppKernel
-notebook API exposes notebook handles, revisions, cells, metadata, and cell
-execution helpers. Codex tools already use explicit cell ids when reading,
-updating, and executing cells.
+`NotebookData` owns one in-memory `parser_pb.Notebook`. React views render
+immutable snapshots. Cells already have stable `refId` values and `metadata`.
+The AppKernel notebook API exposes notebook handles, revisions, cells,
+metadata, and cell execution helpers. Codex tools already use explicit cell ids
+when reading, updating, and executing cells.
 
 ## Storage Decision
 
-Store V0 comments inside the notebook document under top-level notebook
-metadata:
+Use Google Drive Comments API as the canonical V0 comment store.
+
+Comments are available only when:
+
+- the open notebook resolves to a local mirror,
+- that local mirror has a Google Drive upstream file id,
+- the current user has Drive permission to comment on the file.
+
+For non-Drive notebooks:
+
+- hide or disable add-comment controls,
+- show an explanatory disabled state,
+- offer "Save to Google Drive to enable comments" when the notebook can be
+  copied to Drive.
+
+Do not store full comment threads inside notebook metadata for V0.
+
+Do not store comments in an auxiliary Runme sidecar file for V0.
+
+Do not add a new field to cells for V0.
+
+### Why Drive Comments
+
+Drive comments match the product surface we care about first:
+
+- shared Drive notebooks,
+- Google identity,
+- Google permissions,
+- Google-authored timestamps and edit/delete ownership,
+- native replies and resolved state,
+- possible Google-native mention notifications,
+- Workspace Events for comment/reply automation,
+- no extra Runme sync format for comments.
+
+The tradeoff is that comments are not portable notebook content. A user who
+downloads an `.ipynb` or copies a notebook into a non-Drive backend will not get
+the Drive comment threads. That is acceptable for V0 because the commenting
+workflow assumes a shared Drive document.
+
+### Why Not Notebook Metadata
+
+Notebook metadata is still the right portable fallback, but it is the wrong V0
+source of truth for Drive-first collaboration.
+
+Metadata comments would require Runme to implement authorship, permissions,
+notifications, cross-user updates, conflict handling, and deletion semantics.
+Drive already owns those concepts for the primary storage backend.
+
+### Why Not A Sidecar File
+
+A sidecar file gives us portability across storage backends, but it creates a
+new sharing, permissions, discovery, and sync problem. It also does not give us
+Google-native comment notifications or Workspace Events.
+
+Sidecars can be revisited if comments need to work on non-Drive backends.
+
+## Drive Comment Anchor
+
+V0 anchors are cell anchors only.
+
+Store a Runme-specific JSON payload in the Drive comment `anchor` field:
 
 ```json
 {
-  "metadata": {
-    "runme.dev/comments": {
-      "version": 1,
-      "threads": []
-    }
+  "runme": {
+    "version": 1,
+    "type": "cell",
+    "cellId": "code_85a39e07",
+    "cellIdKind": "runme-ref-id"
   }
 }
 ```
 
-Do not store comments in an auxiliary file for V0.
+For imported `.ipynb`, preserve the Jupyter cell `id` and map it to Runme's
+stable cell identity. When a Drive comment anchors to an imported notebook cell,
+the anchor should use the same stable id Runme uses to render that cell.
 
-Do not add a new field to cells for V0.
+If a cell is deleted, keep the Drive comment. The UI should render it as an
+orphaned thread if the anchor no longer resolves.
 
-Do not store full threads independently in each cell's metadata.
+If a cell is moved, the thread follows the cell id.
 
-### Why Inside The Notebook
+If a cell is duplicated, new cells must get new ids. Comments stay attached to
+the original cell only.
 
-Inside-the-notebook storage has the right V0 behavior:
-
-- comments survive local autosave,
-- Drive copies include comments,
-- filesystem-backed notebooks remain self-contained,
-- offline editing works without another sync channel,
-- imported/exported `.ipynb` files can preserve comments,
-- the notebook revision hash reflects comment changes.
-
-The tradeoff is that comments become notebook content. A comment-only change can
-trigger notebook sync conflicts and version churn. That is acceptable for V0
-because the current product does not have live multi-writer collaboration.
-
-### Why Notebook Metadata
-
-Notebook metadata is the safest compatibility point.
-
-Adding a new cell field would make strict `.ipynb` validation fail. Cell
-metadata is valid, but storing full threads in each cell makes global comment
-search, orphan handling, and agent dispatch harder. Notebook-level metadata
-keeps comments in one place while anchors still point to cells.
-
-Cell metadata may later carry denormalized UI hints such as
-`runme.dev/commentCount`, but the source of truth should stay in notebook
-metadata.
-
-### When To Revisit Auxiliary Storage
-
-Move comments to auxiliary storage only when one of these becomes a product
-requirement:
-
-- independent comment permissions,
-- comments on read-only shared notebooks without modifying the notebook file,
-- high-volume comment activity that should not churn notebook revisions,
-- live multi-user comments before notebook save,
-- server-side notifications,
-- Drive-native comment interoperability.
-
-If that happens, the embedded metadata model can become an export/cache format
-while a per-document comments service becomes canonical.
+Google warns that custom anchors are immutable and that their position relative
+to document content is not guaranteed across revisions. Runme should therefore
+treat the Drive anchor as an immutable cell-id pointer and resolve it against
+the current notebook model at render time.
 
 ## Proposed Data Model
 
-Use one document-level metadata object:
+Use a Runme view model over Drive comments:
 
 ```ts
-type NotebookCommentsMetadata = {
-  version: 1
-  threads: CommentThread[]
-}
-
-type CommentThread = {
-  id: string
+type NotebookCommentThread = {
+  driveFileId: string
+  driveCommentId: string
   anchor: CommentAnchor
   status: 'open' | 'resolved'
   createdAt: string
   updatedAt: string
-  resolvedAt?: string
-  author: CommentAuthor
-  comments: CommentMessage[]
+  author: DriveCommentAuthor
+  htmlContent: string
+  content: string
+  mentionedEmailAddresses: string[]
+  assigneeEmailAddress?: string
+  replies: NotebookCommentReply[]
+  orphaned: boolean
   agentDispatch?: AgentDispatchState
 }
 
@@ -257,118 +317,44 @@ type CommentAnchor = {
   type: 'cell'
   cellId: string
   cellIdKind: 'runme-ref-id' | 'ipynb-cell-id'
-  revision?: string
-  preview?: {
-    cellKind?: 'code' | 'markup'
-    languageId?: string
-    firstLine?: string
-  }
 }
 
-type CommentMessage = {
-  id: string
-  body: string
-  htmlBody?: string
-  author: CommentAuthor
+type NotebookCommentReply = {
+  driveReplyId: string
   createdAt: string
   updatedAt: string
-  mentions?: CommentMention[]
+  author: DriveCommentAuthor
+  htmlContent: string
+  content: string
+  deleted: boolean
 }
 
-type CommentAuthor = {
-  id?: string
+type DriveCommentAuthor = {
   displayName: string
-  email?: string
-  avatarUrl?: string
-}
-
-type CommentMention = {
-  raw: string
-  kind: 'agent' | 'user'
-  target: string
+  photoLink?: string
+  me?: boolean
 }
 
 type AgentDispatchState = {
   status: 'pending' | 'sent' | 'acked' | 'failed'
   targetAgent: string
+  source: 'local-tab' | 'workspace-events'
   messageId?: string
   lastError?: string
   updatedAt: string
 }
 ```
 
-Example:
+The view model should be derived from:
 
-```json
-{
-  "version": 1,
-  "threads": [
-    {
-      "id": "thread_01jz9a0tq6x6tnmvz8z64k3dse",
-      "anchor": {
-        "type": "cell",
-        "cellId": "code_85a39e07",
-        "cellIdKind": "runme-ref-id",
-        "preview": {
-          "cellKind": "code",
-          "languageId": "python",
-          "firstLine": "df.groupby('country').revenue.sum()"
-        }
-      },
-      "status": "open",
-      "createdAt": "2026-06-11T18:00:00Z",
-      "updatedAt": "2026-06-11T18:00:00Z",
-      "author": {
-        "displayName": "Jane Doe",
-        "email": "jane@example.com"
-      },
-      "comments": [
-        {
-          "id": "comment_01jz9a10vdt7kz2zh7wqp8m3xq",
-          "body": "@codex run this cell and explain the output",
-          "author": {
-            "displayName": "Jane Doe",
-            "email": "jane@example.com"
-          },
-          "createdAt": "2026-06-11T18:00:00Z",
-          "updatedAt": "2026-06-11T18:00:00Z",
-          "mentions": [
-            {
-              "raw": "@codex",
-              "kind": "agent",
-              "target": "codex"
-            }
-          ]
-        }
-      ],
-      "agentDispatch": {
-        "status": "pending",
-        "targetAgent": "codex",
-        "updatedAt": "2026-06-11T18:00:00Z"
-      }
-    }
-  ]
-}
-```
+- `comments.list` / `comments.get`,
+- Drive comment `anchor`,
+- Drive comment `resolved` and `deleted`,
+- Drive reply lists,
+- the current notebook cell index.
 
-## Comment Anchors
-
-V0 anchors are cell anchors only.
-
-When editing Runme-native notebooks, use `cell.refId`. When importing `.ipynb`,
-preserve the Jupyter cell `id` and map it to `refId` if the native model needs
-one canonical cell identifier. When exporting `.ipynb`, write the anchor cell
-id to the same value as the exported cell `id`.
-
-If a cell is deleted, keep its comment thread in notebook metadata and mark it
-as orphaned in the UI by resolving the anchor at render time. Do not delete
-comments automatically. The preview gives the user enough context to resolve,
-delete, or leave the thread.
-
-If a cell is moved, the thread follows the cell id.
-
-If a cell is duplicated, new cells must get new ids. Comments stay attached to
-the original cell only.
+Runme may cache this model in memory or IndexedDB for responsiveness. The cache
+is not the source of truth.
 
 ## UI Proposal
 
@@ -377,7 +363,9 @@ comments panel.
 
 Notebook body:
 
-- Show a comment icon in each cell toolbar or right gutter.
+- Show a comment icon in each cell toolbar or right gutter for Drive-backed
+  notebooks.
+- Show a disabled icon or omit the affordance for non-Drive notebooks.
 - Show an active/open count on the icon.
 - Click the icon to open the thread composer for that cell.
 - Highlight the active cell when a comment thread is selected.
@@ -386,16 +374,21 @@ Notebook body:
 Comments panel:
 
 - Dock the panel on the right side of the notebook.
-- List open threads first, grouped by notebook order.
+- Load Drive comments for the current Drive file.
+- List Runme-anchored threads first, grouped by notebook order.
 - Provide filters for open, resolved, and all.
 - Select a thread to scroll the notebook to the anchored cell.
-- Support reply, resolve, reopen, edit own comment, and delete own comment.
-- Show orphaned threads in a separate section.
+- Support reply, resolve, reopen, edit own comment, and delete own comment
+  through Drive API calls.
+- Show orphaned Runme-anchored threads in a separate section.
+- Optionally show unanchored Drive comments in a document-level section.
 
 Composer:
 
-- Plain Markdown text input for V0.
-- Detect `@codex` mentions.
+- Plain text input for V0, matching Drive's `content` field.
+- Detect `@codex` mentions locally.
+- Preserve email mentions in the text so Drive can detect Google user mentions
+  if supported for API-created comments.
 - Submit with `Cmd/Ctrl+Enter`.
 - Preserve draft text while the user switches cells.
 
@@ -408,28 +401,49 @@ Accessibility:
 
 ## Agent Hook
 
-Comments should emit a structured event after the notebook model accepts the
-mutation and before/after autosave completes. Autosave should not block agent
-dispatch, but the event must include enough context for the agent to reload the
-notebook if needed.
+Drive comments should trigger agents through two paths.
 
-Proposed event:
+The local path handles comments created in the current browser tab:
+
+```text
+user submits comment in Runme
+  -> Runme creates Drive comment with Runme cell anchor
+  -> Drive returns comment id and normalized resource
+  -> Runme emits NotebookDriveCommentCreatedEvent
+  -> Mention router sees @codex
+  -> router sends Drive file id, comment id, cell id, and cell context
+     to the Codex conversation bridge
+```
+
+The server path handles comments created by other users or in other tabs:
+
+```text
+Workspace Events subscription receives drive.comment.v3.created
+  -> event handler fetches the Drive comment if needed
+  -> handler parses the Runme cell anchor
+  -> handler checks mentions and dispatch state
+  -> handler sends Drive file id, comment id, cell id, and notebook context
+     to the agent service
+```
+
+Proposed local event:
 
 ```ts
-type NotebookCommentCreatedEvent = {
-  type: 'notebook.comment.created'
+type NotebookDriveCommentCreatedEvent = {
+  type: 'notebook.driveComment.created'
   notebook: {
     uri: string
     name: string
+    driveFileId: string
     revision: string
-    remoteUri?: string
   }
-  thread: {
+  driveComment: {
     id: string
-    status: 'open' | 'resolved'
     anchor: CommentAnchor
+    content: string
+    htmlContent: string
+    mentionedEmailAddresses: string[]
   }
-  comment: CommentMessage
   context: {
     cell?: {
       refId: string
@@ -441,125 +455,141 @@ type NotebookCommentCreatedEvent = {
   }
   mentions: CommentMention[]
 }
-```
 
-Dispatch flow:
-
-```text
-user submits comment
-  -> NotebookData.addComment(...)
-  -> comment metadata mutation is committed
-  -> NotebookCommentCreatedEvent is emitted
-  -> Mention router sees @codex
-  -> router sends notebook uri, revision, cell id, comment id, and cell context
-     to the Codex conversation bridge
-  -> agent response is added as a reply or linked from the thread
-```
-
-The mention router should be independent from React. It should subscribe to
-notebook model events or a small comment event bus. That keeps AppKernel,
-external Codex, and future server-side dispatch from depending on component
-lifecycles.
-
-Agent dispatch must be idempotent. Use `(notebookUri, threadId, commentId,
-targetAgent)` as the de-duplication key and persist dispatch status in
-`agentDispatch`.
-
-## API Surface
-
-Add comment methods to `NotebookData` first:
-
-```ts
-class NotebookData {
-  listCommentThreads(): CommentThread[]
-  addCommentThread(args: {
-    cellId: string
-    body: string
-    author: CommentAuthor
-  }): CommentThread
-  replyToCommentThread(args: {
-    threadId: string
-    body: string
-    author: CommentAuthor
-  }): CommentThread
-  resolveCommentThread(threadId: string): CommentThread
-  reopenCommentThread(threadId: string): CommentThread
+type CommentMention = {
+  raw: string
+  kind: 'agent' | 'user'
+  target: string
 }
 ```
 
-Then expose an AppKernel API after the model is stable:
+Agent dispatch must be idempotent. Use `(driveFileId, driveCommentId,
+targetAgent)` as the de-duplication key. For server-side event handling, store
+dispatch state outside the notebook file, for example in the agent service or a
+Runme backend table.
+
+## API Surface
+
+Add a Drive-backed comments service rather than comment methods directly on
+`NotebookData`:
 
 ```ts
-type NotebookCommentMutation =
-  | { op: 'createThread'; cellId: string; body: string }
-  | { op: 'reply'; threadId: string; body: string }
-  | { op: 'resolve'; threadId: string }
-  | { op: 'reopen'; threadId: string }
+type NotebookCommentsAvailability =
+  | { enabled: true; driveFileId: string }
+  | { enabled: false; reason: 'not-drive-backed' | 'missing-permission' }
 
+type NotebookCommentsService = {
+  getAvailability(target?: NotebookTarget): Promise<NotebookCommentsAvailability>
+  listThreads(args: {
+    target?: NotebookTarget
+    status?: 'open' | 'resolved' | 'all'
+  }): Promise<NotebookCommentThread[]>
+  createThread(args: {
+    target?: NotebookTarget
+    cellId: string
+    content: string
+  }): Promise<NotebookCommentThread>
+  reply(args: {
+    target?: NotebookTarget
+    driveCommentId: string
+    content: string
+  }): Promise<NotebookCommentThread>
+  resolve(args: {
+    target?: NotebookTarget
+    driveCommentId: string
+    content?: string
+  }): Promise<NotebookCommentThread>
+  reopen(args: {
+    target?: NotebookTarget
+    driveCommentId: string
+  }): Promise<NotebookCommentThread>
+}
+```
+
+Expose an AppKernel API after the internal service is stable:
+
+```ts
 type NotebooksCommentsApi = {
-  list(args?: { target?: NotebookTarget; status?: 'open' | 'resolved' | 'all' }): Promise<CommentThread[]>
-  update(args: { target?: NotebookTarget; operations: NotebookCommentMutation[] }): Promise<CommentThread[]>
+  availability(target?: NotebookTarget): Promise<NotebookCommentsAvailability>
+  list(args?: { target?: NotebookTarget; status?: 'open' | 'resolved' | 'all' }): Promise<NotebookCommentThread[]>
+  create(args: { target?: NotebookTarget; cellId: string; content: string }): Promise<NotebookCommentThread>
+  reply(args: { target?: NotebookTarget; driveCommentId: string; content: string }): Promise<NotebookCommentThread>
+  resolve(args: { target?: NotebookTarget; driveCommentId: string; content?: string }): Promise<NotebookCommentThread>
+  reopen(args: { target?: NotebookTarget; driveCommentId: string }): Promise<NotebookCommentThread>
 }
 ```
 
 ## Sync And Conflict Behavior
 
-Comments are normal notebook content in V0.
+Drive comments are separate from notebook content.
 
-Local autosave should persist comment mutations like cell mutations. Drive sync
-should upload the changed notebook JSON. Existing conflict handling should show
-comment metadata changes in notebook diffs once diff support includes metadata.
+Comment-only changes should not dirty the notebook or change the notebook JSON.
+They should update the comments panel and any local comment cache. Notebook
+content sync and comment sync are separate channels:
 
-Conflict policy:
+```text
+Notebook content:
+  NotebookData -> LocalNotebooks -> Drive file content
 
-- If two edits add different threads, merge should be possible because thread
-  ids are unique.
-- If two edits append replies to the same thread, merge should order by
-  `createdAt` and preserve both replies.
-- If one edit resolves a thread while another adds a reply, reopen or keep open
-  unless the resolving reply is later than the new reply.
-- If the anchor cell is deleted on one side, preserve the thread as orphaned.
+Notebook comments:
+  Comments panel -> Drive Comments API -> Workspace Events / local refresh
+```
 
-This merge policy is future work. V0 can rely on existing notebook conflict
-resolution and document the limitations.
+If the notebook content changes and cell ids remain stable, comments continue
+to resolve. If a cell id disappears, the comment becomes orphaned in Runme but
+remains a valid Drive comment.
+
+Notebook diff views do not need to show comment changes in V0 because comments
+are not notebook file content.
 
 ## Security And Privacy
 
-Comments are notebook content. Sharing a notebook shares comments. This matches
-the Colab behavior but needs UI copy when sharing or exporting.
+Comments are Drive file collaboration data. A user who can access comments on
+the Drive file can see them according to Drive permissions. A user who exports
+or downloads the notebook file does not automatically export comments.
 
 Agent mentions need explicit product behavior:
 
 - `@codex` should not execute code silently unless the command and current
   product mode allow it.
-- The agent payload should include only the anchored cell and document
-  identifiers by default.
-- Broader notebook context should be requested through existing notebook APIs,
-  not stuffed into the event payload.
+- The agent payload should include the Drive file id, comment id, anchor cell
+  id, and minimal cell context by default.
+- Broader notebook context should be requested through existing notebook APIs.
 - Comments may contain secrets; agent dispatch should follow the same data-use
   rules as the AI chat panel.
+- Workspace Events subscriptions must verify Drive permissions and ignore
+  comments whose anchors are not Runme anchors.
 
 ## Implementation Plan
 
-1. Add parser/serializer helpers for `metadata["runme.dev/comments"]`.
-2. Add `NotebookData` comment mutation methods and events.
-3. Add unit tests for create, reply, resolve, reopen, orphaned anchors, and
-   `.ipynb` metadata preservation.
-4. Add a lightweight comments panel and per-cell comment icon.
-5. Add mention parsing for `@codex`.
-6. Add an agent mention router that receives comment-created events and sends
-   structured context to the existing Codex bridge.
-7. Add AppKernel comments API once internal model and UI behavior settle.
-8. Extend notebook diff handling to summarize comment metadata changes.
+1. Add Drive comment read/write helpers for `comments.list`, `comments.create`,
+   `comments.update`, `replies.create`, and resolve/reopen behavior.
+2. Add Runme anchor parsing and serialization for Drive comment anchors.
+3. Add comments availability detection from the current notebook's Drive
+   upstream file id and user permissions.
+4. Add a lightweight comments panel and per-cell comment icon for Drive-backed
+   notebooks.
+5. Disable comment controls for non-Drive notebooks and add a save-to-Drive
+   entry point.
+6. Add mention parsing for `@codex`.
+7. Emit local comment-created events for comments created in the current tab.
+8. Add AppKernel comments API once the internal Drive comments service settles.
+9. Spike Workspace Events subscriptions for Drive comment and reply events,
+   including Pub/Sub setup, OAuth scopes, renewal behavior, and event payloads.
+10. Decide whether Workspace Events-backed agent dispatch is part of V0 or the
+    first follow-up milestone.
+11. Test whether Drive API-created comments with `@email` trigger Google-native
+    email/web notifications.
 
 ## Open Questions
 
+- Should Workspace Events-backed agent dispatch be required for V0, or can V0
+  ship with only local-tab dispatch and manual refresh?
+- Do API-created comments with `@email` reliably trigger Google-native mention
+  notifications?
+- Should Runme show unanchored Drive comments, or only Runme-anchored comments?
 - Should `@codex run this cell` execute immediately, or should it open a
   confirmation affordance in the thread?
-- Which identity source should populate `CommentAuthor` for local-only users?
-- Should resolved threads remain in exported Markdown representations?
-- Should Drive-backed notebooks eventually mirror Runme comments to the Drive
-  Comments API for external visibility?
-- Should comment-only changes produce the same dirty/sync indicator as cell
-  content changes?
-- Do we want a document-level unanchored comment type after V0?
+- How should comments behave when a local notebook is later saved to Drive?
+- Which OAuth scopes are acceptable for comment read/write and Workspace Events
+  subscriptions?

--- a/docs-dev/design/20260611_notebook_comments.md
+++ b/docs-dev/design/20260611_notebook_comments.md
@@ -1,0 +1,565 @@
+# Notebook Comments
+
+Date: 2026-06-11
+
+Builds on:
+
+- `docs-dev/design/20260409_refactor_notebooks.md`
+- `docs-dev/design/20260520_notebook_session_refactor.md`
+- `docs-dev/design/20260522_notebook_diffs.md`
+
+## Summary
+
+Add cell-level comment threads to notebooks.
+
+V0 should store comments inside the notebook document, under notebook metadata,
+not in an auxiliary file and not as a new cell field. Each thread should anchor
+to a stable cell id. Replies, resolution state, author metadata, and agent
+dispatch state should live with the thread.
+
+This gives Runme a Google Docs/Colab-like review surface while preserving
+Jupyter `.ipynb` compatibility. Jupyter's notebook format does not define a
+standard comments or annotations model. It does define stable cell ids and
+allows arbitrary JSON metadata at the notebook, cell, and output levels. Those
+two facts are the compatibility path.
+
+## Goals
+
+- Let users add comments to notebook cells.
+- Show open and resolved comment threads in a notebook sidebar.
+- Show per-cell comment affordances in the notebook body.
+- Support replies and resolve/reopen actions.
+- Persist comments with local, Drive-backed, and filesystem-backed notebooks.
+- Preserve comments when a Drive-backed notebook is shared or copied.
+- Preserve `.ipynb` compatibility for native notebook support.
+- Emit structured events when a comment mentions an agent, such as
+  `@codex run this cell`.
+
+## Non-Goals
+
+- Text-range comments inside a cell in V0.
+- Multiplayer live cursors or live collaborative editing.
+- Google Drive Comments API parity in V0.
+- A separate permissions model for comments.
+- Suggested edits.
+- Emoji reactions.
+- Email notifications.
+
+## Prior Art
+
+### Google Docs
+
+Google Docs treats comments as discussions anchored to selected content. The
+core user actions are add, edit, reply, filter, delete, resolve, and reopen.
+Users can show all comments in a right-side panel, minimize comments to margin
+icons, expand comments inline, search comments, and jump from a comment to its
+document location.
+
+Docs also uses mentions and action items. A user can type `@` plus a person or
+email in a comment to notify them. Work and school accounts can assign action
+items from comments, and closed comments remain accessible.
+
+Sources:
+
+- <https://support.google.com/docs/answer/65129?hl=en>
+
+Design implications:
+
+- Comments need both local anchors and a global panel.
+- Resolved comments should remain available.
+- Mentions should be parsed from comment text and treated as actionable
+  structured data, not only display text.
+- V0 can skip assignment and notifications while keeping room in the model for
+  them.
+
+### Google Drive Comments API
+
+The Drive API has first-class comments and replies on files. It distinguishes
+anchored comments from unanchored comments. Anchors are stored as app-defined
+JSON strings. Replies are attached to a comment. A comment is resolved by
+posting a reply with an action, and the comment resource then exposes
+`resolved: true`.
+
+Drive's anchor model is useful, but it is not a drop-in storage backend for
+Runme V0. Google Workspace editor apps treat custom anchored comments as
+unanchored, and Drive warns that anchors are immutable and their position across
+document revisions is not guaranteed.
+
+Sources:
+
+- <https://developers.google.com/workspace/drive/api/guides/manage-comments>
+- <https://developers.google.com/workspace/drive/api/reference/rest/v3/comments>
+
+Design implications:
+
+- Model comments as threads with replies and resolved state.
+- Keep anchors immutable after thread creation.
+- Use cell ids rather than line offsets for V0 anchors.
+- Consider Drive comments later for Drive-backed sharing, but do not make them
+  the canonical V0 store.
+
+### Google Colab
+
+Colab is built on Jupyter notebooks and stores notebooks in Google Drive.
+Colab's FAQ states that Colab notebooks can be shared like Google Docs or
+Sheets, that shared notebooks include text, code, output, and comments, and
+that Colab notebooks are stored in the open source Jupyter `.ipynb` format.
+
+Sources:
+
+- <https://research.google.com/colaboratory/faq.html>
+
+Design implications:
+
+- Colab is strong product prior art for comments as notebook content.
+- Colab is not public implementation prior art for a reusable comments schema.
+- The most compatible interpretation is that notebook comments can live inside
+  `.ipynb` metadata while remaining associated with notebook cells.
+
+### Jupyter `.ipynb`
+
+The official notebook format has top-level `metadata`, `nbformat`,
+`nbformat_minor`, and `cells`. Since nbformat 4.5, all cells have an `id`
+field. The id must be unique within the notebook and is intended for stable
+cell identity; uniqueness across notebooks is explicitly not a goal.
+
+Jupyter metadata is the extension point. The format docs say metadata can hold
+arbitrary JSON-able information about a notebook, cell, or output, and custom
+metadata should use a unique namespace. The v4.5 schema allows additional
+properties inside root-level metadata.
+
+There is no official comments or annotations field in the `.ipynb` format. The
+defined cell metadata keys cover rendering and execution concerns such as
+collapsed output, tags, `jupyter.source_hidden`, and execution timestamps.
+
+Sources:
+
+- <https://nbformat.readthedocs.io/en/latest/format_description.html>
+- <https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html>
+- <https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.5.schema.json>
+
+Design implications:
+
+- Do not add a new top-level field or a new cell field for comments in
+  `.ipynb`.
+- Use notebook metadata with a Runme namespace for compatibility.
+- Use `.ipynb` cell `id` as the anchor when present.
+- Map Runme `refId` to `.ipynb` cell `id` when importing/exporting.
+
+## Current Runme Context
+
+The app-facing persistence path is local-first:
+
+```text
+NotebookData / editor tabs
+  -> local://file/<id>
+  -> LocalNotebooks / IndexedDB
+  -> optional upstream from LocalFileRecord.remoteId
+```
+
+`NotebookData` owns one in-memory `parser_pb.Notebook`. React views render
+immutable snapshots. Mutations should go through `NotebookData` and `CellData`,
+then autosave through the local mirror.
+
+Cells already have stable `refId` values and `metadata`. The AppKernel
+notebook API exposes notebook handles, revisions, cells, metadata, and cell
+execution helpers. Codex tools already use explicit cell ids when reading,
+updating, and executing cells.
+
+## Storage Decision
+
+Store V0 comments inside the notebook document under top-level notebook
+metadata:
+
+```json
+{
+  "metadata": {
+    "runme.dev/comments": {
+      "version": 1,
+      "threads": []
+    }
+  }
+}
+```
+
+Do not store comments in an auxiliary file for V0.
+
+Do not add a new field to cells for V0.
+
+Do not store full threads independently in each cell's metadata.
+
+### Why Inside The Notebook
+
+Inside-the-notebook storage has the right V0 behavior:
+
+- comments survive local autosave,
+- Drive copies include comments,
+- filesystem-backed notebooks remain self-contained,
+- offline editing works without another sync channel,
+- imported/exported `.ipynb` files can preserve comments,
+- the notebook revision hash reflects comment changes.
+
+The tradeoff is that comments become notebook content. A comment-only change can
+trigger notebook sync conflicts and version churn. That is acceptable for V0
+because the current product does not have live multi-writer collaboration.
+
+### Why Notebook Metadata
+
+Notebook metadata is the safest compatibility point.
+
+Adding a new cell field would make strict `.ipynb` validation fail. Cell
+metadata is valid, but storing full threads in each cell makes global comment
+search, orphan handling, and agent dispatch harder. Notebook-level metadata
+keeps comments in one place while anchors still point to cells.
+
+Cell metadata may later carry denormalized UI hints such as
+`runme.dev/commentCount`, but the source of truth should stay in notebook
+metadata.
+
+### When To Revisit Auxiliary Storage
+
+Move comments to auxiliary storage only when one of these becomes a product
+requirement:
+
+- independent comment permissions,
+- comments on read-only shared notebooks without modifying the notebook file,
+- high-volume comment activity that should not churn notebook revisions,
+- live multi-user comments before notebook save,
+- server-side notifications,
+- Drive-native comment interoperability.
+
+If that happens, the embedded metadata model can become an export/cache format
+while a per-document comments service becomes canonical.
+
+## Proposed Data Model
+
+Use one document-level metadata object:
+
+```ts
+type NotebookCommentsMetadata = {
+  version: 1
+  threads: CommentThread[]
+}
+
+type CommentThread = {
+  id: string
+  anchor: CommentAnchor
+  status: 'open' | 'resolved'
+  createdAt: string
+  updatedAt: string
+  resolvedAt?: string
+  author: CommentAuthor
+  comments: CommentMessage[]
+  agentDispatch?: AgentDispatchState
+}
+
+type CommentAnchor = {
+  type: 'cell'
+  cellId: string
+  cellIdKind: 'runme-ref-id' | 'ipynb-cell-id'
+  revision?: string
+  preview?: {
+    cellKind?: 'code' | 'markup'
+    languageId?: string
+    firstLine?: string
+  }
+}
+
+type CommentMessage = {
+  id: string
+  body: string
+  htmlBody?: string
+  author: CommentAuthor
+  createdAt: string
+  updatedAt: string
+  mentions?: CommentMention[]
+}
+
+type CommentAuthor = {
+  id?: string
+  displayName: string
+  email?: string
+  avatarUrl?: string
+}
+
+type CommentMention = {
+  raw: string
+  kind: 'agent' | 'user'
+  target: string
+}
+
+type AgentDispatchState = {
+  status: 'pending' | 'sent' | 'acked' | 'failed'
+  targetAgent: string
+  messageId?: string
+  lastError?: string
+  updatedAt: string
+}
+```
+
+Example:
+
+```json
+{
+  "version": 1,
+  "threads": [
+    {
+      "id": "thread_01jz9a0tq6x6tnmvz8z64k3dse",
+      "anchor": {
+        "type": "cell",
+        "cellId": "code_85a39e07",
+        "cellIdKind": "runme-ref-id",
+        "preview": {
+          "cellKind": "code",
+          "languageId": "python",
+          "firstLine": "df.groupby('country').revenue.sum()"
+        }
+      },
+      "status": "open",
+      "createdAt": "2026-06-11T18:00:00Z",
+      "updatedAt": "2026-06-11T18:00:00Z",
+      "author": {
+        "displayName": "Jane Doe",
+        "email": "jane@example.com"
+      },
+      "comments": [
+        {
+          "id": "comment_01jz9a10vdt7kz2zh7wqp8m3xq",
+          "body": "@codex run this cell and explain the output",
+          "author": {
+            "displayName": "Jane Doe",
+            "email": "jane@example.com"
+          },
+          "createdAt": "2026-06-11T18:00:00Z",
+          "updatedAt": "2026-06-11T18:00:00Z",
+          "mentions": [
+            {
+              "raw": "@codex",
+              "kind": "agent",
+              "target": "codex"
+            }
+          ]
+        }
+      ],
+      "agentDispatch": {
+        "status": "pending",
+        "targetAgent": "codex",
+        "updatedAt": "2026-06-11T18:00:00Z"
+      }
+    }
+  ]
+}
+```
+
+## Comment Anchors
+
+V0 anchors are cell anchors only.
+
+When editing Runme-native notebooks, use `cell.refId`. When importing `.ipynb`,
+preserve the Jupyter cell `id` and map it to `refId` if the native model needs
+one canonical cell identifier. When exporting `.ipynb`, write the anchor cell
+id to the same value as the exported cell `id`.
+
+If a cell is deleted, keep its comment thread in notebook metadata and mark it
+as orphaned in the UI by resolving the anchor at render time. Do not delete
+comments automatically. The preview gives the user enough context to resolve,
+delete, or leave the thread.
+
+If a cell is moved, the thread follows the cell id.
+
+If a cell is duplicated, new cells must get new ids. Comments stay attached to
+the original cell only.
+
+## UI Proposal
+
+V0 should use a Google Docs-like split between margin affordances and a global
+comments panel.
+
+Notebook body:
+
+- Show a comment icon in each cell toolbar or right gutter.
+- Show an active/open count on the icon.
+- Click the icon to open the thread composer for that cell.
+- Highlight the active cell when a comment thread is selected.
+- Show a compact marker for cells with open comments.
+
+Comments panel:
+
+- Dock the panel on the right side of the notebook.
+- List open threads first, grouped by notebook order.
+- Provide filters for open, resolved, and all.
+- Select a thread to scroll the notebook to the anchored cell.
+- Support reply, resolve, reopen, edit own comment, and delete own comment.
+- Show orphaned threads in a separate section.
+
+Composer:
+
+- Plain Markdown text input for V0.
+- Detect `@codex` mentions.
+- Submit with `Cmd/Ctrl+Enter`.
+- Preserve draft text while the user switches cells.
+
+Accessibility:
+
+- All comment controls need labels.
+- The active thread needs focus management between the panel and cell.
+- Keyboard shortcuts can follow Docs later: next/previous comment, reply,
+  resolve, and exit.
+
+## Agent Hook
+
+Comments should emit a structured event after the notebook model accepts the
+mutation and before/after autosave completes. Autosave should not block agent
+dispatch, but the event must include enough context for the agent to reload the
+notebook if needed.
+
+Proposed event:
+
+```ts
+type NotebookCommentCreatedEvent = {
+  type: 'notebook.comment.created'
+  notebook: {
+    uri: string
+    name: string
+    revision: string
+    remoteUri?: string
+  }
+  thread: {
+    id: string
+    status: 'open' | 'resolved'
+    anchor: CommentAnchor
+  }
+  comment: CommentMessage
+  context: {
+    cell?: {
+      refId: string
+      kind: string
+      languageId: string
+      value: string
+      metadata: Record<string, string>
+    }
+  }
+  mentions: CommentMention[]
+}
+```
+
+Dispatch flow:
+
+```text
+user submits comment
+  -> NotebookData.addComment(...)
+  -> comment metadata mutation is committed
+  -> NotebookCommentCreatedEvent is emitted
+  -> Mention router sees @codex
+  -> router sends notebook uri, revision, cell id, comment id, and cell context
+     to the Codex conversation bridge
+  -> agent response is added as a reply or linked from the thread
+```
+
+The mention router should be independent from React. It should subscribe to
+notebook model events or a small comment event bus. That keeps AppKernel,
+external Codex, and future server-side dispatch from depending on component
+lifecycles.
+
+Agent dispatch must be idempotent. Use `(notebookUri, threadId, commentId,
+targetAgent)` as the de-duplication key and persist dispatch status in
+`agentDispatch`.
+
+## API Surface
+
+Add comment methods to `NotebookData` first:
+
+```ts
+class NotebookData {
+  listCommentThreads(): CommentThread[]
+  addCommentThread(args: {
+    cellId: string
+    body: string
+    author: CommentAuthor
+  }): CommentThread
+  replyToCommentThread(args: {
+    threadId: string
+    body: string
+    author: CommentAuthor
+  }): CommentThread
+  resolveCommentThread(threadId: string): CommentThread
+  reopenCommentThread(threadId: string): CommentThread
+}
+```
+
+Then expose an AppKernel API after the model is stable:
+
+```ts
+type NotebookCommentMutation =
+  | { op: 'createThread'; cellId: string; body: string }
+  | { op: 'reply'; threadId: string; body: string }
+  | { op: 'resolve'; threadId: string }
+  | { op: 'reopen'; threadId: string }
+
+type NotebooksCommentsApi = {
+  list(args?: { target?: NotebookTarget; status?: 'open' | 'resolved' | 'all' }): Promise<CommentThread[]>
+  update(args: { target?: NotebookTarget; operations: NotebookCommentMutation[] }): Promise<CommentThread[]>
+}
+```
+
+## Sync And Conflict Behavior
+
+Comments are normal notebook content in V0.
+
+Local autosave should persist comment mutations like cell mutations. Drive sync
+should upload the changed notebook JSON. Existing conflict handling should show
+comment metadata changes in notebook diffs once diff support includes metadata.
+
+Conflict policy:
+
+- If two edits add different threads, merge should be possible because thread
+  ids are unique.
+- If two edits append replies to the same thread, merge should order by
+  `createdAt` and preserve both replies.
+- If one edit resolves a thread while another adds a reply, reopen or keep open
+  unless the resolving reply is later than the new reply.
+- If the anchor cell is deleted on one side, preserve the thread as orphaned.
+
+This merge policy is future work. V0 can rely on existing notebook conflict
+resolution and document the limitations.
+
+## Security And Privacy
+
+Comments are notebook content. Sharing a notebook shares comments. This matches
+the Colab behavior but needs UI copy when sharing or exporting.
+
+Agent mentions need explicit product behavior:
+
+- `@codex` should not execute code silently unless the command and current
+  product mode allow it.
+- The agent payload should include only the anchored cell and document
+  identifiers by default.
+- Broader notebook context should be requested through existing notebook APIs,
+  not stuffed into the event payload.
+- Comments may contain secrets; agent dispatch should follow the same data-use
+  rules as the AI chat panel.
+
+## Implementation Plan
+
+1. Add parser/serializer helpers for `metadata["runme.dev/comments"]`.
+2. Add `NotebookData` comment mutation methods and events.
+3. Add unit tests for create, reply, resolve, reopen, orphaned anchors, and
+   `.ipynb` metadata preservation.
+4. Add a lightweight comments panel and per-cell comment icon.
+5. Add mention parsing for `@codex`.
+6. Add an agent mention router that receives comment-created events and sends
+   structured context to the existing Codex bridge.
+7. Add AppKernel comments API once internal model and UI behavior settle.
+8. Extend notebook diff handling to summarize comment metadata changes.
+
+## Open Questions
+
+- Should `@codex run this cell` execute immediately, or should it open a
+  confirmation affordance in the thread?
+- Which identity source should populate `CommentAuthor` for local-only users?
+- Should resolved threads remain in exported Markdown representations?
+- Should Drive-backed notebooks eventually mirror Runme comments to the Drive
+  Comments API for external visibility?
+- Should comment-only changes produce the same dirty/sync indicator as cell
+  content changes?
+- Do we want a document-level unanchored comment type after V0?


### PR DESCRIPTION
## Summary

- Implements Drive-backed notebook comments using the Google Drive Comments API for V0 storage.
- Adds a right-side comments panel with open/resolved/all filters, per-cell comment badges, thread creation, replies, resolve/reopen, and orphaned/unanchored thread handling.
- Uses Runme cell-id anchors in Drive comments: `{ "runme": { "version": 1, "type": "cell", "cellId": "...", "cellIdKind": "runme-ref-id" } }`.
- Exposes local WebMCP helpers for service-account Drive testing and notebook fixture creation.
- Fixes Drive browser media/comment requests to use direct fetch for actionable errors and service-account compatibility.
- Disables comment UX for local/non-Drive notebooks with explicit disabled messaging.

## Browser demos

- Drive comment workflow: `/private/tmp/runme-comments-demo/drive-comments-workflow.mp4`
- Local-only disabled state: `/private/tmp/runme-comments-demo/local-disabled-comments.mp4`

## Validation

- `pnpm -C app test --run src/storage/drive.test.ts src/lib/notebookComments.test.ts src/lib/runtime/sandboxJsKernel.test.ts`
- `runme run build test`
- `git diff --check`
- In-app browser tested on port 5198 using service account `runme-web-test@aisre-gdrive-oai-test.iam.gserviceaccount.com` against shared drive `runme-testing`. Created a Drive-backed notebook, created a cell comment, added a reply, resolved it, and verified resolved filter state.

## Notes

- Full `pnpm -C app test --run` still has unrelated existing failures in `AppConsole.test.tsx` (`useGoogleAuth must be used within a GoogleAuthProvider`) and `SidePanel.test.tsx` (Drive refresh expectation).
- Service accounts cannot write to My Drive because they have no storage quota, so the browser validation uses the shared drive visible to the service account.