### PR TITLE
[codex] Expose notebook owner session in tabs

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -9,6 +9,7 @@ import {
 
 import { parser_pb, RunmeMetadataKey } from '../../runme/client'
 import type { CellData } from '../../lib/notebookData'
+import type { NotebookOwnershipRecord } from '../../lib/tabCoordination/notebookOwnership'
 import { computeNotebookDiff } from '../../lib/notebookDiff/diff'
 import {
   getNotebookDiffDocumentUri,
@@ -24,6 +25,7 @@ const contextMocks = vi.hoisted(() => ({
     requestedUri?: string
     state?: 'loading' | 'loaded' | 'blocked' | 'error'
     readOnly?: boolean
+    owner?: NotebookOwnershipRecord | null
   }>,
   currentDoc: null as string | null,
   setCurrentDoc: vi.fn(),
@@ -293,6 +295,15 @@ describe('Actions tabs', () => {
 
   it('marks read-only notebook tabs and content clearly', () => {
     const uri = 'local://file/reference.runme.md'
+    const owner: NotebookOwnershipRecord = {
+      notebookUri: uri,
+      ownerTabId: 'tab-other',
+      ownerSessionId: 'calm-harbor',
+      ownerLabel: 'Other tab',
+      ownerUrl: 'http://localhost/?session=calm-harbor',
+      ownerStartedAt: '2026-05-22T12:00:00.000Z',
+      epoch: 'epoch-other',
+    }
     contextMocks.currentDoc = uri
     contextMocks.workspaceDocuments = [
       {
@@ -300,6 +311,7 @@ describe('Actions tabs', () => {
         title: 'reference.runme.md',
         state: 'loaded',
         readOnly: true,
+        owner,
       },
     ]
     contextMocks.notebookSnapshots.set(uri, {
@@ -319,8 +331,35 @@ describe('Actions tabs', () => {
     ).toBeGreaterThan(0)
     expect(
       screen.getByTestId('notebook-readonly-banner').textContent
-    ).toContain('Read-only')
+    ).toContain('session calm-harbor')
     expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
+  it('shows the owner session when a notebook is blocked by another tab', () => {
+    const uri = 'local://file/blocked.runme.md'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'blocked.runme.md',
+        state: 'blocked',
+        owner: {
+          notebookUri: uri,
+          ownerTabId: 'tab-other',
+          ownerSessionId: 'quiet-signal',
+          ownerLabel: 'Other tab',
+          ownerUrl: 'http://localhost/?session=quiet-signal',
+          ownerStartedAt: '2026-05-22T12:00:00.000Z',
+          epoch: 'epoch-other',
+        },
+      },
+    ]
+
+    render(<Actions />)
+
+    expect(screen.getByTestId('notebook-blocked-state').textContent).toContain(
+      'Open in session: quiet-signal'
+    )
   })
 
   it('shows Drive syncing state instead of empty notebook prompt', async () => {
@@ -469,7 +508,7 @@ describe('Actions tabs', () => {
 
     render(<Actions />)
 
-    fireEvent.contextMenu(screen.getByRole('tab', { name: 'restored.json' }))
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /restored\.json/ }))
     fireEvent.click(await screen.findByRole('button', { name: 'Rename' }))
 
     await waitFor(() => {
@@ -532,6 +571,46 @@ describe('Actions tabs', () => {
         '[202602a_tb_aws_codex_136](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV%2Fview)'
       )
     })
+  })
+
+  it('copies the owner session id from a read-only tab context menu', async () => {
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    const uri = 'local://file/restored'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'restored.json',
+        readOnly: true,
+        owner: {
+          notebookUri: uri,
+          ownerTabId: 'tab-other',
+          ownerSessionId: 'silver-river',
+          ownerLabel: 'Other tab',
+          ownerUrl: 'http://localhost/?session=silver-river',
+          ownerStartedAt: '2026-05-22T12:00:00.000Z',
+          epoch: 'epoch-other',
+        },
+      },
+    ]
+
+    render(<Actions />)
+
+    await act(async () => {
+      fireEvent.contextMenu(screen.getByRole('tab', { name: /restored\.json/ }))
+    })
+    const copyOwnerSessionButton = await screen.findByRole('button', {
+      name: 'Copy Owner Session ID',
+    })
+    await act(async () => {
+      fireEvent.click(copyOwnerSessionButton)
+    })
+
+    expect(writeText).toHaveBeenCalledWith('silver-river')
   })
 
   it('opens a conflict diff from the notebook sync indicator', async () => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -18,6 +18,7 @@ import { MimeType, RunmeMetadataKey, parser_pb } from '../../runme/client'
 import { CellData } from '../../lib/notebookData'
 import { useNotebookContext } from '../../contexts/NotebookContext'
 import type { OpenNotebookEntry } from '../../lib/notebookDataController'
+import type { NotebookOwnershipRecord } from '../../lib/tabCoordination/notebookOwnership'
 import { useNotebookStore } from '../../contexts/NotebookStoreContext'
 import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
 import { useOutput } from '../../contexts/OutputContext'
@@ -117,6 +118,26 @@ TabPanel.displayName = 'TabPanel'
 
 function getNotebookDisplayName(uri: string, name?: string): string {
   return name || uri.split('/').filter(Boolean).pop() || uri
+}
+
+// Ownership records created before ownerSessionId existed can still be active
+// in IndexedDB, so UI reads the explicit field first and falls back to the URL.
+function getNotebookOwnerSessionId(
+  owner: NotebookOwnershipRecord | null | undefined
+): string | null {
+  const explicitSession = owner?.ownerSessionId?.trim()
+  if (explicitSession) {
+    return explicitSession
+  }
+  const ownerUrl = owner?.ownerUrl?.trim()
+  if (!ownerUrl) {
+    return null
+  }
+  try {
+    return new URL(ownerUrl).searchParams.get('session')?.trim() || null
+  } catch {
+    return null
+  }
 }
 
 function syncIndicatorPresentation(state: NotebookSyncState | null): {
@@ -1740,6 +1761,7 @@ function NotebookTabContent({
   }
 
   if (entry.state === 'blocked') {
+    const ownerSessionId = getNotebookOwnerSessionId(entry.owner)
     const ownerText = entry.owner?.ownerStartedAt
       ? `Tab opened at ${new Date(entry.owner.ownerStartedAt).toLocaleTimeString()}`
       : 'Another browser tab'
@@ -1758,6 +1780,11 @@ function NotebookTabContent({
           <Text size="2" as="p">
             Owned by: {ownerText}
           </Text>
+          {ownerSessionId && (
+            <Text size="2" as="p">
+              Open in session: {ownerSessionId}
+            </Text>
+          )}
           <Text size="2" as="p">
             Close this notebook in the other tab, then retry here.
           </Text>
@@ -1802,6 +1829,7 @@ function NotebookTabContent({
   }
 
   const data = getNotebookData(notebookSnapshot.uri)
+  const ownerSessionId = getNotebookOwnerSessionId(entry.owner)
 
   if (
     cellDatas.length === 0 &&
@@ -1829,8 +1857,9 @@ function NotebookTabContent({
           >
             <LockClosedIcon className="h-4 w-4 text-nb-text-muted" />
             <span>
-              Read-only. This notebook is open for editing in another browser
-              tab.
+              {ownerSessionId
+                ? `Read-only. This notebook is open for editing in session ${ownerSessionId}.`
+                : 'Read-only. This notebook is open for editing in another browser tab.'}
             </span>
           </div>
         )}
@@ -2042,6 +2071,7 @@ export default function Actions() {
     title: string
     shareableUri: string
     googleDriveUri: string | null
+    ownerSessionId: string | null
     readOnly?: boolean
   } | null>(null)
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -2282,7 +2312,10 @@ export default function Actions() {
     if (typeof window === 'undefined') {
       return tabContextMenu
     }
-    const itemCount = tabContextMenu.googleDriveUri ? 5 : 4
+    const itemCount =
+      4 +
+      (tabContextMenu.googleDriveUri ? 1 : 0) +
+      (tabContextMenu.ownerSessionId ? 1 : 0)
     const menuWidth = 220
     const menuHeight = itemCount * 36 + 8
     return {
@@ -2310,6 +2343,7 @@ export default function Actions() {
         title,
         shareableUri: docUri,
         googleDriveUri: isGoogleDriveFileUri(docUri) ? docUri : null,
+        ownerSessionId: getNotebookOwnerSessionId(document?.owner),
         readOnly: document?.readOnly,
       })
 
@@ -2453,6 +2487,34 @@ export default function Actions() {
           scope: 'storage.local',
           code: 'TAB_COPY_LOCAL_URI_FAILED',
           uri: tabContextMenu.docUri,
+          error: String(error),
+        },
+      })
+    } finally {
+      setTabContextMenu(null)
+    }
+  }, [tabContextMenu])
+
+  const handleCopyTabOwnerSessionId = useCallback(async () => {
+    if (!tabContextMenu?.ownerSessionId) {
+      setTabContextMenu(null)
+      return
+    }
+    try {
+      if (
+        typeof window === 'undefined' ||
+        !window.navigator?.clipboard?.writeText
+      ) {
+        throw new Error('Clipboard access is unavailable in this browser')
+      }
+      await window.navigator.clipboard.writeText(tabContextMenu.ownerSessionId)
+    } catch (error) {
+      appLogger.error('Failed to copy owner session ID from tab context menu', {
+        attrs: {
+          scope: 'tab.owner-session',
+          code: 'TAB_COPY_OWNER_SESSION_ID_FAILED',
+          uri: tabContextMenu.docUri,
+          ownerSessionId: tabContextMenu.ownerSessionId,
           error: String(error),
         },
       })
@@ -2692,6 +2754,18 @@ export default function Actions() {
               >
                 Copy local URI
               </button>
+              {adjustedTabContextMenu.ownerSessionId && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleCopyTabOwnerSessionId()
+                  }}
+                >
+                  Copy Owner Session ID
+                </button>
+              )}
               {adjustedTabContextMenu.googleDriveUri && (
                 <button
                   type="button"

--- a/app/src/components/AppConsole/AppConsole.test.tsx
+++ b/app/src/components/AppConsole/AppConsole.test.tsx
@@ -77,6 +77,12 @@ vi.mock("../../contexts/NotebookStoreContext", () => ({
   }),
 }));
 
+vi.mock("../../contexts/GoogleAuthContext", () => ({
+  useGoogleAuth: () => ({
+    ensureAccessToken: vi.fn(async () => "token"),
+  }),
+}));
+
 vi.mock("../../lib/runtime/AppState", () => ({
   appState: {
     localNotebooks: null,

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -19,6 +19,11 @@ let runnersState: { name: string; endpoint: string; reconnect: boolean }[] = []
 let chatKitMountCount = 0
 let chatKitUnmountCount = 0
 const ensureAccessTokenMock = vi.fn(async () => 'token')
+const startGoogleDriveOAuthMock = vi.fn(async () => ({
+  status: 'started',
+  authFlow: 'popup',
+  mode: 'popup',
+}))
 const loginWithRedirectMock = vi.fn()
 const logoutMock = vi.fn()
 const togglePanelMock = vi.fn()
@@ -59,6 +64,7 @@ vi.mock('../../contexts/CurrentDocContext', () => ({
 vi.mock('../../contexts/GoogleAuthContext', () => ({
   useGoogleAuth: () => ({
     ensureAccessToken: ensureAccessTokenMock,
+    startGoogleDriveOAuth: startGoogleDriveOAuthMock,
     isDriveSyncing,
   }),
 }))
@@ -99,6 +105,7 @@ describe('SidePanelToolbar drive status button', () => {
     chatKitMountCount = 0
     chatKitUnmountCount = 0
     ensureAccessTokenMock.mockClear()
+    startGoogleDriveOAuthMock.mockClear()
     loginWithRedirectMock.mockClear()
     logoutMock.mockClear()
     togglePanelMock.mockClear()
@@ -124,9 +131,8 @@ describe('SidePanelToolbar drive status button', () => {
       fireEvent.click(driveStatusButton)
       await Promise.resolve()
     })
-    expect(ensureAccessTokenMock).toHaveBeenCalledWith({
-      interactive: true,
-    })
+    expect(startGoogleDriveOAuthMock).toHaveBeenCalledWith()
+    expect(ensureAccessTokenMock).not.toHaveBeenCalled()
     expect(showDocumentMock).not.toHaveBeenCalled()
     expect(setCurrentDocMock).not.toHaveBeenCalled()
   })
@@ -151,6 +157,7 @@ describe('SidePanelToolbar drive status button', () => {
     })
     expect(setCurrentDocMock).toHaveBeenCalledWith('status://drive-sync')
     expect(ensureAccessTokenMock).not.toHaveBeenCalled()
+    expect(startGoogleDriveOAuthMock).not.toHaveBeenCalled()
   })
 
   it('opens sync status from the Drive status keyboard menu', () => {
@@ -170,6 +177,7 @@ describe('SidePanelToolbar drive status button', () => {
     })
     expect(setCurrentDocMock).toHaveBeenCalledWith('status://drive-sync')
     expect(ensureAccessTokenMock).not.toHaveBeenCalled()
+    expect(startGoogleDriveOAuthMock).not.toHaveBeenCalled()
   })
 
   it('dismisses the Drive status context menu when clicking away', () => {

--- a/app/src/lib/tabCoordination/notebookOwnership.test.ts
+++ b/app/src/lib/tabCoordination/notebookOwnership.test.ts
@@ -1,194 +1,203 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __resetTabIdForTests } from '../tabIdentity'
+import { NotebookOwnershipManager } from './notebookOwnership'
 
 const dexieState = vi.hoisted(() => ({
   databases: new Map<string, Map<string, unknown>>(),
-}));
+}))
 
-vi.mock("dexie", () => {
+vi.mock('dexie', () => {
   class MockDexie {
-    private readonly databaseName: string;
+    private readonly databaseName: string
 
     constructor(databaseName: string) {
-      this.databaseName = databaseName;
+      this.databaseName = databaseName
     }
 
     version() {
       return {
         stores: () => this,
-      };
+      }
     }
 
     table() {
-      let records = dexieState.databases.get(this.databaseName);
+      let records = dexieState.databases.get(this.databaseName)
       if (!records) {
-        records = new Map<string, unknown>();
-        dexieState.databases.set(this.databaseName, records);
+        records = new Map<string, unknown>()
+        dexieState.databases.set(this.databaseName, records)
       }
       return {
         put: async (record: { notebookUri: string }) => {
-          records.set(record.notebookUri, record);
+          records.set(record.notebookUri, record)
         },
         get: async (notebookUri: string) => records.get(notebookUri),
         delete: async (notebookUri: string) => {
-          records.delete(notebookUri);
+          records.delete(notebookUri)
         },
-      };
+      }
     }
 
     close() {}
   }
 
-  return { default: MockDexie };
-});
+  return { default: MockDexie }
+})
 
-import { NotebookOwnershipManager } from "./notebookOwnership";
+type LockCallback = (
+  lock: { name: string } | null
+) => Promise<unknown> | unknown
 
-type LockCallback = (lock: { name: string } | null) => Promise<unknown> | unknown;
-
-const heldLocks = new Map<string, Promise<unknown>>();
+const heldLocks = new Map<string, Promise<unknown>>()
 
 function installFakeWebLocks(): void {
-  Object.defineProperty(navigator, "locks", {
+  Object.defineProperty(navigator, 'locks', {
     configurable: true,
     value: {
       request: vi.fn(
         async (
           name: string,
           options: { ifAvailable?: boolean },
-          callback: LockCallback,
+          callback: LockCallback
         ) => {
           if (heldLocks.has(name) && options.ifAvailable) {
-            return callback(null);
+            return callback(null)
           }
           const result = Promise.resolve(callback({ name })).finally(() => {
-            heldLocks.delete(name);
-          });
-          heldLocks.set(name, result);
-          return result;
-        },
+            heldLocks.delete(name)
+          })
+          heldLocks.set(name, result)
+          return result
+        }
       ),
     },
-  });
+  })
 }
 
-async function flushReleasedLock(): Promise<void> {
+async function flushReleasedNotebookLocks(): Promise<void> {
   await vi.waitFor(() => {
-    expect(heldLocks.size).toBe(0);
-  });
+    expect(
+      Array.from(heldLocks.keys()).filter((name) =>
+        name.startsWith('runme:notebook:')
+      )
+    ).toEqual([])
+  })
 }
 
-describe("NotebookOwnershipManager", () => {
+describe('NotebookOwnershipManager', () => {
   beforeEach(() => {
-    dexieState.databases.clear();
-    heldLocks.clear();
-    installFakeWebLocks();
-    document.title = "Runme Test";
-    window.history.replaceState(null, "", "/notebooks");
-  });
+    __resetTabIdForTests()
+    dexieState.databases.clear()
+    heldLocks.clear()
+    installFakeWebLocks()
+    document.title = 'Runme Test'
+    window.history.replaceState(null, '', '/notebooks')
+  })
 
-  it("returns unsupported when Web Locks are unavailable", async () => {
-    Object.defineProperty(navigator, "locks", {
+  it('returns unsupported when Web Locks are unavailable', async () => {
+    Object.defineProperty(navigator, 'locks', {
       configurable: true,
       value: undefined,
-    });
+    })
     const manager = new NotebookOwnershipManager({
-      dbName: "unsupported-test",
-      tabId: "tab-a",
-    });
+      dbName: 'unsupported-test',
+      tabId: 'tab-a',
+    })
 
-    await expect(manager.acquire("local://file/a")).resolves.toEqual({
-      status: "unsupported",
-      reason: "web_locks_unavailable",
-    });
+    await expect(manager.acquire('local://file/a')).resolves.toEqual({
+      status: 'unsupported',
+      reason: 'web_locks_unavailable',
+    })
 
-    manager.dispose();
-  });
+    manager.dispose()
+  })
 
-  it("blocks another tab while a notebook lock is held", async () => {
+  it('blocks another tab while a notebook lock is held', async () => {
     const first = new NotebookOwnershipManager({
-      dbName: "blocked-test",
-      tabId: "tab-a",
-    });
+      dbName: 'blocked-test',
+      tabId: 'tab-a',
+    })
     const second = new NotebookOwnershipManager({
-      dbName: "blocked-test",
-      tabId: "tab-b",
-    });
+      dbName: 'blocked-test',
+      tabId: 'tab-b',
+    })
 
-    const acquired = await first.acquire("local://file/a");
-    expect(acquired.status).toBe("acquired");
-    const blocked = await second.acquire("local://file/a");
+    const acquired = await first.acquire('local://file/a')
+    expect(acquired.status).toBe('acquired')
+    const blocked = await second.acquire('local://file/a')
 
-    expect(blocked.status).toBe("blocked");
-    if (blocked.status === "blocked") {
+    expect(blocked.status).toBe('blocked')
+    if (blocked.status === 'blocked') {
       expect(blocked.owner).toEqual(
         expect.objectContaining({
-          notebookUri: "local://file/a",
-          ownerTabId: "tab-a",
-          ownerLabel: "Runme Test",
-        }),
-      );
+          notebookUri: 'local://file/a',
+          ownerTabId: 'tab-a',
+          ownerSessionId: expect.any(String),
+          ownerLabel: 'Runme Test',
+        })
+      )
     }
 
-    if (acquired.status === "acquired") {
-      acquired.lease.release();
+    if (acquired.status === 'acquired') {
+      acquired.lease.release()
     }
-    await flushReleasedLock();
-    first.dispose();
-    second.dispose();
-  });
+    await flushReleasedNotebookLocks()
+    first.dispose()
+    second.dispose()
+  })
 
-  it("releases ownership so another tab can acquire the notebook", async () => {
+  it('releases ownership so another tab can acquire the notebook', async () => {
     const first = new NotebookOwnershipManager({
-      dbName: "release-test",
-      tabId: "tab-a",
-    });
+      dbName: 'release-test',
+      tabId: 'tab-a',
+    })
     const second = new NotebookOwnershipManager({
-      dbName: "release-test",
-      tabId: "tab-b",
-    });
+      dbName: 'release-test',
+      tabId: 'tab-b',
+    })
 
-    const acquired = await first.acquire("local://file/a");
-    expect(acquired.status).toBe("acquired");
-    if (acquired.status === "acquired") {
-      acquired.lease.release();
+    const acquired = await first.acquire('local://file/a')
+    expect(acquired.status).toBe('acquired')
+    if (acquired.status === 'acquired') {
+      acquired.lease.release()
     }
-    await flushReleasedLock();
+    await flushReleasedNotebookLocks()
 
-    const reacquired = await second.acquire("local://file/a");
+    const reacquired = await second.acquire('local://file/a')
 
-    expect(reacquired.status).toBe("acquired");
-    if (reacquired.status === "acquired") {
-      reacquired.lease.release();
+    expect(reacquired.status).toBe('acquired')
+    if (reacquired.status === 'acquired') {
+      reacquired.lease.release()
     }
-    await flushReleasedLock();
-    first.dispose();
-    second.dispose();
-  });
+    await flushReleasedNotebookLocks()
+    first.dispose()
+    second.dispose()
+  })
 
-  it("does not report stale same-tab ownership after release starts", async () => {
+  it('does not report stale same-tab ownership after release starts', async () => {
     const manager = new NotebookOwnershipManager({
-      dbName: "stale-release-test",
-      tabId: "tab-a",
-    });
+      dbName: 'stale-release-test',
+      tabId: 'tab-a',
+    })
 
-    const acquired = await manager.acquire("local://file/a");
-    expect(acquired.status).toBe("acquired");
-    if (acquired.status !== "acquired") {
-      return;
+    const acquired = await manager.acquire('local://file/a')
+    expect(acquired.status).toBe('acquired')
+    if (acquired.status !== 'acquired') {
+      return
     }
 
-    acquired.lease.release();
+    acquired.lease.release()
 
-    const ownerCheck = acquired.lease.isCurrentOwner();
-    const reacquire = manager.acquire("local://file/a");
+    const ownerCheck = acquired.lease.isCurrentOwner()
+    const reacquire = manager.acquire('local://file/a')
 
-    await expect(ownerCheck).resolves.toBe(false);
+    await expect(ownerCheck).resolves.toBe(false)
     await expect(reacquire).resolves.toEqual(
-      expect.objectContaining({ status: "blocked" }),
-    );
+      expect.objectContaining({ status: 'blocked' })
+    )
 
-    await flushReleasedLock();
-    manager.dispose();
-  });
-});
+    await flushReleasedNotebookLocks()
+    manager.dispose()
+  })
+})

--- a/app/src/lib/tabCoordination/notebookOwnership.ts
+++ b/app/src/lib/tabCoordination/notebookOwnership.ts
@@ -1,69 +1,70 @@
-import Dexie, { type Table } from "dexie";
+import Dexie, { type Table } from 'dexie'
 
-import { getTabId } from "../tabIdentity";
+import { getClaimedSessionId, getTabId } from '../tabIdentity'
 
 export interface NotebookOwnershipRecord {
-  notebookUri: string;
-  ownerTabId: string;
-  ownerLabel: string;
-  ownerUrl: string;
-  ownerStartedAt: string;
-  epoch: string;
+  notebookUri: string
+  ownerTabId: string
+  ownerSessionId?: string
+  ownerLabel: string
+  ownerUrl: string
+  ownerStartedAt: string
+  epoch: string
 }
 
 export type AcquireResult =
-  | { status: "acquired"; lease: NotebookLease }
-  | { status: "blocked"; owner: NotebookOwnershipRecord | null }
-  | { status: "unsupported"; reason: "web_locks_unavailable" };
+  | { status: 'acquired'; lease: NotebookLease }
+  | { status: 'blocked'; owner: NotebookOwnershipRecord | null }
+  | { status: 'unsupported'; reason: 'web_locks_unavailable' }
 
 export interface NotebookLease {
-  notebookUri: string;
-  tabId: string;
-  epoch: string;
-  release(): void;
-  isCurrentOwner(): Promise<boolean>;
+  notebookUri: string
+  tabId: string
+  epoch: string
+  release(): void
+  isCurrentOwner(): Promise<boolean>
 }
 
 class NotebookOwnershipDatabase extends Dexie {
-  ownership!: Table<NotebookOwnershipRecord, string>;
+  ownership!: Table<NotebookOwnershipRecord, string>
 
-  constructor(databaseName = "runme-tab-coordination") {
-    super(databaseName);
+  constructor(databaseName = 'runme-tab-coordination') {
+    super(databaseName)
     this.version(1).stores({
-      ownership: "&notebookUri, ownerTabId, epoch",
-    });
-    this.ownership = this.table("ownership");
+      ownership: '&notebookUri, ownerTabId, epoch',
+    })
+    this.ownership = this.table('ownership')
   }
 }
 
 type HeldLease = {
-  record: NotebookOwnershipRecord;
-  release: () => void;
-};
+  record: NotebookOwnershipRecord
+  release: () => void
+}
 
 function buildLockName(notebookUri: string): string {
-  return `runme:notebook:${notebookUri}`;
+  return `runme:notebook:${notebookUri}`
 }
 
 function getOwnerLabel(): string {
-  if (typeof document === "undefined") {
-    return "Runme tab";
+  if (typeof document === 'undefined') {
+    return 'Runme tab'
   }
-  return document.title || "Runme tab";
+  return document.title || 'Runme tab'
 }
 
 function getOwnerUrl(): string {
-  if (typeof window === "undefined") {
-    return "";
+  if (typeof window === 'undefined') {
+    return ''
   }
-  return window.location.href;
+  return window.location.href
 }
 
 function hasWebLocks(): boolean {
   return (
-    typeof navigator !== "undefined" &&
-    typeof navigator.locks?.request === "function"
-  );
+    typeof navigator !== 'undefined' &&
+    typeof navigator.locks?.request === 'function'
+  )
 }
 
 /**
@@ -73,133 +74,134 @@ function hasWebLocks(): boolean {
  * blocked UI and are deliberately allowed to be stale.
  */
 export class NotebookOwnershipManager {
-  private readonly db: NotebookOwnershipDatabase;
-  private readonly tabId: string;
-  private readonly heldLeases = new Map<string, HeldLease>();
-  private readonly listeners = new Set<() => void>();
-  private readonly channel: BroadcastChannel | null;
+  private readonly db: NotebookOwnershipDatabase
+  private readonly tabId: string
+  private readonly heldLeases = new Map<string, HeldLease>()
+  private readonly listeners = new Set<() => void>()
+  private readonly channel: BroadcastChannel | null
 
   constructor(options?: { dbName?: string; tabId?: string }) {
-    this.db = new NotebookOwnershipDatabase(options?.dbName);
-    this.tabId = options?.tabId ?? getTabId();
+    this.db = new NotebookOwnershipDatabase(options?.dbName)
+    this.tabId = options?.tabId ?? getTabId()
     this.channel =
-      typeof BroadcastChannel === "function"
-        ? new BroadcastChannel("runme-notebook-ownership")
-        : null;
-    this.channel?.addEventListener("message", () => this.emit());
+      typeof BroadcastChannel === 'function'
+        ? new BroadcastChannel('runme-notebook-ownership')
+        : null
+    this.channel?.addEventListener('message', () => this.emit())
   }
 
   async acquire(notebookUri: string): Promise<AcquireResult> {
-    const existing = this.heldLeases.get(notebookUri);
+    const existing = this.heldLeases.get(notebookUri)
     if (existing) {
       return {
-        status: "acquired",
+        status: 'acquired',
         lease: this.createLease(existing.record),
-      };
+      }
     }
     if (!hasWebLocks()) {
-      return { status: "unsupported", reason: "web_locks_unavailable" };
+      return { status: 'unsupported', reason: 'web_locks_unavailable' }
     }
 
-    const lockName = buildLockName(notebookUri);
+    const lockName = buildLockName(notebookUri)
     return new Promise<AcquireResult>((resolve) => {
-      let settled = false;
+      let settled = false
       const settle = (result: AcquireResult) => {
         if (settled) {
-          return;
+          return
         }
-        settled = true;
-        resolve(result);
-      };
+        settled = true
+        resolve(result)
+      }
 
       void navigator.locks
         .request(lockName, { ifAvailable: true }, async (lock) => {
           if (!lock) {
             settle({
-              status: "blocked",
+              status: 'blocked',
               owner: await this.getOwner(notebookUri),
-            });
-            return;
+            })
+            return
           }
 
-          let releaseLock!: () => void;
+          let releaseLock!: () => void
           const released = new Promise<void>((release) => {
-            releaseLock = release;
-          });
+            releaseLock = release
+          })
           const record: NotebookOwnershipRecord = {
             notebookUri,
             ownerTabId: this.tabId,
+            ownerSessionId: await getClaimedSessionId(),
             ownerLabel: getOwnerLabel(),
             ownerUrl: getOwnerUrl(),
             ownerStartedAt: new Date().toISOString(),
             epoch: crypto.randomUUID(),
-          };
+          }
 
-          await this.db.ownership.put(record);
+          await this.db.ownership.put(record)
           this.heldLeases.set(notebookUri, {
             record,
             release: releaseLock,
-          });
-          this.broadcast("owner-acquired", record);
-          this.emit();
+          })
+          this.broadcast('owner-acquired', record)
+          this.emit()
           settle({
-            status: "acquired",
+            status: 'acquired',
             lease: this.createLease(record),
-          });
+          })
 
-          await released;
-          await this.deleteRecordIfCurrent(record);
-          this.heldLeases.delete(notebookUri);
-          this.broadcast("owner-released", record);
-          this.emit();
+          await released
+          await this.deleteRecordIfCurrent(record)
+          this.heldLeases.delete(notebookUri)
+          this.broadcast('owner-released', record)
+          this.emit()
         })
         .catch(async () => {
           settle({
-            status: "blocked",
+            status: 'blocked',
             owner: await this.getOwner(notebookUri),
-          });
-        });
-    });
+          })
+        })
+    })
   }
 
   release(notebookUri: string): void {
-    const held = this.heldLeases.get(notebookUri);
+    const held = this.heldLeases.get(notebookUri)
     if (!held) {
-      return;
+      return
     }
-    this.heldLeases.delete(notebookUri);
-    held.release();
+    this.heldLeases.delete(notebookUri)
+    held.release()
   }
 
   async getOwner(notebookUri: string): Promise<NotebookOwnershipRecord | null> {
-    return (await this.db.ownership.get(notebookUri)) ?? null;
+    return (await this.db.ownership.get(notebookUri)) ?? null
   }
 
   subscribe(listener: () => void): () => void {
-    this.listeners.add(listener);
+    this.listeners.add(listener)
     return () => {
-      this.listeners.delete(listener);
-    };
+      this.listeners.delete(listener)
+    }
   }
 
   async isCurrentOwner(notebookUri: string, epoch?: string): Promise<boolean> {
-    const held = this.heldLeases.get(notebookUri);
+    const held = this.heldLeases.get(notebookUri)
     if (!held) {
-      return false;
+      return false
     }
     if (epoch && held.record.epoch !== epoch) {
-      return false;
+      return false
     }
-    return true;
+    return true
   }
 
   dispose(): void {
     for (const uri of Array.from(this.heldLeases.keys())) {
-      this.release(uri);
+      this.release(uri)
     }
-    this.listeners.clear();
-    this.channel?.close();
-    void this.db.close();
+    this.listeners.clear()
+    this.channel?.close()
+    void this.db.close()
   }
 
   private createLease(record: NotebookOwnershipRecord): NotebookLease {
@@ -210,32 +212,32 @@ export class NotebookOwnershipManager {
       release: () => this.release(record.notebookUri),
       isCurrentOwner: () =>
         this.isCurrentOwner(record.notebookUri, record.epoch),
-    };
+    }
   }
 
   private async deleteRecordIfCurrent(
-    record: NotebookOwnershipRecord,
+    record: NotebookOwnershipRecord
   ): Promise<void> {
-    const current = await this.db.ownership.get(record.notebookUri);
+    const current = await this.db.ownership.get(record.notebookUri)
     if (
       current?.ownerTabId === record.ownerTabId &&
       current.epoch === record.epoch
     ) {
-      await this.db.ownership.delete(record.notebookUri);
+      await this.db.ownership.delete(record.notebookUri)
     }
   }
 
   private broadcast(
-    type: "owner-acquired" | "owner-released",
-    record: NotebookOwnershipRecord,
+    type: 'owner-acquired' | 'owner-released',
+    record: NotebookOwnershipRecord
   ): void {
-    this.channel?.postMessage({ type, record });
+    this.channel?.postMessage({ type, record })
   }
 
   private emit(): void {
     for (const listener of this.listeners) {
       try {
-        listener();
+        listener()
       } catch {
         // Ignore listener failures so ownership cleanup is not interrupted.
       }
@@ -243,20 +245,20 @@ export class NotebookOwnershipManager {
   }
 }
 
-let manager: NotebookOwnershipManager = new NotebookOwnershipManager();
+let manager: NotebookOwnershipManager = new NotebookOwnershipManager()
 
 export function getNotebookOwnershipManager(): NotebookOwnershipManager {
-  return manager;
+  return manager
 }
 
 export function __setNotebookOwnershipManagerForTests(
-  next: NotebookOwnershipManager,
+  next: NotebookOwnershipManager
 ): void {
-  manager.dispose();
-  manager = next;
+  manager.dispose()
+  manager = next
 }
 
 export function __resetNotebookOwnershipManagerForTests(): void {
-  manager.dispose();
-  manager = new NotebookOwnershipManager();
+  manager.dispose()
+  manager = new NotebookOwnershipManager()
 }


### PR DESCRIPTION
## Summary
- store the owning tab's claimed Runme session id in notebook ownership metadata
- show the owner session in blocked/read-only notebook UI and add a tab menu action to copy it
- update app test harnesses for current Google auth APIs so the app suite is green

## Validation
- pnpm -C app exec vitest run src/components/Actions/Actions.test.tsx src/lib/tabCoordination/notebookOwnership.test.ts
- pnpm -C app exec vitest run
- runme run build test