### PR TITLE
Add Drive upstream revision diffs

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -55,6 +55,7 @@ const contextMocks = vi.hoisted(() => ({
 
 const conflictMocks = vi.hoisted(() => ({
   openNotebookConflictDiff: vi.fn(async () => undefined),
+  openNotebookUpstreamDiff: vi.fn(async () => undefined),
   refreshNotebookConflictDiff: vi.fn(async () => undefined),
   restoreDeletedConflictCell: vi.fn(async () => undefined),
 }))
@@ -131,6 +132,7 @@ vi.mock('../../contexts/CommentsPanelContext', () => ({
 
 vi.mock('../../lib/notebookDiff/conflict', () => ({
   openNotebookConflictDiff: conflictMocks.openNotebookConflictDiff,
+  openNotebookUpstreamDiff: conflictMocks.openNotebookUpstreamDiff,
   refreshNotebookConflictDiff: conflictMocks.refreshNotebookConflictDiff,
   restoreDeletedConflictCell: conflictMocks.restoreDeletedConflictCell,
 }))
@@ -262,6 +264,8 @@ beforeEach(() => {
   contextMocks.notebookStore = null
   conflictMocks.openNotebookConflictDiff.mockReset()
   conflictMocks.openNotebookConflictDiff.mockResolvedValue(undefined)
+  conflictMocks.openNotebookUpstreamDiff.mockReset()
+  conflictMocks.openNotebookUpstreamDiff.mockResolvedValue(undefined)
   conflictMocks.refreshNotebookConflictDiff.mockReset()
   conflictMocks.refreshNotebookConflictDiff.mockResolvedValue(undefined)
 })
@@ -577,6 +581,51 @@ describe('Actions tabs', () => {
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(
         '[202602a_tb_aws_codex_136](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV%2Fview)'
+      )
+    })
+  })
+
+  it('opens an upstream diff from the Drive-backed tab context menu', async () => {
+    const uri = 'local://file/restored'
+    const remoteUri =
+      'https://drive.google.com/file/d/1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV/view'
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(async () => ({
+        uri,
+        name: 'restored.json',
+        type: 'file',
+        children: [],
+        remoteUri,
+        parents: [],
+      })),
+      getSyncState: vi.fn(async () => ({
+        status: 'synced',
+        localUri: uri,
+        remoteId: remoteUri,
+      })),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'restored.json',
+      },
+    ]
+
+    render(<Actions />)
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /restored\.json/ }))
+    const compareButton = await screen.findByRole('button', {
+      name: 'Compare with upstream',
+    })
+    fireEvent.click(compareButton)
+
+    await waitFor(() => {
+      expect(conflictMocks.openNotebookUpstreamDiff).toHaveBeenCalledWith(
+        contextMocks.notebookStore,
+        uri
       )
     })
   })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -76,7 +76,10 @@ import {
   getNotebookDiffDocument,
   NOTEBOOK_DIFF_DOCUMENT_CHANGED,
 } from '../../lib/notebookDiff/registry'
-import { openNotebookConflictDiff } from '../../lib/notebookDiff/conflict'
+import {
+  openNotebookConflictDiff,
+  openNotebookUpstreamDiff,
+} from '../../lib/notebookDiff/conflict'
 import {
   isDriveItemUri,
   parseDriveItem,
@@ -2462,6 +2465,7 @@ export default function Actions() {
     shareableUri: string
     googleDriveUri: string | null
     ownerSessionId: string | null
+    canOpenUpstreamDiff: boolean
     readOnly?: boolean
   } | null>(null)
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -2705,7 +2709,8 @@ export default function Actions() {
     const itemCount =
       4 +
       (tabContextMenu.googleDriveUri ? 1 : 0) +
-      (tabContextMenu.ownerSessionId ? 1 : 0)
+      (tabContextMenu.ownerSessionId ? 1 : 0) +
+      (tabContextMenu.canOpenUpstreamDiff ? 1 : 0)
     const menuWidth = 220
     const menuHeight = itemCount * 36 + 8
     return {
@@ -2723,6 +2728,10 @@ export default function Actions() {
       event.preventDefault()
       event.stopPropagation()
       const document = workspaceDocuments.find((doc) => doc.uri === docUri)
+      const requestedUri = document?.requestedUri
+      const requestedDriveUri = isGoogleDriveFileUri(requestedUri)
+        ? requestedUri
+        : null
       const title =
         document?.title?.trim() ||
         getNotebookDisplayName(docUri, document?.title ?? docUri)
@@ -2732,8 +2741,12 @@ export default function Actions() {
         docUri,
         title,
         shareableUri: docUri,
-        googleDriveUri: isGoogleDriveFileUri(docUri) ? docUri : null,
+        googleDriveUri: isGoogleDriveFileUri(docUri)
+          ? docUri
+          : requestedDriveUri,
         ownerSessionId: getNotebookOwnerSessionId(document?.owner),
+        canOpenUpstreamDiff:
+          docUri.startsWith('local://') && Boolean(requestedDriveUri),
         readOnly: document?.readOnly,
       })
 
@@ -2755,6 +2768,8 @@ export default function Actions() {
               googleDriveUri: isGoogleDriveFileUri(remoteUri)
                 ? remoteUri
                 : current.googleDriveUri,
+              canOpenUpstreamDiff:
+                docUri.startsWith('local://') && isGoogleDriveFileUri(remoteUri),
             }
           })
         } catch (error) {
@@ -2942,6 +2957,35 @@ export default function Actions() {
       setTabContextMenu(null)
     }
   }, [tabContextMenu])
+
+  const handleOpenTabUpstreamDiff = useCallback(async () => {
+    if (!tabContextMenu?.canOpenUpstreamDiff) {
+      setTabContextMenu(null)
+      return
+    }
+    if (!store) {
+      setTabContextMenu(null)
+      return
+    }
+    try {
+      await openNotebookUpstreamDiff(store, tabContextMenu.docUri)
+    } catch (error) {
+      appLogger.error('Failed to open upstream diff from tab context menu', {
+        attrs: {
+          scope: 'notebook.diff',
+          code: 'TAB_OPEN_UPSTREAM_DIFF_FAILED',
+          uri: tabContextMenu.docUri,
+          error: String(error),
+        },
+      })
+      showToast({
+        message: 'Unable to open upstream diff. Please try again.',
+        tone: 'error',
+      })
+    } finally {
+      setTabContextMenu(null)
+    }
+  }, [store, tabContextMenu])
 
   // Each document gets its own scroll container keyed by URI so the browser
   // does not reuse the previous document's scroll position.
@@ -3166,6 +3210,18 @@ export default function Actions() {
                   }}
                 >
                   Copy Google Drive Link
+                </button>
+              )}
+              {adjustedTabContextMenu.canOpenUpstreamDiff && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleOpenTabUpstreamDiff()
+                  }}
+                >
+                  Compare with upstream
                 </button>
               )}
             </div>

--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -113,6 +113,70 @@ describe('NotebookDiffContent', () => {
     ).toBeTruthy()
   })
 
+  it('loads an older Drive revision from the Base revision selector', async () => {
+    const upstreamNotebook = notebook("print('upstream')")
+    const olderNotebook = notebook("print('older')")
+    const localNotebook = notebook("print('local')")
+    const localUri = 'local://file/conflict'
+    const record = {
+      id: localUri,
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        upstreamVersion: { revisionId: 'revision-2' },
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const localStore = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      getDriveRevisionDoc: vi.fn(async () => serialize(olderNotebook)),
+      listDriveRevisions: vi.fn(async () => [
+        {
+          id: 'revision-2',
+          modifiedTime: '2026-06-14T20:00:00.000Z',
+        },
+        {
+          id: 'revision-1',
+          modifiedTime: '2026-06-14T19:00:00.000Z',
+        },
+      ]),
+    } as unknown as LocalNotebooks
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'revision-2' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(upstreamNotebook, localNotebook, {
+        includeMetadata: true,
+        includeOutputs: true,
+      }),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri,
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={localStore}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    const selector = await screen.findByLabelText('Compare against')
+    fireEvent.change(selector, { target: { value: 'revision-1' } })
+
+    await waitFor(() => {
+      expect(localStore.getDriveRevisionDoc).toHaveBeenCalledWith(
+        localUri,
+        'revision-1'
+      )
+    })
+  })
+
   it('inserts a deleted upstream cell into the local notebook and refreshes the diff', async () => {
     const upstreamNotebook = create(parser_pb.NotebookSchema, {
       cells: [

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -12,9 +12,11 @@ import type {
   TextDiffLine,
 } from '../../lib/notebookDiff/model'
 import {
+  openNotebookDriveRevisionDiff,
   refreshNotebookConflictDiff,
   restoreDeletedConflictCell,
 } from '../../lib/notebookDiff/conflict'
+import type { DriveRevision } from '../../storage/drive'
 import { NotebookConflictChangedError } from '../../storage/local'
 import { getNotebookDataController } from '../../lib/notebookDataController'
 import { showToast } from '../../lib/toast'
@@ -259,6 +261,134 @@ function RestoreDeletedCellButton({
   )
 }
 
+function revisionLabel(revision: DriveRevision): string {
+  const modified = revision.modifiedTime
+    ? new Date(revision.modifiedTime).toLocaleString()
+    : 'Unknown time'
+  const author =
+    revision.lastModifyingUser?.displayName ||
+    revision.lastModifyingUser?.emailAddress
+  return author ? `${modified} by ${author}` : modified
+}
+
+function sortDriveRevisions(revisions: DriveRevision[]): DriveRevision[] {
+  return [...revisions].sort((a, b) => {
+    const aTime = a.modifiedTime ? Date.parse(a.modifiedTime) : 0
+    const bTime = b.modifiedTime ? Date.parse(b.modifiedTime) : 0
+    return bTime - aTime
+  })
+}
+
+function DriveRevisionSelector({
+  localUri,
+  selectedRevisionId,
+  resolutionKind,
+}: {
+  localUri: string
+  selectedRevisionId?: string
+  resolutionKind: NonNullable<NotebookDiffDocument['resolution']>['kind']
+}) {
+  const { store } = useNotebookStore()
+  const [revisions, setRevisions] = useState<DriveRevision[]>([])
+  const [loading, setLoading] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!store) {
+      setRevisions([])
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    void (async () => {
+      try {
+        const nextRevisions = await store.listDriveRevisions(localUri)
+        if (!cancelled) {
+          setRevisions(sortDriveRevisions(nextRevisions))
+        }
+      } catch {
+        if (!cancelled) {
+          setError('Unable to load Drive revisions.')
+          setRevisions([])
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [localUri, store])
+
+  const selectRevision = async (revisionId: string) => {
+    if (!store || !revisionId || revisionId === selectedRevisionId) {
+      return
+    }
+
+    setApplying(true)
+    setError(null)
+    try {
+      await openNotebookDriveRevisionDiff(store, localUri, revisionId, {
+        resolutionKind,
+      })
+    } catch {
+      setError('Unable to load selected Drive revision.')
+      showToast({
+        message: 'Unable to load selected Drive revision. Please try again.',
+        tone: 'error',
+      })
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1 normal-case tracking-normal">
+      <label
+        htmlFor="drive-revision-select"
+        className="text-[11px] font-medium uppercase tracking-wide text-nb-text-muted"
+      >
+        Compare against
+      </label>
+      <select
+        id="drive-revision-select"
+        className="max-w-full rounded border border-nb-border bg-white px-2 py-1 text-sm font-normal normal-case text-nb-text"
+        disabled={!store || loading || applying}
+        value={selectedRevisionId ?? ''}
+        onChange={(event) => {
+          void selectRevision(event.target.value)
+        }}
+      >
+        {!selectedRevisionId && <option value="">Select a revision</option>}
+        {selectedRevisionId &&
+          !revisions.some((revision) => revision.id === selectedRevisionId) && (
+            <option value={selectedRevisionId}>
+              {currentRevisionLabel(selectedRevisionId)}
+            </option>
+          )}
+        {revisions.map((revision) =>
+          revision.id ? (
+            <option key={revision.id} value={revision.id}>
+              {revisionLabel(revision)}
+            </option>
+          ) : null
+        )}
+      </select>
+      {error && <span className="text-xs text-red-700">{error}</span>}
+    </div>
+  )
+}
+
+function currentRevisionLabel(revisionId: string): string {
+  return `Current revision ${revisionId}`
+}
+
 function DiffRow({
   row,
   conflictLocalUri,
@@ -416,6 +546,11 @@ export function NotebookDiffContent({
     currentDocument.resolution?.kind === 'notebook-sync-conflict'
       ? currentDocument.resolution
       : null
+  const driveRevisionResolution =
+    currentDocument.resolution?.kind === 'notebook-sync-conflict' ||
+    currentDocument.resolution?.kind === 'drive-upstream-diff'
+      ? currentDocument.resolution
+      : null
 
   return (
     <div className="flex h-full w-full flex-col bg-nb-surface">
@@ -456,7 +591,16 @@ export function NotebookDiffContent({
         </div>
         <div className="mt-4 grid min-w-[920px] grid-cols-2 gap-3 overflow-x-auto text-xs font-medium uppercase tracking-wide text-nb-text-muted">
           <div className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2">
-            Base: {currentDocument.base.label}
+            <div>Base: {currentDocument.base.label}</div>
+            {driveRevisionResolution && (
+              <div className="mt-2">
+                <DriveRevisionSelector
+                  localUri={driveRevisionResolution.localUri}
+                  selectedRevisionId={currentDocument.base.revisionId}
+                  resolutionKind={driveRevisionResolution.kind}
+                />
+              </div>
+            )}
           </div>
           <div className="rounded border border-nb-border bg-nb-surface-2 px-3 py-2">
             Compare: {currentDocument.compare.label}

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
     moveToTrash: vi.fn(),
     sync: vi.fn(),
   },
+  openNotebookUpstreamDiff: vi.fn(),
   workspaceItems: [] as string[],
 }))
 
@@ -125,6 +126,10 @@ vi.mock('../../lib/toast', () => ({
   showToast: vi.fn(),
 }))
 
+vi.mock('../../lib/notebookDiff/conflict', () => ({
+  openNotebookUpstreamDiff: mocks.openNotebookUpstreamDiff,
+}))
+
 describe('WorkspaceExplorer current document handling', () => {
   beforeEach(() => {
     mocks.currentDoc = 'diff://notebook/diff-1'
@@ -165,6 +170,8 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.store.moveToTrash.mockReset()
     mocks.store.moveToTrash.mockResolvedValue(undefined)
     mocks.store.sync.mockReset()
+    mocks.openNotebookUpstreamDiff.mockReset()
+    mocks.openNotebookUpstreamDiff.mockResolvedValue(undefined)
     vi.spyOn(window, 'prompt').mockReturnValue('Reports')
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
@@ -262,6 +269,55 @@ describe('WorkspaceExplorer current document handling', () => {
     )
     await waitFor(() => {
       expect(mocks.store.moveToTrash).toHaveBeenCalledWith(
+        'local://file/untitled'
+      )
+    })
+  })
+
+  it('opens an upstream diff from a Drive-backed file context menu', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/untitled'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/untitled') {
+        return {
+          uri,
+          name: 'untitled.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/file123/view',
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    await waitFor(() => {
+      expect(screen.getByText('untitled.json')).toBeTruthy()
+    })
+
+    fireEvent.contextMenu(screen.getByText('untitled.json'))
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Compare with upstream',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.openNotebookUpstreamDiff).toHaveBeenCalledWith(
+        mocks.store,
         'local://file/untitled'
       )
     })

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -43,6 +43,7 @@ import { useCurrentDoc } from "../../contexts/CurrentDocContext";
 import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
+import { openNotebookUpstreamDiff } from "../../lib/notebookDiff/conflict";
 
 interface ContextMenuState {
   uri: string;
@@ -180,7 +181,7 @@ function getContextMenuItemCount(menu: ContextMenuState): number {
     return (
       (menu.uri.startsWith("fs://") ? 0 : 1) +
       2 +
-      (menu.remoteUri ? 4 : 0)
+      (menu.remoteUri ? 5 : 0)
     );
   }
 
@@ -1020,6 +1021,33 @@ function formatShortTimestamp(date: Date): string {
     [],
   );
 
+  const handleOpenUpstreamDiff = useCallback(
+    async (localUri: string) => {
+      if (!store) {
+        return;
+      }
+
+      try {
+        await openNotebookUpstreamDiff(store, localUri);
+        setErrorMessage(null);
+      } catch (error) {
+        appLogger.error("Failed to open upstream diff from explorer menu", {
+          attrs: {
+            scope: "notebook.diff",
+            code: "EXPLORER_OPEN_UPSTREAM_DIFF_FAILED",
+            uri: localUri,
+            error: String(error),
+          },
+        });
+        showToast({
+          message: "Unable to open upstream diff. Please try again.",
+          tone: "error",
+        });
+      }
+    },
+    [store],
+  );
+
   const handleMoveDriveFileToTrash = useCallback(
     async (menu: ContextMenuState) => {
       if (!menu.remoteUri || !store) {
@@ -1212,6 +1240,20 @@ function formatShortTimestamp(date: Date): string {
               >
                 New Document
               </button>
+              {adjustedContextMenu.remoteUri && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setContextMenu(null);
+                    void handleOpenUpstreamDiff(adjustedContextMenu.uri);
+                  }}
+                >
+                  Compare with upstream
+                </button>
+              )}
               {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"

--- a/app/src/lib/notebookDiff/conflict.test.ts
+++ b/app/src/lib/notebookDiff/conflict.test.ts
@@ -3,8 +3,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { RunmeMetadataKey, parser_pb } from '../../runme/client'
 import type LocalNotebooks from '../../storage/local'
-import { restoreDeletedConflictCell } from './conflict'
+import {
+  openNotebookDriveRevisionDiff,
+  openNotebookUpstreamDiff,
+  restoreDeletedConflictCell,
+} from './conflict'
 import { computeNotebookDiff } from './diff'
+import { getNotebookDiffDocument } from './registry'
 
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
@@ -159,5 +164,122 @@ describe('restoreDeletedConflictCell', () => {
       'c',
     ])
     expect(saved?.cells[0]?.value).toBe('unsaved a edit')
+  })
+})
+
+describe('Drive upstream diff documents', () => {
+  it('opens a generic upstream diff for Drive-backed notebooks without a conflict', async () => {
+    const localUri = 'local://file/drive'
+    const record = {
+      id: localUri,
+      name: 'drive.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base',
+      lastSynced: '',
+      doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
+      md5Checksum: 'local',
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getDriveUpstreamDoc: vi.fn(async () => ({
+        doc: serialize(notebook([cell({ refId: 'a', value: 'upstream' })])),
+        version: { revisionId: 'revision-5' },
+      })),
+    } as unknown as LocalNotebooks
+
+    await openNotebookUpstreamDiff(store, localUri)
+
+    const document = getNotebookDiffDocument(
+      `drive-upstream-diff-${encodeURIComponent(localUri)}`
+    )
+    expect(document?.base).toEqual({
+      label: 'Upstream version',
+      revisionId: 'revision-5',
+    })
+    expect(document?.resolution).toEqual({
+      kind: 'drive-upstream-diff',
+      localUri,
+    })
+  })
+
+  it('reuses the upstream document when selecting the current upstream revision', async () => {
+    const localUri = 'local://file/drive'
+    const record = {
+      id: localUri,
+      name: 'drive.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base',
+      lastSynced: '',
+      doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
+      md5Checksum: 'local',
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getDriveUpstreamDoc: vi.fn(async () => ({
+        doc: serialize(notebook([cell({ refId: 'a', value: 'upstream' })])),
+        version: { revisionId: 'revision-5' },
+      })),
+      getDriveRevisionDoc: vi.fn(),
+    } as unknown as LocalNotebooks
+
+    await openNotebookDriveRevisionDiff(store, localUri, 'revision-5', {
+      resolutionKind: 'drive-upstream-diff',
+    })
+
+    expect(store.getDriveRevisionDoc).not.toHaveBeenCalled()
+    expect(
+      getNotebookDiffDocument(
+        `drive-upstream-diff-${encodeURIComponent(localUri)}`
+      )?.base.label
+    ).toBe('Upstream version')
+  })
+
+  it('keeps conflict revision selections in the existing conflict diff document', async () => {
+    const localUri = 'local://file/conflict'
+    const record = {
+      id: localUri,
+      name: 'conflict.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base',
+      lastSynced: '',
+      doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
+      md5Checksum: 'local',
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        upstreamVersion: { revisionId: 'revision-5' },
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () =>
+        serialize(notebook([cell({ refId: 'a', value: 'upstream' })]))
+      ),
+      getDriveRevisionDoc: vi.fn(async () =>
+        serialize(notebook([cell({ refId: 'a', value: 'older' })]))
+      ),
+    } as unknown as LocalNotebooks
+
+    await openNotebookDriveRevisionDiff(store, localUri, 'revision-1')
+
+    const document = getNotebookDiffDocument(
+      `conflict-${encodeURIComponent(localUri)}`
+    )
+    expect(store.getDriveRevisionDoc).toHaveBeenCalledWith(
+      localUri,
+      'revision-1'
+    )
+    expect(document?.base).toEqual({
+      label: 'Drive revision revision-1',
+      revisionId: 'revision-1',
+    })
+    expect(document?.resolution?.kind).toBe('notebook-sync-conflict')
   })
 })

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -5,6 +5,7 @@ import type {
   LocalFileRecord,
   LocalNotebooks,
   NotebookConflictState,
+  UpstreamVersion,
 } from '../../storage/local'
 import { computeNotebookDiff } from './diff'
 import type { CellDiff, NotebookDiffDocument } from './model'
@@ -20,6 +21,21 @@ export interface RestoredConflictCellResult {
 
 export interface RestoreDeletedConflictCellOptions {
   localNotebook?: parser_pb.Notebook
+}
+
+type DriveDiffResolutionKind = NonNullable<
+  NotebookDiffDocument['resolution']
+>['kind']
+
+function diffDocumentIdForResolution(
+  localUri: string,
+  resolutionKind: DriveDiffResolutionKind
+): string {
+  const prefix =
+    resolutionKind === 'notebook-sync-conflict'
+      ? 'conflict'
+      : resolutionKind
+  return `${prefix}-${encodeURIComponent(localUri)}`
 }
 
 function parseNotebookJson(
@@ -47,7 +63,7 @@ async function registerConflictDiffDocument(
   const upstreamNotebook = parseNotebookJson(upstreamDoc, 'upstream')
   const localNotebook = parseNotebookJson(record.doc ?? '', 'local')
   return registerNotebookDiffDocument({
-    id: `conflict-${encodeURIComponent(localUri)}`,
+    id: diffDocumentIdForResolution(localUri, 'notebook-sync-conflict'),
     base: {
       label: 'Upstream version',
       revisionId: conflict.upstreamVersion?.revisionId,
@@ -79,6 +95,97 @@ export async function loadNotebookConflictDiffDocument(
   }
 
   return registerConflictDiffDocument(store, localUri, record, record.conflict)
+}
+
+async function registerUpstreamDiffDocument(
+  localUri: string,
+  record: LocalFileRecord,
+  upstreamDoc: string,
+  upstreamVersion: UpstreamVersion | undefined,
+  resolutionKind: DriveDiffResolutionKind = 'drive-upstream-diff'
+): Promise<NotebookDiffDocument> {
+  const upstreamNotebook = parseNotebookJson(upstreamDoc, 'upstream')
+  const localNotebook = parseNotebookJson(record.doc ?? '', 'local')
+  return registerNotebookDiffDocument({
+    id: diffDocumentIdForResolution(localUri, resolutionKind),
+    base: {
+      label: 'Upstream version',
+      revisionId: upstreamVersion?.revisionId,
+    },
+    compare: {
+      label: 'Local version',
+    },
+    diff: computeNotebookDiff(upstreamNotebook, localNotebook, {
+      includeOutputs: true,
+      includeMetadata: true,
+    }),
+    resolution: {
+      kind: resolutionKind,
+      localUri,
+    },
+  })
+}
+
+async function registerDriveRevisionDiffDocument(
+  store: LocalNotebooks,
+  localUri: string,
+  revisionId: string,
+  resolutionKind: DriveDiffResolutionKind = 'notebook-sync-conflict'
+): Promise<NotebookDiffDocument> {
+  const normalizedRevisionId = revisionId.trim()
+  if (!normalizedRevisionId) {
+    throw new Error('Drive revision diff requires a revision id')
+  }
+
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+
+  if (resolutionKind === 'drive-upstream-diff') {
+    const upstream = await store.getDriveUpstreamDoc(localUri)
+    if (upstream.version?.revisionId === normalizedRevisionId) {
+      return registerUpstreamDiffDocument(
+        localUri,
+        record,
+        upstream.doc,
+        upstream.version,
+        resolutionKind
+      )
+    }
+  }
+
+  if (record.conflict?.upstreamVersion?.revisionId === normalizedRevisionId) {
+    return registerConflictDiffDocument(store, localUri, record, record.conflict)
+  }
+
+  const revisionDoc = await store.getDriveRevisionDoc(
+    localUri,
+    normalizedRevisionId
+  )
+  const revisionNotebook = parseNotebookJson(
+    revisionDoc,
+    `Drive revision ${normalizedRevisionId}`
+  )
+  const localNotebook = parseNotebookJson(record.doc ?? '', 'local')
+  return registerNotebookDiffDocument({
+    id: diffDocumentIdForResolution(localUri, resolutionKind),
+    base: {
+      label: `Drive revision ${normalizedRevisionId}`,
+      revisionId: normalizedRevisionId,
+    },
+    compare: {
+      label: 'Local version',
+    },
+    diff: computeNotebookDiff(revisionNotebook, localNotebook, {
+      includeOutputs: true,
+      includeMetadata: true,
+    }),
+    resolution: {
+      kind: resolutionKind,
+      localUri,
+    },
+  })
 }
 
 function findRestoredCellIndex(
@@ -215,6 +322,52 @@ export async function openNotebookConflictDiff(
   localUri: string
 ): Promise<void> {
   const document = await loadNotebookConflictDiffDocument(store, localUri)
+  openNotebookDiffDocument(document)
+}
+
+export async function openNotebookUpstreamDiff(
+  store: LocalNotebooks,
+  localUri: string
+): Promise<void> {
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+
+  if (record.conflict) {
+    const document = await registerConflictDiffDocument(
+      store,
+      localUri,
+      record,
+      record.conflict
+    )
+    openNotebookDiffDocument(document)
+    return
+  }
+
+  const upstream = await store.getDriveUpstreamDoc(localUri)
+  const document = await registerUpstreamDiffDocument(
+    localUri,
+    record,
+    upstream.doc,
+    upstream.version,
+    'drive-upstream-diff'
+  )
+  openNotebookDiffDocument(document)
+}
+
+export async function openNotebookDriveRevisionDiff(
+  store: LocalNotebooks,
+  localUri: string,
+  revisionId: string,
+  options: { resolutionKind?: DriveDiffResolutionKind } = {}
+): Promise<void> {
+  const document = await registerDriveRevisionDiffDocument(
+    store,
+    localUri,
+    revisionId,
+    options.resolutionKind ?? 'notebook-sync-conflict'
+  )
   openNotebookDiffDocument(document)
 }
 

--- a/app/src/lib/notebookDiff/model.ts
+++ b/app/src/lib/notebookDiff/model.ts
@@ -88,7 +88,7 @@ export interface NotebookDiffDocument {
   }
   diff: NotebookDiff
   resolution?: {
-    kind: 'notebook-sync-conflict'
+    kind: 'notebook-sync-conflict' | 'drive-upstream-diff'
     localUri: string
   }
 }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -12,6 +12,7 @@ import LocalNotebooks, {
   NotebookConflictChangedError,
 } from './local'
 import { NotebookStoreItemType } from './notebook'
+import { MemoryRevisionDocStorage } from './revisionDocs'
 
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
@@ -63,6 +64,7 @@ function createTestStore(driveStore: unknown) {
   localStore.syncSubjects = new Map()
   localStore.markdownSyncSubjects = new Map()
   localStore.conflictDocStorage = new MemoryConflictDocStorage()
+  localStore.revisionDocStorage = new MemoryRevisionDocStorage()
   return localStore as LocalNotebooks
 }
 
@@ -525,6 +527,96 @@ describe('LocalNotebooks moveToTrash', () => {
 })
 
 describe('LocalNotebooks Drive conflict resolution', () => {
+  it('loads the current Drive upstream document without creating a conflict', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const upstreamNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('upstream')",
+        }),
+      ],
+    })
+    const driveStore = {
+      load: vi.fn(async () => upstreamNotebook),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'upstream-checksum',
+        headRevisionId: 'upstream-revision',
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/drive',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '2026-05-01T00:00:00.000Z',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+    })
+
+    await expect(store.getDriveUpstreamDoc('local://file/drive')).resolves.toEqual({
+      doc: toJsonString(
+        parser_pb.NotebookSchema,
+        upstreamNotebook,
+        NOTEBOOK_JSON_WRITE_OPTIONS
+      ),
+      version: {
+        checksum: 'upstream-checksum',
+        revisionId: 'upstream-revision',
+      },
+    })
+    const record = await store.files.get('local://file/drive')
+    expect(record?.conflict).toBeUndefined()
+    expect(driveStore.load).toHaveBeenCalledWith(remoteUri)
+    expect(driveStore.getVersionMetadata).toHaveBeenCalledWith(remoteUri)
+  })
+
+  it('stores selected Drive revisions in revision document storage', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const revisionNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('revision')",
+        }),
+      ],
+    })
+    const driveStore = {
+      loadRevision: vi.fn(async () => revisionNotebook),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/drive',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '2026-05-01T00:00:00.000Z',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+    })
+
+    await expect(
+      store.getDriveRevisionDoc('local://file/drive', 'revision-1')
+    ).resolves.toBe(
+      toJsonString(
+        parser_pb.NotebookSchema,
+        revisionNotebook,
+        NOTEBOOK_JSON_WRITE_OPTIONS
+      )
+    )
+    await expect(
+      store.getDriveRevisionDoc('local://file/drive', 'revision-1')
+    ).resolves.toContain("print('revision')")
+    expect(driveStore.loadRevision).toHaveBeenCalledTimes(1)
+    expect(driveStore.loadRevision).toHaveBeenCalledWith(
+      remoteUri,
+      'revision-1'
+    )
+  })
+
   it('records a conflict instead of creating a timestamped Drive copy', async () => {
     const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const localDoc = notebookJson("print('local')")

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -15,11 +15,16 @@ import {
 } from './conflictDocs'
 import {
   DriveNotebookStore,
+  type DriveRevision,
   type DriveVersionMetadata,
   isDriveItemUri,
 } from './drive'
 import type { FilesystemNotebookStore } from './fs'
 import { NotebookStoreItem, NotebookStoreItemType } from './notebook'
+import {
+  type RevisionDocStorage,
+  createDefaultRevisionDocStorage,
+} from './revisionDocs'
 
 // Local folder URI is a special folder that contains all notebooks which are local (i.e. not synced to Drive)
 export const LOCAL_FOLDER_URI = 'local://folder/local'
@@ -187,6 +192,7 @@ export class LocalNotebooks extends Dexie {
   private readonly driveStore: DriveNotebookStore
   private filesystemStore: FilesystemNotebookStore | null = null
   private readonly conflictDocStorage: ConflictDocStorage
+  private readonly revisionDocStorage: RevisionDocStorage
 
   private readonly syncSubjects = new Map<string, Subject<void>>()
   private readonly markdownSyncSubjects = new Map<string, Subject<void>>()
@@ -196,7 +202,8 @@ export class LocalNotebooks extends Dexie {
   constructor(
     driveStore: DriveNotebookStore,
     databaseName: string = 'runme-local-notebooks',
-    conflictDocStorage: ConflictDocStorage = createDefaultConflictDocStorage()
+    conflictDocStorage: ConflictDocStorage = createDefaultConflictDocStorage(),
+    revisionDocStorage: RevisionDocStorage = createDefaultRevisionDocStorage()
   ) {
     super(databaseName)
 
@@ -286,6 +293,7 @@ export class LocalNotebooks extends Dexie {
 
     this.driveStore = driveStore
     this.conflictDocStorage = conflictDocStorage
+    this.revisionDocStorage = revisionDocStorage
 
     void this.ensureFolderRecord(LOCAL_FOLDER_URI, 'Local Notebooks')
   }
@@ -840,6 +848,90 @@ export class LocalNotebooks extends Dexie {
     throw new Error(
       `Conflict upstream document is missing for local notebook ${localUri}`
     )
+  }
+
+  async getDriveUpstreamDoc(
+    localUri: string
+  ): Promise<{ doc: string; version?: UpstreamVersion }> {
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (!isDriveUri(record.remoteId)) {
+      throw new Error(
+        `Drive upstream loading is only supported for Drive-backed notebooks; got ${record.remoteId}`
+      )
+    }
+    if (record.conflict) {
+      return {
+        doc: await this.getConflictUpstreamDoc(localUri),
+        version: record.conflict.upstreamVersion,
+      }
+    }
+
+    const upstreamNotebook = await this.driveStore.load(record.remoteId)
+    const upstreamDoc = serializeNotebook(upstreamNotebook)
+    const upstreamVersion = driveMetadataToUpstreamVersion(
+      await this.driveStore.getVersionMetadata(record.remoteId)
+    )
+    return {
+      doc: upstreamDoc,
+      version: upstreamVersion,
+    }
+  }
+
+  async listDriveRevisions(localUri: string): Promise<DriveRevision[]> {
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (!isDriveUri(record.remoteId)) {
+      throw new Error(
+        `Drive revisions are only supported for Drive-backed notebooks; got ${record.remoteId}`
+      )
+    }
+    return this.driveStore.listRevisions(record.remoteId)
+  }
+
+  async getDriveRevisionDoc(
+    localUri: string,
+    revisionId: string
+  ): Promise<string> {
+    const normalizedRevisionId = revisionId.trim()
+    if (!normalizedRevisionId) {
+      throw new Error('getDriveRevisionDoc requires a revision id')
+    }
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (!isDriveUri(record.remoteId)) {
+      throw new Error(
+        `Drive revision loading is only supported for Drive-backed notebooks; got ${record.remoteId}`
+      )
+    }
+
+    try {
+      return await this.getRevisionDocStorage().read(
+        localUri,
+        normalizedRevisionId
+      )
+    } catch {
+      // Revisions are immutable, so a cache miss can be repaired by fetching
+      // the exact Drive revision and storing it in OPFS for future diffs.
+    }
+
+    const revisionNotebook = await this.driveStore.loadRevision(
+      record.remoteId,
+      normalizedRevisionId
+    )
+    const revisionDoc = serializeNotebook(revisionNotebook)
+    await this.getRevisionDocStorage().write(
+      localUri,
+      normalizedRevisionId,
+      revisionDoc
+    )
+    return this.getRevisionDocStorage().read(localUri, normalizedRevisionId)
   }
 
   private async persistNotebook(
@@ -1973,10 +2065,11 @@ export class LocalNotebooks extends Dexie {
   }
 
   private getConflictDocStorage(): ConflictDocStorage {
-    return (
-      (this as unknown as { conflictDocStorage?: ConflictDocStorage })
-        .conflictDocStorage ?? createDefaultConflictDocStorage()
-    )
+    return this.conflictDocStorage ?? createDefaultConflictDocStorage()
+  }
+
+  private getRevisionDocStorage(): RevisionDocStorage {
+    return this.revisionDocStorage ?? createDefaultRevisionDocStorage()
   }
 
   private async deleteConflictDoc(

--- a/app/src/storage/revisionDocs.ts
+++ b/app/src/storage/revisionDocs.ts
@@ -1,0 +1,159 @@
+import md5 from 'md5'
+
+export interface RevisionDocumentRef {
+  storage: 'opfs'
+  path: string
+  revisionId: string
+  sizeBytes: number
+  checksum: string
+}
+
+export interface RevisionDocStorage {
+  write(
+    localUri: string,
+    revisionId: string,
+    revisionDoc: string
+  ): Promise<RevisionDocumentRef>
+  read(localUri: string, revisionId: string): Promise<string>
+  delete(localUri: string, revisionId: string): Promise<void>
+}
+
+const ROOT_DIR = 'runme'
+const REVISION_DIR = 'revisions'
+const REVISION_DOC_FILE = 'revision.json'
+
+const textEncoder = new TextEncoder()
+
+function normalizeRevisionId(revisionId: string): string {
+  const normalized = revisionId.trim()
+  if (!normalized) {
+    throw new Error('Drive revision id is required')
+  }
+  return normalized
+}
+
+function revisionPathForLocalUri(localUri: string, revisionId: string): string {
+  return [
+    ROOT_DIR,
+    REVISION_DIR,
+    encodeURIComponent(localUri),
+    encodeURIComponent(normalizeRevisionId(revisionId)),
+    REVISION_DOC_FILE,
+  ].join('/')
+}
+
+function opfsUnavailableError(): Error {
+  return new Error('Origin private file system is not available')
+}
+
+async function getOpfsRoot(): Promise<FileSystemDirectoryHandle> {
+  const storage = globalThis.navigator?.storage
+  if (!storage?.getDirectory) {
+    throw opfsUnavailableError()
+  }
+  return storage.getDirectory()
+}
+
+async function getDirectory(
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+  options: FileSystemGetDirectoryOptions = {}
+): Promise<FileSystemDirectoryHandle> {
+  let dir = root
+  for (const segment of segments) {
+    dir = await dir.getDirectoryHandle(segment, options)
+  }
+  return dir
+}
+
+export class OpfsRevisionDocStorage implements RevisionDocStorage {
+  async write(
+    localUri: string,
+    revisionId: string,
+    revisionDoc: string
+  ): Promise<RevisionDocumentRef> {
+    const normalizedRevisionId = normalizeRevisionId(revisionId)
+    const path = revisionPathForLocalUri(localUri, normalizedRevisionId)
+    const root = await getOpfsRoot()
+    const dir = await getDirectory(
+      root,
+      [
+        ROOT_DIR,
+        REVISION_DIR,
+        encodeURIComponent(localUri),
+        encodeURIComponent(normalizedRevisionId),
+      ],
+      { create: true }
+    )
+    const handle = await dir.getFileHandle(REVISION_DOC_FILE, {
+      create: true,
+    })
+    const writable = await handle.createWritable()
+    await writable.write(revisionDoc)
+    await writable.close()
+
+    return {
+      storage: 'opfs',
+      path,
+      revisionId: normalizedRevisionId,
+      sizeBytes: textEncoder.encode(revisionDoc).byteLength,
+      checksum: md5(revisionDoc),
+    }
+  }
+
+  async read(localUri: string, revisionId: string): Promise<string> {
+    const path = revisionPathForLocalUri(localUri, revisionId)
+    const segments = path.split('/').filter(Boolean)
+    const root = await getOpfsRoot()
+    const dir = await getDirectory(root, segments.slice(0, -1))
+    const handle = await dir.getFileHandle(segments[segments.length - 1])
+    const file = await handle.getFile()
+    return file.text()
+  }
+
+  async delete(localUri: string, revisionId: string): Promise<void> {
+    const path = revisionPathForLocalUri(localUri, revisionId)
+    const segments = path.split('/').filter(Boolean)
+    const root = await getOpfsRoot()
+    const dir = await getDirectory(root, segments.slice(0, -1))
+    await dir.removeEntry(segments[segments.length - 1]).catch(() => {})
+  }
+}
+
+export class MemoryRevisionDocStorage implements RevisionDocStorage {
+  private readonly docs = new Map<string, string>()
+
+  async write(
+    localUri: string,
+    revisionId: string,
+    revisionDoc: string
+  ): Promise<RevisionDocumentRef> {
+    const normalizedRevisionId = normalizeRevisionId(revisionId)
+    const path = revisionPathForLocalUri(localUri, normalizedRevisionId)
+    this.docs.set(path, revisionDoc)
+    return {
+      storage: 'opfs',
+      path,
+      revisionId: normalizedRevisionId,
+      sizeBytes: textEncoder.encode(revisionDoc).byteLength,
+      checksum: md5(revisionDoc),
+    }
+  }
+
+  async read(localUri: string, revisionId: string): Promise<string> {
+    const path = revisionPathForLocalUri(localUri, revisionId)
+    const doc = this.docs.get(path)
+    if (doc === undefined) {
+      throw new Error(`Revision document not found: ${path}`)
+    }
+    return doc
+  }
+
+  async delete(localUri: string, revisionId: string): Promise<void> {
+    this.docs.delete(revisionPathForLocalUri(localUri, revisionId))
+  }
+}
+
+export function createDefaultRevisionDocStorage(): RevisionDocStorage {
+  return new OpfsRevisionDocStorage()
+}


### PR DESCRIPTION
## Summary
- add Drive-backed upstream diff opening from notebook tabs and workspace explorer context menus
- add Drive revision selector under the Base header in notebook diff views
- reuse cached upstream/conflict documents for current upstream revisions and fetch older revisions into OPFS-backed revision storage

## Verification
- pnpm -C app exec vitest run src/lib/notebookDiff/conflict.test.ts src/components/NotebookDiff/NotebookDiffView.test.tsx src/components/Actions/Actions.test.tsx src/components/Workspace/WorkspaceExplorer.test.tsx src/storage/local.test.ts
- runme run build test