### PR TITLE
[codex] Add Google Drive service account auth

### DIFF
--- a/app/src/auth/googleServiceAccount.test.ts
+++ b/app/src/auth/googleServiceAccount.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createGoogleServiceAccountJwt,
+  mintGoogleServiceAccountAccessToken,
+  type GoogleServiceAccountCredentials,
+} from './googleServiceAccount'
+
+function base64UrlDecodeJson(value: string): Record<string, unknown> {
+  const padded = `${value}${'='.repeat((4 - (value.length % 4)) % 4)}`
+  const base64 = padded.replace(/-/g, '+').replace(/_/g, '/')
+  return JSON.parse(globalThis.atob(base64))
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return globalThis.btoa(binary)
+}
+
+async function generatePrivateKeyPem(): Promise<string> {
+  const keyPair = await globalThis.crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  )
+  const pkcs8 = await globalThis.crypto.subtle.exportKey(
+    'pkcs8',
+    keyPair.privateKey
+  )
+  const base64 = bytesToBase64(new Uint8Array(pkcs8))
+  const lines = base64.match(/.{1,64}/g) ?? []
+  return [
+    '-----BEGIN PRIVATE KEY-----',
+    ...lines,
+    '-----END PRIVATE KEY-----',
+  ].join('\n')
+}
+
+describe('Google service account auth', () => {
+  let credentials: GoogleServiceAccountCredentials
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    credentials = {
+      clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+      privateKey: await generatePrivateKeyPem(),
+      privateKeyId: 'test-key-id',
+      tokenUri: 'https://oauth2.googleapis.com/token',
+    }
+  })
+
+  it('creates a JWT bearer assertion with Drive scopes', async () => {
+    const jwt = await createGoogleServiceAccountJwt(
+      credentials,
+      ['https://www.googleapis.com/auth/drive'],
+      1_700_000_000
+    )
+
+    const [headerRaw, claimsRaw, signatureRaw] = jwt.split('.')
+
+    expect(headerRaw).toBeTruthy()
+    expect(claimsRaw).toBeTruthy()
+    expect(signatureRaw).toBeTruthy()
+    expect(base64UrlDecodeJson(headerRaw)).toMatchObject({
+      alg: 'RS256',
+      typ: 'JWT',
+      kid: 'test-key-id',
+    })
+    expect(base64UrlDecodeJson(claimsRaw)).toMatchObject({
+      iss: 'runme-drive-test@example.iam.gserviceaccount.com',
+      scope: 'https://www.googleapis.com/auth/drive',
+      aud: 'https://oauth2.googleapis.com/token',
+      iat: 1_700_000_000,
+      exp: 1_700_003_600,
+    })
+  })
+
+  it('exchanges the JWT assertion for an access token', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: 'service-account-access-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const token = await mintGoogleServiceAccountAccessToken(credentials, [
+      'https://www.googleapis.com/auth/drive',
+    ])
+
+    expect(token.access_token).toBe('service-account-access-token')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const requestBody = fetchMock.mock.calls[0]?.[1]?.body as URLSearchParams
+    expect(requestBody.get('grant_type')).toBe(
+      'urn:ietf:params:oauth:grant-type:jwt-bearer'
+    )
+    expect(requestBody.get('assertion')?.split('.')).toHaveLength(3)
+  })
+})

--- a/app/src/auth/googleServiceAccount.ts
+++ b/app/src/auth/googleServiceAccount.ts
@@ -1,0 +1,182 @@
+import type { OAuthTokenEndpointResponse } from './types'
+
+export type GoogleServiceAccountCredentials = {
+  clientEmail: string
+  privateKey: string
+  privateKeyId?: string
+  tokenUri?: string
+  subject?: string
+  scopes?: string[]
+}
+
+const DEFAULT_TOKEN_URI = 'https://oauth2.googleapis.com/token'
+const JWT_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+const DEFAULT_EXPIRES_IN = 3600
+
+type GoogleTokenErrorResponse = {
+  error?: string
+  error_description?: string
+}
+
+function assertBrowserEncodingSupport(): void {
+  if (typeof globalThis.btoa !== 'function') {
+    throw new Error('Google service account auth requires btoa support.')
+  }
+  if (typeof globalThis.atob !== 'function') {
+    throw new Error('Google service account auth requires atob support.')
+  }
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  assertBrowserEncodingSupport()
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return globalThis
+    .btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+function base64UrlEncodeJson(value: unknown): string {
+  return base64UrlEncodeBytes(
+    new TextEncoder().encode(JSON.stringify(value))
+  )
+}
+
+function decodePemPrivateKey(privateKey: string): Uint8Array {
+  assertBrowserEncodingSupport()
+  const normalizedKey = privateKey.replace(/\\n/g, '\n')
+  const base64 = normalizedKey
+    .replace(/-----BEGIN PRIVATE KEY-----/g, '')
+    .replace(/-----END PRIVATE KEY-----/g, '')
+    .replace(/\s+/g, '')
+
+  if (!base64) {
+    throw new Error('Google service account private_key is empty.')
+  }
+
+  const binary = globalThis.atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+async function importPrivateKey(privateKey: string): Promise<CryptoKey> {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Google service account auth requires Web Crypto support.')
+  }
+
+  return globalThis.crypto.subtle.importKey(
+    'pkcs8',
+    decodePemPrivateKey(privateKey),
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: 'SHA-256',
+    },
+    false,
+    ['sign']
+  )
+}
+
+export async function createGoogleServiceAccountJwt(
+  credentials: GoogleServiceAccountCredentials,
+  scopes: string[],
+  nowSeconds = Math.floor(Date.now() / 1000)
+): Promise<string> {
+  const clientEmail = credentials.clientEmail.trim()
+  const privateKey = credentials.privateKey.trim()
+  const resolvedScopes =
+    credentials.scopes && credentials.scopes.length > 0
+      ? credentials.scopes
+      : scopes
+  const scope = resolvedScopes.map((item) => item.trim()).filter(Boolean)
+  const tokenUri = credentials.tokenUri?.trim() || DEFAULT_TOKEN_URI
+
+  if (!clientEmail) {
+    throw new Error('Google service account config is missing client_email.')
+  }
+  if (!privateKey) {
+    throw new Error('Google service account config is missing private_key.')
+  }
+  if (scope.length === 0) {
+    throw new Error('Google service account auth requires at least one scope.')
+  }
+
+  const header: Record<string, string> = {
+    alg: 'RS256',
+    typ: 'JWT',
+  }
+  if (credentials.privateKeyId?.trim()) {
+    header.kid = credentials.privateKeyId.trim()
+  }
+
+  const claimSet: Record<string, string | number> = {
+    iss: clientEmail,
+    scope: scope.join(' '),
+    aud: tokenUri,
+    iat: nowSeconds,
+    exp: nowSeconds + DEFAULT_EXPIRES_IN,
+  }
+  if (credentials.subject?.trim()) {
+    claimSet.sub = credentials.subject.trim()
+  }
+
+  const signingInput = `${base64UrlEncodeJson(header)}.${base64UrlEncodeJson(
+    claimSet
+  )}`
+  const key = await importPrivateKey(privateKey)
+  const signature = await globalThis.crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(signingInput)
+  )
+
+  return `${signingInput}.${base64UrlEncodeBytes(new Uint8Array(signature))}`
+}
+
+export async function mintGoogleServiceAccountAccessToken(
+  credentials: GoogleServiceAccountCredentials,
+  scopes: string[]
+): Promise<OAuthTokenEndpointResponse> {
+  const tokenUri = credentials.tokenUri?.trim() || DEFAULT_TOKEN_URI
+  const assertion = await createGoogleServiceAccountJwt(credentials, scopes)
+  const response = await fetch(tokenUri, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: JWT_GRANT_TYPE,
+      assertion,
+    }),
+  })
+
+  let token: Partial<OAuthTokenEndpointResponse> &
+    GoogleTokenErrorResponse = {}
+  try {
+    token = (await response.json()) as Partial<OAuthTokenEndpointResponse> &
+      GoogleTokenErrorResponse
+  } catch {
+    token = {}
+  }
+
+  if (!response.ok || token.error || !token.access_token) {
+    throw new Error(
+      token.error_description ??
+        token.error ??
+        `Google service account token exchange failed (${response.status})`
+    )
+  }
+
+  return {
+    access_token: token.access_token,
+    token_type: token.token_type,
+    scope: token.scope,
+    expires_in: token.expires_in ?? DEFAULT_EXPIRES_IN,
+  }
+}

--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useCurrentDoc } from "../../contexts/CurrentDocContext";
 import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
+import { useGoogleAuth } from "../../contexts/GoogleAuthContext";
 import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { useRunners } from "../../contexts/RunnersContext";
@@ -135,6 +136,7 @@ function OutputGroups({ outputs }: { outputs: parser_pb.CellOutput[] }) {
 export default function AppConsole({ showHeader = true }: { showHeader?: boolean }) {
   const appConsoleData = getAppConsoleData();
   const { cells, hydrated, loadError } = useAppConsoleSnapshot();
+  const { ensureAccessToken } = useGoogleAuth();
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === "undefined") {
       return false;
@@ -418,6 +420,7 @@ export default function AppConsole({ showHeader = true }: { showHeader?: boolean
             }
             return items;
           }, []),
+      ensureAccessToken,
       runnerSync: {
         onUpdated: (runner) => {
           updateRunner(

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -375,7 +375,15 @@ export function WorkspaceExplorer() {
           continue;
         }
 
-        const metadata = await store.getMetadata(localUri);
+        let metadata = await store.getMetadata(localUri);
+        if (metadata?.remoteUri && metadata.name === "Drive") {
+          try {
+            await store.updateFolder(metadata.remoteUri);
+            metadata = await store.getMetadata(localUri);
+          } catch (error) {
+            console.error("Failed to refresh Drive folder name", error);
+          }
+        }
         const name = metadata?.name ?? localUri;
         const type = metadata?.type ?? NotebookStoreItemType.Folder;
         if (type !== NotebookStoreItemType.Folder) {

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -41,6 +41,38 @@ async function renderWithGoogleAuthProvider() {
   return captured!
 }
 
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return globalThis.btoa(binary)
+}
+
+async function generatePrivateKeyPem(): Promise<string> {
+  const keyPair = await globalThis.crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  )
+  const pkcs8 = await globalThis.crypto.subtle.exportKey(
+    'pkcs8',
+    keyPair.privateKey
+  )
+  const base64 = bytesToBase64(new Uint8Array(pkcs8))
+  const lines = base64.match(/.{1,64}/g) ?? []
+  return [
+    '-----BEGIN PRIVATE KEY-----',
+    ...lines,
+    '-----END PRIVATE KEY-----',
+  ].join('\n')
+}
+
 describe('GoogleAuthProvider implicit redirect flow', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -168,5 +200,42 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
       'test-access-token'
     )
+  })
+
+  it('mints a service account access token without interactive OAuth', async () => {
+    googleClientManager.setOAuthClient({
+      clientId: '',
+      authFlow: 'service_account',
+      authUxMode: 'new_tab',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey: await generatePrivateKeyPem(),
+      },
+    })
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: 'service-account-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const openSpy = vi.spyOn(window, 'open')
+    const auth = await renderWithGoogleAuthProvider()
+
+    let token = ''
+    await act(async () => {
+      token = await auth.ensureAccessToken({ interactive: false })
+    })
+
+    expect(token).toBe('service-account-token')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(openSpy).not.toHaveBeenCalled()
   })
 })

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react'
 import pkceChallenge from 'pkce-challenge'
+import { mintGoogleServiceAccountAccessToken } from '../auth/googleServiceAccount'
 import { googleClientManager } from '../lib/googleClientManager'
 import {
   APP_ROUTE_PATHS,
@@ -615,6 +616,27 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     return token.access_token
   }, [setAccessToken])
 
+  const mintServiceAccountAccessToken = useCallback(async (): Promise<
+    string | null
+  > => {
+    const oauthClient = googleClientManager.getOAuthClient()
+    if (oauthClient.authFlow !== 'service_account') {
+      return null
+    }
+    if (!oauthClient.serviceAccount) {
+      throw new Error('Google Drive service account credentials are missing.')
+    }
+
+    const token = await mintGoogleServiceAccountAccessToken(
+      oauthClient.serviceAccount,
+      DRIVE_SCOPES
+    )
+    setAccessToken(token.access_token, token.expires_in ?? 3600, {
+      refreshToken: null,
+    })
+    return token.access_token
+  }, [setAccessToken])
+
   useEffect(() => {
     tokenInfoRef.current = tokenInfo
   }, [tokenInfo])
@@ -891,6 +913,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           return refreshedInfo.token
         }
 
+        const serviceAccountToken = await mintServiceAccountAccessToken()
+        if (serviceAccountToken) {
+          return serviceAccountToken
+        }
+
         try {
           const refreshedToken = await refreshAccessToken()
           if (refreshedToken) {
@@ -988,6 +1015,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     [
       ensureTokenClient,
       hasRedirectAuthHandoffInProgress,
+      mintServiceAccountAccessToken,
       refreshAccessToken,
       setAccessToken,
       startImplicitRedirect,

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -340,6 +340,43 @@ describe('appConfig OIDC Google shorthand', () => {
     })
   })
 
+  it('applies Google Drive service account auth without an OAuth client ID', async () => {
+    const { applyAppConfig } = await loadModules()
+    const { googleClientManager } = await import('./googleClientManager')
+
+    const result = applyAppConfig(
+      {
+        agent: {
+          endpoint: 'http://localhost:9977',
+        },
+        googleDrive: {
+          authFlow: 'service_account',
+          serviceAccount: {
+            client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
+            private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+            private_key_id: 'key-id',
+            scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+          },
+        },
+      },
+      'http://localhost/configs/app-configs.yaml'
+    )
+
+    expect(result.warnings).toEqual([])
+    expect(googleClientManager.getOAuthClient()).toMatchObject({
+      clientId: '',
+      authFlow: 'service_account',
+      authUxMode: 'new_tab',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        privateKeyId: 'key-id',
+        scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+      },
+    })
+  })
+
   it('toggles app-config local precedence on load', async () => {
     const {
       disableAppConfigOverridesOnLoad,

--- a/app/src/lib/appConfig.ts
+++ b/app/src/lib/appConfig.ts
@@ -1,6 +1,7 @@
 import YAML from 'yaml'
 
 import type { OidcConfig } from '../auth/oidcConfig'
+import type { GoogleServiceAccountCredentials } from '../auth/googleServiceAccount'
 import { OIDC_STORAGE_KEY, oidcConfigManager } from '../auth/oidcConfig'
 import { agentEndpointManager } from './agentEndpointManager'
 import { getOidcCallbackUrl, resolveAppUrl } from './appBase'
@@ -66,6 +67,7 @@ export interface GoogleDriveRuntimeConfig {
   baseUrl: string
   authFlow: GoogleDriveAuthFlow
   authUxMode: GoogleDriveAuthUxMode
+  serviceAccount?: GoogleServiceAccountCredentials
 }
 
 export interface ChatkitRuntimeConfig {
@@ -147,8 +149,15 @@ function asGoogleDriveAuthFlow(
     return undefined
   }
   const normalized = value.trim().toLowerCase()
-  if (normalized === 'implicit' || normalized === 'pkce') {
+  if (
+    normalized === 'implicit' ||
+    normalized === 'pkce' ||
+    normalized === 'service_account'
+  ) {
     return normalized
+  }
+  if (normalized === 'service-account' || normalized === 'serviceaccount') {
+    return 'service_account'
   }
   return undefined
 }
@@ -181,6 +190,29 @@ function asStringArray(value: unknown): string[] {
     .map((item) => asNonEmptyString(item))
     .filter((item): item is string => Boolean(item))
   return values
+}
+
+function parseGoogleDriveServiceAccount(
+  value: unknown
+): GoogleServiceAccountCredentials | undefined {
+  const record = asRecord(value)
+  if (!record) {
+    return undefined
+  }
+  const clientEmail = pickString(record, ['clientEmail', 'client_email'])
+  const privateKey = pickString(record, ['privateKey', 'private_key'])
+  if (!clientEmail && !privateKey) {
+    return undefined
+  }
+  return {
+    clientEmail,
+    privateKey,
+    privateKeyId:
+      pickString(record, ['privateKeyId', 'private_key_id']) || undefined,
+    tokenUri: pickString(record, ['tokenUri', 'token_uri']) || undefined,
+    subject: pickString(record, ['subject']) || undefined,
+    scopes: asStringArray(record.scopes),
+  }
 }
 
 function readSettingsFromStorage(storage: Storage): Record<string, unknown> {
@@ -406,6 +438,7 @@ function createDefaultRuntimeAppConfig(): RuntimeAppConfig {
       baseUrl: '',
       authFlow: 'implicit',
       authUxMode: 'new_tab',
+      serviceAccount: undefined,
     },
     chatkit: {
       domainKey: '',
@@ -511,6 +544,9 @@ export class RuntimeAppConfigSchema {
             drive.oauthUxMode ??
             drive.uxMode
         ) ?? 'new_tab'
+      const serviceAccount = parseGoogleDriveServiceAccount(
+        drive.serviceAccount ?? drive.service_account
+      )
       parsed.googleDrive = {
         clientId: pickString(drive, ['clientId', 'clientID']),
         clientSecret: hasClientMaterial
@@ -519,6 +555,7 @@ export class RuntimeAppConfigSchema {
         baseUrl: asNonEmptyString(drive.baseUrl),
         authFlow,
         authUxMode,
+        serviceAccount,
       }
     }
 
@@ -652,21 +689,31 @@ export function applyAppConfig(
   const googleClientSecret = normalizeString(parsed.googleDrive.clientSecret)
   const googleAuthFlow = parsed.googleDrive.authFlow
   const googleAuthUxMode = parsed.googleDrive.authUxMode
+  const googleServiceAccount = parsed.googleDrive.serviceAccount
   const skipGoogleDriveFromConfig =
     preserveLocalConfiguration && hasLocalDriveConfig
   if (skipGoogleDriveFromConfig) {
     googleOAuth = googleClientManager.getOAuthClient()
   } else {
-    if (googleClientId) {
+    if (googleClientId || googleAuthFlow === 'service_account') {
       try {
         googleOAuth = googleClientManager.setOAuthClient({
-          clientId: googleClientId,
+          clientId: googleClientId ?? '',
           clientSecret: googleClientSecret,
           authFlow: googleAuthFlow,
           authUxMode: googleAuthUxMode,
+          serviceAccount: googleServiceAccount,
         })
       } catch (error) {
         warnings.push(`Google OAuth config not applied: ${String(error)}`)
+      }
+      if (
+        googleAuthFlow === 'service_account' &&
+        (!googleServiceAccount?.clientEmail || !googleServiceAccount.privateKey)
+      ) {
+        warnings.push(
+          'Google Drive service account config missing client_email/private_key'
+        )
       }
     } else if (hasGoogleDriveBlock) {
       warnings.push('Google Drive config missing clientID/clientId')

--- a/app/src/lib/googleClientManager.test.ts
+++ b/app/src/lib/googleClientManager.test.ts
@@ -82,4 +82,79 @@ describe('GoogleClientManager', () => {
       authUxMode: 'new_tab',
     })
   })
+
+  it('infers service account auth when JSON contains service account credentials', () => {
+    const manager = createManager()
+
+    manager.setOAuthClientFromJson(
+      JSON.stringify({
+        type: 'service_account',
+        client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
+        private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        private_key_id: 'key-id',
+        token_uri: 'https://oauth2.googleapis.com/token',
+      })
+    )
+
+    expect(manager.getOAuthClient()).toMatchObject({
+      clientId: '',
+      authFlow: 'service_account',
+      authUxMode: 'new_tab',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        privateKeyId: 'key-id',
+        tokenUri: 'https://oauth2.googleapis.com/token',
+      },
+    })
+  })
+
+  it('does not restore service account mode without credentials from local storage', () => {
+    const manager = createManager()
+
+    manager.setOAuthClientFromJson(
+      JSON.stringify({
+        type: 'service_account',
+        client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
+        private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        private_key_id: 'key-id',
+        token_uri: 'https://oauth2.googleapis.com/token',
+      })
+    )
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(GOOGLE_CLIENT_STORAGE_KEY) ?? '{}'
+    ) as Record<string, string | undefined>
+    expect(JSON.stringify(stored)).not.toContain('PRIVATE KEY')
+    expect(stored.oauthAuthFlow).toBeUndefined()
+
+    const reloadedManager = createManager()
+    expect(reloadedManager.getOAuthClient()).toMatchObject({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    expect(reloadedManager.getOAuthClient()).not.toHaveProperty(
+      'serviceAccount'
+    )
+  })
+
+  it('clears service account credentials when switching to an OAuth flow', () => {
+    const manager = createManager()
+
+    manager.setOAuthClientFromJson(
+      JSON.stringify({
+        type: 'service_account',
+        client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
+        private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+      })
+    )
+    manager.setAuthFlow('implicit')
+
+    expect(manager.getOAuthClient()).toMatchObject({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    expect(manager.getOAuthClient()).not.toHaveProperty('serviceAccount')
+  })
 })

--- a/app/src/lib/googleClientManager.ts
+++ b/app/src/lib/googleClientManager.ts
@@ -1,8 +1,11 @@
+import type { GoogleServiceAccountCredentials } from '../auth/googleServiceAccount'
+
 export type GoogleOAuthClientConfig = {
   clientId: string
   clientSecret?: string
   authFlow: GoogleDriveAuthFlow
   authUxMode: GoogleDriveAuthUxMode
+  serviceAccount?: GoogleServiceAccountCredentials
 }
 
 export type GoogleDrivePickerConfig = {
@@ -14,7 +17,7 @@ export type GoogleDrivePickerConfig = {
 export const GOOGLE_CLIENT_STORAGE_KEY = 'googleClientConfig'
 const STORAGE_KEY = GOOGLE_CLIENT_STORAGE_KEY
 
-export type GoogleDriveAuthFlow = 'implicit' | 'pkce'
+export type GoogleDriveAuthFlow = 'implicit' | 'pkce' | 'service_account'
 export type GoogleDriveAuthUxMode = 'popup' | 'redirect' | 'new_tab'
 
 const DEFAULT_AUTH_FLOW: GoogleDriveAuthFlow = 'implicit'
@@ -24,10 +27,11 @@ const DEFAULT_AUTH_UX_MODE_FOR_FLOW: Record<
 > = {
   implicit: 'new_tab',
   pkce: 'new_tab',
+  service_account: 'new_tab',
 }
 
 function isGoogleDriveAuthFlow(value: unknown): value is GoogleDriveAuthFlow {
-  return value === 'implicit' || value === 'pkce'
+  return value === 'implicit' || value === 'pkce' || value === 'service_account'
 }
 
 function isGoogleDriveAuthUxMode(
@@ -45,6 +49,49 @@ function resolveDefaultUxModeForFlow(
 type GoogleClientConfig = {
   oauth: GoogleOAuthClientConfig
   drivePicker: GoogleDrivePickerConfig
+}
+
+type ServiceAccountJson = {
+  client_email?: string
+  clientEmail?: string
+  private_key?: string
+  privateKey?: string
+  private_key_id?: string
+  privateKeyId?: string
+  token_uri?: string
+  tokenUri?: string
+  subject?: string
+  scopes?: unknown
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  const values = value.filter(
+    (scope): scope is string =>
+      typeof scope === 'string' && scope.trim().length > 0
+  )
+  return values.length > 0 ? values : undefined
+}
+
+function parseServiceAccountCredentials(
+  value: ServiceAccountJson | null | undefined
+): GoogleServiceAccountCredentials | undefined {
+  const clientEmail = (value?.client_email ?? value?.clientEmail ?? '').trim()
+  const privateKey = (value?.private_key ?? value?.privateKey ?? '').trim()
+  if (!clientEmail && !privateKey) {
+    return undefined
+  }
+  return {
+    clientEmail,
+    privateKey,
+    privateKeyId:
+      (value?.private_key_id ?? value?.privateKeyId ?? '').trim() || undefined,
+    tokenUri: (value?.token_uri ?? value?.tokenUri ?? '').trim() || undefined,
+    subject: value?.subject?.trim() || undefined,
+    scopes: parseStringArray(value?.scopes),
+  }
 }
 
 export class GoogleClientManager {
@@ -115,12 +162,23 @@ export class GoogleClientManager {
         ? resolveDefaultUxModeForFlow(nextAuthFlow)
         : this.config.oauth.authUxMode)
 
-    this.config.oauth = {
+    const serviceAccount =
+      nextAuthFlow === 'service_account'
+        ? config.serviceAccount ?? this.config.oauth.serviceAccount
+        : undefined
+
+    const nextOAuthClient: GoogleOAuthClientConfig = {
       ...this.config.oauth,
       ...config,
       authFlow: nextAuthFlow,
       authUxMode: nextAuthUxMode,
     }
+    if (serviceAccount) {
+      nextOAuthClient.serviceAccount = serviceAccount
+    } else {
+      delete nextOAuthClient.serviceAccount
+    }
+    this.config.oauth = nextOAuthClient
     if (config.clientId !== undefined) {
       this.config.drivePicker = {
         ...this.config.drivePicker,
@@ -156,6 +214,18 @@ export class GoogleClientManager {
       authUxMode?: string
       oauthUxMode?: string
       uxMode?: string
+      service_account?: ServiceAccountJson
+      serviceAccount?: ServiceAccountJson
+      client_email?: string
+      clientEmail?: string
+      private_key?: string
+      privateKey?: string
+      private_key_id?: string
+      privateKeyId?: string
+      token_uri?: string
+      tokenUri?: string
+      subject?: string
+      scopes?: unknown
     } | null = null
     try {
       parsed = JSON.parse(raw) as {
@@ -170,13 +240,28 @@ export class GoogleClientManager {
         authUxMode?: string
         oauthUxMode?: string
         uxMode?: string
+        service_account?: ServiceAccountJson
+        serviceAccount?: ServiceAccountJson
+        client_email?: string
+        clientEmail?: string
+        private_key?: string
+        privateKey?: string
+        private_key_id?: string
+        privateKeyId?: string
+        token_uri?: string
+        tokenUri?: string
+        subject?: string
+        scopes?: unknown
       }
     } catch {
       throw new Error('Invalid JSON: unable to parse OAuth client config')
     }
 
     const clientId = (parsed?.client_id ?? parsed?.clientId ?? '').trim()
-    if (!clientId) {
+    const serviceAccount = parseServiceAccountCredentials(
+      parsed?.service_account ?? parsed?.serviceAccount ?? parsed
+    )
+    if (!clientId && !serviceAccount) {
       throw new Error('OAuth client config is missing client_id')
     }
     const clientSecret = parsed?.client_secret?.trim() ?? ''
@@ -201,12 +286,16 @@ export class GoogleClientManager {
         `Unsupported auth_ux_mode value: ${String(rawAuthUxMode)}`
       )
     }
+    const resolvedAuthFlow =
+      (rawAuthFlow?.trim() as GoogleDriveAuthFlow | undefined) ??
+      (serviceAccount ? 'service_account' : undefined)
 
     return this.setOAuthClient({
       clientId,
       clientSecret: clientSecret.length > 0 ? clientSecret : undefined,
-      authFlow: rawAuthFlow?.trim() as GoogleDriveAuthFlow | undefined,
+      authFlow: resolvedAuthFlow,
       authUxMode: rawAuthUxMode?.trim() as GoogleDriveAuthUxMode | undefined,
+      serviceAccount,
     })
   }
 
@@ -271,7 +360,13 @@ export class GoogleClientManager {
       }
       const parsed = JSON.parse(raw) as { oauthAuthFlow?: string } | null
       const authFlow = parsed?.oauthAuthFlow?.trim()
-      return authFlow && isGoogleDriveAuthFlow(authFlow) ? authFlow : null
+      if (!authFlow || !isGoogleDriveAuthFlow(authFlow)) {
+        return null
+      }
+      // Service account private keys are intentionally not restored from
+      // localStorage. Persisting only the auth flow would leave the app in
+      // service-account mode without credentials after reload.
+      return authFlow === 'service_account' ? null : authFlow
     } catch (error) {
       console.warn('Failed to read Google OAuth auth flow', error)
       return null
@@ -303,13 +398,17 @@ export class GoogleClientManager {
       return
     }
     try {
+      const persistableAuthFlow =
+        config.authFlow === 'service_account' ? undefined : config.authFlow
+      const persistableAuthUxMode =
+        config.authFlow === 'service_account' ? undefined : config.authUxMode
       window.localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
           oauthClientId: config.clientId,
           oauthClientSecret: config.clientSecret,
-          oauthAuthFlow: config.authFlow,
-          oauthAuthUxMode: config.authUxMode,
+          oauthAuthFlow: persistableAuthFlow,
+          oauthAuthUxMode: persistableAuthUxMode,
         })
       )
     } catch (error) {

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { parser_pb } from '../../runme/client'
+import { GoogleClientManager } from '../googleClientManager'
 import { appState } from './AppState'
 import { createAppJsGlobals } from './appJsGlobals'
 import type { NotebookDataLike, RunmeConsoleApi } from './runmeConsole'
@@ -45,9 +46,17 @@ function createRunme(current: NotebookDataLike | null = null): RunmeConsoleApi {
 
 describe('createAppJsGlobals notebook reference helpers', () => {
   afterEach(() => {
+    vi.unstubAllGlobals()
     appState.setLocalNotebooks(null)
     appState.setOpenNotebookHandler(null)
     appState.setGoogleDriveOAuthHandler(null)
+    window.localStorage.clear()
+    ;(
+      GoogleClientManager as unknown as {
+        singleton: GoogleClientManager | null
+      }
+    ).singleton = null
+    delete (window as any).showOpenFilePicker
     window.history.replaceState(null, '', '/')
   })
 
@@ -147,5 +156,106 @@ describe('createAppJsGlobals notebook reference helpers', () => {
       accessToken: '<redacted>',
     })
     expect(output.join('')).toContain('Google Drive OAuth authorized.')
+  })
+
+  it('loads Google service account credentials from a picked local JSON file', async () => {
+    const sendOutput = vi.fn()
+    const serviceAccountJson = JSON.stringify({
+      type: 'service_account',
+      client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
+      private_key:
+        '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+      private_key_id: 'key-id',
+      token_uri: 'https://oauth2.googleapis.com/token',
+    })
+    ;(window as any).showOpenFilePicker = vi.fn(async () => [
+      {
+        getFile: async () => ({
+          name: 'service-account.json',
+          text: async () => serviceAccountJson,
+        }),
+      },
+    ])
+
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+      sendOutput,
+    })
+
+    const config = await globals.credentials.google.setServiceAccountFromFile()
+
+    expect(config).toMatchObject({
+      authFlow: 'service_account',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        privateKeyId: 'key-id',
+        tokenUri: 'https://oauth2.googleapis.com/token',
+      },
+    })
+    expect(globals.googleClientManager.get()).toMatchObject({
+      authFlow: 'service_account',
+    })
+    expect(sendOutput).toHaveBeenCalledWith(
+      'Loaded Google Drive service account credentials from service-account.json.\r\n'
+    )
+  })
+
+  it('loads Google service account credentials from a local dev-server path', async () => {
+    const sendOutput = vi.fn()
+    const keyPath = '/Users/jlewi/secrets/service-account.json'
+    const serviceAccountJson = JSON.stringify({
+      type: 'service_account',
+      client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
+      private_key:
+        '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+      private_key_id: 'key-id',
+      token_uri: 'https://oauth2.googleapis.com/token',
+    })
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain('/__runme-dev/service-account-key')
+      expect(url).toContain(
+        'path=%2FUsers%2Fjlewi%2Fsecrets%2Fservice-account.json'
+      )
+      return new Response(
+        JSON.stringify({
+          name: 'service-account.json',
+          path: keyPath,
+          text: serviceAccountJson,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const ensureAccessToken = vi.fn(async () => 'service-account-token')
+
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+      sendOutput,
+      ensureAccessToken,
+    })
+
+    const config =
+      await globals.credentials.google.setServiceAccountFromFilePath(keyPath)
+
+    expect(config).toMatchObject({
+      authFlow: 'service_account',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        privateKeyId: 'key-id',
+        tokenUri: 'https://oauth2.googleapis.com/token',
+      },
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(ensureAccessToken).toHaveBeenCalledWith({ interactive: false })
+    expect(sendOutput).toHaveBeenCalledWith(
+      `Loaded Google Drive service account credentials from ${keyPath}.\r\n`
+    )
   })
 })

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -108,8 +108,130 @@ type RunnerSync = {
   onDefaultSet?: (name: string) => void
 }
 
+type EnsureAccessToken = (options?: { interactive?: boolean }) => Promise<string>
+
+type LocalTextSelection = {
+  name: string
+  text: string
+}
+
+type LocalServiceAccountKeyResponse = {
+  name?: string
+  path?: string
+  text?: string
+}
+
+const LOCAL_SERVICE_ACCOUNT_KEY_ENDPOINT =
+  '/__runme-dev/service-account-key'
+
 function emitLine(sendOutput: SendOutput | undefined, message: string): void {
   sendOutput?.(`${message}\r\n`)
+}
+
+async function readTextFile(file: File): Promise<LocalTextSelection> {
+  if (typeof file.text === 'function') {
+    return {
+      name: file.name || 'selected.json',
+      text: await file.text(),
+    }
+  }
+  if (typeof file.arrayBuffer === 'function') {
+    const buffer = await file.arrayBuffer()
+    return {
+      name: file.name || 'selected.json',
+      text: new TextDecoder().decode(new Uint8Array(buffer)),
+    }
+  }
+  throw new Error('Selected file does not support text or arrayBuffer reads')
+}
+
+async function pickJsonFromLocalFilesystem(): Promise<LocalTextSelection | null> {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.showOpenFilePicker === 'function'
+  ) {
+    try {
+      const [handle] = await window.showOpenFilePicker({
+        multiple: false,
+        excludeAcceptAllOption: false,
+        types: [
+          {
+            description: 'JSON files',
+            accept: {
+              'application/json': ['.json'],
+              'text/plain': ['.json'],
+            },
+          },
+        ],
+      })
+      if (!handle) {
+        return null
+      }
+      return readTextFile(await handle.getFile())
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return null
+      }
+      throw error
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json,application/json'
+    input.style.display = 'none'
+
+    input.onchange = async () => {
+      const file = input.files?.[0] ?? null
+      input.remove()
+      if (!file) {
+        resolve(null)
+        return
+      }
+      try {
+        resolve(await readTextFile(file))
+      } catch (error) {
+        reject(error)
+      }
+    }
+
+    input.oncancel = () => {
+      input.remove()
+      resolve(null)
+    }
+
+    document.body.appendChild(input)
+    input.click()
+  })
+}
+
+async function readServiceAccountJsonFromLocalPath(
+  keyPath: string
+): Promise<LocalTextSelection> {
+  const trimmedPath = keyPath.trim()
+  if (!trimmedPath) {
+    throw new Error('Service account key path is required.')
+  }
+
+  const url = new URL(LOCAL_SERVICE_ACCOUNT_KEY_ENDPOINT, window.location.origin)
+  url.searchParams.set('path', trimmedPath)
+  const response = await fetch(url.toString())
+  const responseText = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read service account key from local dev server (${response.status}): ${responseText}`
+    )
+  }
+
+  const parsed = JSON.parse(responseText) as LocalServiceAccountKeyResponse
+  if (!parsed.text) {
+    throw new Error('Local dev server did not return service account JSON text.')
+  }
+  return {
+    name: parsed.name || trimmedPath.split('/').pop() || 'service-account.json',
+    text: parsed.text,
+  }
 }
 
 function createRunmeApi(
@@ -198,6 +320,7 @@ export function createAppJsGlobals({
   runnerSync,
   resolveNotebook,
   listNotebooks,
+  ensureAccessToken,
   opfsApi,
   networkApi,
 }: {
@@ -210,6 +333,7 @@ export function createAppJsGlobals({
   runnerSync?: RunnerSync
   resolveNotebook?: (target?: unknown) => NotebookDataLike | null
   listNotebooks?: () => NotebookDataLike[]
+  ensureAccessToken?: EnsureAccessToken
   opfsApi?: AppKernelOpfsApi
   networkApi?: AppKernelNetworkApi
 }) {
@@ -840,6 +964,85 @@ export function createAppJsGlobals({
     },
   }
 
+  const googleClientRuntimeApi = {
+    get: () => googleClientManager.getOAuthClient(),
+    getOAuthClient: () => googleClientManager.getOAuthClient(),
+    setOAuthClient: (config: {
+      clientId?: string
+      clientSecret?: string
+      authFlow?: 'implicit' | 'pkce' | 'service_account'
+      authUxMode?: 'popup' | 'redirect' | 'new_tab'
+      serviceAccount?: {
+        clientEmail: string
+        privateKey: string
+        privateKeyId?: string
+        tokenUri?: string
+        subject?: string
+        scopes?: string[]
+      }
+    }) => googleClientManager.setOAuthClient(config),
+    setClientId: (clientId: string) =>
+      googleClientManager.setOAuthClient({ clientId }),
+    setClientSecret: (clientSecret: string) =>
+      googleClientManager.setClientSecret(clientSecret),
+    setAuthFlow: (authFlow: 'implicit' | 'pkce' | 'service_account') =>
+      googleClientManager.setAuthFlow(authFlow),
+    setAuthUxMode: (authUxMode: 'popup' | 'redirect' | 'new_tab') =>
+      googleClientManager.setAuthUxMode(authUxMode),
+    setFromJson: (raw: string) => googleClientManager.setOAuthClientFromJson(raw),
+    setOAuthClientFromJson: (raw: string) =>
+      googleClientManager.setOAuthClientFromJson(raw),
+    setServiceAccountFromFile: async () => {
+      const selection = await pickJsonFromLocalFilesystem()
+      if (!selection) {
+        const message = 'Google service account credential selection cancelled.'
+        emitLine(sendOutput, message)
+        return null
+      }
+      const config = googleClientManager.setOAuthClientFromJson(selection.text)
+      if (config.authFlow !== 'service_account') {
+        throw new Error(
+          `Selected JSON file (${selection.name}) did not contain Google service account credentials.`
+        )
+      }
+      await ensureAccessToken?.({ interactive: false })
+      const message = `Loaded Google Drive service account credentials from ${selection.name}.`
+      emitLine(sendOutput, message)
+      return config
+    },
+    setServiceAccountFromFilePath: async (keyPath: string) => {
+      const selection = await readServiceAccountJsonFromLocalPath(keyPath)
+      const config = googleClientManager.setOAuthClientFromJson(selection.text)
+      if (config.authFlow !== 'service_account') {
+        throw new Error(
+          `Selected JSON file (${selection.name}) did not contain Google service account credentials.`
+        )
+      }
+      await ensureAccessToken?.({ interactive: false })
+      const message = `Loaded Google Drive service account credentials from ${keyPath}.`
+      emitLine(sendOutput, message)
+      return config
+    },
+    getDrivePickerConfig: () => googleClientManager.getDrivePickerConfig(),
+    setDrivePickerConfig: (
+      config: Partial<ReturnType<typeof googleClientManager.getDrivePickerConfig>>
+    ) => googleClientManager.setDrivePickerConfig(config),
+    help: () => {
+      const message = [
+        'googleClientManager.get()                         - Show Google Drive auth config',
+        'googleClientManager.setClientId(clientId)         - Set Google OAuth client ID',
+        'googleClientManager.setClientSecret(secret)       - Set Google OAuth client secret',
+        'googleClientManager.setAuthFlow(flow)             - Set implicit, pkce, or service_account',
+        'googleClientManager.setAuthUxMode(mode)           - Set popup, redirect, or new_tab',
+        'googleClientManager.setFromJson(jsonText)         - Load OAuth or service account JSON text',
+        'await googleClientManager.setServiceAccountFromFile() - Pick a local service account JSON key file',
+        'await googleClientManager.setServiceAccountFromFilePath(path) - Load a service account JSON key path from the dev server',
+      ].join('\n')
+      emitLine(sendOutput, message)
+      return message
+    },
+  }
+
   return {
     runme: runmeApi,
     notebooks: notebooksHelpers,
@@ -1194,25 +1397,7 @@ export function createAppJsGlobals({
         return message
       },
     },
-    googleClientManager: {
-      get: () => googleClientManager.getOAuthClient(),
-      setOAuthClient: (config: {
-        clientId?: string
-        clientSecret?: string
-        authFlow?: 'implicit' | 'pkce'
-        authUxMode?: 'popup' | 'redirect' | 'new_tab'
-      }) => googleClientManager.setOAuthClient(config),
-      setClientId: (clientId: string) =>
-        googleClientManager.setOAuthClient({ clientId }),
-      setClientSecret: (clientSecret: string) =>
-        googleClientManager.setClientSecret(clientSecret),
-      setAuthFlow: (authFlow: 'implicit' | 'pkce') =>
-        googleClientManager.setAuthFlow(authFlow),
-      setAuthUxMode: (authUxMode: 'popup' | 'redirect' | 'new_tab') =>
-        googleClientManager.setAuthUxMode(authUxMode),
-      setFromJson: (raw: string) =>
-        googleClientManager.setOAuthClientFromJson(raw),
-    },
+    googleClientManager: googleClientRuntimeApi,
     oidc: {
       get: () => oidcConfigManager.getConfig(),
       getRedirectURI: () => oidcConfigManager.getRedirectURI(),
@@ -1266,7 +1451,7 @@ export function createAppJsGlobals({
       },
     },
     credentials: {
-      google: googleClientManager,
+      google: googleClientRuntimeApi,
       oidc: oidcConfigManager,
       openai: {
         get: () => responsesDirect.getSnapshot(),

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -84,6 +84,60 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("uses shared drive name for shared drive root folder metadata", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        if (url.pathname === "/drive/v3/files/drive123") {
+          expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+          expect(url.searchParams.get("fields")).toBe(
+            "id,name,mimeType,parents,driveId",
+          );
+          return new Response(
+            JSON.stringify({
+              id: "drive123",
+              name: "Drive",
+              mimeType: "application/vnd.google-apps.folder",
+              driveId: "drive123",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        if (url.pathname === "/drive/v3/drives/drive123") {
+          expect(url.searchParams.get("fields")).toBe("id,name");
+          return new Response(
+            JSON.stringify({
+              id: "drive123",
+              name: "runme-testing",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        throw new Error(`Unexpected Drive request: ${url.toString()}`);
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.getMetadata(
+      "https://drive.google.com/drive/folders/drive123",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      uri: "https://drive.google.com/drive/folders/drive123",
+      name: "runme-testing",
+      type: NotebookStoreItemType.Folder,
+      remoteUri: "https://drive.google.com/drive/folders/drive123",
+    });
+  });
+
   it("creates Drive folders with the folder MIME type", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -34,7 +34,13 @@ export type DriveDoc = {
   name?: string
   mimeType?: string
   parents?: string[]
+  driveId?: string
   content?: string
+}
+
+type Drive = {
+  id?: string
+  name?: string
 }
 
 type GapiDriveFileMethods = {
@@ -42,6 +48,10 @@ type GapiDriveFileMethods = {
   update: (request: Record<string, unknown>) => Promise<unknown>
   get: (request: Record<string, unknown>) => Promise<unknown>
   list: (request: Record<string, unknown>) => Promise<unknown>
+}
+
+type GapiDriveMethods = {
+  get: (request: Record<string, unknown>) => Promise<unknown>
 }
 
 type GapiDriveRevisionMethods = {
@@ -65,6 +75,7 @@ interface GapiGlobal {
     getToken?: () => { access_token?: string } | null
     drive: {
       files: GapiDriveFileMethods
+      drives: GapiDriveMethods
       revisions: GapiDriveRevisionMethods
     }
     request: (args: GapiRequestArgs) => Promise<unknown>
@@ -73,6 +84,7 @@ interface GapiGlobal {
 
 type DriveCreateResponse = { result?: DriveDoc }
 type DriveUpdateResponse = { result?: DriveDoc }
+type DriveGetResponse = { result?: Drive }
 type DriveListResponse = { result?: { files?: DriveDoc[] } }
 type DriveRevisionListResponse = {
   result?: { revisions?: DriveRevision[]; nextPageToken?: string }
@@ -84,6 +96,7 @@ interface DriveFilesClient {
   get(
     request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }>
+  getDrive(request: Record<string, unknown>): Promise<DriveGetResponse>
   list(request: Record<string, unknown>): Promise<DriveListResponse>
   listRevisions(
     request: Record<string, unknown>
@@ -96,10 +109,12 @@ interface DriveFilesClient {
 
 class GapiDriveFilesClient implements DriveFilesClient {
   private readonly files: GapiDriveFileMethods
+  private readonly drives: GapiDriveMethods
   private readonly revisions: GapiDriveRevisionMethods
 
   constructor(private readonly gapi: GapiGlobal) {
     this.files = this.gapi.client.drive.files
+    this.drives = this.gapi.client.drive.drives
     this.revisions = this.gapi.client.drive.revisions
   }
 
@@ -205,6 +220,10 @@ class GapiDriveFilesClient implements DriveFilesClient {
 
   list(request: Record<string, unknown>): Promise<DriveListResponse> {
     return this.files.list(request as any) as Promise<DriveListResponse>
+  }
+
+  getDrive(request: Record<string, unknown>): Promise<DriveGetResponse> {
+    return this.drives.get(request as any) as Promise<DriveGetResponse>
   }
 
   listRevisions(
@@ -397,6 +416,15 @@ class FetchDriveFilesClient implements DriveFilesClient {
     return this.request('GET', '/drive/v3/files', {
       params: request,
     }) as Promise<DriveListResponse>
+  }
+
+  getDrive(request: Record<string, unknown>): Promise<DriveGetResponse> {
+    const driveId = String(request.driveId ?? '')
+    return this.request(
+      'GET',
+      `/drive/v3/drives/${encodeURIComponent(driveId)}`,
+      { params: request }
+    ) as Promise<DriveGetResponse>
   }
 
   listRevisions(
@@ -1099,14 +1127,27 @@ export class DriveNotebookStore {
     const response = await client.get({
       fileId: id,
       supportsAllDrives: true,
-      fields: 'id,name,mimeType,parents',
+      fields: 'id,name,mimeType,parents,driveId',
     })
     const result = response.result as {
       name?: string
       mimeType?: string
       parents?: string[]
+      driveId?: string
     }
     const isFolder = result?.mimeType === DRIVE_FOLDER_MIME_TYPE
+    let displayName = result?.name
+    if (isFolder && result?.driveId === id && result.name === 'Drive') {
+      try {
+        const driveResponse = await client.getDrive({
+          driveId: id,
+          fields: 'id,name',
+        })
+        displayName = driveResponse.result?.name ?? displayName
+      } catch (error) {
+        console.error('Failed to resolve shared Drive name', error)
+      }
+    }
     const resolvedType = isFolder
       ? NotebookStoreItemType.Folder
       : NotebookStoreItemType.File
@@ -1123,7 +1164,7 @@ export class DriveNotebookStore {
     })
     return {
       uri,
-      name: result?.name ?? uri,
+      name: displayName ?? uri,
       type: resolvedType,
       children: [],
       remoteUri: uri,

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -80,6 +80,39 @@ function notebookJson(value: string): string {
 }
 
 describe('LocalNotebooks pending Drive create', () => {
+  it('upgrades a legacy Drive placeholder folder to the remote folder name', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: parentRemoteUri,
+        name: 'runme testing',
+        type: NotebookStoreItemType.Folder,
+        children: [],
+        remoteUri: parentRemoteUri,
+        parents: [],
+      })),
+      list: vi.fn(async () => []),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/drive',
+      name: 'Drive',
+      remoteId: parentRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+
+    await store.updateFolder(parentRemoteUri)
+
+    expect(driveStore.getMetadata).toHaveBeenCalledWith(parentRemoteUri)
+    await expect(store.folders.get('local://folder/drive')).resolves.toMatchObject(
+      {
+        name: 'runme testing',
+        remoteId: parentRemoteUri,
+      }
+    )
+  })
+
   it('creates a Drive-backed folder and attaches it locally', async () => {
     const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
     const childRemoteUri = 'https://drive.google.com/drive/folders/child123'

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -441,7 +441,12 @@ export class LocalNotebooks extends Dexie {
     // When callers don't provide a name, resolve the remote folder metadata so
     // new mounts use the human-readable Drive name instead of an id-derived
     // fallback. If an existing record still has that fallback name, upgrade it.
-    if (!name && (!existingFolder || existingFolder.name === fallbackName)) {
+    if (
+      !name &&
+      (!existingFolder ||
+        existingFolder.name === fallbackName ||
+        existingFolder.name === 'Drive')
+    ) {
       try {
         const metadata = await this.driveStore.getMetadata(remoteUri)
         const remoteName = metadata?.name?.trim()

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -1,5 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { defineConfig } from "vite";
 import svgr from "vite-plugin-svgr";
 
@@ -7,6 +9,59 @@ const backendProxyTarget =
   process.env.VITE_BACKEND_PROXY_TARGET ??
   process.env.CUJ_BACKEND_URL ??
   "http://127.0.0.1:9977";
+const LOCAL_SERVICE_ACCOUNT_KEY_ENDPOINT =
+  "/__runme-dev/service-account-key";
+const MAX_LOCAL_KEY_BYTES = 1024 * 1024;
+
+function localServiceAccountKeyPlugin() {
+  return {
+    name: "runme-local-service-account-key",
+    configureServer(server) {
+      server.middlewares.use(
+        LOCAL_SERVICE_ACCOUNT_KEY_ENDPOINT,
+        async (req, res) => {
+          try {
+            const requestUrl = new URL(
+              req.url ?? "",
+              "http://localhost",
+            );
+            const rawPath = requestUrl.searchParams.get("path") ?? "";
+            if (!rawPath || !path.isAbsolute(rawPath)) {
+              res.statusCode = 400;
+              res.end("Expected absolute service account JSON path.");
+              return;
+            }
+            if (path.extname(rawPath).toLowerCase() !== ".json") {
+              res.statusCode = 400;
+              res.end("Service account key path must end in .json.");
+              return;
+            }
+
+            const text = await readFile(rawPath, "utf8");
+            if (Buffer.byteLength(text, "utf8") > MAX_LOCAL_KEY_BYTES) {
+              res.statusCode = 413;
+              res.end("Service account key file is too large.");
+              return;
+            }
+            JSON.parse(text);
+
+            res.setHeader("Content-Type", "application/json");
+            res.end(
+              JSON.stringify({
+                name: path.basename(rawPath),
+                path: rawPath,
+                text,
+              }),
+            );
+          } catch (error) {
+            res.statusCode = 500;
+            res.end(`Failed to read service account key: ${String(error)}`);
+          }
+        },
+      );
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -20,6 +75,7 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
+    localServiceAccountKeyPlugin(),
     svgr({
       // Copied options from UIKit
       svgrOptions: {

--- a/docs-dev/design/20260613_drive_service_account_auth.md
+++ b/docs-dev/design/20260613_drive_service_account_auth.md
@@ -1,0 +1,164 @@
+# Google Drive Service Account Auth
+
+## Status
+
+Implemented for local and automated testing.
+
+## Motivation
+
+Automated browser tests need Google Drive access without a human OAuth consent
+flow. A Google Cloud service account can be granted access only to test Drive
+folders, which limits the blast radius compared with using a developer's
+personal Google account.
+
+## Verification
+
+Google supports service-account OAuth for server-to-server calls. The service
+account signs a JWT assertion with its private key, exchanges that assertion at
+Google's OAuth token endpoint, and uses the returned access token as a bearer
+token for Google APIs:
+
+- https://developers.google.com/identity/protocols/oauth2/service-account
+
+Google Drive access still follows Drive ACLs. Files, folders, and shared drives
+have permission resources, and the authenticated principal only gets the roles
+granted to that principal or inherited from a parent:
+
+- https://developers.google.com/workspace/drive/api/guides/manage-sharing
+- https://developers.google.com/drive/api/guides/about-files
+
+That means a service account works for Drive when one of these is true:
+
+- the target My Drive folder/file is shared with the service account email,
+- the target shared drive grants the service account membership or folder
+  access,
+- or a Google Workspace admin grants domain-wide delegation and the JWT includes
+  a delegated user subject.
+
+For test isolation, the preferred model is to create a dedicated folder or shared
+drive for test fixtures and share only that location with the service account.
+
+## Decision
+
+Add a third Google Drive auth flow:
+
+```yaml
+googleDrive:
+  authFlow: "service_account"
+  serviceAccount:
+    client_email: "runme-drive-test@project.iam.gserviceaccount.com"
+    private_key_id: "..."
+    private_key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
+
+The browser app mints short-lived OAuth access tokens from the service-account
+credentials using Web Crypto and Google's JWT bearer grant. The existing
+`DriveNotebookStore` does not change because it already only needs a bearer
+token callback.
+
+For manual local setup, the App Console exposes:
+
+```js
+await credentials.google.setServiceAccountFromFile()
+await credentials.google.setServiceAccountFromFilePath(
+  "/Users/jlewi/secrets/aisre-gdrive-oai-test-8ba1a40f228e.json"
+)
+```
+
+`setServiceAccountFromFile()` opens a browser file picker, reads a local
+service-account JSON key file, and applies it through the same parser used by
+app config.
+
+`setServiceAccountFromFilePath(path)` is only available behind the local Vite
+dev server. It asks the dev server to read an absolute `.json` path because
+browser JavaScript cannot read arbitrary local paths by itself.
+
+This is not a production browser-auth recommendation. Supplying a private key to
+browser JavaScript exposes that key to anyone who can read the page, local
+storage, config response, devtools, or test logs. The supported use case is
+local/CI test automation with a tightly scoped service account and disposable
+test Drive resources. A production deployment should mint the access token on a
+trusted server and send only the short-lived token to the browser.
+
+## Token Flow
+
+1. Runtime config selects `googleDrive.authFlow: service_account`.
+2. `GoogleAuthProvider.ensureAccessToken()` checks the cached access token.
+3. If no valid token exists, the provider builds a JWT:
+   - header: `alg=RS256`, `typ=JWT`, optional `kid`,
+   - claims: `iss`, `scope`, `aud`, `iat`, `exp`, optional `sub`,
+   - signature: RSA SHA-256 over the base64url header and claims.
+4. The provider POSTs the assertion to `token_uri` or
+   `https://oauth2.googleapis.com/token`.
+5. The returned access token is cached with the same expiry handling as normal
+   Drive OAuth tokens.
+6. Existing Drive REST/gapi clients use the bearer token unchanged.
+
+## Scope And Permissions
+
+By default the flow uses the app's current Drive scopes:
+
+- `https://www.googleapis.com/auth/drive`
+- `https://www.googleapis.com/auth/drive.install`
+
+Tests can override scopes:
+
+```yaml
+googleDrive:
+  authFlow: "service_account"
+  serviceAccount:
+    client_email: "runme-drive-test@project.iam.gserviceaccount.com"
+    private_key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+```
+
+For domain-wide delegation, set `subject` to the user being impersonated:
+
+```yaml
+googleDrive:
+  authFlow: "service_account"
+  serviceAccount:
+    client_email: "runme-drive-test@project.iam.gserviceaccount.com"
+    private_key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+    subject: "test-user@example.com"
+```
+
+## Alternatives Considered
+
+### Put private keys into the existing OAuth client secret field
+
+Rejected. OAuth client secrets and service-account private keys represent
+different credential types and need different token grants. Overloading the
+field would make config validation and troubleshooting unclear.
+
+### Require a backend token broker first
+
+Deferred. A broker is the right production shape, but local browser tests can
+move now with a clearly test-only service-account flow. The Drive store boundary
+still accepts a token callback, so a broker can be added later without changing
+Drive operations.
+
+### Use signed JWT directly as the Drive bearer token
+
+Rejected for this implementation. Google's service-account docs say some Google
+APIs support direct JWT bearer calls, but the standard and broadly compatible
+path is to exchange the JWT for an OAuth access token first.
+
+## Test Plan
+
+- Unit-test JWT construction from a generated RSA key.
+- Unit-test JWT bearer token exchange request shape.
+- Unit-test app-config parsing for `authFlow: service_account`.
+- Unit-test `GoogleAuthProvider.ensureAccessToken({ interactive: false })` so it
+  mints a service-account token without opening OAuth UI.
+- Run `runme run build test` before merging.

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -52,6 +52,10 @@ Meaning:
 
 - `authFlow: "implicit"` asks Google for an access token directly in the browser.
 - `authFlow: "pkce"` uses the authorization-code flow and exchanges the code after the callback.
+- `authFlow: "service_account"` mints short-lived OAuth access tokens from a
+  Google Cloud service account private key. Use this only for local or automated
+  testing with tightly scoped Drive folders; do not ship browser deployments
+  that expose production private keys.
 - `authUxMode: "popup"` uses the Google Identity Services popup flow.
 - `authUxMode: "redirect"` redirects the current tab to Google and back.
 - `authUxMode: "new_tab"` opens the Drive auth flow in a separate tab and is the default.
@@ -60,7 +64,23 @@ Recommended defaults:
 
 - Use `implicit` + `new_tab` for the least disruptive browser UX.
 - Use `pkce` + `new_tab` when you want authorization-code flow semantics but still want to avoid taking over the current tab.
+- Use `service_account` for automated tests that need Drive access without human
+  consent. Share the target test Drive folder with the service account email.
 - Use `redirect` only when you explicitly want the current tab to navigate through the OAuth flow.
+
+Service account example:
+
+```yaml
+googleDrive:
+  authFlow: "service_account"
+  serviceAccount:
+    client_email: "<service-account>@<project>.iam.gserviceaccount.com"
+    private_key_id: "<key-id>"
+    private_key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
 
 ## Useful App Console commands
 

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -85,6 +85,8 @@ oidc.setGoogleDefaults()
 oidc.setClientToDrive()
 credentials.google.setClientId('...')
 credentials.google.setClientSecret('...')
+await credentials.google.setServiceAccountFromFile()
+await credentials.google.setServiceAccountFromFilePath('/Users/jlewi/secrets/aisre-gdrive-oai-test-8ba1a40f228e.json')
 ```
 
 Start or refresh Google Drive OAuth:

--- a/docs/14-authentication-and-app-configuration.md
+++ b/docs/14-authentication-and-app-configuration.md
@@ -33,6 +33,8 @@ credentials.google.setAuthUxMode("redirect") // or "popup"
 await drive.authorize()
 await drive.refreshAuth()
 await app.startGoogleDriveOAuth()
+await credentials.google.setServiceAccountFromFile()
+await credentials.google.setServiceAccountFromFilePath("/Users/jlewi/secrets/aisre-gdrive-oai-test-8ba1a40f228e.json")
 ```
 
 `drive.authorize()` and `app.startGoogleDriveOAuth()` both start a new Google
@@ -43,6 +45,33 @@ recovery path when stale OAuth state prevents the Drive auth button from
 launching a new flow.
 
 `drive.refreshAuth()` is an alias for `drive.authorize()`.
+
+## Google Drive service-account auth
+
+For automated tests, app config can select service-account Drive auth:
+
+```yaml
+googleDrive:
+  authFlow: "service_account"
+  serviceAccount:
+    client_email: "<service-account>@<project>.iam.gserviceaccount.com"
+    private_key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
+
+This is intended for local/CI testing with a service account shared only into
+test Drive folders. Do not expose production service-account keys to browser
+deployments.
+
+`setServiceAccountFromFile()` opens a browser file picker and reads a local
+service-account JSON key file. Browser JavaScript cannot read arbitrary local
+filesystem paths directly.
+
+`setServiceAccountFromFilePath(path)` is available when the app is served by the
+local Vite dev server. It asks the dev server to read an absolute `.json` path,
+so it is intended for local automation only.
 
 ## App config helpers
 


### PR DESCRIPTION
## Summary

Adds Google Drive service-account authentication for automated tests and local Codex workflows. The app can mint Google OAuth access tokens from a service-account JSON key using the JWT bearer grant while preserving the existing Drive store token callback boundary.

## What changed

- Added WebCrypto-based service-account JWT creation and token exchange.
- Extended Google Drive auth config with service_account credential parsing.
- Added App Console helpers to load service-account credentials from a picked JSON file or a local dev-server absolute path.
- Added a Vite dev-server-only endpoint for local key-file loading during automation.
- Fixed shared-drive root folder labels so shared drives display the actual drive name instead of Google’s generic Drive root folder name.
- Documented the design, configuration, helper methods, and test-only security model.

## Review notes

During local review I fixed two follow-up issues:

- Avoid persisting an unusable service_account auth mode without the private key after reload.
- Clear in-memory service-account credentials when switching back to an OAuth flow.

## Validation

- pnpm -C app exec tsc --noEmit
- pnpm -C app exec vitest run src/lib/googleClientManager.test.ts src/lib/appConfig.test.ts src/contexts/GoogleAuthContext.test.tsx src/auth/googleServiceAccount.test.ts src/lib/runtime/appJsGlobals.test.ts src/storage/drive.test.ts src/storage/local.test.ts
- runme run build test
- IAB smoke test with /Users/jlewi/secrets/aisre-gdrive-oai-test-8ba1a40f228e.json: mounted shared Drive folder, created hello-world.json, and verified Drive status showed syncing.
- Direct Drive API check confirmed files.get returns Drive for shared-drive root 0AMdUS1hL9Av2Uk9PVA, while drives.get returns runme-testing; IAB then showed runme-testing after the metadata fix.