### PR TITLE
Fix Drive revision diff review issues

### DIFF
--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -177,6 +177,52 @@ describe('NotebookDiffContent', () => {
     })
   })
 
+  it('hides conflict resolution controls when a conflict diff shows an older Drive revision', () => {
+    const olderNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'older-only',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('old upstream cell')",
+        }),
+      ],
+      metadata: {},
+    })
+    const localNotebook = create(parser_pb.NotebookSchema, {
+      cells: [],
+      metadata: {},
+    })
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Drive revision revision-1', revisionId: 'revision-1' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(olderNotebook, localNotebook, {
+        includeMetadata: true,
+        includeOutputs: true,
+      }),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={{} as unknown as LocalNotebooks}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    expect(screen.queryByText('Save local version')).toBeNull()
+    expect(screen.queryByText('Refresh diff')).toBeNull()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Insert upstream cell into local notebook',
+      })
+    ).toBeNull()
+    expect(screen.getByLabelText('Compare against')).toBeTruthy()
+  })
+
   it('inserts a deleted upstream cell into the local notebook and refreshes the diff', async () => {
     const upstreamNotebook = create(parser_pb.NotebookSchema, {
       cells: [

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -283,10 +283,12 @@ function DriveRevisionSelector({
   localUri,
   selectedRevisionId,
   resolutionKind,
+  currentUpstreamRevisionId,
 }: {
   localUri: string
   selectedRevisionId?: string
   resolutionKind: NonNullable<NotebookDiffDocument['resolution']>['kind']
+  currentUpstreamRevisionId?: string
 }) {
   const { store } = useNotebookStore()
   const [revisions, setRevisions] = useState<DriveRevision[]>([])
@@ -336,6 +338,7 @@ function DriveRevisionSelector({
     try {
       await openNotebookDriveRevisionDiff(store, localUri, revisionId, {
         resolutionKind,
+        currentUpstreamRevisionId,
       })
     } catch {
       setError('Unable to load selected Drive revision.')
@@ -546,6 +549,10 @@ export function NotebookDiffContent({
     currentDocument.resolution?.kind === 'notebook-sync-conflict'
       ? currentDocument.resolution
       : null
+  const activeConflictResolution =
+    conflictResolution && currentDocument.base.label === 'Upstream version'
+      ? conflictResolution
+      : null
   const driveRevisionResolution =
     currentDocument.resolution?.kind === 'notebook-sync-conflict' ||
     currentDocument.resolution?.kind === 'drive-upstream-diff'
@@ -564,7 +571,7 @@ export function NotebookDiffContent({
               {currentDocument.base.label} compared with{' '}
               {currentDocument.compare.label}
             </Text>
-            {conflictResolution && (
+            {activeConflictResolution && (
               <Text
                 as="p"
                 size="2"
@@ -576,8 +583,10 @@ export function NotebookDiffContent({
               </Text>
             )}
           </div>
-          {conflictResolution && (
-            <ConflictResolutionActions localUri={conflictResolution.localUri} />
+          {activeConflictResolution && (
+            <ConflictResolutionActions
+              localUri={activeConflictResolution.localUri}
+            />
           )}
         </div>
         <div className="mt-3 flex flex-wrap gap-2 text-sm text-nb-text-muted">
@@ -598,6 +607,12 @@ export function NotebookDiffContent({
                   localUri={driveRevisionResolution.localUri}
                   selectedRevisionId={currentDocument.base.revisionId}
                   resolutionKind={driveRevisionResolution.kind}
+                  currentUpstreamRevisionId={
+                    driveRevisionResolution.upstreamRevisionId ??
+                    (currentDocument.base.label === 'Upstream version'
+                      ? currentDocument.base.revisionId
+                      : undefined)
+                  }
                 />
               </div>
             )}
@@ -613,7 +628,7 @@ export function NotebookDiffContent({
             <DiffRow
               key={row.id}
               row={row}
-              conflictLocalUri={conflictResolution?.localUri}
+              conflictLocalUri={activeConflictResolution?.localUri}
               onConflictDocumentChanged={setCurrentDocument}
             />
           ))}

--- a/app/src/lib/notebookDiff/conflict.test.ts
+++ b/app/src/lib/notebookDiff/conflict.test.ts
@@ -176,6 +176,7 @@ describe('Drive upstream diff documents', () => {
       remoteId: 'https://drive.google.com/file/d/file123/view',
       lastRemoteChecksum: 'base',
       lastSynced: '',
+      lastUpstreamVersion: { revisionId: 'revision-5' },
       doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
       md5Checksum: 'local',
     }
@@ -201,6 +202,7 @@ describe('Drive upstream diff documents', () => {
     expect(document?.resolution).toEqual({
       kind: 'drive-upstream-diff',
       localUri,
+      upstreamRevisionId: 'revision-5',
     })
   })
 
@@ -212,6 +214,7 @@ describe('Drive upstream diff documents', () => {
       remoteId: 'https://drive.google.com/file/d/file123/view',
       lastRemoteChecksum: 'base',
       lastSynced: '',
+      lastUpstreamVersion: { revisionId: 'revision-5' },
       doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
       md5Checksum: 'local',
     }
@@ -228,6 +231,7 @@ describe('Drive upstream diff documents', () => {
 
     await openNotebookDriveRevisionDiff(store, localUri, 'revision-5', {
       resolutionKind: 'drive-upstream-diff',
+      currentUpstreamRevisionId: 'revision-5',
     })
 
     expect(store.getDriveRevisionDoc).not.toHaveBeenCalled()
@@ -236,6 +240,97 @@ describe('Drive upstream diff documents', () => {
         `drive-upstream-diff-${encodeURIComponent(localUri)}`
       )?.base.label
     ).toBe('Upstream version')
+  })
+
+  it('does not fetch the current upstream document before loading an older generic revision', async () => {
+    const localUri = 'local://file/drive'
+    const record = {
+      id: localUri,
+      name: 'drive.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base',
+      lastSynced: '',
+      lastUpstreamVersion: { revisionId: 'revision-5' },
+      doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
+      md5Checksum: 'local',
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getDriveUpstreamDoc: vi.fn(async () => {
+        throw new Error('current upstream should not be fetched')
+      }),
+      getDriveRevisionDoc: vi.fn(async () =>
+        serialize(notebook([cell({ refId: 'a', value: 'older' })]))
+      ),
+    } as unknown as LocalNotebooks
+
+    await openNotebookDriveRevisionDiff(store, localUri, 'revision-1', {
+      resolutionKind: 'drive-upstream-diff',
+      currentUpstreamRevisionId: 'revision-5',
+    })
+
+    expect(store.getDriveUpstreamDoc).not.toHaveBeenCalled()
+    expect(store.getDriveRevisionDoc).toHaveBeenCalledWith(
+      localUri,
+      'revision-1'
+    )
+    expect(
+      getNotebookDiffDocument(
+        `drive-upstream-diff-${encodeURIComponent(localUri)}`
+      )?.base
+    ).toEqual({
+      label: 'Drive revision revision-1',
+      revisionId: 'revision-1',
+    })
+  })
+
+  it('loads a stale current-upstream revision as a historical revision after verifying Drive head', async () => {
+    const localUri = 'local://file/drive'
+    const record = {
+      id: localUri,
+      name: 'drive.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base',
+      lastSynced: '',
+      lastUpstreamVersion: { revisionId: 'revision-5' },
+      doc: serialize(notebook([cell({ refId: 'a', value: 'local' })])),
+      md5Checksum: 'local',
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getDriveUpstreamDoc: vi.fn(async () => ({
+        doc: serialize(
+          notebook([cell({ refId: 'a', value: 'new upstream head' })])
+        ),
+        version: { revisionId: 'revision-6' },
+      })),
+      getDriveRevisionDoc: vi.fn(async () =>
+        serialize(notebook([cell({ refId: 'a', value: 'older' })]))
+      ),
+    } as unknown as LocalNotebooks
+
+    await openNotebookDriveRevisionDiff(store, localUri, 'revision-5', {
+      resolutionKind: 'drive-upstream-diff',
+      currentUpstreamRevisionId: 'revision-5',
+    })
+
+    expect(store.getDriveUpstreamDoc).toHaveBeenCalledWith(localUri)
+    expect(store.getDriveRevisionDoc).toHaveBeenCalledWith(
+      localUri,
+      'revision-5'
+    )
+    expect(
+      getNotebookDiffDocument(
+        `drive-upstream-diff-${encodeURIComponent(localUri)}`
+      )?.base
+    ).toEqual({
+      label: 'Drive revision revision-5',
+      revisionId: 'revision-5',
+    })
   })
 
   it('keeps conflict revision selections in the existing conflict diff document', async () => {

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -122,6 +122,10 @@ async function registerUpstreamDiffDocument(
     resolution: {
       kind: resolutionKind,
       localUri,
+      upstreamRevisionId:
+        resolutionKind === 'drive-upstream-diff'
+          ? upstreamVersion?.revisionId
+          : undefined,
     },
   })
 }
@@ -130,7 +134,8 @@ async function registerDriveRevisionDiffDocument(
   store: LocalNotebooks,
   localUri: string,
   revisionId: string,
-  resolutionKind: DriveDiffResolutionKind = 'notebook-sync-conflict'
+  resolutionKind: DriveDiffResolutionKind = 'notebook-sync-conflict',
+  currentUpstreamRevisionId?: string
 ): Promise<NotebookDiffDocument> {
   const normalizedRevisionId = revisionId.trim()
   if (!normalizedRevisionId) {
@@ -142,7 +147,10 @@ async function registerDriveRevisionDiffDocument(
     throw new Error(`Local notebook record not found for ${localUri}`)
   }
 
-  if (resolutionKind === 'drive-upstream-diff') {
+  if (
+    resolutionKind === 'drive-upstream-diff' &&
+    currentUpstreamRevisionId === normalizedRevisionId
+  ) {
     const upstream = await store.getDriveUpstreamDoc(localUri)
     if (upstream.version?.revisionId === normalizedRevisionId) {
       return registerUpstreamDiffDocument(
@@ -184,6 +192,10 @@ async function registerDriveRevisionDiffDocument(
     resolution: {
       kind: resolutionKind,
       localUri,
+      upstreamRevisionId:
+        resolutionKind === 'drive-upstream-diff'
+          ? currentUpstreamRevisionId
+          : undefined,
     },
   })
 }
@@ -360,13 +372,17 @@ export async function openNotebookDriveRevisionDiff(
   store: LocalNotebooks,
   localUri: string,
   revisionId: string,
-  options: { resolutionKind?: DriveDiffResolutionKind } = {}
+  options: {
+    resolutionKind?: DriveDiffResolutionKind
+    currentUpstreamRevisionId?: string
+  } = {}
 ): Promise<void> {
   const document = await registerDriveRevisionDiffDocument(
     store,
     localUri,
     revisionId,
-    options.resolutionKind ?? 'notebook-sync-conflict'
+    options.resolutionKind ?? 'notebook-sync-conflict',
+    options.currentUpstreamRevisionId
   )
   openNotebookDiffDocument(document)
 }

--- a/app/src/lib/notebookDiff/model.ts
+++ b/app/src/lib/notebookDiff/model.ts
@@ -90,5 +90,6 @@ export interface NotebookDiffDocument {
   resolution?: {
     kind: 'notebook-sync-conflict' | 'drive-upstream-diff'
     localUri: string
+    upstreamRevisionId?: string
   }
 }


### PR DESCRIPTION
## Summary
- hide conflict save/insert controls when a conflict diff is comparing against an older Drive revision instead of the conflict upstream baseline
- avoid fetching the current Drive upstream body before loading older generic Drive revisions
- add regression coverage for both review findings

## Verification
- pnpm -C app exec vitest run src/lib/notebookDiff/conflict.test.ts src/components/NotebookDiff/NotebookDiffView.test.tsx
- runme run build test

Follow-up to #267 addressing Codex review comments.