### PR TITLE
[codex] Persist Google service account credentials

### DIFF
--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -202,6 +202,55 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     )
   })
 
+  it('does not reuse a cached OAuth token for service account auth', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        token: 'prior-oauth-token',
+        expiresAt: Date.now() + 30 * 60 * 1000,
+        authFlow: 'implicit',
+      })
+    )
+    googleClientManager.setOAuthClient({
+      clientId: '',
+      authFlow: 'service_account',
+      authUxMode: 'new_tab',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey: await generatePrivateKeyPem(),
+      },
+    })
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: 'service-account-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = await renderWithGoogleAuthProvider()
+
+    let token = ''
+    await act(async () => {
+      token = await auth.ensureAccessToken({ interactive: false })
+    })
+
+    expect(token).toBe('service-account-token')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(
+      JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}')
+    ).toMatchObject({
+      token: 'service-account-token',
+      authFlow: 'service_account',
+    })
+  })
+
   it('mints a service account access token without interactive OAuth', async () => {
     googleClientManager.setOAuthClient({
       clientId: '',

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -44,6 +44,7 @@ const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
 interface AccessTokenInfo {
   token: string
   expiresAt: number
+  authFlow?: GoogleDriveAuthFlow
   refreshToken?: string
 }
 
@@ -166,6 +167,12 @@ function loadStoredToken(): AccessTokenInfo | null {
     return {
       token: parsed.token,
       expiresAt: parsed.expiresAt,
+      authFlow:
+        parsed.authFlow === 'implicit' ||
+        parsed.authFlow === 'pkce' ||
+        parsed.authFlow === 'service_account'
+          ? parsed.authFlow
+          : undefined,
       refreshToken,
     }
   } catch (error) {
@@ -229,6 +236,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       const info: AccessTokenInfo = {
         token,
         expiresAt,
+        authFlow: googleClientManager.getOAuthClient().authFlow,
         ...(refreshToken ? { refreshToken } : {}),
       }
       setTokenInfo(info)
@@ -654,6 +662,17 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     tokenInfo?.token && tokenInfo.expiresAt > nowMs
   )
 
+  const canUseCachedToken = useCallback((info: AccessTokenInfo | null) => {
+    if (!info?.token || info.expiresAt <= Date.now() + REFRESH_MARGIN_MS) {
+      return false
+    }
+    const authFlow = googleClientManager.getOAuthClient().authFlow
+    if (authFlow === 'service_account') {
+      return info.authFlow === 'service_account'
+    }
+    return info.authFlow !== 'service_account'
+  }, [])
+
   useEffect(() => {
     const handleStorage = (event: StorageEvent) => {
       if (
@@ -887,10 +906,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     (options?: EnsureAccessTokenOptions) => {
       const interactive = options?.interactive ?? true
       const currentInfo = tokenInfoRef.current
-      if (
-        currentInfo?.token &&
-        currentInfo.expiresAt > Date.now() + REFRESH_MARGIN_MS
-      ) {
+      if (canUseCachedToken(currentInfo)) {
         return Promise.resolve(currentInfo.token)
       }
 
@@ -922,10 +938,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
 
         const refreshedInfo = tokenInfoRef.current
-        if (
-          refreshedInfo?.token &&
-          refreshedInfo.expiresAt > Date.now() + REFRESH_MARGIN_MS
-        ) {
+        if (canUseCachedToken(refreshedInfo)) {
           return refreshedInfo.token
         }
 
@@ -1029,6 +1042,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       return pendingPromiseRef.current
     },
     [
+      canUseCachedToken,
       ensureTokenClient,
       hasRedirectAuthHandoffInProgress,
       mintServiceAccountAccessToken,

--- a/app/src/lib/googleClientManager.test.ts
+++ b/app/src/lib/googleClientManager.test.ts
@@ -90,7 +90,8 @@ describe('GoogleClientManager', () => {
       JSON.stringify({
         type: 'service_account',
         client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
-        private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        private_key:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
         private_key_id: 'key-id',
         token_uri: 'https://oauth2.googleapis.com/token',
       })
@@ -110,14 +111,15 @@ describe('GoogleClientManager', () => {
     })
   })
 
-  it('does not restore service account mode without credentials from local storage', () => {
+  it('persists and restores service account credentials from local storage', () => {
     const manager = createManager()
 
     manager.setOAuthClientFromJson(
       JSON.stringify({
         type: 'service_account',
         client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
-        private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        private_key:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
         private_key_id: 'key-id',
         token_uri: 'https://oauth2.googleapis.com/token',
       })
@@ -125,9 +127,52 @@ describe('GoogleClientManager', () => {
 
     const stored = JSON.parse(
       window.localStorage.getItem(GOOGLE_CLIENT_STORAGE_KEY) ?? '{}'
-    ) as Record<string, string | undefined>
-    expect(JSON.stringify(stored)).not.toContain('PRIVATE KEY')
-    expect(stored.oauthAuthFlow).toBeUndefined()
+    ) as {
+      oauthAuthFlow?: string
+      oauthAuthUxMode?: string
+      oauthServiceAccount?: {
+        clientEmail?: string
+        privateKey?: string
+        privateKeyId?: string
+        tokenUri?: string
+      }
+    }
+    expect(stored.oauthAuthFlow).toBe('service_account')
+    expect(stored.oauthAuthUxMode).toBe('new_tab')
+    expect(stored.oauthServiceAccount).toMatchObject({
+      clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+      privateKey:
+        '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+      privateKeyId: 'key-id',
+      tokenUri: 'https://oauth2.googleapis.com/token',
+    })
+
+    const reloadedManager = createManager()
+    expect(reloadedManager.getOAuthClient()).toMatchObject({
+      clientId: '',
+      authFlow: 'service_account',
+      authUxMode: 'new_tab',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        privateKeyId: 'key-id',
+        tokenUri: 'https://oauth2.googleapis.com/token',
+      },
+    })
+  })
+
+  it('does not restore service account mode from incomplete local storage credentials', () => {
+    window.localStorage.setItem(
+      GOOGLE_CLIENT_STORAGE_KEY,
+      JSON.stringify({
+        oauthAuthFlow: 'service_account',
+        oauthAuthUxMode: 'new_tab',
+        oauthServiceAccount: {
+          clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        },
+      })
+    )
 
     const reloadedManager = createManager()
     expect(reloadedManager.getOAuthClient()).toMatchObject({
@@ -146,7 +191,8 @@ describe('GoogleClientManager', () => {
       JSON.stringify({
         type: 'service_account',
         client_email: 'runme-drive-test@example.iam.gserviceaccount.com',
-        private_key: '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
+        private_key:
+          '-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----\\n',
       })
     )
     manager.setAuthFlow('implicit')

--- a/app/src/lib/googleClientManager.ts
+++ b/app/src/lib/googleClientManager.ts
@@ -94,6 +94,25 @@ function parseServiceAccountCredentials(
   }
 }
 
+function isCompleteServiceAccountCredentials(
+  value: GoogleServiceAccountCredentials | undefined
+): value is GoogleServiceAccountCredentials {
+  return Boolean(value?.clientEmail.trim() && value.privateKey.trim())
+}
+
+function serializeServiceAccountCredentials(
+  value: GoogleServiceAccountCredentials
+): ServiceAccountJson {
+  return {
+    clientEmail: value.clientEmail,
+    privateKey: value.privateKey,
+    privateKeyId: value.privateKeyId,
+    tokenUri: value.tokenUri,
+    subject: value.subject,
+    scopes: value.scopes,
+  }
+}
+
 export class GoogleClientManager {
   private static singleton: GoogleClientManager | null = null
   private config: GoogleClientConfig
@@ -104,18 +123,29 @@ export class GoogleClientManager {
     const storedClientSecret = this.readOAuthClientSecretFromStorage()
     const storedAuthFlow = this.readOAuthAuthFlowFromStorage()
     const storedAuthUxMode = this.readOAuthAuthUxModeFromStorage()
+    const storedServiceAccount = this.readOAuthServiceAccountFromStorage()
     const resolvedClientId = storedClientId ?? defaultClientId
     const resolvedClientSecret = storedClientSecret ?? undefined
-    const resolvedAuthFlow = storedAuthFlow ?? DEFAULT_AUTH_FLOW
+    const resolvedAuthFlow =
+      storedAuthFlow === 'service_account' && storedServiceAccount
+        ? 'service_account'
+        : storedAuthFlow === 'service_account'
+          ? DEFAULT_AUTH_FLOW
+          : (storedAuthFlow ??
+            (storedServiceAccount ? 'service_account' : DEFAULT_AUTH_FLOW))
     const resolvedAuthUxMode =
       storedAuthUxMode ?? resolveDefaultUxModeForFlow(resolvedAuthFlow)
+    const oauth: GoogleOAuthClientConfig = {
+      clientId: resolvedClientId,
+      clientSecret: resolvedClientSecret,
+      authFlow: resolvedAuthFlow,
+      authUxMode: resolvedAuthUxMode,
+    }
+    if (resolvedAuthFlow === 'service_account' && storedServiceAccount) {
+      oauth.serviceAccount = storedServiceAccount
+    }
     this.config = {
-      oauth: {
-        clientId: resolvedClientId,
-        clientSecret: resolvedClientSecret,
-        authFlow: resolvedAuthFlow,
-        authUxMode: resolvedAuthUxMode,
-      },
+      oauth,
       drivePicker: {
         clientId: resolvedClientId,
         developerKey: '',
@@ -164,7 +194,7 @@ export class GoogleClientManager {
 
     const serviceAccount =
       nextAuthFlow === 'service_account'
-        ? config.serviceAccount ?? this.config.oauth.serviceAccount
+        ? (config.serviceAccount ?? this.config.oauth.serviceAccount)
         : undefined
 
     const nextOAuthClient: GoogleOAuthClientConfig = {
@@ -363,10 +393,7 @@ export class GoogleClientManager {
       if (!authFlow || !isGoogleDriveAuthFlow(authFlow)) {
         return null
       }
-      // Service account private keys are intentionally not restored from
-      // localStorage. Persisting only the auth flow would leave the app in
-      // service-account mode without credentials after reload.
-      return authFlow === 'service_account' ? null : authFlow
+      return authFlow
     } catch (error) {
       console.warn('Failed to read Google OAuth auth flow', error)
       return null
@@ -393,22 +420,48 @@ export class GoogleClientManager {
     }
   }
 
+  private readOAuthServiceAccountFromStorage(): GoogleServiceAccountCredentials | null {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null
+    }
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) {
+        return null
+      }
+      const parsed = JSON.parse(raw) as {
+        oauthServiceAccount?: ServiceAccountJson
+        serviceAccount?: ServiceAccountJson
+      } | null
+      const serviceAccount = parseServiceAccountCredentials(
+        parsed?.oauthServiceAccount ?? parsed?.serviceAccount
+      )
+      return isCompleteServiceAccountCredentials(serviceAccount)
+        ? serviceAccount
+        : null
+    } catch (error) {
+      console.warn('Failed to read Google service account config', error)
+      return null
+    }
+  }
+
   private persistOAuthClient(config: GoogleOAuthClientConfig): void {
     if (typeof window === 'undefined' || !window.localStorage) {
       return
     }
     try {
-      const persistableAuthFlow =
-        config.authFlow === 'service_account' ? undefined : config.authFlow
-      const persistableAuthUxMode =
-        config.authFlow === 'service_account' ? undefined : config.authUxMode
+      const serviceAccount =
+        config.authFlow === 'service_account' && config.serviceAccount
+          ? serializeServiceAccountCredentials(config.serviceAccount)
+          : undefined
       window.localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
           oauthClientId: config.clientId,
           oauthClientSecret: config.clientSecret,
-          oauthAuthFlow: persistableAuthFlow,
-          oauthAuthUxMode: persistableAuthUxMode,
+          oauthAuthFlow: config.authFlow,
+          oauthAuthUxMode: config.authUxMode,
+          oauthServiceAccount: serviceAccount,
         })
       )
     } catch (error) {

--- a/docs-dev/design/20260613_drive_service_account_auth.md
+++ b/docs-dev/design/20260613_drive_service_account_auth.md
@@ -76,12 +76,29 @@ app config.
 dev server. It asks the dev server to read an absolute `.json` path because
 browser JavaScript cannot read arbitrary local paths by itself.
 
+Service-account credentials loaded through App Console are persisted in the
+existing `googleClientConfig` localStorage record so local automation survives a
+page reload. The app restores `service_account` auth only when the stored
+credentials include both `clientEmail` and `privateKey`; otherwise it falls back
+to the default OAuth flow rather than entering service-account mode without a
+usable key.
+
 This is not a production browser-auth recommendation. Supplying a private key to
 browser JavaScript exposes that key to anyone who can read the page, local
 storage, config response, devtools, or test logs. The supported use case is
 local/CI test automation with a tightly scoped service account and disposable
 test Drive resources. A production deployment should mint the access token on a
 trusted server and send only the short-lived token to the browser.
+
+IndexedDB is the main browser-native alternative to localStorage for structured
+persistent app data and would avoid synchronous storage APIs, but it is not a
+meaningful security boundary against JavaScript running on the page. Web Crypto
+can import the private key as non-extractable for signing, but the app still
+needs the raw key again after reload unless a separate wrapping key or
+passphrase is introduced. Credential Management and WebAuthn are not a portable
+fit for storing and later exporting arbitrary service-account private keys. For
+this local testing feature, localStorage is the simplest persistence mechanism;
+for production, use a server-side token broker instead of browser key storage.
 
 ## Token Flow
 

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -82,6 +82,12 @@ googleDrive:
       -----END PRIVATE KEY-----
 ```
 
+Service-account credentials loaded from App Console are saved in
+`localStorage.googleClientConfig` so automated local sessions continue working
+after a reload. This is convenient for tests but means the private key is stored
+in browser-accessible storage. Keep these keys tightly scoped to disposable test
+Drive folders and prefer a server-side token broker for production.
+
 ## Useful App Console commands
 
 ```js

--- a/docs/14-authentication-and-app-configuration.md
+++ b/docs/14-authentication-and-app-configuration.md
@@ -73,6 +73,14 @@ filesystem paths directly.
 local Vite dev server. It asks the dev server to read an absolute `.json` path,
 so it is intended for local automation only.
 
+Both service-account helpers persist the loaded credentials in
+`localStorage.googleClientConfig` so reloads keep using the same test service
+account. Browser storage is not a production secret boundary: IndexedDB is a
+better structured persistent store than localStorage, but page JavaScript can
+still read data it is authorized to use. Use browser-persisted private keys only
+for tightly scoped local/CI testing, and use a trusted token broker for
+production.
+
 ## App config helpers
 
 ```js


### PR DESCRIPTION
## Summary

Persist Google Drive service-account credentials in the existing googleClientConfig localStorage record so App Console-loaded GSA keys survive page reloads.

## What changed

- Store service-account credentials as oauthServiceAccount when authFlow is service_account.
- Restore service_account auth only when persisted credentials include both clientEmail and privateKey.
- Keep falling back to the default OAuth flow when stored service-account credentials are incomplete.
- Document browser storage tradeoffs for localStorage, IndexedDB, Web Crypto, and production token brokers.

## Review

I reviewed the diff before opening the PR. The main risk is secret persistence, so the docs explicitly scope this to local/CI testing and recommend server-side token brokering for production.

## Validation

- pnpm -C app exec vitest run src/lib/googleClientManager.test.ts src/contexts/GoogleAuthContext.test.tsx src/auth/googleServiceAccount.test.ts src/lib/runtime/appJsGlobals.test.ts
- pnpm -C app exec tsc --noEmit
- runme run build test