### PR TITLE
Fix conflict diff insert refresh

### DIFF
--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -1,6 +1,6 @@
-import { create } from '@bufbuild/protobuf'
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
 import { parser_pb } from '../../runme/client'
 import type LocalNotebooks from '../../storage/local'
@@ -20,6 +20,12 @@ function notebook(value: string) {
     ],
     metadata: {},
   })
+}
+
+function serialize(notebookValue: parser_pb.Notebook): string {
+  return toJsonString(parser_pb.NotebookSchema, notebookValue, {
+    emitDefaultValues: true,
+  } as unknown as Parameters<typeof toJsonString>[2])
 }
 
 describe('NotebookDiffContent', () => {
@@ -105,5 +111,86 @@ describe('NotebookDiffContent', () => {
         name: 'Insert upstream cell into local notebook',
       })
     ).toBeTruthy()
+  })
+
+  it('inserts a deleted upstream cell into the local notebook and refreshes the diff', async () => {
+    const upstreamNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'remote-only',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('restore me')",
+        }),
+      ],
+      metadata: {},
+    })
+    const localNotebook = create(parser_pb.NotebookSchema, {
+      cells: [],
+      metadata: {},
+    })
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const localStore = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(upstreamNotebook, localNotebook, {
+        includeMetadata: true,
+        includeOutputs: true,
+      }),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={localStore}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert upstream cell into local notebook',
+      })
+    )
+
+    await waitFor(() => {
+      expect(localStore.save).toHaveBeenCalledTimes(1)
+      expect(
+        screen.queryByRole('button', {
+          name: 'Insert upstream cell into local notebook',
+        })
+      ).toBeNull()
+    })
+    const savedNotebook = fromJsonString(parser_pb.NotebookSchema, record.doc, {
+      ignoreUnknownFields: true,
+    })
+    expect(savedNotebook.cells.map((cell) => cell.refId)).toEqual([
+      'remote-only',
+    ])
+    expect(screen.getByText('0 deleted')).toBeTruthy()
   })
 })

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Badge, Button, ScrollArea, Text } from '@radix-ui/themes'
 
@@ -205,9 +205,11 @@ function CellPanel({ row, side }: { row: CellDiff; side: 'base' | 'compare' }) {
 function RestoreDeletedCellButton({
   localUri,
   row,
+  onRestored,
 }: {
   localUri: string
   row: CellDiff
+  onRestored: (document: NotebookDiffDocument) => void
 }) {
   const { store } = useNotebookStore()
   const [isRestoring, setIsRestoring] = useState(false)
@@ -224,6 +226,7 @@ function RestoreDeletedCellButton({
         localNotebook: notebookData?.getSnapshot().notebook,
       })
       notebookData?.loadNotebook(result.localNotebook, { persist: false })
+      onRestored(result.document)
       showToast({
         message: 'Inserted upstream cell into the local notebook.',
         tone: 'success',
@@ -259,9 +262,11 @@ function RestoreDeletedCellButton({
 function DiffRow({
   row,
   conflictLocalUri,
+  onConflictDocumentChanged,
 }: {
   row: CellDiff
   conflictLocalUri?: string
+  onConflictDocumentChanged: (document: NotebookDiffDocument) => void
 }) {
   if (row.kind === 'unchanged') {
     return (
@@ -292,7 +297,11 @@ function DiffRow({
           )}
         </div>
         {conflictLocalUri && row.kind === 'deleted' && (
-          <RestoreDeletedCellButton localUri={conflictLocalUri} row={row} />
+          <RestoreDeletedCellButton
+            localUri={conflictLocalUri}
+            row={row}
+            onRestored={onConflictDocumentChanged}
+          />
         )}
       </div>
       <div className="grid min-w-[920px] grid-cols-2 gap-3">
@@ -396,10 +405,16 @@ export function NotebookDiffContent({
 }: {
   document: NotebookDiffDocument
 }) {
-  const { diff } = document
+  const [currentDocument, setCurrentDocument] = useState(document)
+
+  useEffect(() => {
+    setCurrentDocument(document)
+  }, [document])
+
+  const { diff } = currentDocument
   const conflictResolution =
-    document.resolution?.kind === 'notebook-sync-conflict'
-      ? document.resolution
+    currentDocument.resolution?.kind === 'notebook-sync-conflict'
+      ? currentDocument.resolution
       : null
 
   return (
@@ -411,7 +426,8 @@ export function NotebookDiffContent({
               Notebook Diff
             </Text>
             <Text as="p" size="2" className="text-nb-text-muted">
-              {document.base.label} compared with {document.compare.label}
+              {currentDocument.base.label} compared with{' '}
+              {currentDocument.compare.label}
             </Text>
             {conflictResolution && (
               <Text
@@ -440,10 +456,10 @@ export function NotebookDiffContent({
         </div>
         <div className="mt-4 grid min-w-[920px] grid-cols-2 gap-3 overflow-x-auto text-xs font-medium uppercase tracking-wide text-nb-text-muted">
           <div className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2">
-            Base: {document.base.label}
+            Base: {currentDocument.base.label}
           </div>
           <div className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2">
-            Compare: {document.compare.label}
+            Compare: {currentDocument.compare.label}
           </div>
         </div>
       </header>
@@ -454,6 +470,7 @@ export function NotebookDiffContent({
               key={row.id}
               row={row}
               conflictLocalUri={conflictResolution?.localUri}
+              onConflictDocumentChanged={setCurrentDocument}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Refresh the rendered conflict diff immediately after inserting a deleted upstream cell
- Keep the restored notebook persisted and remove the stale Insert button from the diff panel
- Add an interaction regression test for the visual Insert action

## Tests
- pnpm -C app exec vitest run src/components/NotebookDiff/NotebookDiffView.test.tsx
- pnpm -C app exec vitest run src/components/Actions/Actions.test.tsx
- runme run build test