### PR TITLE
[codex] Add Google Drive trash action

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -18,32 +18,53 @@ const mocks = vi.hoisted(() => ({
   store: {
     getMetadata: vi.fn(),
     createFolder: vi.fn(),
+    moveToTrash: vi.fn(),
     sync: vi.fn(),
   },
   workspaceItems: [] as string[],
 }))
 
-vi.mock('react-arborist', () => ({
-  Tree: ({ data, children }: any) => (
-    <div data-testid="tree">
-      {(data ?? []).map((item: any) => (
-        <div key={item.id}>
-          {children({
-            node: {
-              data: item,
-              isEditing: false,
-              isOpen: false,
-              handleClick: vi.fn(),
-              toggle: vi.fn(),
-              parent: null,
-            },
-            style: {},
-          })}
-        </div>
-      ))}
-    </div>
-  ),
-}))
+vi.mock('react-arborist', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Tree = React.forwardRef(({ data, children, onToggle }: any, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      get: (id: string) => ({
+        data: { uri: id, type: 'folder' },
+        isOpen: true,
+        openParents: vi.fn(),
+        parent: { open: vi.fn() },
+      }),
+      open: vi.fn(),
+      edit: vi.fn(async () => undefined),
+    }))
+
+    const renderItems = (items: any[], parent: any = null): React.ReactNode =>
+      (items ?? []).map((item: any) => {
+        const node = {
+          data: item,
+          isEditing: false,
+          isOpen: true,
+          handleClick: vi.fn(),
+          toggle: vi.fn(() => onToggle?.(item.id)),
+          parent,
+          reset: vi.fn(),
+        }
+        return (
+          <div key={item.id}>
+            {children({
+              node,
+              style: {},
+            })}
+            {item.children?.length ? renderItems(item.children, node) : null}
+          </div>
+        )
+      })
+
+    return <div data-testid="tree">{renderItems(data ?? [])}</div>
+  })
+  Tree.displayName = 'MockTree'
+  return { Tree }
+})
 
 vi.mock('./GoogleDrivePickerButton', () => ({
   GoogleDrivePickerButton: () => <button type="button">Pick Drive</button>,
@@ -141,8 +162,11 @@ describe('WorkspaceExplorer current document handling', () => {
       remoteUri: 'https://drive.google.com/drive/folders/new',
       parents: ['local://folder/drive'],
     })
+    mocks.store.moveToTrash.mockReset()
+    mocks.store.moveToTrash.mockResolvedValue(undefined)
     mocks.store.sync.mockReset()
     vi.spyOn(window, 'prompt').mockReturnValue('Reports')
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
   it('does not treat notebook diff URIs as Google Drive documents', async () => {
@@ -188,6 +212,57 @@ describe('WorkspaceExplorer current document handling', () => {
       expect(mocks.store.createFolder).toHaveBeenCalledWith(
         'local://folder/drive',
         'Reports'
+      )
+    })
+  })
+
+  it('moves a Drive-backed file to Google Drive trash from the context menu after confirmation', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/untitled'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/untitled') {
+        return {
+          uri,
+          name: 'untitled.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/file123/view',
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    await waitFor(() => {
+      expect(screen.getByText('untitled.json')).toBeTruthy()
+    })
+
+    fireEvent.contextMenu(screen.getByText('untitled.json'))
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Move to Google Drive Trash',
+      })
+    )
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Move "untitled.json" to Google Drive trash? You can restore it from Google Drive trash.'
+    )
+    await waitFor(() => {
+      expect(mocks.store.moveToTrash).toHaveBeenCalledWith(
+        'local://file/untitled'
       )
     })
   })

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -180,7 +180,7 @@ function getContextMenuItemCount(menu: ContextMenuState): number {
     return (
       (menu.uri.startsWith("fs://") ? 0 : 1) +
       2 +
-      (menu.remoteUri ? 3 : 0)
+      (menu.remoteUri ? 4 : 0)
     );
   }
 
@@ -1020,6 +1020,57 @@ function formatShortTimestamp(date: Date): string {
     [],
   );
 
+  const handleMoveDriveFileToTrash = useCallback(
+    async (menu: ContextMenuState) => {
+      if (!menu.remoteUri || !store) {
+        return;
+      }
+
+      const confirmed =
+        typeof window === "undefined"
+          ? true
+          : window.confirm(
+              `Move "${menu.name}" to Google Drive trash? You can restore it from Google Drive trash.`,
+            );
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        await store.moveToTrash(menu.uri);
+        if (currentDoc === menu.uri) {
+          setCurrentDoc(null);
+        }
+        if (menu.parentUri) {
+          await fetchChildren(menu.parentUri);
+        } else {
+          removeItem(menu.uri);
+        }
+        setErrorMessage(null);
+        showToast({
+          message: `Moved "${menu.name}" to Google Drive trash`,
+          tone: "success",
+        });
+      } catch (error) {
+        appLogger.error("Failed to move Drive file to trash", {
+          attrs: {
+            scope: "storage.drive.trash",
+            code: "DRIVE_FILE_TRASH_FAILED",
+            uri: menu.uri,
+            remoteUri: menu.remoteUri,
+            error: String(error),
+          },
+        });
+        setErrorMessage("Unable to move file to Google Drive trash.");
+        showToast({
+          message: "Could not move file to Google Drive trash",
+          tone: "error",
+        });
+      }
+    },
+    [currentDoc, fetchChildren, removeItem, setCurrentDoc, store],
+  );
+
   if (!store) {
     return (
       <div className="flex h-full min-h-0 flex-col gap-3">
@@ -1190,6 +1241,21 @@ function formatShortTimestamp(date: Date): string {
                   }}
                 >
                   Copy Markdown Link
+                </button>
+              )}
+              {adjustedContextMenu.remoteUri && (
+                <button
+                  type="button"
+                  className="ctx-menu-item text-red-600"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    const menu = adjustedContextMenu;
+                    setContextMenu(null);
+                    void handleMoveDriveFileToTrash(menu);
+                  }}
+                >
+                  Move to Google Drive Trash
                 </button>
               )}
               {adjustedContextMenu.remoteUri && (

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -165,6 +165,46 @@ export async function updateDriveFileBytes(
   }
 }
 
+export async function moveDriveFileToTrash(idOrUri: string) {
+  if (!idOrUri?.trim()) {
+    throw new Error("drive.trash requires a Drive file id or URI");
+  }
+
+  const uri = idOrUri.includes("://") ? idOrUri : driveFileUrl(idOrUri.trim());
+  const item = parseDriveItem(uri);
+  if (item.type !== NotebookStoreItemType.File) {
+    throw new Error("drive.trash target must be a Drive file");
+  }
+
+  appLogger.info("Moving Google Drive file to trash", {
+    attrs: {
+      scope: "drive.transfer",
+      uri,
+      fileId: item.id,
+    },
+  });
+  try {
+    const trashed = await ensureDriveStore().moveToTrash(uri);
+    appLogger.info("Moved Google Drive file to trash", {
+      attrs: {
+        scope: "drive.transfer",
+        fileId: item.id,
+      },
+    });
+    return trashed;
+  } catch (error) {
+    appLogger.error("Failed to move Google Drive file to trash", {
+      attrs: {
+        scope: "drive.transfer",
+        uri,
+        fileId: item.id,
+        error: String(error),
+      },
+    });
+    throw error;
+  }
+}
+
 export async function saveNotebookAsDriveCopy(
   notebook: parser_pb.Notebook,
   folder: string,

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -47,6 +47,7 @@ function createRunme(current: NotebookDataLike | null = null): RunmeConsoleApi {
 describe('createAppJsGlobals notebook reference helpers', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    appState.setDriveNotebookStore(null)
     appState.setLocalNotebooks(null)
     appState.setOpenNotebookHandler(null)
     appState.setGoogleDriveOAuthHandler(null)
@@ -156,6 +157,38 @@ describe('createAppJsGlobals notebook reference helpers', () => {
       accessToken: '<redacted>',
     })
     expect(output.join('')).toContain('Google Drive OAuth authorized.')
+  })
+
+  it('moves Google Drive files to trash from browser AppKernel drive globals', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const moveToTrash = vi.fn(async () => ({
+      uri: remoteUri,
+      name: 'untitled.json',
+      type: 'file',
+      children: [],
+      remoteUri,
+      parents: [],
+    }))
+    const output: string[] = []
+    appState.setDriveNotebookStore({
+      moveToTrash,
+    } as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+      sendOutput: (data) => output.push(data),
+    })
+
+    const result = await globals.drive.trash(remoteUri)
+
+    expect(moveToTrash).toHaveBeenCalledWith(remoteUri)
+    expect(result).toMatchObject({
+      uri: remoteUri,
+      name: 'untitled.json',
+      remoteUri,
+    })
+    expect(output.join('')).toContain(
+      'Moved Drive file to trash: untitled.json'
+    )
   })
 
   it('loads Google service account credentials from a picked local JSON file', async () => {

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -32,6 +32,7 @@ import {
   copyDriveNotebookFile,
   createDriveFile,
   listDriveFolderItems,
+  moveDriveFileToTrash,
   saveNotebookAsDriveCopy,
   updateDriveFileBytes,
 } from '../driveTransfer'
@@ -1783,6 +1784,16 @@ export function createAppJsGlobals({
         emitLine(sendOutput, `Updated Drive file ${id}`)
         return id
       },
+      trash: async (idOrUri: string) => {
+        const item = await moveDriveFileToTrash(idOrUri)
+        emitLine(sendOutput, `Moved Drive file to trash: ${item.name}`)
+        return item
+      },
+      moveToTrash: async (idOrUri: string) => {
+        const item = await moveDriveFileToTrash(idOrUri)
+        emitLine(sendOutput, `Moved Drive file to trash: ${item.name}`)
+        return item
+      },
       saveAsCurrentNotebook: async (folder: string, name: string) => {
         if (!folder?.trim() || !name?.trim()) {
           throw new Error(
@@ -1855,6 +1866,8 @@ export function createAppJsGlobals({
           'drive.refreshAuth(options?)    - Alias for drive.authorize(options?)',
           'drive.create(folder, name)     - Create a Drive file in folder; returns file id',
           'drive.update(id, bytes)        - Write UTF-8 bytes to a Drive file id/URI',
+          'drive.trash(idOrUri)           - Move a Drive file to Google Drive trash',
+          'drive.moveToTrash(idOrUri)     - Alias for drive.trash(idOrUri)',
           'drive.saveAsCurrentNotebook(folder, fileName) - Save current notebook to Drive and switch current doc',
           'drive.copyNotebook(source, targetFolder, fileName?) - Copy a notebook file to another Drive folder',
           'drive.listPendingSync()        - List Drive-backed local notebooks that currently need sync',

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -224,6 +224,45 @@ describe("DriveNotebookStore", () => {
     });
   });
 
+  it("moves Drive files to trash through the metadata update API", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/file123");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.method).toBe("PATCH");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          trashed: true,
+        });
+        return new Response(
+          JSON.stringify({
+            id: "file123",
+            name: "untitled.json",
+            mimeType: "application/json",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.moveToTrash(
+      "https://drive.google.com/file/d/file123/view",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      uri: "https://drive.google.com/file/d/file123/view",
+      name: "untitled.json",
+      type: NotebookStoreItemType.File,
+      remoteUri: "https://drive.google.com/file/d/file123/view",
+    });
+  });
+
   it("paginates Drive revisions", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -36,6 +36,7 @@ export type DriveDoc = {
   parents?: string[]
   driveId?: string
   content?: string
+  trashed?: boolean
 }
 
 type Drive = {
@@ -160,6 +161,9 @@ class GapiDriveFilesClient implements DriveFilesClient {
     }
     if (Array.isArray(doc.parents)) {
       resource.parents = doc.parents
+    }
+    if (typeof doc.trashed === 'boolean') {
+      resource.trashed = doc.trashed
     }
     return resource
   }
@@ -332,6 +336,9 @@ class FetchDriveFilesClient implements DriveFilesClient {
     }
     if (Array.isArray(doc.parents)) {
       resource.parents = doc.parents
+    }
+    if (typeof doc.trashed === 'boolean') {
+      resource.trashed = doc.trashed
     }
     return resource
   }
@@ -1090,6 +1097,28 @@ export class DriveNotebookStore {
         : NotebookStoreItemType.File,
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
+      parents: [],
+    }
+  }
+
+  async moveToTrash(uri: string): Promise<NotebookStoreItem> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.moveToTrash expects a file URI')
+    }
+    const client = await this.getFilesClient()
+    const file = await client.update({
+      id,
+      trashed: true,
+    })
+
+    const fileId = file.id ?? id
+    return {
+      uri: driveFileUrl(fileId),
+      name: file.name ?? uri,
+      type: NotebookStoreItemType.File,
+      children: [],
+      remoteUri: driveFileUrl(fileId),
       parents: [],
     }
   }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -34,6 +34,9 @@ function createMockTable<T extends { id: string }>() {
       store.set(id, { ...existing, ...changes })
       return 1
     }),
+    delete: vi.fn(async (id: string) => {
+      store.delete(id)
+    }),
     where: vi.fn((field: keyof T) => ({
       equals: vi.fn((value: unknown) => ({
         first: vi.fn(async () =>
@@ -477,6 +480,47 @@ describe('LocalNotebooks rename', () => {
     expect((await store.files.get('local://file/drive'))?.name).toBe(
       'original.json'
     )
+  })
+})
+
+describe('LocalNotebooks moveToTrash', () => {
+  it('trashes Drive-backed files upstream and removes the local mirror from its parent', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const driveStore = {
+      moveToTrash: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'untitled.json',
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri,
+        parents: [],
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/drive',
+      name: 'untitled.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/drive',
+      name: 'Drive',
+      remoteId: 'https://drive.google.com/drive/folders/folder123',
+      children: ['local://file/drive'],
+      lastSynced: '',
+    })
+
+    await store.moveToTrash('local://file/drive')
+
+    expect(driveStore.moveToTrash).toHaveBeenCalledWith(remoteUri)
+    await expect(store.files.get('local://file/drive')).resolves.toBeUndefined()
+    expect(
+      (await store.folders.get('local://folder/drive'))?.children
+    ).not.toContain('local://file/drive')
   })
 })
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1094,6 +1094,34 @@ export class LocalNotebooks extends Dexie {
     }
   }
 
+  async moveToTrash(uri: string): Promise<void> {
+    if (!uri.startsWith('local://file/')) {
+      throw new Error('LocalNotebooks.moveToTrash expects a file URI')
+    }
+
+    const record = await this.files.get(uri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${uri}`)
+    }
+    if (!isDriveUri(record.remoteId)) {
+      throw new Error(
+        'LocalNotebooks.moveToTrash expects a Drive-backed file'
+      )
+    }
+
+    await this.driveStore.moveToTrash(record.remoteId)
+
+    const parentFolder = await this.findParentFolder(uri)
+    if (parentFolder) {
+      await this.folders.update(parentFolder.id, {
+        children: parentFolder.children.filter((childUri) => childUri !== uri),
+        lastSynced: nowIsoString(),
+      })
+    }
+    await this.deleteConflictDoc(record.conflict)
+    await this.files.delete(uri)
+  }
+
   /**
    * Ensure a Markdown sidecar file exists and is synced to Drive for the given file.
    * The purpose of the sidecar file is to make the content available to company knowledge for

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -90,6 +90,7 @@ await drive.authorize()
 await drive.refreshAuth()
 drive.list(folderIdOrUri)
 drive.create(folderIdOrUri, "name.json")
+drive.trash(fileIdOrUri)
 drive.saveAsCurrentNotebook(folderIdOrUri, "name.json")
 drive.copyNotebook(sourceIdOrUri, targetFolderIdOrUri, "name.json")
 drive.listPendingSync()
@@ -105,6 +106,22 @@ Use this when the Drive status button appears stuck, when an agent needs to
 explicitly refresh Drive auth from App Console, or before asking a user to clear
 browser storage manually. `drive.refreshAuth()` is an alias for the same
 operation.
+
+`drive.trash(fileIdOrUri)` moves a Google Drive file to Drive trash. It is
+available in browser AppKernel JavaScript, including App Console and browser JS
+notebook cells, and is intentionally not exposed in the AppKernel sandbox. For
+bulk cleanup, have Codex insert a browser JS notebook cell that lists candidate
+files first, then review and run the trash command manually:
+
+```js
+const files = await drive.list(folderIdOrUri)
+const targets = files.filter(
+  (item) => item.type === "file" && item.name.toLowerCase().startsWith("untitled"),
+)
+console.table(targets)
+// After review:
+// for (const item of targets) await drive.trash(item.uri)
+```
 
 Optional arguments:
 


### PR DESCRIPTION
## Summary
- Add a Google Drive move-to-trash storage path and Drive transfer helper.
- Expose drive.trash()/drive.moveToTrash() in browser AppKernel/App Console while leaving the sandbox Drive helper limited to auth only.
- Add a right-click Explorer menu item for Drive-backed files with a browser confirmation, local mirror cleanup, tests, and docs for Codex-generated cleanup notebooks.

## Validation
- runme run build test
- pnpm --dir app exec vitest run src/storage/drive.test.ts src/storage/local.test.ts src/lib/runtime/appJsGlobals.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx

## Notes
- pnpm run lint is currently blocked because the root workspace does not install an eslint binary for the existing lint script.