### PR TITLE
[codex] Add Drive-backed Excalidraw documents

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "@connectrpc/connect-node": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@datadog/datadog-api-client": "^1.45.0",
+    "@excalidraw/excalidraw": "0.18.1",
     "@heroicons/react": "2.2.0",
     "@monaco-editor/react": "^4.7.0",
     "@openai/chatkit-react": "1.5.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -94,6 +94,10 @@ function AppRouter() {
 }
 
 function App({ branding }: AppProps) {
+  return <RunmeApp branding={branding} />
+}
+
+function RunmeApp({ branding }: AppProps) {
   const appBranding = {
     name: branding?.name ?? 'runme notebook',
     logo: branding?.logo ?? runmeIcon,

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -65,6 +65,7 @@ import {
   isDriveLinkStatusUri,
   isDriveSyncStatusUri,
   isAppConsoleUri,
+  isExcalidrawWorkspaceDocument,
   isLogsUri,
   isNotebookDiffUri,
   isNotebookDocumentUri,
@@ -104,6 +105,7 @@ import AppConsole from '../AppConsole/AppConsole'
 import LogsPane from '../Logs/LogsPane'
 import { ActionOutputItems } from './ActionOutputItems'
 import React from 'react'
+import ExcalidrawDocument from '../Excalidraw/ExcalidrawDocument'
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
   'data-state'?: 'active' | 'inactive'
@@ -2215,6 +2217,10 @@ function renderWorkspaceDocument({
   onDriveLogin: () => void
   onDriveRetry: () => void
 }) {
+  if (isExcalidrawWorkspaceDocument(document)) {
+    return <ExcalidrawDocument document={document} />
+  }
+
   if (isNotebookDocumentUri(document.uri)) {
     const entry: OpenNotebookEntry = {
       uri: document.uri,

--- a/app/src/components/Excalidraw/ExcalidrawDocument.tsx
+++ b/app/src/components/Excalidraw/ExcalidrawDocument.tsx
@@ -1,0 +1,313 @@
+import {
+  CaptureUpdateAction,
+  Excalidraw,
+  restore,
+  serializeAsJSON,
+} from '@excalidraw/excalidraw'
+import '@excalidraw/excalidraw/index.css'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type {
+  AppState,
+  BinaryFiles,
+  ExcalidrawInitialDataState,
+  ExcalidrawImperativeAPI,
+} from '@excalidraw/excalidraw/types'
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types'
+
+import { appLogger } from '../../lib/logging/runtime'
+import { appState } from '../../lib/runtime/AppState'
+import type { WorkspaceDocument } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
+import {
+  EXCALIDRAW_MIME_TYPE,
+  createInitialExcalidrawDocumentJson,
+} from '../../storage/excalidraw'
+
+type SaveState = 'loading' | 'ready' | 'saving' | 'saved' | 'error'
+
+export default function ExcalidrawDocument({
+  document,
+}: {
+  document: WorkspaceDocument
+}) {
+  const remoteUri = useMemo(
+    () => document.requestedUri?.trim() || '',
+    [document.requestedUri, document.uri]
+  )
+  const localUri = useMemo(
+    () => (document.uri.startsWith('local://file/') ? document.uri : ''),
+    [document.uri]
+  )
+  const [initialData, setInitialData] =
+    useState<ExcalidrawInitialDataState | null>(null)
+  const [saveState, setSaveState] = useState<SaveState>('loading')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const saveTimerRef = useRef<number | null>(null)
+  const latestJsonRef = useRef<string>('')
+  const lastSavedJsonRef = useRef<string>('')
+  const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>(null)
+  const applyingExternalUpdateRef = useRef(false)
+
+  const flushSave = useCallback(
+    async (options: { updateState?: boolean } = {}) => {
+      const updateState = options.updateState ?? true
+      const json = latestJsonRef.current
+      if (!json || json === lastSavedJsonRef.current) {
+        return
+      }
+      const localStore = appState.localNotebooks
+      const driveStore = appState.driveNotebookStore
+      if (!localStore && (!driveStore || !remoteUri)) {
+        if (updateState) {
+          setSaveState('error')
+          setErrorMessage('Excalidraw document storage is not initialized')
+        }
+        return
+      }
+
+      if (updateState) {
+        setSaveState('saving')
+      }
+      try {
+        if (localStore && localUri) {
+          await localStore.saveContent(localUri, json, EXCALIDRAW_MIME_TYPE)
+        } else if (driveStore && remoteUri) {
+          await driveStore.saveContent(remoteUri, json, EXCALIDRAW_MIME_TYPE)
+        }
+        lastSavedJsonRef.current = json
+        if (updateState) {
+          setSaveState('saved')
+          setErrorMessage(null)
+        }
+      } catch (error) {
+        appLogger.error('Failed to save Excalidraw document', {
+          attrs: {
+            scope: 'excalidraw.drive',
+            uri: document.uri,
+            remoteUri,
+            error: String(error),
+          },
+        })
+        if (updateState) {
+          setSaveState('error')
+          setErrorMessage(String(error))
+        }
+      }
+    },
+    [document.uri, localUri, remoteUri]
+  )
+
+  const restoreSerializedScene = useCallback((raw: string) => {
+    const json = raw.trim() ? raw : createInitialExcalidrawDocumentJson()
+    const parsed = JSON.parse(json)
+    const restored = restore(parsed, null, null)
+    const normalizedJson = serializeAsJSON(
+      restored.elements,
+      restored.appState,
+      restored.files,
+      'local'
+    )
+    return { restored, normalizedJson }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setInitialData(null)
+    setSaveState('loading')
+    setErrorMessage(null)
+    latestJsonRef.current = ''
+    lastSavedJsonRef.current = ''
+
+    void (async () => {
+      const localStore = appState.localNotebooks
+
+      let raw: string
+      if (localStore && localUri) {
+        raw = await localStore.loadContent(localUri)
+      } else if (remoteUri) {
+        const driveStore = appState.driveNotebookStore
+        if (!driveStore) {
+          throw new Error('Google Drive store is not initialized')
+        }
+        raw = await driveStore.loadContent(remoteUri)
+      } else {
+        throw new Error('Excalidraw document storage is not initialized')
+      }
+      const { restored, normalizedJson } = restoreSerializedScene(raw)
+      if (cancelled) {
+        return
+      }
+      lastSavedJsonRef.current = normalizedJson
+      latestJsonRef.current = normalizedJson
+      setInitialData(restored)
+      setSaveState('ready')
+    })().catch((error) => {
+      appLogger.error('Failed to load Excalidraw document', {
+        attrs: {
+          scope: 'excalidraw.drive',
+          uri: document.uri,
+          remoteUri,
+          error: String(error),
+        },
+      })
+      if (!cancelled) {
+        setErrorMessage(String(error))
+        setSaveState('error')
+      }
+    })
+
+    return () => {
+      cancelled = true
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current)
+        saveTimerRef.current = null
+      }
+      void flushSave({ updateState: false })
+    }
+  }, [document.uri, flushSave, localUri, remoteUri, restoreSerializedScene])
+
+  useEffect(() => {
+    if (!localUri) {
+      return
+    }
+    const localStore = appState.localNotebooks
+    if (!localStore) {
+      return
+    }
+
+    const refreshFromLocalStore = () => {
+      void (async () => {
+        const raw = await localStore.loadContent(localUri)
+        const { restored, normalizedJson } = restoreSerializedScene(raw)
+        if (normalizedJson === latestJsonRef.current) {
+          return
+        }
+        if (saveTimerRef.current !== null) {
+          window.clearTimeout(saveTimerRef.current)
+          saveTimerRef.current = null
+        }
+        applyingExternalUpdateRef.current = true
+        latestJsonRef.current = normalizedJson
+        lastSavedJsonRef.current = normalizedJson
+        setInitialData(restored)
+        const api = excalidrawApiRef.current
+        if (api) {
+          const files = Object.values(restored.files ?? {})
+          if (files.length > 0) {
+            api.addFiles(files)
+          }
+          api.updateScene({
+            elements: restored.elements,
+            appState: restored.appState,
+            captureUpdate: CaptureUpdateAction.NEVER,
+          })
+        }
+        setSaveState('saved')
+        setErrorMessage(null)
+        window.setTimeout(() => {
+          applyingExternalUpdateRef.current = false
+        }, 0)
+      })().catch((error) => {
+        appLogger.error('Failed to refresh Excalidraw document from local store', {
+          attrs: {
+            scope: 'excalidraw.drive',
+            uri: document.uri,
+            remoteUri,
+            error: String(error),
+          },
+        })
+        applyingExternalUpdateRef.current = false
+        setSaveState('error')
+        setErrorMessage(String(error))
+      })
+    }
+
+    const unsubscribe = localStore.subscribeSync(localUri, refreshFromLocalStore)
+    return unsubscribe
+  }, [document.uri, localUri, remoteUri, restoreSerializedScene])
+
+  const scheduleSave = useCallback(() => {
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current)
+    }
+    saveTimerRef.current = window.setTimeout(() => {
+      saveTimerRef.current = null
+      void flushSave()
+    }, 800)
+  }, [flushSave])
+
+  const handleChange = useCallback(
+    (
+      elements: readonly ExcalidrawElement[],
+      sceneAppState: AppState,
+      files: BinaryFiles
+    ) => {
+      const json = serializeAsJSON(elements, sceneAppState, files, 'local')
+      latestJsonRef.current = json
+      if (applyingExternalUpdateRef.current) {
+        lastSavedJsonRef.current = json
+        return
+      }
+      if (json !== lastSavedJsonRef.current) {
+        setSaveState('ready')
+        scheduleSave()
+      }
+    },
+    [scheduleSave]
+  )
+
+  if (saveState === 'error') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+        <div className="text-sm font-medium text-nb-text">
+          Could not open Excalidraw diagram
+        </div>
+        <div className="max-w-xl text-xs text-nb-error">
+          {errorMessage ?? 'Unknown error'}
+        </div>
+      </div>
+    )
+  }
+
+  if (saveState === 'loading' || !initialData) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-nb-text-muted">
+        Loading Excalidraw diagram...
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-white">
+      <div className="flex h-8 shrink-0 items-center justify-between border-b border-nb-border bg-nb-surface px-3 text-xs text-nb-text-muted">
+        <span className="truncate">{document.title}</span>
+        <span data-testid="excalidraw-save-status">
+          {saveState === 'saving'
+            ? 'Saving...'
+            : saveState === 'saved'
+              ? 'Saved'
+              : 'Ready'}
+        </span>
+      </div>
+      <div
+        className="min-h-0 flex-1"
+        data-testid="excalidraw-document-canvas"
+      >
+        <Excalidraw
+          key={document.uri}
+          excalidrawAPI={(api) => {
+            excalidrawApiRef.current = api
+          }}
+          initialData={initialData}
+          name={document.title}
+          onChange={handleChange}
+          UIOptions={{
+            canvasActions: {
+              loadScene: false,
+              saveToActiveFile: false,
+            },
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -36,6 +36,7 @@ import {
   isDriveLinkStatusUri,
   isDriveSyncStatusUri,
   DRIVE_SYNC_STATUS_DOCUMENT_URI,
+  isExcalidrawWorkspaceDocument,
   isNotebookDiffUri,
   isNotebookDocumentUri,
   isVersionInfoUri,
@@ -137,23 +138,25 @@ function OpenDocumentsPanel() {
                 doc.state,
                 doc.readOnly
               )
-              const kind = isNotebookDocumentUri(doc.uri)
-                ? 'Notebook'
-                : isNotebookDiffUri(doc.uri)
-                  ? 'Diff'
-                  : isDriveLinkStatusUri(doc.uri)
-                    ? 'Status'
-                    : isDriveSyncStatusUri(doc.uri)
-                      ? 'Drive Sync'
-                      : isVersionInfoUri(doc.uri)
-                        ? 'Version'
-                        : isRunnerStatusUri(doc.uri)
-                          ? 'Runner Status'
-                          : isAppConsoleUri(doc.uri)
-                            ? 'App Console'
-                            : isLogsUri(doc.uri)
-                              ? 'Logs'
-                              : 'Document'
+              const kind = isExcalidrawWorkspaceDocument(doc)
+                ? 'Excalidraw'
+                : isNotebookDocumentUri(doc.uri)
+                  ? 'Notebook'
+                  : isNotebookDiffUri(doc.uri)
+                    ? 'Diff'
+                    : isDriveLinkStatusUri(doc.uri)
+                      ? 'Status'
+                      : isDriveSyncStatusUri(doc.uri)
+                        ? 'Drive Sync'
+                        : isVersionInfoUri(doc.uri)
+                          ? 'Version'
+                          : isRunnerStatusUri(doc.uri)
+                            ? 'Runner Status'
+                            : isAppConsoleUri(doc.uri)
+                              ? 'App Console'
+                              : isLogsUri(doc.uri)
+                                ? 'Logs'
+                                : 'Document'
               return (
                 <li key={doc.uri}>
                   <div

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   removeItem: vi.fn(),
   store: {
     getMetadata: vi.fn(),
+    createContent: vi.fn(),
     createFolder: vi.fn(),
     moveToTrash: vi.fn(),
     sync: vi.fn(),
@@ -167,6 +168,16 @@ describe('WorkspaceExplorer current document handling', () => {
       remoteUri: 'https://drive.google.com/drive/folders/new',
       parents: ['local://folder/drive'],
     })
+    mocks.store.createContent.mockReset()
+    mocks.store.createContent.mockResolvedValue({
+      uri: 'local://file/excalidraw',
+      name: 'untitled-20260616-1200.excalidraw',
+      type: NotebookStoreItemType.File,
+      children: [],
+      remoteUri: undefined,
+      mimeType: 'application/vnd.excalidraw+json',
+      parents: ['local://folder/drive'],
+    })
     mocks.store.moveToTrash.mockReset()
     mocks.store.moveToTrash.mockResolvedValue(undefined)
     mocks.store.sync.mockReset()
@@ -221,6 +232,92 @@ describe('WorkspaceExplorer current document handling', () => {
         'Reports'
       )
     })
+  })
+
+  it('creates an Excalidraw diagram through the local mirror before Drive sync', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    const driveRoot = await screen.findByText('Drive Root')
+    fireEvent.contextMenu(driveRoot)
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'New Excalidraw Diagram',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.store.createContent).toHaveBeenCalledWith(
+        'local://folder/drive',
+        expect.stringMatching(/^untitled-\d{8}-\d{4}\.excalidraw$/),
+        expect.stringMatching(/"type":\s*"excalidraw"/),
+        'application/vnd.excalidraw+json'
+      )
+    })
+    expect(mocks.showDocument).not.toHaveBeenCalled()
+    expect(mocks.setCurrentDoc).not.toHaveBeenCalledWith(
+      'local://file/excalidraw'
+    )
+  })
+
+  it('opens a pending local Excalidraw diagram before the Drive URI is available', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/excalidraw'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/excalidraw') {
+        return {
+          uri,
+          name: 'diagram.excalidraw',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: undefined,
+          mimeType: 'application/vnd.excalidraw+json',
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.click(await screen.findByText('diagram.excalidraw'))
+
+    await waitFor(() => {
+      expect(mocks.showDocument).toHaveBeenCalledWith(
+        'local://file/excalidraw',
+        {
+          title: 'diagram.excalidraw',
+          requestedUri: undefined,
+          mimeType: 'application/vnd.excalidraw+json',
+        }
+      )
+    })
+    expect(mocks.setCurrentDoc).toHaveBeenCalledWith('local://file/excalidraw')
   })
 
   it('moves a Drive-backed file to Google Drive trash from the context menu after confirmation', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -44,6 +44,12 @@ import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
 import { openNotebookUpstreamDiff } from "../../lib/notebookDiff/conflict";
+import {
+  EXCALIDRAW_MIME_TYPE,
+  createInitialExcalidrawDocumentJson,
+  isExcalidrawFileName,
+  isExcalidrawDocumentMetadata,
+} from "../../storage/excalidraw";
 
 interface ContextMenuState {
   uri: string;
@@ -111,6 +117,10 @@ function createFileNode(
 
 function isJsonNotebookFile(name: string): boolean {
   return /\.json$/i.test(name.trim());
+}
+
+function isVisibleDocumentFile(name: string): boolean {
+  return isJsonNotebookFile(name) || isExcalidrawFileName(name)
 }
 
 function setChildrenForFolder(
@@ -505,7 +515,9 @@ export function WorkspaceExplorer() {
             }
           }
 
-          const localFileUri = await store.addFile(item.uri, item.name);
+          const localFileUri = await store.addFile(item.uri, item.name, {
+            mimeType: item.mimeType,
+          });
           if (!workspaceItems.includes(localFileUri)) {
             addItem(localFileUri);
             workspaceItems = [...workspaceItems, localFileUri];
@@ -657,7 +669,7 @@ export function WorkspaceExplorer() {
             } else if (childMetadata?.type === NotebookStoreItemType.File) {
               if (
                 folderMetadata.remoteUri &&
-                !isJsonNotebookFile(childMetadata.name)
+                !isVisibleDocumentFile(childMetadata.name)
               ) {
                 continue;
               }
@@ -701,6 +713,22 @@ export function WorkspaceExplorer() {
           console.error("Notebook metadata missing for", uri);
           return;
         }
+        if (isExcalidrawDocumentMetadata(item)) {
+          const remoteUri = item.remoteUri;
+          if (remoteUri && !isDriveItemUri(remoteUri)) {
+            throw new Error(
+              "Excalidraw document has an invalid Google Drive URI.",
+            );
+          }
+          showDocument(item.uri, {
+            title: item.name,
+            requestedUri: remoteUri,
+            mimeType: item.mimeType ?? EXCALIDRAW_MIME_TYPE,
+          });
+          setCurrentDoc(item.uri);
+          setErrorMessage(null);
+          return;
+        }
         const result = await openNotebook(item.uri, { name: item.name });
         setCurrentDoc(result.localUri);
         setErrorMessage(null);
@@ -711,7 +739,57 @@ export function WorkspaceExplorer() {
         );
       }
     },
-    [fsStore, openNotebook, setCurrentDoc, store],
+    [fsStore, openNotebook, setCurrentDoc, showDocument, store],
+  );
+
+  const handleCreateExcalidrawDocument = useCallback(
+    async (folderUri: string) => {
+      if (!store) {
+        return;
+      }
+      try {
+        const folderMetadata = await store.getMetadata(folderUri);
+        const remoteFolderUri =
+          folderMetadata?.remoteUri ??
+          (isDriveItemUri(folderUri) ? folderUri : undefined);
+        if (
+          !remoteFolderUri ||
+          folderMetadata?.type !== NotebookStoreItemType.Folder
+        ) {
+          throw new Error(
+            "Excalidraw diagrams can only be created in Google Drive folders.",
+          );
+        }
+        treeRef.current?.open(folderUri);
+        const timestamp = formatShortTimestamp(new Date());
+        const name = `untitled-${timestamp}.excalidraw`;
+        const created = await store.createContent(
+          folderUri,
+          name,
+          createInitialExcalidrawDocumentJson(),
+          EXCALIDRAW_MIME_TYPE,
+        );
+        await fetchChildren(folderUri);
+        setPendingEditId(created.uri);
+        setErrorMessage(null);
+        showToast({
+          message: remoteFolderUri
+            ? "Excalidraw diagram queued for Google Drive sync"
+            : "Excalidraw diagram created",
+          tone: "success",
+        });
+      } catch (error) {
+        console.error("Failed to create Excalidraw diagram", error);
+        setErrorMessage(
+          "Unable to create an Excalidraw diagram. Please try again.",
+        );
+        showToast({
+          message: "Could not create Excalidraw diagram",
+          tone: "error",
+        });
+      }
+    },
+    [fetchChildren, store],
   );
 
   const handleCreateDocument = useCallback(
@@ -1240,6 +1318,27 @@ function formatShortTimestamp(date: Date): string {
               >
                 New Document
               </button>
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setContextMenu(null);
+                  if (adjustedContextMenu.parentUri) {
+                    void handleCreateExcalidrawDocument(
+                      adjustedContextMenu.parentUri,
+                    );
+                  } else {
+                    console.warn(
+                      "Cannot create Excalidraw diagram: no parent folder for",
+                      adjustedContextMenu.uri,
+                    );
+                  }
+                }}
+              >
+                New Excalidraw Diagram
+              </button>
               {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"
@@ -1354,6 +1453,22 @@ function formatShortTimestamp(date: Date): string {
               >
                 New Document
               </button>
+              {adjustedContextMenu.remoteUri && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setContextMenu(null);
+                    void handleCreateExcalidrawDocument(
+                      adjustedContextMenu.uri,
+                    );
+                  }}
+                >
+                  New Excalidraw Diagram
+                </button>
+              )}
               {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -981,7 +981,8 @@ export class NotebookData {
                     method,
                     args,
                     runmeApi,
-                    notebooksApiBridgeServer
+                    notebooksApiBridgeServer,
+                    appGlobals
                   ),
               },
               hooks,
@@ -1060,7 +1061,8 @@ export class NotebookData {
     method: string,
     args: unknown[],
     runmeApi: RunmeConsoleApi,
-    notebooksApiBridgeServer: NotebooksApiBridgeServer
+    notebooksApiBridgeServer: NotebooksApiBridgeServer,
+    appGlobals: ReturnType<typeof createAppJsGlobals>
   ): Promise<unknown> {
     const target = args[0]
     switch (method) {
@@ -1089,6 +1091,18 @@ export class NotebookData {
         return getClaimedSessionId()
       case 'app.getSessionID':
         return getClaimedSessionId()
+      case 'documents.get':
+        return appGlobals.documents.get(String(args[0] ?? ''))
+      case 'documents.update':
+        return appGlobals.documents.update(
+          String(args[0] ?? ''),
+          String(args[1] ?? ''),
+          (args[2] as {
+            mimeType?: string
+            expectedVersion?: string
+            flush?: boolean
+          }) ?? undefined
+        )
       default:
         if (method.startsWith('notebooks.')) {
           return notebooksApiBridgeServer.handleMessage({

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -2,6 +2,25 @@
 import { create } from '@bufbuild/protobuf'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('@excalidraw/excalidraw', () => ({
+  CaptureUpdateAction: { NEVER: 'never' },
+  Excalidraw: () => null,
+  restore: (data: any) => ({
+    elements: data?.elements ?? [],
+    appState: data?.appState ?? {},
+    files: data?.files ?? {},
+  }),
+  serializeAsJSON: (elements: unknown[], appState: unknown, files: unknown) =>
+    JSON.stringify({
+      type: 'excalidraw',
+      elements,
+      appState,
+      files,
+    }),
+}))
+
+vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
+
 import { parser_pb } from '../../runme/client'
 import { GoogleClientManager } from '../googleClientManager'
 import { appState } from './AppState'
@@ -125,6 +144,168 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     await expect(globals.notebooks.shareUrl()).resolves.toBe(
       'http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fcurrent'
     )
+  })
+
+  it('reads raw document content from the local mirror', async () => {
+    const localStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: 'local://file/diagram',
+        name: 'test4.excalidraw',
+        type: 'file',
+        mimeType: 'application/vnd.excalidraw+json',
+        children: [],
+        remoteUri: undefined,
+        parents: [],
+      })),
+      files: {
+        get: vi.fn(async () => ({
+          id: 'local://file/diagram',
+          name: 'test4.excalidraw',
+          mimeType: 'application/vnd.excalidraw+json',
+          remoteId: 'local://file/diagram',
+          doc: '{"type":"excalidraw"}',
+          md5Checksum: 'local-checksum',
+        })),
+      },
+      loadContent: vi.fn(async () => '{"type":"excalidraw"}'),
+      getSyncState: vi.fn(async () => ({
+        status: 'local-only',
+        localUri: 'local://file/diagram',
+        remoteId: 'local://file/diagram',
+      })),
+    }
+    appState.setLocalNotebooks(localStore as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const doc = await globals.documents.get('local://file/diagram')
+
+    expect(localStore.loadContent).toHaveBeenCalledWith('local://file/diagram')
+    expect(doc).toMatchObject({
+      uri: 'local://file/diagram',
+      name: 'test4.excalidraw',
+      mimeType: 'application/vnd.excalidraw+json',
+      content: '{"type":"excalidraw"}',
+      syncStatus: 'local-only',
+      version: {
+        checksum: 'local-checksum',
+      },
+    })
+  })
+
+  it('updates raw document content in the local mirror', async () => {
+    const localStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: 'local://file/diagram',
+        name: 'test4.excalidraw',
+        type: 'file',
+        mimeType: 'application/vnd.excalidraw+json',
+        children: [],
+        remoteUri: undefined,
+        parents: [],
+      })),
+      files: {
+        get: vi
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'local://file/diagram',
+            name: 'test4.excalidraw',
+            mimeType: 'application/vnd.excalidraw+json',
+            remoteId: 'local://file/diagram',
+            doc: '{"type":"excalidraw"}',
+            md5Checksum: 'before',
+          })
+          .mockResolvedValueOnce({
+            id: 'local://file/diagram',
+            name: 'test4.excalidraw',
+            mimeType: 'application/vnd.excalidraw+json',
+            remoteId: 'local://file/diagram',
+            doc: '{"type":"excalidraw","elements":[]}',
+            md5Checksum: 'after',
+          }),
+      },
+      loadContent: vi.fn(async () => '{"type":"excalidraw"}'),
+      getSyncState: vi.fn(async () => ({
+        status: 'local-only',
+        localUri: 'local://file/diagram',
+        remoteId: 'local://file/diagram',
+      })),
+      saveContent: vi.fn(async () => undefined),
+      sync: vi.fn(async () => undefined),
+    }
+    appState.setLocalNotebooks(localStore as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const result = await globals.documents.update(
+      'local://file/diagram',
+      '{"type":"excalidraw","elements":[]}',
+      {
+        mimeType: 'application/vnd.excalidraw+json',
+        expectedVersion: 'before',
+        flush: true,
+      }
+    )
+
+    expect(localStore.saveContent).toHaveBeenCalledWith(
+      'local://file/diagram',
+      '{"type":"excalidraw","elements":[]}',
+      'application/vnd.excalidraw+json'
+    )
+    expect(localStore.sync).toHaveBeenCalledWith('local://file/diagram')
+    expect(result).toMatchObject({
+      uri: 'local://file/diagram',
+      name: 'test4.excalidraw',
+      syncStatus: 'local-only',
+      version: {
+        checksum: 'after',
+      },
+    })
+    expect(result).not.toHaveProperty('content')
+  })
+
+  it('rejects raw document updates when the expected version does not match', async () => {
+    const localStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: 'local://file/diagram',
+        name: 'test4.excalidraw',
+        type: 'file',
+        mimeType: 'application/vnd.excalidraw+json',
+        children: [],
+        remoteUri: undefined,
+        parents: [],
+      })),
+      files: {
+        get: vi.fn(async () => ({
+          id: 'local://file/diagram',
+          name: 'test4.excalidraw',
+          mimeType: 'application/vnd.excalidraw+json',
+          remoteId: 'local://file/diagram',
+          doc: '{"type":"excalidraw"}',
+          md5Checksum: 'actual',
+        })),
+      },
+      loadContent: vi.fn(async () => '{"type":"excalidraw"}'),
+      getSyncState: vi.fn(async () => ({
+        status: 'local-only',
+        localUri: 'local://file/diagram',
+        remoteId: 'local://file/diagram',
+      })),
+      saveContent: vi.fn(async () => undefined),
+    }
+    appState.setLocalNotebooks(localStore as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    await expect(
+      globals.documents.update('local://file/diagram', '{}', {
+        expectedVersion: 'stale',
+      })
+    ).rejects.toThrow('Document version mismatch')
+    expect(localStore.saveContent).not.toHaveBeenCalled()
   })
 
   it('starts Google Drive OAuth from runtime globals without returning raw tokens', async () => {

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -103,6 +103,22 @@ type NotebookReferenceInfo = {
   source: 'local' | 'fs' | 'drive' | 'unknown'
 }
 
+type DocumentContent = {
+  uri: string
+  requestedUri?: string
+  name: string
+  mimeType?: string
+  content: string
+  syncStatus?: string
+  version?: {
+    checksum?: string
+    revisionId?: string
+    modifiedTime?: string
+  }
+}
+
+type DocumentUpdateResult = Omit<DocumentContent, 'content'>
+
 type RunnerSync = {
   onUpdated?: (runner: Runner) => void
   onDeleted?: (name: string) => void
@@ -796,6 +812,129 @@ export function createAppJsGlobals({
     )
   }
 
+  const resolveDocumentLocalUri = async (reference: string) => {
+    const rawReference = String(reference ?? '').trim()
+    if (!rawReference) {
+      throw new Error('Usage: documents.get(uri). URI is required.')
+    }
+    const parsedUri = normalizeNotebookReferenceUri(rawReference)
+    const driveUri = canonicalizeDriveUri(parsedUri)
+    if (parsedUri.startsWith('local://file/')) {
+      return {
+        localUri: parsedUri,
+        requestedUri: parsedUri === rawReference ? undefined : rawReference,
+      }
+    }
+    if (driveUri) {
+      const record = await findLocalRecordForRemote(driveUri)
+      if (!record) {
+        throw new Error(
+          `Drive document ${driveUri} is not mirrored locally. Open it in Runme before using documents.get/update.`
+        )
+      }
+      return {
+        localUri: record.id,
+        requestedUri: rawReference,
+      }
+    }
+    throw new Error(
+      `Unsupported document URI ${rawReference}. Expected local://file/<id> or a mirrored Google Drive file URL.`
+    )
+  }
+
+  const buildDocumentContent = async (
+    uri: string,
+    requestedUri?: string,
+    includeContent = true
+  ): Promise<DocumentContent> => {
+    const localStore = resolveLocalMirrorStore()
+    const metadata = await localStore.getMetadata(uri)
+    if (!metadata || metadata.type !== NotebookStoreItemType.File) {
+      throw new Error(`Local document record not found for ${uri}`)
+    }
+    const record = await localStore.files.get(uri)
+    if (!record) {
+      throw new Error(`Local document record not found for ${uri}`)
+    }
+    const [content, syncState] = await Promise.all([
+      includeContent ? localStore.loadContent(uri) : Promise.resolve(''),
+      localStore.getSyncState(uri),
+    ])
+    const versionSource = syncState.lastUpstreamVersion ?? {}
+    return {
+      uri,
+      ...(requestedUri && requestedUri !== uri ? { requestedUri } : {}),
+      name: metadata.name || record.name,
+      mimeType: metadata.mimeType ?? record.mimeType,
+      content,
+      syncStatus: syncState.status,
+      version: {
+        checksum: versionSource.checksum ?? record.md5Checksum,
+        revisionId: versionSource.revisionId,
+        modifiedTime: versionSource.modifiedTime,
+      },
+    }
+  }
+
+  const documentsHelpers = {
+    get: async (uri: string): Promise<DocumentContent> => {
+      const resolved = await resolveDocumentLocalUri(uri)
+      return buildDocumentContent(resolved.localUri, resolved.requestedUri)
+    },
+    update: async (
+      uri: string,
+      content: string,
+      options?: {
+        mimeType?: string
+        expectedVersion?: string
+        flush?: boolean
+      }
+    ): Promise<DocumentUpdateResult> => {
+      const resolved = await resolveDocumentLocalUri(uri)
+      const localStore = resolveLocalMirrorStore()
+      const current = await buildDocumentContent(
+        resolved.localUri,
+        resolved.requestedUri
+      )
+      const expectedVersion = options?.expectedVersion?.trim()
+      if (expectedVersion) {
+        const acceptedVersions = new Set(
+          [
+            current.version?.checksum,
+            current.version?.revisionId,
+          ].filter((item): item is string => !!item)
+        )
+        if (!acceptedVersions.has(expectedVersion)) {
+          throw new Error(
+            `Document version mismatch for ${resolved.localUri}: expected ${expectedVersion}, current ${current.version?.revisionId ?? current.version?.checksum ?? '<unknown>'}`
+          )
+        }
+      }
+      const mimeType =
+        options?.mimeType?.trim() || current.mimeType || 'application/json'
+      await localStore.saveContent(resolved.localUri, String(content), mimeType)
+      if (options?.flush) {
+        await localStore.sync(resolved.localUri)
+      }
+      const updated = await buildDocumentContent(
+        resolved.localUri,
+        resolved.requestedUri,
+        false
+      )
+      const { content: _content, ...result } = updated
+      return result
+    },
+    help: () => {
+      return [
+        'documents.get(uri)                         - Read raw document content from the local mirror',
+        'documents.update(uri, content, options?)   - Write raw document content to the local mirror',
+        '  options.mimeType                         - Preserve or set the content MIME type',
+        '  options.expectedVersion                  - Optional optimistic checksum/revision guard',
+        '  options.flush                            - Wait for the backing-store sync attempt',
+      ].join('\n')
+    },
+  }
+
   const resolveNotebookReference = async (
     reference?: unknown
   ): Promise<NotebookReferenceInfo> => {
@@ -1057,6 +1196,7 @@ export function createAppJsGlobals({
   return {
     runme: runmeApi,
     notebooks: notebooksHelpers,
+    documents: documentsHelpers,
     notebookDiff: notebookDiffApi,
     codex: codexApi,
     opfs: {
@@ -1638,6 +1778,7 @@ export function createAppJsGlobals({
         'Available namespaces:',
         '  runme           - Notebook helpers (run all, clear outputs)',
         '  notebooks       - Notebook document API plus create/append helpers',
+        '  documents       - Raw URI-based document content get/update helpers',
         '  notebookDiff    - Compare revisions and resolve notebook sync conflicts',
         '  opfs            - Origin-private browser file storage helpers',
         '  net             - Browser network helpers',
@@ -1657,6 +1798,7 @@ export function createAppJsGlobals({
         '  await app.getSessionId()',
         '  await app.getSessionID()',
         '  await notebooks.createLocal("hello")',
+        '  const doc = await documents.get("local://file/...")',
         '  await notebooks.appendCell({ kind: "code", value: "print(1)", languageId: "python" })',
         '  const diff = await notebookDiff.diffDriveRevision({ revisionId })',
         '  await drive.authorize()',

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -472,6 +472,18 @@ async function handleSandboxAppKernelBridgeCall({
         String(args[1] ?? '')
       )
     }
+    case 'documents.get':
+      return globals.documents.get(String(args[0] ?? ''))
+    case 'documents.update':
+      return globals.documents.update(
+        String(args[0] ?? ''),
+        String(args[1] ?? ''),
+        (args[2] as {
+          mimeType?: string
+          expectedVersion?: string
+          flush?: boolean
+        }) ?? undefined
+      )
     case 'notebookDiff.listDriveRevisions':
       return notebookDiffApi.listDriveRevisions(args[0] as any)
     case 'notebookDiff.diffDriveRevision':

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -16,6 +16,7 @@ type Scenario =
   | 'credentials'
   | 'drive'
   | 'driveSave'
+  | 'documents'
   | 'notebooksCreate'
 
 class MockSandboxPort {
@@ -97,6 +98,23 @@ class MockSandboxPort {
           method: 'drive.saveAsCurrentNotebook',
           args: ['root', 'Comments demo.ipynb'],
         })
+      } else if (this.scenario === 'documents') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'documents.get',
+          args: ['local://file/test4'],
+        })
+        this.emit({
+          type: 'host-call',
+          callId: 2,
+          method: 'documents.update',
+          args: [
+            'local://file/test4',
+            '{"type":"excalidraw","elements":[{"id":"label","type":"text","text":"Box A"}]}',
+            { mimeType: 'application/vnd.excalidraw+json' },
+          ],
+        })
       } else if (this.scenario === 'notebooksCreate') {
         this.emit({
           type: 'host-call',
@@ -152,6 +170,14 @@ class MockSandboxPort {
         this.emit({
           type: 'stdout',
           data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'documents' && this.hostResults.has(2)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(2) ?? null)}\n`,
         })
         this.emit({ type: 'exit', exitCode: 0 })
         return
@@ -601,6 +627,70 @@ describe('SandboxJSKernel', () => {
     )
     expect(stdout).toContain('"authFlow":"service_account"')
     expect(stdout).toContain('runme-drive-test@example.iam.gserviceaccount.com')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports raw document helpers through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string, args: unknown[]) => {
+      if (method === 'documents.get') {
+        return {
+          uri: args[0],
+          name: 'test4.excalidraw',
+          mimeType: 'application/vnd.excalidraw+json',
+          content: '{"type":"excalidraw","elements":[]}',
+        }
+      }
+      if (method === 'documents.update') {
+        return {
+          uri: args[0],
+          name: 'test4.excalidraw',
+          mimeType: (args[2] as { mimeType?: string } | undefined)?.mimeType,
+          syncStatus: 'local-only',
+        }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('documents'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      [
+        "const doc = await documents.get('local://file/test4');",
+        "const scene = JSON.parse(doc.content);",
+        "scene.elements.push({ id: 'label', type: 'text', text: 'Box A' });",
+        "console.log(await documents.update(doc.uri, JSON.stringify(scene), { mimeType: doc.mimeType }));",
+      ].join('\n')
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('documents.get', [
+      'local://file/test4',
+    ])
+    expect(bridgeCall).toHaveBeenCalledWith('documents.update', [
+      'local://file/test4',
+      '{"type":"excalidraw","elements":[{"id":"label","type":"text","text":"Box A"}]}',
+      { mimeType: 'application/vnd.excalidraw+json' },
+    ])
+    expect(stdout).toContain('test4.excalidraw')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
   })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -59,6 +59,8 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'drive.create',
   'drive.update',
   'drive.saveAsCurrentNotebook',
+  'documents.get',
+  'documents.update',
   ...SANDBOX_NOTEBOOKS_API_METHODS,
   'notebooks.createLocal',
   'notebooks.appendCell',
@@ -282,6 +284,14 @@ function buildSandboxSrcDoc(options: {
         });
 
         const notebooks = createSandboxNotebooksApiClient(hostCall);
+        const documents = {
+          get: (uri) => hostCall("documents.get", [uri]),
+          update: (uri, content, options) => hostCall("documents.update", [uri, content, options]),
+          help: () => {
+            consoleProxy.log("documents.get(uri)");
+            consoleProxy.log("documents.update(uri, content, { mimeType?, expectedVersion?, flush? })");
+          },
+        };
         const notebookDiff = {
           listDriveRevisions: (target) => hostCall("notebookDiff.listDriveRevisions", [target]),
           diffDriveRevision: (args) => hostCall("notebookDiff.diffDriveRevision", [args]),
@@ -361,6 +371,8 @@ function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.show([reference])");
           consoleProxy.log("- notebooks.shareUrl([reference])");
           consoleProxy.log("- notebooks.markdownLink([reference])");
+          consoleProxy.log("- documents.get(uri)");
+          consoleProxy.log("- documents.update(uri, content, { mimeType?, expectedVersion?, flush? })");
           consoleProxy.log("- notebookDiff.listDriveRevisions([target])");
           consoleProxy.log("- notebookDiff.diffDriveRevision({ target?, revisionId, includeOutputs?, includeMetadata? })");
           consoleProxy.log("- notebookDiff.openDiffTab(diff)");
@@ -389,6 +401,7 @@ function buildSandboxSrcDoc(options: {
               "opfs",
               "net",
               "notebooks",
+              "documents",
               "notebookDiff",
               "codex",
               "app",
@@ -397,7 +410,7 @@ function buildSandboxSrcDoc(options: {
               "help",
               '"use strict"; return (async () => {\\n' + code + '\\n})();',
             );
-            await runner(consoleProxy, runme, opfs, net, notebooks, notebookDiff, codex, app, credentials, drive, help);
+            await runner(consoleProxy, runme, opfs, net, notebooks, documents, notebookDiff, codex, app, credentials, drive, help);
           } catch (error) {
             exitCode = 1;
             post({ type: "stderr", data: String(error) + "\\n" });

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { WorkspaceDocumentController } from "./workspaceDocumentController";
-import { deriveWorkspaceDocumentTitle } from "./workspaceDocumentTypes";
+import {
+  deriveWorkspaceDocumentTitle,
+  type WorkspaceDocument,
+} from "./workspaceDocumentTypes";
+import { EXCALIDRAW_MIME_TYPE } from "../../storage/excalidraw";
 
-function createMemoryPersistence(initial: Array<{ uri: string; title: string }> = []) {
+function createMemoryPersistence(initial: WorkspaceDocument[] = []) {
   let documents = initial;
   return {
     loadDocuments: vi.fn(() => documents),
-    saveDocuments: vi.fn((next: Array<{ uri: string; title: string }>) => {
+    saveDocuments: vi.fn((next: WorkspaceDocument[]) => {
       documents = next.map((item) => ({ ...item }));
     }),
   };
@@ -45,10 +49,15 @@ describe("WorkspaceDocumentController", () => {
     ]);
   });
 
-  it("persists only restorable notebook documents", () => {
+  it("persists only restorable workspace documents", () => {
     const controller = new WorkspaceDocumentController();
 
     controller.showDocument("local://file/a", { title: "a.json" });
+    controller.showDocument("local://file/diagram123", {
+      title: "diagram.excalidraw",
+      requestedUri: "https://drive.google.com/file/d/diagram123/view",
+      mimeType: EXCALIDRAW_MIME_TYPE,
+    });
     controller.showDocument("diff://notebook/1", { title: "Diff" });
     controller.showDocument("status://drive-link", { title: "Drive Link Status" });
 
@@ -56,20 +65,39 @@ describe("WorkspaceDocumentController", () => {
       JSON.parse(window.sessionStorage.getItem("runme/workspaceDocuments") ?? "[]"),
     ).toEqual([
       { uri: "local://file/a", title: "a.json" },
+      {
+        uri: "local://file/diagram123",
+        title: "diagram.excalidraw",
+        requestedUri: "https://drive.google.com/file/d/diagram123/view",
+        mimeType: EXCALIDRAW_MIME_TYPE,
+      },
     ]);
   });
 
-  it("restores only restorable notebook documents", () => {
+  it("restores only restorable workspace documents", () => {
     const controller = new WorkspaceDocumentController(
       createMemoryPersistence([
         { uri: "diff://notebook/1", title: "Diff" },
         { uri: "local://file/a", title: "a.json" },
+        {
+          uri: "local://file/diagram123",
+          title: "diagram.excalidraw",
+          requestedUri: "https://drive.google.com/file/d/diagram123/view",
+          mimeType: EXCALIDRAW_MIME_TYPE,
+        },
+        { uri: "excalidraw://drive/old", title: "old.excalidraw" },
         { uri: "status://drive-link", title: "Drive Link Status" },
       ]),
     );
 
     expect(controller.getSnapshot().documents).toEqual([
       { uri: "local://file/a", title: "a.json" },
+      {
+        uri: "local://file/diagram123",
+        title: "diagram.excalidraw",
+        requestedUri: "https://drive.google.com/file/d/diagram123/view",
+        mimeType: EXCALIDRAW_MIME_TYPE,
+      },
     ]);
   });
 

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -87,6 +87,8 @@ class SessionStorageWorkspaceDocumentPersistence
       const persisted = restorable.map((item) => ({
         uri: item.uri,
         title: item.title,
+        requestedUri: item.requestedUri,
+        mimeType: item.mimeType,
       }))
       window.sessionStorage.setItem(
         WORKSPACE_DOCUMENTS_STORAGE_KEY,
@@ -110,6 +112,8 @@ function normalizeWorkspaceDocument(item: unknown): WorkspaceDocument | null {
   return {
     uri,
     title: candidate.title?.trim() || deriveWorkspaceDocumentTitle(uri),
+    requestedUri: candidate.requestedUri?.trim() || undefined,
+    mimeType: candidate.mimeType?.trim() || undefined,
   }
 }
 
@@ -148,6 +152,7 @@ export class WorkspaceDocumentController {
       uri: normalizedUri,
       title,
       requestedUri: options?.requestedUri,
+      mimeType: options?.mimeType,
       state: options?.state,
       readOnly: options?.readOnly,
       errorMessage: options?.errorMessage,
@@ -161,6 +166,7 @@ export class WorkspaceDocumentController {
       if (
         existing?.title === nextDocument.title &&
         existing?.requestedUri === nextDocument.requestedUri &&
+        existing?.mimeType === nextDocument.mimeType &&
         existing?.state === nextDocument.state &&
         existing?.readOnly === nextDocument.readOnly &&
         existing?.errorMessage === nextDocument.errorMessage &&

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -1,5 +1,6 @@
 import type { NotebookTabState } from '../notebookDataController'
 import type { NotebookOwnershipRecord } from '../tabCoordination/notebookOwnership'
+import { isExcalidrawDocumentMetadata } from '../../storage/excalidraw'
 
 export const DRIVE_LINK_STATUS_DOCUMENT_URI = 'status://drive-link'
 export const DRIVE_SYNC_STATUS_DOCUMENT_URI = 'status://drive-sync'
@@ -12,6 +13,7 @@ export interface WorkspaceDocument {
   uri: string
   title: string
   requestedUri?: string
+  mimeType?: string
   state?: NotebookTabState
   readOnly?: boolean
   errorMessage?: string
@@ -31,6 +33,15 @@ export function isNotebookDocumentUri(
 
 export function isNotebookDiffUri(uri: string | null | undefined): boolean {
   return typeof uri === 'string' && uri.startsWith('diff://notebook/')
+}
+
+export function isExcalidrawWorkspaceDocument(
+  document: Pick<WorkspaceDocument, 'title' | 'mimeType'> | null | undefined
+): boolean {
+  return isExcalidrawDocumentMetadata({
+    name: document?.title,
+    mimeType: document?.mimeType,
+  })
 }
 
 export function isDriveLinkStatusUri(uri: string | null | undefined): boolean {

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -84,6 +84,79 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("creates arbitrary Drive content with the provided MIME type", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        if (url.pathname === "/drive/v3/files") {
+          expect(init?.method).toBe("POST");
+          expect(JSON.parse(String(init?.body))).toMatchObject({
+            name: "diagram.excalidraw",
+            mimeType: "application/vnd.excalidraw+json",
+            parents: ["folder123"],
+          });
+          return new Response(
+            JSON.stringify({
+              id: "file123",
+              name: "diagram.excalidraw",
+              mimeType: "application/vnd.excalidraw+json",
+              parents: ["folder123"],
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        if (url.pathname === "/upload/drive/v3/files/file123") {
+          expect(init?.method).toBe("PATCH");
+          expect(init?.headers).toMatchObject({
+            "Content-Type": "application/vnd.excalidraw+json",
+          });
+          expect(init?.body).toBe('{"type":"excalidraw"}');
+          return new Response("", { status: 200 });
+        }
+        throw new Error(`Unexpected Drive request: ${url.toString()}`);
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.createContent(
+      "https://drive.google.com/drive/folders/folder123",
+      "diagram.excalidraw",
+      '{"type":"excalidraw"}',
+      "application/vnd.excalidraw+json",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      uri: "https://drive.google.com/file/d/file123/view",
+      name: "diagram.excalidraw",
+      type: NotebookStoreItemType.File,
+      remoteUri: "https://drive.google.com/file/d/file123/view",
+      mimeType: "application/vnd.excalidraw+json",
+    });
+  });
+
+  it("loads arbitrary Drive file content as text", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe("/drive/v3/files/file123");
+      expect(url.searchParams.get("alt")).toBe("media");
+      return new Response('{"type":"excalidraw"}', {
+        status: 200,
+        headers: { "Content-Type": "application/vnd.excalidraw+json" },
+      });
+    });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    await expect(
+      store.loadContent("https://drive.google.com/file/d/file123/view"),
+    ).resolves.toBe('{"type":"excalidraw"}');
+  });
+
   it("uses shared drive name for shared drive root folder metadata", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi
@@ -180,6 +253,7 @@ describe("DriveNotebookStore", () => {
       type: NotebookStoreItemType.Folder,
       children: [],
       remoteUri: "https://drive.google.com/drive/folders/folder123",
+      mimeType: "application/vnd.google-apps.folder",
       parents: ["https://drive.google.com/drive/folders/parent123"],
     });
   });

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1107,6 +1107,44 @@ export class DriveNotebookStore {
         : NotebookStoreItemType.File,
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
+      mimeType: file.mimeType ?? 'application/json',
+      parents: [parentUri],
+    }
+  }
+
+  async createContent(
+    parentUri: string,
+    name: string,
+    content: string,
+    mimeType: string = 'application/octet-stream'
+  ): Promise<NotebookStoreItem> {
+    const { id, type } = parseDriveItem(parentUri)
+    if (type !== NotebookStoreItemType.Folder) {
+      throw new Error('DriveNotebookStore.createContent expects a folder URI')
+    }
+    const client = await this.getFilesClient()
+    let file = await client.create({
+      name,
+      mimeType,
+      parents: [id],
+      content,
+    })
+
+    if (!file.id) {
+      throw new Error('Failed to create Google Drive file')
+    }
+    const fileId = file.id
+    file = await client.ensureParent(file, id)
+    const isFolder = file.mimeType === DRIVE_FOLDER_MIME_TYPE
+    return {
+      uri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
+      name: file.name ?? name,
+      type: isFolder
+        ? NotebookStoreItemType.Folder
+        : NotebookStoreItemType.File,
+      children: [],
+      remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
+      mimeType: file.mimeType ?? mimeType,
       parents: [parentUri],
     }
   }
@@ -1138,6 +1176,7 @@ export class DriveNotebookStore {
       type: NotebookStoreItemType.Folder,
       children: [],
       remoteUri: folderUri,
+      mimeType: folder.mimeType ?? DRIVE_FOLDER_MIME_TYPE,
       parents: [parentUri],
     }
   }
@@ -1261,6 +1300,7 @@ export class DriveNotebookStore {
           : NotebookStoreItemType.File,
         children: [],
         remoteUri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
+        mimeType: file.mimeType,
         parents: [],
       }
     })
@@ -1480,6 +1520,7 @@ export class DriveNotebookStore {
         : NotebookStoreItemType.File,
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
+      mimeType,
       parents: [],
     }
   }
@@ -1502,6 +1543,7 @@ export class DriveNotebookStore {
       type: NotebookStoreItemType.File,
       children: [],
       remoteUri: driveFileUrl(fileId),
+      mimeType: file.mimeType,
       parents: [],
     }
   }
@@ -1525,6 +1567,20 @@ export class DriveNotebookStore {
       mimeType,
       content,
     })
+  }
+
+  async loadContent(uri: string): Promise<string> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error('DriveNotebookStore.loadContent expects a file URI')
+    }
+    const client = await this.getFilesClient()
+    const response = await client.get({
+      fileId: id,
+      supportsAllDrives: true,
+      alt: 'media',
+    })
+    return extractBody(response)
   }
 
   async getMetadata(uri: string): Promise<NotebookStoreItem | null> {
@@ -1580,6 +1636,7 @@ export class DriveNotebookStore {
       type: resolvedType,
       children: [],
       remoteUri: uri,
+      mimeType: result?.mimeType,
       parents: parentUris,
     }
   }
@@ -1624,6 +1681,7 @@ export async function fetchDriveItemWithParents(
     type: isFolder ? NotebookStoreItemType.Folder : NotebookStoreItemType.File,
     children: [],
     remoteUri: isFolder ? driveFolderUrl(meta.id) : driveFileUrl(meta.id),
+    mimeType: meta.mimeType,
     parents: parentUris,
   }
 
@@ -1652,6 +1710,7 @@ export async function fetchDriveItemWithParents(
         remoteUri: parentIsFolder
           ? driveFolderUrl(parentMeta.id)
           : driveFileUrl(parentMeta.id),
+        mimeType: parentMeta.mimeType,
         parents: [],
       })
     } catch (error) {

--- a/app/src/storage/excalidraw.test.ts
+++ b/app/src/storage/excalidraw.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXCALIDRAW_MIME_TYPE,
+  createInitialExcalidrawDocumentJson,
+  isExcalidrawDocumentMetadata,
+  isExcalidrawFileName,
+  isExcalidrawMimeType,
+} from "./excalidraw";
+
+describe("excalidraw storage helpers", () => {
+  it("recognizes Excalidraw file names", () => {
+    expect(isExcalidrawFileName("diagram.excalidraw")).toBe(true);
+    expect(isExcalidrawFileName("diagram.excalidraw.json")).toBe(true);
+    expect(isExcalidrawFileName("notebook.json")).toBe(false);
+  });
+
+  it("recognizes Excalidraw MIME metadata", () => {
+    expect(isExcalidrawMimeType(EXCALIDRAW_MIME_TYPE)).toBe(true);
+    expect(isExcalidrawMimeType("application/json")).toBe(false);
+    expect(
+      isExcalidrawDocumentMetadata({
+        name: "diagram.json",
+        mimeType: EXCALIDRAW_MIME_TYPE,
+      }),
+    ).toBe(true);
+  });
+
+  it("creates an empty Excalidraw JSON document", () => {
+    expect(JSON.parse(createInitialExcalidrawDocumentJson())).toMatchObject({
+      type: "excalidraw",
+      version: 2,
+      elements: [],
+      files: {},
+    });
+  });
+});

--- a/app/src/storage/excalidraw.ts
+++ b/app/src/storage/excalidraw.ts
@@ -1,0 +1,37 @@
+export const EXCALIDRAW_MIME_TYPE = 'application/vnd.excalidraw+json'
+
+export type ExcalidrawDocumentMetadata = {
+  name?: string
+  mimeType?: string
+}
+
+export function isExcalidrawFileName(name: string | undefined): boolean {
+  return /\.(excalidraw|excalidraw\.json)$/i.test((name ?? '').trim())
+}
+
+export function isExcalidrawMimeType(mimeType: string | undefined): boolean {
+  return (mimeType ?? '').trim().toLowerCase() === EXCALIDRAW_MIME_TYPE
+}
+
+export function isExcalidrawDocumentMetadata(
+  item: ExcalidrawDocumentMetadata | null | undefined
+): boolean {
+  return isExcalidrawMimeType(item?.mimeType) || isExcalidrawFileName(item?.name)
+}
+
+export function createInitialExcalidrawDocumentJson(): string {
+  return JSON.stringify(
+    {
+      type: 'excalidraw',
+      version: 2,
+      source: 'runme',
+      elements: [],
+      appState: {
+        viewBackgroundColor: '#ffffff',
+      },
+      files: {},
+    },
+    null,
+    2
+  )
+}

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { MimeType, parser_pb } from '../runme/client'
 import { MemoryConflictDocStorage } from './conflictDocs'
+import {
+  EXCALIDRAW_MIME_TYPE,
+  createInitialExcalidrawDocumentJson,
+} from './excalidraw'
 import LocalNotebooks, {
   type LocalFileRecord,
   type LocalFolderRecord,
@@ -348,6 +352,154 @@ describe('LocalNotebooks pending Drive create', () => {
       remoteUri,
       '{malformed-json',
       'application/json'
+    )
+  })
+
+  it('creates pending Excalidraw files with raw content and MIME type', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const content = createInitialExcalidrawDocumentJson()
+    const driveStore = {
+      create: vi.fn(),
+      createContent: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'diagram.excalidraw',
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri,
+        mimeType: EXCALIDRAW_MIME_TYPE,
+        parents: [parentRemoteUri],
+      })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'remote-created',
+        headRevisionId: 'revision-1',
+      })),
+      getMetadata: vi.fn(),
+      saveContent: vi.fn(async () => undefined),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/drive',
+      name: 'Drive',
+      remoteId: parentRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+
+    const item = await store.createContent(
+      'local://folder/drive',
+      'diagram.excalidraw',
+      content,
+      EXCALIDRAW_MIME_TYPE
+    )
+    await store.sync(item.uri)
+
+    expect(driveStore.create).not.toHaveBeenCalled()
+    expect(driveStore.createContent).toHaveBeenCalledWith(
+      parentRemoteUri,
+      'diagram.excalidraw',
+      content,
+      EXCALIDRAW_MIME_TYPE
+    )
+    await expect(store.files.get(item.uri)).resolves.toMatchObject({
+      remoteId: remoteUri,
+      mimeType: EXCALIDRAW_MIME_TYPE,
+      doc: content,
+      lastRemoteChecksum: 'remote-created',
+    })
+  })
+
+  it('saves Drive-backed Excalidraw files as raw content without notebook loading', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const content = createInitialExcalidrawDocumentJson()
+    const driveStore = {
+      getVersionMetadata: vi
+        .fn()
+        .mockResolvedValueOnce({
+          md5Checksum: 'remote-before-save',
+          headRevisionId: 'revision-1',
+        })
+        .mockResolvedValueOnce({
+          md5Checksum: 'remote-after-save',
+          headRevisionId: 'revision-2',
+      }),
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'diagram.excalidraw',
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri,
+        mimeType: EXCALIDRAW_MIME_TYPE,
+        parents: [],
+      })),
+      load: vi.fn(),
+      saveContent: vi.fn(async () => undefined),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/excalidraw',
+      name: 'diagram.excalidraw',
+      mimeType: EXCALIDRAW_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.saveContent(
+      'local://file/excalidraw',
+      content,
+      EXCALIDRAW_MIME_TYPE
+    )
+    await store.sync('local://file/excalidraw')
+
+    expect(driveStore.load).not.toHaveBeenCalled()
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      remoteUri,
+      content,
+      EXCALIDRAW_MIME_TYPE
+    )
+    await expect(store.files.get('local://file/excalidraw')).resolves.toMatchObject(
+      {
+        doc: content,
+        mimeType: EXCALIDRAW_MIME_TYPE,
+        lastRemoteChecksum: 'remote-after-save',
+      }
+    )
+  })
+
+  it('hydrates raw Excalidraw content from Drive into the local mirror', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const content = createInitialExcalidrawDocumentJson()
+    const driveStore = {
+      loadContent: vi.fn(async () => content),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'remote-content',
+        headRevisionId: 'revision-1',
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/excalidraw',
+      name: 'diagram.excalidraw',
+      mimeType: EXCALIDRAW_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await expect(store.loadContent('local://file/excalidraw')).resolves.toBe(
+      content
+    )
+    expect(driveStore.loadContent).toHaveBeenCalledWith(remoteUri)
+    await expect(store.files.get('local://file/excalidraw')).resolves.toMatchObject(
+      {
+        doc: content,
+        lastRemoteChecksum: 'remote-content',
+      }
     )
   })
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -25,6 +25,10 @@ import {
   type RevisionDocStorage,
   createDefaultRevisionDocStorage,
 } from './revisionDocs'
+import {
+  EXCALIDRAW_MIME_TYPE,
+  isExcalidrawFileName,
+} from './excalidraw'
 
 // Local folder URI is a special folder that contains all notebooks which are local (i.e. not synced to Drive)
 export const LOCAL_FOLDER_URI = 'local://folder/local'
@@ -32,6 +36,8 @@ export const LOCAL_FOLDER_URI = 'local://folder/local'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
+
+const NOTEBOOK_MIME_TYPE = 'application/json'
 
 /**
  * LocalFileRecord captures the information needed to persist a notebook locally.
@@ -45,6 +51,8 @@ export interface LocalFileRecord {
   id: string
   /** Friendly name for the notebook, used when rendering the UI. */
   name: string
+  /** Content MIME type used to select the document renderer. */
+  mimeType?: string
   /** Upstream URI. Browser-only notebooks use the same local://file/... URI. */
   remoteId: string
   /** Creation-time upstream parent URI used to finish a pending remote create. */
@@ -286,6 +294,10 @@ export class LocalNotebooks extends Dexie {
             delete file.parentRemoteIdWhenCreated
           })
       })
+    this.version(6).stores({
+      files: '&id, remoteId, lastRemoteChecksum, md5Checksum, name, lastSynced',
+      folders: '&id, remoteId, name, lastSynced',
+    })
 
     // Bind the table helpers so callers can access them directly.
     this.files = this.table('files')
@@ -307,7 +319,11 @@ export class LocalNotebooks extends Dexie {
    * local URI. If the file has already been mirrored we simply hand back the
    * existing identifier.
    */
-  async addFile(remoteUri: string, name?: string): Promise<string> {
+  async addFile(
+    remoteUri: string,
+    name?: string,
+    options?: { mimeType?: string }
+  ): Promise<string> {
     if (!remoteUri) {
       throw new Error('addFile requires a non-empty remote URI')
     }
@@ -317,8 +333,16 @@ export class LocalNotebooks extends Dexie {
       .equals(remoteUri)
       .first()
     if (existing) {
+      const changes: Partial<LocalFileRecord> = {}
       if (name && name !== existing.name) {
-        await this.files.update(existing.id, { name })
+        changes.name = name
+      }
+      const mimeType = resolveDocumentMimeType(name, options?.mimeType)
+      if (mimeType && mimeType !== existing.mimeType) {
+        changes.mimeType = mimeType
+      }
+      if (Object.keys(changes).length > 0) {
+        await this.files.update(existing.id, changes)
       }
       return existing.id
     }
@@ -326,10 +350,12 @@ export class LocalNotebooks extends Dexie {
     const id = this.generateLocalUri('file')
     const resolvedName =
       name ?? this.deriveDisplayNameFromUri(remoteUri) ?? 'Untitled Notebook'
+    const mimeType = resolveDocumentMimeType(resolvedName, options?.mimeType)
 
     const record: LocalFileRecord = {
       id,
       name: resolvedName,
+      mimeType,
       remoteId: remoteUri,
       lastRemoteChecksum: '',
       lastSynced: '',
@@ -414,6 +440,7 @@ export class LocalNotebooks extends Dexie {
     const record: LocalFileRecord = {
       id,
       name,
+      mimeType: NOTEBOOK_MIME_TYPE,
       remoteId: upstreamUri,
       lastRemoteChecksum: checksum,
       lastUpstreamVersion: { checksum },
@@ -490,7 +517,9 @@ export class LocalNotebooks extends Dexie {
 
     for (const item of items) {
       if (item.type === NotebookStoreItemType.File) {
-        const localUri = await this.addFile(item.uri, item.name)
+        const localUri = await this.addFile(item.uri, item.name, {
+          mimeType: item.mimeType,
+        })
         childUris.push(localUri)
       } else if (item.type === NotebookStoreItemType.Folder) {
         const localFolderUri = await this.updateFolder(item.uri, item.name)
@@ -660,6 +689,7 @@ export class LocalNotebooks extends Dexie {
       return {
         uri: record.id,
         name: record.name,
+        mimeType: record.mimeType,
         type: NotebookStoreItemType.File,
         children: [],
         remoteUri: publicRemoteUri(record),
@@ -702,6 +732,76 @@ export class LocalNotebooks extends Dexie {
     if (!record?.conflict) {
       this.enqueueSync(uri)
       this.enqueueMarkdownSync(uri)
+    }
+  }
+
+  async loadContent(uri: string): Promise<string> {
+    if (!uri.startsWith('local://file/')) {
+      throw new Error(
+        'LocalNotebooks.loadContent expects a local://file/ URI; got ' + uri
+      )
+    }
+
+    const record = await this.files.get(uri)
+    if (!record) {
+      throw new Error(`Local file record not found for ${uri}`)
+    }
+    if (record.doc || !isDriveUri(record.remoteId)) {
+      return record.doc ?? ''
+    }
+
+    const content = await this.driveStore.loadContent(record.remoteId)
+    let upstreamVersion: UpstreamVersion = {}
+    try {
+      upstreamVersion = driveMetadataToUpstreamVersion(
+        await this.driveStore.getVersionMetadata(record.remoteId)
+      )
+    } catch (error) {
+      appLogger.warn('Failed to record version metadata for raw Drive content', {
+        attrs: {
+          scope: 'storage.drive.sync',
+          localUri: uri,
+          remoteUri: record.remoteId,
+          error: String(error),
+        },
+      })
+    }
+    await this.files.update(uri, {
+      doc: content,
+      md5Checksum: md5(content),
+      lastRemoteChecksum: upstreamVersion.checksum ?? '',
+      lastUpstreamVersion: upstreamVersion,
+      lastSynced: nowIsoString(),
+      lastSyncError: undefined,
+    })
+    return content
+  }
+
+  async saveContent(
+    uri: string,
+    content: string,
+    mimeType: string
+  ): Promise<void> {
+    if (!uri.startsWith('local://file/')) {
+      throw new Error(
+        'LocalNotebooks.saveContent expects a local://file/ URI; got ' + uri
+      )
+    }
+
+    const record = await this.files.get(uri)
+    if (!record) {
+      throw new Error(`Local file record not found for ${uri}`)
+    }
+
+    const checksum = md5(content)
+    await this.files.update(uri, {
+      doc: content,
+      md5Checksum: checksum,
+      mimeType,
+    })
+    this.notifySync(uri)
+    if (!record.conflict) {
+      this.enqueueSync(uri)
     }
   }
 
@@ -1009,6 +1109,26 @@ export class LocalNotebooks extends Dexie {
   }
 
   async create(parentUri: string, name: string): Promise<NotebookStoreItem> {
+    return this.createLocalFile(parentUri, name, {
+      mimeType: NOTEBOOK_MIME_TYPE,
+      content: '',
+    })
+  }
+
+  async createContent(
+    parentUri: string,
+    name: string,
+    content: string,
+    mimeType: string
+  ): Promise<NotebookStoreItem> {
+    return this.createLocalFile(parentUri, name, { mimeType, content })
+  }
+
+  private async createLocalFile(
+    parentUri: string,
+    name: string,
+    options: { mimeType: string; content: string }
+  ): Promise<NotebookStoreItem> {
     if (!parentUri.startsWith('local://folder/')) {
       throw new Error('LocalNotebooks.create expects a folder parent URI')
     }
@@ -1020,17 +1140,19 @@ export class LocalNotebooks extends Dexie {
 
     const fileUri = this.generateLocalUri('file')
     const isDriveBackedParent = isDriveUri(parent.remoteId)
+    const checksum = options.content ? md5(options.content) : ''
     const record: LocalFileRecord = {
       id: fileUri,
       name,
+      mimeType: options.mimeType,
       remoteId: isDriveBackedParent ? '' : fileUri,
       parentRemoteIdWhenCreated: isDriveBackedParent
         ? parent.remoteId
         : undefined,
       lastRemoteChecksum: '',
       lastSynced: isDriveBackedParent ? '' : nowIsoString(),
-      doc: '',
-      md5Checksum: '',
+      doc: options.content,
+      md5Checksum: checksum,
     }
     await this.files.put(record)
 
@@ -1070,6 +1192,7 @@ export class LocalNotebooks extends Dexie {
       type: NotebookStoreItemType.File,
       children: [],
       remoteUri: undefined,
+      mimeType: options.mimeType,
       parents: [parentUri],
     }
   }
@@ -1596,12 +1719,39 @@ export class LocalNotebooks extends Dexie {
     )
     let synced = false
 
+    if (record.mimeType && record.mimeType !== NOTEBOOK_MIME_TYPE) {
+      await this.saveLocalDocToDrive(
+        localUri,
+        remoteUri,
+        localDoc,
+        record.mimeType
+      )
+      const updatedVersion = driveMetadataToUpstreamVersion(
+        await this.driveStore.getVersionMetadata(remoteUri)
+      )
+      const updatedChecksum = updatedVersion.checksum ?? localChecksum
+      await this.files.update(localUri, {
+        lastRemoteChecksum: updatedChecksum,
+        lastUpstreamVersion: updatedVersion,
+        md5Checksum: localChecksum,
+        lastSynced: nowIsoString(),
+        lastSyncError: undefined,
+      })
+      synced = true
+      return
+    }
+
     // Case 1: The checksum reported by Drive matches the version we last
     // observed. This means no external party has modified the remote file and
     // the local content is authoritative. We can safely push our data back to
     // Drive without risking data loss.
     if (currentRemoteChecksum === lastReadChecksum) {
-      await this.saveLocalDocToDrive(localUri, remoteUri, localDoc)
+      await this.saveLocalDocToDrive(
+        localUri,
+        remoteUri,
+        localDoc,
+        record.mimeType
+      )
       const updatedVersion = driveMetadataToUpstreamVersion(
         await this.driveStore.getVersionMetadata(remoteUri)
       )
@@ -1626,7 +1776,12 @@ export class LocalNotebooks extends Dexie {
         completedPendingCreate &&
         serializedNotebookHasUserContent(localDoc)
       ) {
-        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc)
+        await this.saveLocalDocToDrive(
+          localUri,
+          remoteUri,
+          localDoc,
+          record.mimeType
+        )
         const updatedVersion = driveMetadataToUpstreamVersion(
           await this.driveStore.getVersionMetadata(remoteUri)
         )
@@ -1733,7 +1888,12 @@ export class LocalNotebooks extends Dexie {
     // keep the baseline empty.
     if (!currentRemoteChecksum) {
       if (localDoc) {
-        await this.saveLocalDocToDrive(localUri, remoteUri, localDoc)
+        await this.saveLocalDocToDrive(
+          localUri,
+          remoteUri,
+          localDoc,
+          record.mimeType
+        )
         const updatedVersion = driveMetadataToUpstreamVersion(
           await this.driveStore.getVersionMetadata(remoteUri)
         )
@@ -1769,8 +1929,14 @@ export class LocalNotebooks extends Dexie {
   private async saveLocalDocToDrive(
     localUri: string,
     remoteUri: string,
-    localDoc: string
+    localDoc: string,
+    mimeType: string | undefined
   ): Promise<void> {
+    if (mimeType && mimeType !== NOTEBOOK_MIME_TYPE) {
+      await this.driveStore.saveContent(remoteUri, localDoc, mimeType)
+      return
+    }
+
     if (!localDoc) {
       await this.driveStore.save(
         remoteUri,
@@ -1810,7 +1976,15 @@ export class LocalNotebooks extends Dexie {
       )
     }
 
-    const newFile = await this.driveStore.create(parentRemoteUri, record.name)
+    const newFile =
+      record.mimeType && record.mimeType !== NOTEBOOK_MIME_TYPE
+        ? await this.driveStore.createContent(
+            parentRemoteUri,
+            record.name,
+            record.doc ?? '',
+            record.mimeType
+          )
+        : await this.driveStore.create(parentRemoteUri, record.name)
     let version: UpstreamVersion = {}
     try {
       version = driveMetadataToUpstreamVersion(
@@ -1835,6 +2009,7 @@ export class LocalNotebooks extends Dexie {
 
     await this.files.update(localUri, {
       name: newFile.name ?? record.name,
+      mimeType: newFile.mimeType ?? record.mimeType ?? NOTEBOOK_MIME_TYPE,
       remoteId: newFile.uri,
       parentRemoteIdWhenCreated: undefined,
       lastRemoteChecksum: version.checksum ?? '',
@@ -2332,6 +2507,20 @@ function publicRemoteUri(record: {
   return isLocalFileUpstream(record.remoteId, record.id)
     ? undefined
     : record.remoteId || undefined
+}
+
+function resolveDocumentMimeType(
+  name: string | undefined,
+  mimeType: string | undefined
+): string | undefined {
+  const trimmedMimeType = mimeType?.trim()
+  if (trimmedMimeType) {
+    return trimmedMimeType
+  }
+  if (isExcalidrawFileName(name)) {
+    return EXCALIDRAW_MIME_TYPE
+  }
+  return undefined
 }
 
 function isFilesystemUri(uri: string | undefined): boolean {

--- a/app/src/storage/notebook.ts
+++ b/app/src/storage/notebook.ts
@@ -9,6 +9,7 @@ export interface NotebookStoreItem {
   type: NotebookStoreItemType;
   children: string[];
   remoteUri?: string;
+  mimeType?: string;
   parents: string[];
 }
 

--- a/docs-dev/design/20260616_excalidraw_drive_documents.md
+++ b/docs-dev/design/20260616_excalidraw_drive_documents.md
@@ -1,0 +1,427 @@
+# Excalidraw Drive Documents
+
+## Status
+
+Draft PR implementation.
+
+## Summary
+
+Add Excalidraw diagrams as first-class workspace documents backed by Google
+Drive JSON files.
+
+The app stores each diagram as a normal Drive file with an Excalidraw JSON
+payload. The workspace explorer creates and opens `.excalidraw` files from
+Drive folders. The main document tab system renders those files with the
+embedded `@excalidraw/excalidraw` editor and autosaves scene updates back to
+Drive.
+
+This is intentionally not a new storage backend. It extends the existing Drive
+store with generic text content helpers and reuses workspace document tabs for
+non-notebook content.
+
+## Motivation
+
+Runme notebooks often need lightweight diagrams next to runnable docs. Users
+already organize notebooks in Google Drive, so diagrams should live in the same
+Drive folders and open from the same workspace explorer.
+
+The shortest useful path is:
+
+- create a `.excalidraw` file in a mounted Drive folder,
+- open it as a document tab,
+- edit with Excalidraw,
+- save the Excalidraw scene JSON back to the same Drive file.
+
+## Goals
+
+- Create Excalidraw diagrams in Google Drive folders.
+- Show existing `.excalidraw` and `.excalidraw.json` files in Drive-backed
+  workspace explorer folders.
+- Open Excalidraw diagrams as workspace document tabs.
+- Autosave editor changes to the backing Drive file.
+- Restore open Excalidraw tabs across session reloads.
+- Verify the editor and Drive-save interface in the in-app browser.
+
+## Non-Goals
+
+- Add local filesystem or IndexedDB Excalidraw storage.
+- Convert Excalidraw diagrams into notebook cells.
+- Add collaborative editing, Drive revisions UI, or conflict resolution for
+  Excalidraw files.
+- Export diagrams as PNG, SVG, or Markdown embeds.
+- Build a server-side Excalidraw backend.
+
+## User Flow
+
+1. The user mounts or opens a Google Drive folder in the workspace explorer.
+2. The user right-clicks the folder and selects `New Excalidraw Diagram`.
+3. The app creates a local mirror row immediately with
+   `untitled-YYYYMMDD-HHMM.excalidraw`.
+4. The row enters rename mode, matching regular notebook creation.
+5. The local store asynchronously creates the backing Drive file and updates the
+   local row with its Drive URI.
+6. The user opens the diagram and edits in Excalidraw.
+7. The editor serializes the scene and writes it back to the Drive file after a
+   short debounce.
+
+Existing files follow the same open path. A Drive file named `.excalidraw` or
+`.excalidraw.json` appears in the explorer and opens in the Excalidraw editor.
+
+## Data Model
+
+The Drive file body is Excalidraw's JSON scene format:
+
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "runme",
+  "elements": [],
+  "appState": {
+    "viewBackgroundColor": "#ffffff"
+  },
+  "files": {}
+}
+```
+
+The file MIME type is:
+
+```text
+application/vnd.excalidraw+json
+```
+
+The workspace document URI remains the local document URI:
+
+```text
+local://file/<uuid>
+```
+
+The local record stores the backing Drive URI in `remoteId`, exposed to the tab
+as `requestedUri`. The local record and workspace document also carry the MIME
+type. The renderer uses `application/vnd.excalidraw+json` to select
+Excalidraw.
+
+We do not introduce an `excalidraw://` URI scheme. A URI identifies the stored
+document, not the renderer. The MIME type and filename fallback control how the
+document is rendered.
+
+## Architecture
+
+### Drive Store
+
+`DriveNotebookStore` gains generic content methods:
+
+```ts
+createContent(
+  parentUri: string,
+  name: string,
+  content: string,
+  mimeType?: string,
+): Promise<NotebookStoreItem>
+
+loadContent(uri: string): Promise<string>
+```
+
+The existing `saveContent(uri, content, mimeType)` method already supports
+updating arbitrary Drive file bytes. Excalidraw uses these methods:
+
+- `createContent` creates the initial `.excalidraw` file when local pending
+  sync completes.
+- `loadContent` reads the current scene JSON.
+- `saveContent` writes serialized scene JSON after edits.
+
+These helpers do not make `DriveNotebookStore` Excalidraw-specific. They are
+generic text-content operations for Drive files.
+
+### Local Store Metadata
+
+`LocalFileRecord` gains an optional `mimeType`:
+
+```ts
+interface LocalFileRecord {
+  id: string
+  name: string
+  mimeType?: string
+  remoteId: string
+  // ...
+}
+```
+
+`NotebookStoreItem` also gains `mimeType?: string` so Drive listing metadata can
+flow through the local mirror to the workspace explorer and document tabs.
+
+For new files in Drive-backed folders, `LocalNotebooks.createContent(...)`
+creates the local row first, stores the initial content and MIME type, and lets
+the existing pending-create sync path create the upstream Drive file. For
+existing Drive-backed files, `LocalNotebooks.addFile(...)` stores the Drive file
+MIME type and returns the stable `local://file/<uuid>` URI. For old records or
+Drive files that do not report the custom MIME type, `.excalidraw` and
+`.excalidraw.json` remain a fallback.
+
+### Excalidraw Storage Helpers
+
+`app/src/storage/excalidraw.ts` owns Excalidraw-specific constants and
+metadata helpers:
+
+- `EXCALIDRAW_MIME_TYPE`
+- `isExcalidrawFileName(name)`
+- `isExcalidrawMimeType(mimeType)`
+- `isExcalidrawDocumentMetadata(item)`
+- `createInitialExcalidrawDocumentJson()`
+
+This keeps filename and MIME detection out of React components.
+
+### Workspace Explorer
+
+The explorer treats `.json` notebooks and Excalidraw diagrams as visible Drive
+document files. For Excalidraw files:
+
+- opening the file creates a workspace document tab,
+- the document URI is the local mirror URI,
+- the document title uses the Drive file name,
+- the requested URI remains the backing Drive file URI,
+- the MIME type is `application/vnd.excalidraw+json`.
+
+The context menu creates new diagrams only for Drive folders. Local notebook
+folders are excluded because this implementation does not add local
+Excalidraw storage.
+
+### Workspace Documents
+
+Workspace document restore persists `uri`, `title`, `requestedUri`, and
+`mimeType` for local document tabs. This lets a Drive-backed Excalidraw tab
+survive reloads in the same browser session while keeping the tab URI as
+`local://file/<uuid>`.
+
+Notebook runtime helpers should still treat only notebook URIs as notebooks.
+Because Excalidraw also uses `local://file/<uuid>`, `Actions.tsx` checks the
+MIME type before falling back to the notebook renderer.
+
+### AppKernel Content API
+
+WebMCP needs a storage-level content API that works for notebooks and
+non-notebook documents. The API should operate on document URIs, not Drive file
+ids, so callers can use the same URI the app shows in tabs and explorer rows.
+
+The AppKernel should expose two methods:
+
+```ts
+type DocumentContent = {
+  uri: string
+  requestedUri?: string
+  name: string
+  mimeType?: string
+  content: string
+  syncStatus?: NotebookSyncStatus
+  version?: {
+    checksum?: string
+    revisionId?: string
+    modifiedTime?: string
+  }
+}
+
+type DocumentUpdateResult = {
+  uri: string
+  requestedUri?: string
+  name: string
+  mimeType?: string
+  syncStatus?: NotebookSyncStatus
+  version?: {
+    checksum?: string
+    revisionId?: string
+    modifiedTime?: string
+  }
+}
+
+interface DocumentContentApi {
+  get(uri: string): Promise<DocumentContent>
+  update(
+    uri: string,
+    content: string,
+    options?: {
+      mimeType?: string
+      expectedVersion?: string
+      flush?: boolean
+    },
+  ): Promise<DocumentUpdateResult>
+}
+```
+
+`get(uri)` resolves the URI through the local mirror first. For
+`local://file/<uuid>`, it returns the IndexedDB content. If the local content is
+empty and the record has a Drive `remoteId`, it may hydrate the local mirror
+from Drive before returning. For a Drive URI, the API should first attach or
+find the local mirror row, then return the local URI and content.
+
+`update(uri, content, options)` writes through the local mirror first. It should
+update IndexedDB immediately, preserve the document MIME type, notify any open
+tabs, and enqueue normal Drive sync. When `options.flush` is true, it should
+also wait for the backing store sync attempt and return the resulting sync
+state. This matches notebook editing: local state is the interactive source of
+truth, and Drive is the upstream synchronization target.
+
+The API should support these MIME types without special WebMCP code paths:
+
+- `application/json` for notebook JSON,
+- `application/vnd.excalidraw+json` for Excalidraw scenes,
+- future text-like document MIME types.
+
+Notebook-specific APIs can remain for semantic notebook operations, such as
+adding cells or running code. `get` and `update` are raw document-content
+operations. They should not parse Excalidraw as a notebook, and they should not
+require callers to know whether a document is currently local-only,
+pending-Drive-create, or Drive-backed.
+
+Example WebMCP usage:
+
+```js
+const doc = await documents.get("local://file/63b0...")
+const scene = JSON.parse(doc.content)
+scene.elements.push({
+  id: crypto.randomUUID(),
+  type: "text",
+  x: 120,
+  y: 80,
+  width: 80,
+  height: 25,
+  angle: 0,
+  strokeColor: "#1e1e1e",
+  backgroundColor: "transparent",
+  fillStyle: "solid",
+  strokeWidth: 2,
+  strokeStyle: "solid",
+  roughness: 1,
+  opacity: 100,
+  groupIds: [],
+  frameId: null,
+  roundness: null,
+  seed: Date.now(),
+  version: 1,
+  versionNonce: Date.now(),
+  isDeleted: false,
+  boundElements: null,
+  updated: Date.now(),
+  link: null,
+  locked: false,
+  text: "Box A",
+  fontSize: 20,
+  fontFamily: 5,
+  textAlign: "left",
+  verticalAlign: "top",
+  containerId: null,
+  originalText: "Box A",
+  lineHeight: 1.25,
+})
+
+await documents.update(doc.uri, JSON.stringify(scene, null, 2), {
+  mimeType: "application/vnd.excalidraw+json",
+  flush: true,
+})
+```
+
+The first implementation can expose this as `documents.get` and
+`documents.update` in App Console and WebMCP. The backing implementation should
+delegate to `LocalNotebooks.getContent/updateContent` for local URIs and to the
+Drive attach flow for Drive URIs. The names should stay document-oriented
+rather than Drive-oriented because the URI, not the storage provider, selects
+the backing path.
+
+### Editor Component
+
+`ExcalidrawDocument` loads the backing Drive JSON, restores it through
+Excalidraw's `restore` helper, and renders the editor.
+
+On every editor change:
+
+1. The component serializes the scene with `serializeAsJSON`.
+2. It compares the serialized scene with the last saved scene.
+3. If the scene changed, it schedules a debounced save.
+4. The save writes the JSON to Drive with `EXCALIDRAW_MIME_TYPE`.
+5. The header shows `Ready`, `Saving...`, or `Saved to Drive`.
+
+Loaded scenes are normalized through Excalidraw serialization before dirty
+comparison. This avoids treating formatting differences in the loaded JSON as
+user edits.
+
+### Development Verification
+
+Development verification should use the existing Google Drive service-account
+auth path with a test/development service account. That keeps the test path on
+the production Drive store, folder mirroring, MIME metadata, and autosave code.
+
+The PR does not add an Excalidraw-specific in-app browser harness. A fake Drive
+store would verify less of the storage design than the service-account path.
+
+## Licensing
+
+The embedded package is `@excalidraw/excalidraw@0.18.1`. Its package metadata
+declares the license as `MIT`.
+
+This license does not block embedding the editor in the Runme web app. The PR
+does not copy Excalidraw source into the repository; it consumes the published
+npm package through the existing dependency workflow.
+
+## Error Handling
+
+The editor shows a centered error state when:
+
+- the Drive store is not initialized,
+- the backing Drive file cannot be loaded,
+- the scene JSON is invalid,
+- or Drive save fails.
+
+Save failures replace the editor with an error state in this draft. That is
+simple and visible, but it is not the best long-term user experience. A later
+iteration should keep the editor mounted, show a persistent error banner, and
+allow retry without losing unsaved local scene state.
+
+## Risks And Tradeoffs
+
+### No Conflict Resolution
+
+Excalidraw files currently autosave directly to Drive. If two browser sessions
+edit the same file, the last writer wins. This matches the first implementation
+scope but is weaker than notebook conflict handling.
+
+### Browser Bundle Size
+
+Embedding Excalidraw adds a large editor dependency to the app bundle. The
+draft implementation imports the editor directly in the document component.
+Lazy-loading the Excalidraw document renderer is a reasonable follow-up if
+bundle size becomes a release concern.
+
+### Drive-Only Creation
+
+Creation is limited to Drive folders. That keeps the storage model small and
+matches the requested use case, but it means local workspaces cannot create
+diagrams yet.
+
+## Verification
+
+Automated checks:
+
+```bash
+pnpm -C app exec vitest run \
+  src/storage/excalidraw.test.ts \
+  src/storage/drive.test.ts \
+  src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+
+runme run build test
+```
+
+Manual Drive verification:
+
+1. Configure Google Drive auth with the test/development service account.
+2. Mount a Drive folder.
+3. Right-click the folder and select `New Excalidraw Diagram`.
+4. Draw in the opened editor.
+5. Reload and reopen the `.excalidraw` file.
+6. Confirm the scene is restored from Drive.
+
+## Follow-Ups
+
+- Keep the editor mounted when saves fail and add retry UI.
+- Lazy-load the Excalidraw editor bundle.
+- Add Drive revision or conflict indicators for diagram files.
+- Add export actions for PNG/SVG.
+- Support local filesystem-backed Excalidraw files.

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -25,6 +25,7 @@ Benefits:
 - authenticate Drive access,
 - mount a Drive link or folder,
 - open a Drive notebook,
+- create or open an Excalidraw diagram in a Drive folder,
 - save the current notebook to Drive,
 - copy a notebook into another Drive folder,
 - inspect or requeue pending sync.
@@ -87,6 +88,48 @@ Service-account credentials loaded from App Console are saved in
 after a reload. This is convenient for tests but means the private key is stored
 in browser-accessible storage. Keep these keys tightly scoped to disposable test
 Drive folders and prefer a server-side token broker for production.
+
+## Excalidraw diagrams in Drive
+
+Drive-backed workspace folders can contain Excalidraw diagrams alongside Runme
+notebooks. Runme stores each diagram as a normal Drive file with an Excalidraw
+JSON scene body.
+
+Supported file names:
+
+- `*.excalidraw`
+- `*.excalidraw.json`
+
+Runme creates new diagrams with this MIME type:
+
+```text
+application/vnd.excalidraw+json
+```
+
+To create a diagram:
+
+1. Mount a Google Drive folder in the workspace explorer.
+2. Right-click the mounted Drive folder.
+3. Select `New Excalidraw Diagram`.
+4. Rename the new explorer entry if needed.
+5. Open the diagram and draw in the Excalidraw tab.
+
+New diagrams appear in the explorer immediately through the local mirror. Runme
+then creates the backing Drive file asynchronously and updates the local row
+with the Drive URI. The editor autosaves changes back to the backing Drive file
+after a short debounce. The tab header shows `Ready`, `Saving...`, or
+`Saved to Drive`.
+
+Existing `.excalidraw` files appear in Drive-backed folders and open as
+workspace document tabs. The tab URI remains the local mirror URI
+(`local://file/<uuid>`); the file's MIME type or filename selects the
+Excalidraw renderer.
+
+Current limitations:
+
+- diagram creation is Drive-only,
+- concurrent edits are last-writer-wins,
+- there is no PNG/SVG export action yet.
 
 ## Useful App Console commands
 

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -15,6 +15,7 @@ help()
 
 - `runme`: notebook helpers,
 - `notebooks`: notebook document API,
+- `documents`: raw URI-based document content API,
 - `explorer`: workspace and file-mount helpers,
 - `runmeRunners`: runner configuration,
 - `jupyter`: Jupyter server and kernel lifecycle,
@@ -33,6 +34,7 @@ help()
 explorer.help()
 runme.help()
 notebooks.help()
+documents.help()
 runmeRunners.help()
 drive.help()
 agent.help()
@@ -70,6 +72,51 @@ await notebooks.show(
 await notebooks.show(
   '[Notebook](https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view)'
 )
+```
+
+Read and update raw document content, including Excalidraw scenes:
+
+```js
+const doc = await documents.get('local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018')
+const scene = JSON.parse(doc.content)
+scene.elements.push({
+  id: crypto.randomUUID(),
+  type: 'text',
+  x: 120,
+  y: 80,
+  width: 80,
+  height: 25,
+  angle: 0,
+  strokeColor: '#1e1e1e',
+  backgroundColor: 'transparent',
+  fillStyle: 'solid',
+  strokeWidth: 2,
+  strokeStyle: 'solid',
+  roughness: 1,
+  opacity: 100,
+  groupIds: [],
+  frameId: null,
+  roundness: null,
+  seed: Date.now(),
+  version: 1,
+  versionNonce: Date.now(),
+  isDeleted: false,
+  boundElements: null,
+  updated: Date.now(),
+  link: null,
+  locked: false,
+  text: 'Box A',
+  fontSize: 20,
+  fontFamily: 5,
+  textAlign: 'left',
+  verticalAlign: 'top',
+  containerId: null,
+  originalText: 'Box A',
+  lineHeight: 1.25,
+})
+await documents.update(doc.uri, JSON.stringify(scene, null, 2), {
+  mimeType: doc.mimeType,
+})
 ```
 
 Runner setup:
@@ -124,6 +171,8 @@ app.harness.setDefault('configured-harness-name')
 - If a user wants an action that has no visible button, check the App Console before saying the feature is missing.
 - Prefer `notebooks.appendCell({ kind, ... })` for simple inserts before writing
   raw `notebooks.update(...)` mutations by hand.
+- Use `documents.get(uri)` and `documents.update(uri, content, options)` for
+  raw content edits to non-notebook documents such as Excalidraw diagrams.
 - Use `notebooks.resolve(reference)` to turn local URIs, Runme share URLs,
   Drive URLs, and Markdown links into a title, `localUri`, `remoteUri`,
   `shareUrl`, and replacement-ready `markdownLink`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 3.2.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tailwindcss/vite':
         specifier: ^4.1.14
-        version: 4.1.14(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 4.1.14(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       '@vscode/webview-ui-toolkit':
         specifier: ^1.2.2
         version: 1.4.0(react@19.2.0)
@@ -155,7 +155,7 @@ importers:
         version: 1.72.4
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 4.7.0(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^2.1.9
         version: 2.1.9(vitest@2.1.9)
@@ -188,13 +188,13 @@ importers:
         version: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.3)
       vite:
         specifier: ^6.3.6
-        version: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+        version: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
       vite-plugin-compression:
         specifier: ^0.5.1
-        version: 0.5.1(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 0.5.1(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@20.12.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)
+        version: 2.1.9(@types/node@20.12.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)(sass@1.51.0)
 
   app:
     dependencies:
@@ -225,6 +225,9 @@ importers:
       '@datadog/datadog-api-client':
         specifier: ^1.45.0
         version: 1.51.0
+      '@excalidraw/excalidraw':
+        specifier: 0.18.1
+        version: 0.18.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@heroicons/react':
         specifier: 2.2.0
         version: 2.2.0(react@19.2.0)
@@ -248,7 +251,7 @@ importers:
         version: link:../packages/renderers
       '@tailwindcss/vite':
         specifier: ^4.0.17
-        version: 4.1.14(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 4.1.14(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       '@tanstack/react-query':
         specifier: 5.89.0
         version: 5.89.0(react@19.2.0)
@@ -357,7 +360,7 @@ importers:
         version: 1.72.4
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 4.7.0(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
         version: 5.2.0(eslint@9.37.0(jiti@2.6.1))
@@ -384,16 +387,16 @@ importers:
         version: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.3)
       vite:
         specifier: ^6.3.6
-        version: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+        version: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
       vite-plugin-compression:
         specifier: ^0.5.1
-        version: 0.5.1(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 0.5.1(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       vite-plugin-svgr:
         specifier: 4.3.0
-        version: 4.3.0(rollup@4.52.4)(typescript@5.8.3)(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 4.3.0(rollup@4.52.4)(typescript@5.8.3)(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@27.4.0)(lightningcss@1.30.1)
+        version: 2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@27.4.0)(lightningcss@1.30.1)(sass@1.51.0)
 
   packages/react-console:
     dependencies:
@@ -460,7 +463,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))
+        version: 4.7.0(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9)
@@ -469,7 +472,7 @@ importers:
         version: 25.0.1
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)
+        version: 2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)(sass@1.51.0)
 
 packages:
 
@@ -482,6 +485,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -584,6 +590,12 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@braintree/sanitize-url@6.0.2':
+    resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
   '@buf/bufbuild_protovalidate.bufbuild_es@2.2.3-20250625184727-c923a0c2a132.1':
     resolution: {tarball: https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.2.3-20250625184727-c923a0c2a132.1.tgz}
@@ -697,6 +709,24 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@chevrotain/cst-dts-gen@11.0.3':
+    resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
+
+  '@chevrotain/gast@11.0.3':
+    resolution: {integrity: sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==}
+
+  '@chevrotain/regexp-to-ast@11.0.3':
+    resolution: {integrity: sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==}
+
+  '@chevrotain/types@11.0.3':
+    resolution: {integrity: sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@chevrotain/utils@11.0.3':
+    resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
 
   '@connectrpc/connect-node@2.1.0':
     resolution: {integrity: sha512-6akCXZSX5uWHLR654ne9Tnq7AnPUkLS65NvgsI5885xBkcuVy2APBd8sA4sLqaplUt84cVEr6LhjEFNx6W1KtQ==}
@@ -1083,6 +1113,25 @@ packages:
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@excalidraw/excalidraw@0.18.1':
+    resolution: {integrity: sha512-6i5Gt7IDTOH//qa0Z315Ly5iVRhjWpu2whrlQFqkuwrkKUWgRsMk0P5qdE7bpyDpai7jeLeWYkyj1eVAfni1lw==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.2.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.2.0 || ^19.0.0
+
+  '@excalidraw/laser-pointer@1.3.1':
+    resolution: {integrity: sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g==}
+
+  '@excalidraw/markdown-to-text@0.1.2':
+    resolution: {integrity: sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==}
+
+  '@excalidraw/mermaid-to-excalidraw@2.2.2':
+    resolution: {integrity: sha512-5VKQq5CdRocC82vOIUpQ5ufJOVV9FpBTdHGA+ULqazeIVV+cr299877omQCibsdS3Bpitz2fsnTwnIXEmLVDSg==}
+
+  '@excalidraw/random-username@1.1.0':
+    resolution: {integrity: sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA==}
+    engines: {node: '>=10'}
+
   '@exodus/bytes@1.10.0':
     resolution: {integrity: sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1127,6 +1176,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
 
   '@inquirer/external-editor@1.0.2':
     resolution: {integrity: sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==}
@@ -1188,6 +1243,12 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mermaid-js/parser@0.6.3':
+    resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+
   '@microsoft/fast-element@1.14.0':
     resolution: {integrity: sha512-zXvuSOzvsu8zDTy9eby8ix8VqLop2rwKRgp++ZN2kTCsoB3+QJVoaGD2T/Cyso2ViZQFXNpiNCVKfnmxBvmWkQ==}
 
@@ -1246,6 +1307,12 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
+  '@radix-ui/primitive@1.0.0':
+    resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
+
+  '@radix-ui/primitive@1.1.1':
+    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -1277,6 +1344,19 @@ packages:
 
   '@radix-ui/react-alert-dialog@1.1.15':
     resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.2':
+    resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1353,6 +1433,12 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.0.1':
+    resolution: {integrity: sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -1364,6 +1450,20 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.0.0':
+    resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-compose-refs@1.1.1':
+    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-compose-refs@1.1.2':
@@ -1388,6 +1488,20 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-context@1.0.0':
+    resolution: {integrity: sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-context@1.1.1':
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -1410,6 +1524,11 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.0.0':
+    resolution: {integrity: sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -1421,6 +1540,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.5':
+    resolution: {integrity: sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1445,6 +1577,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.1':
+    resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1452,6 +1593,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.2':
+    resolution: {integrity: sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-focus-scope@1.1.7':
@@ -1497,6 +1651,20 @@ packages:
     resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
     peerDependencies:
       react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
+
+  '@radix-ui/react-id@1.0.0':
+    resolution: {integrity: sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-id@1.1.0':
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
@@ -1598,8 +1766,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popover@1.1.6':
+    resolution: {integrity: sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.2':
+    resolution: {integrity: sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.4':
+    resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1624,8 +1831,46 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.0.0':
+    resolution: {integrity: sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-presence@1.1.2':
+    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@1.0.1':
+    resolution: {integrity: sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1675,6 +1920,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@radix-ui/react-roving-focus@1.0.2':
+    resolution: {integrity: sha512-HLK+CqD/8pN6GfJm3U+cqpqhSKYAWiOJDe+A+8MfxBnOue39QEeMa43csUn2CXCHQT0/mewh1LrrG4tfkM9DMA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
@@ -1741,6 +1992,20 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slot@1.0.1':
+    resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -1762,6 +2027,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@radix-ui/react-tabs@1.0.2':
+    resolution: {integrity: sha512-gOUwh+HbjCuL0UCo8kZ+kdUEG8QtpdO4sMQduJ34ZEz0r4922g9REOBM+vIsfwtGxSug4Yb1msJMJYN2Bk8TpQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
 
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
@@ -1841,8 +2112,36 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.0.0':
+    resolution: {integrity: sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-callback-ref@1.1.0':
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.0.0':
+    resolution: {integrity: sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-controllable-state@1.1.0':
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1868,6 +2167,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.0':
+    resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
@@ -1879,6 +2187,20 @@ packages:
 
   '@radix-ui/react-use-is-hydrated@0.1.0':
     resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.0.0':
+    resolution: {integrity: sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-layout-effect@1.1.0':
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1904,8 +2226,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.0':
+    resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1934,6 +2274,9 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@radix-ui/rect@1.1.0':
+    resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
@@ -2330,6 +2673,99 @@ packages:
   '@types/buffer-from@1.1.3':
     resolution: {integrity: sha512-2lq4YC9uLUMGHkl2IDtX4tCXSo2+hwMpOJcY1qiIk1kybc31rIlPyM1HCVJhkPFIo75a/pOVxqyvwuf5TpCG/w==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -2338,6 +2774,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2463,6 +2902,10 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -2589,6 +3032,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -2634,6 +3081,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -2643,6 +3094,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browser-fs-access@0.29.1:
+    resolution: {integrity: sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==}
 
   browserslist@4.26.3:
     resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
@@ -2670,6 +3124,9 @@ packages:
 
   caniuse-lite@1.0.30001749:
     resolution: {integrity: sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==}
+
+  canvas-roundrect-polyfill@0.0.1:
+    resolution: {integrity: sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2704,6 +3161,18 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  chevrotain-allstar@0.3.1:
+    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
+    peerDependencies:
+      chevrotain: ^11.0.0
+
+  chevrotain@11.0.3:
+    resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -2714,6 +3183,10 @@ packages:
 
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
+  clsx@1.1.1:
+    resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2733,6 +3206,10 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2746,6 +3223,12 @@ packages:
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -2754,6 +3237,15 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@0.3.0:
+    resolution: {integrity: sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==}
+    engines: {node: '>=0.8'}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -2782,6 +3274,23 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -2852,6 +3361,9 @@ packages:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
@@ -2868,6 +3380,9 @@ packages:
     resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
     engines: {node: '>=12'}
 
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
   d3-scale-chromatic@3.1.0:
     resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
     engines: {node: '>=12'}
@@ -2879,6 +3394,9 @@ packages:
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
 
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
@@ -2910,6 +3428,9 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -2917,6 +3438,9 @@ packages:
   data-urls@6.0.1:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2995,6 +3519,9 @@ packages:
   dompurify@3.1.7:
     resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
 
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
@@ -3051,6 +3578,13 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+
+  es6-promise-pool@2.5.0:
+    resolution: {integrity: sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==}
+    engines: {node: '>=0.10.0'}
 
   es6-promise@4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
@@ -3146,6 +3680,7 @@ packages:
 
   exenv-es6@1.1.1:
     resolution: {integrity: sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -3216,6 +3751,10 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  fractional-indexing@3.2.0:
+    resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -3235,6 +3774,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuzzy@0.1.3:
+    resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
+    engines: {node: '>= 0.6.0'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3262,11 +3805,13 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -3281,6 +3826,9 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  glur@1.1.2:
+    resolution: {integrity: sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3290,6 +3838,9 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3376,9 +3927,18 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  image-blob-reduce@3.0.1:
+    resolution: {integrity: sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q==}
+
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -3388,8 +3948,14 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -3403,6 +3969,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
 
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
@@ -3477,6 +4047,24 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jotai-scope@0.7.2:
+    resolution: {integrity: sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg==}
+    peerDependencies:
+      jotai: '>=2.9.2'
+      react: '>=17.0.0'
+
+  jotai@2.11.0:
+    resolution: {integrity: sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -3542,8 +4130,25 @@ packages:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  langium@3.3.1:
+    resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
+    engines: {node: '>=16.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3633,11 +4238,23 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3693,6 +4310,11 @@ packages:
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -3756,6 +4378,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3890,9 +4515,22 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multimath@2.0.0:
+    resolution: {integrity: sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.3:
+    resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@4.0.2:
+    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
+    engines: {node: ^14 || ^16 || >=18}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -3913,6 +4551,10 @@ packages:
   node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   nwsapi@2.2.22:
     resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
 
@@ -3922,6 +4564,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  open-color@1.9.1:
+    resolution: {integrity: sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3964,6 +4609,12 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  pako@2.0.3:
+    resolution: {integrity: sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -3983,6 +4634,9 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4011,6 +4665,12 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  perfect-freehand@1.2.0:
+    resolution: {integrity: sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==}
+
+  pica@7.1.1:
+    resolution: {integrity: sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4029,6 +4689,24 @@ packages:
   pkce-challenge@4.1.0:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
     engines: {node: '>=16.20.0'}
+
+  png-chunk-text@1.0.0:
+    resolution: {integrity: sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw==}
+
+  png-chunks-encode@1.0.0:
+    resolution: {integrity: sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA==}
+
+  png-chunks-extract@1.0.0:
+    resolution: {integrity: sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-curve@1.0.1:
+    resolution: {integrity: sha512-3nmX4/LIiyuwGLwuUrfhTlDeQFlAhi7lyK/zcRNGhalwapDWgAGR82bUpmn2mA03vII3fvNCG8jAONzKXwpxAg==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -4064,6 +4742,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pwacompat@2.0.17:
+    resolution: {integrity: sha512-6Du7IZdIy7cHiv7AhtDy4X2QRM8IAD5DII69mt5qWibC2d15ZU8DmBG1WdZKekG11cChSu4zkSUGPF9sweOl6w==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -4234,6 +4915,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -4288,6 +4973,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  roughjs@4.6.4:
+    resolution: {integrity: sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -4305,6 +4996,11 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass@1.51.0:
+    resolution: {integrity: sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -4347,6 +5043,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sliced@1.0.1:
+    resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    deprecated: Unsupported
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -4410,6 +5110,9 @@ packages:
   style-to-object@1.0.11:
     resolution: {integrity: sha512-5A560JmXr7wDyGLK12Nq/EYS38VkGlglVzkis1JEdbGWSnbQIEhZzTJhzURXN5/8WwwFCs/f/VVcmkTppbXLow==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4433,7 +5136,7 @@ packages:
   tar@7.5.1:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -4448,6 +5151,10 @@ packages:
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -4521,11 +5228,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4747,6 +5461,26 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -4764,6 +5498,9 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webworkify@1.5.0:
+    resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -4846,6 +5583,21 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -4859,6 +5611,11 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -5001,6 +5758,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@braintree/sanitize-url@6.0.2': {}
+
+  '@braintree/sanitize-url@7.1.2': {}
 
   '@buf/bufbuild_protovalidate.bufbuild_es@2.2.3-20250625184727-c923a0c2a132.1(@bufbuild/protobuf@2.9.0)':
     dependencies:
@@ -5197,6 +5958,25 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.2
       prettier: 2.8.8
+
+  '@chevrotain/cst-dts-gen@11.0.3':
+    dependencies:
+      '@chevrotain/gast': 11.0.3
+      '@chevrotain/types': 11.0.3
+      lodash-es: 4.17.21
+
+  '@chevrotain/gast@11.0.3':
+    dependencies:
+      '@chevrotain/types': 11.0.3
+      lodash-es: 4.17.21
+
+  '@chevrotain/regexp-to-ast@11.0.3': {}
+
+  '@chevrotain/types@11.0.3': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@chevrotain/utils@11.0.3': {}
 
   '@connectrpc/connect-node@2.1.0(@bufbuild/protobuf@2.9.0)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.9.0))':
     dependencies:
@@ -5441,6 +6221,59 @@ snapshots:
       '@eslint/core': 0.16.0
       levn: 0.4.1
 
+  '@excalidraw/excalidraw@0.18.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@braintree/sanitize-url': 6.0.2
+      '@excalidraw/laser-pointer': 1.3.1
+      '@excalidraw/mermaid-to-excalidraw': 2.2.2
+      '@excalidraw/random-username': 1.1.0
+      '@radix-ui/react-popover': 1.1.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-tabs': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      browser-fs-access: 0.29.1
+      canvas-roundrect-polyfill: 0.0.1
+      clsx: 1.1.1
+      cross-env: 7.0.3
+      es6-promise-pool: 2.5.0
+      fractional-indexing: 3.2.0
+      fuzzy: 0.1.3
+      image-blob-reduce: 3.0.1
+      jotai: 2.11.0(@types/react@19.2.2)(react@19.2.0)
+      jotai-scope: 0.7.2(jotai@2.11.0(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
+      lodash.debounce: 4.0.8
+      lodash.throttle: 4.1.1
+      nanoid: 3.3.3
+      open-color: 1.9.1
+      pako: 2.0.3
+      perfect-freehand: 1.2.0
+      pica: 7.1.1
+      png-chunk-text: 1.0.0
+      png-chunks-encode: 1.0.0
+      png-chunks-extract: 1.0.0
+      points-on-curve: 1.0.1
+      pwacompat: 2.0.17
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      roughjs: 4.6.4
+      sass: 1.51.0
+      tunnel-rat: 0.1.2(@types/react@19.2.2)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - immer
+
+  '@excalidraw/laser-pointer@1.3.1': {}
+
+  '@excalidraw/markdown-to-text@0.1.2': {}
+
+  '@excalidraw/mermaid-to-excalidraw@2.2.2':
+    dependencies:
+      '@excalidraw/markdown-to-text': 0.1.2
+      '@mermaid-js/parser': 0.6.3
+      mermaid: 11.15.0
+      nanoid: 4.0.2
+
+  '@excalidraw/random-username@1.1.0': {}
+
   '@exodus/bytes@1.10.0': {}
 
   '@floating-ui/core@1.7.3':
@@ -5474,6 +6307,14 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@inquirer/external-editor@1.0.2(@types/node@20.12.7)':
     dependencies:
@@ -5546,6 +6387,14 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mermaid-js/parser@0.6.3':
+    dependencies:
+      langium: 3.3.1
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
   '@microsoft/fast-element@1.14.0': {}
 
   '@microsoft/fast-foundation@2.50.0':
@@ -5605,6 +6454,12 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
+  '@radix-ui/primitive@1.0.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
+  '@radix-ui/primitive@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -5641,6 +6496,15 @@ snapshots:
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -5710,6 +6574,16 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-collection@1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.0)
+      '@radix-ui/react-context': 1.0.0(react@19.2.0)
+      '@radix-ui/react-primitive': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.0.1(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
@@ -5721,6 +6595,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-compose-refs@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.0
+
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
@@ -5741,6 +6626,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-context@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.0
+
+  '@radix-ui/react-context@1.1.1(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
@@ -5770,6 +6666,11 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-direction@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.0
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       react: 19.2.0
@@ -5783,6 +6684,19 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -5804,11 +6718,28 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-focus-guards@1.1.1(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-focus-scope@1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -5855,6 +6786,19 @@ snapshots:
   '@radix-ui/react-icons@1.3.2(react@19.2.0)':
     dependencies:
       react: 19.2.0
+
+  '@radix-ui/react-id@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.2.0)
+      react: 19.2.0
+
+  '@radix-ui/react-id@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   '@radix-ui/react-id@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
@@ -5997,6 +6941,47 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-popover@1.1.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-popper': 1.2.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.1(@types/react@19.2.2)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-popper@1.2.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/rect': 1.1.0
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -6015,6 +7000,16 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-portal@1.1.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -6025,10 +7020,44 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-presence@1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-primitive@1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/react-slot': 1.0.1(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -6071,6 +7100,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-roving-focus@1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-collection': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.0)
+      '@radix-ui/react-context': 1.0.0(react@19.2.0)
+      '@radix-ui/react-direction': 1.0.0(react@19.2.0)
+      '@radix-ui/react-id': 1.0.0(react@19.2.0)
+      '@radix-ui/react-primitive': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -6163,6 +7207,19 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-slot@1.0.1(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.0)
+      react: 19.2.0
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
@@ -6184,6 +7241,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-tabs@1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-context': 1.0.0(react@19.2.0)
+      '@radix-ui/react-direction': 1.0.0(react@19.2.0)
+      '@radix-ui/react-id': 1.0.0(react@19.2.0)
+      '@radix-ui/react-presence': 1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -6282,8 +7353,32 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-use-callback-ref@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.0
+
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-use-controllable-state@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.2.0)
+      react: 19.2.0
+
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.2
@@ -6303,6 +7398,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
@@ -6314,6 +7416,17 @@ snapshots:
     dependencies:
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-use-layout-effect@1.0.0(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.0
+
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -6329,9 +7442,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@radix-ui/react-use-rect@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.0
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@radix-ui/rect': 1.1.1
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.2
@@ -6351,6 +7478,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/rect@1.1.0': {}
 
   '@radix-ui/rect@1.1.1': {}
 
@@ -6584,19 +7713,19 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.14
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.14
 
-  '@tailwindcss/vite@4.1.14(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.14(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.14
       '@tailwindcss/oxide': 4.1.14
       tailwindcss: 4.1.14
-      vite: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
 
-  '@tailwindcss/vite@4.1.14(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.14(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.14
       '@tailwindcss/oxide': 4.1.14
       tailwindcss: 4.1.14
-      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
 
   '@tanstack/query-core@5.89.0': {}
 
@@ -6688,6 +7817,123 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -6697,6 +7943,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -6849,7 +8097,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))':
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react@4.7.0(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -6857,11 +8110,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -6869,7 +8122,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6887,7 +8140,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@20.12.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)
+      vitest: 2.1.9(@types/node@20.12.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)(sass@1.51.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6898,21 +8151,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@20.12.7)(lightningcss@1.30.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0)
 
-  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -6942,7 +8195,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@27.4.0)(lightningcss@1.30.1)
+      vitest: 2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@27.4.0)(lightningcss@1.30.1)(sass@1.51.0)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -7009,6 +8262,11 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -7045,6 +8303,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  binary-extensions@2.3.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -7057,6 +8317,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-fs-access@0.29.1: {}
 
   browserslist@4.26.3:
     dependencies:
@@ -7080,6 +8342,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001749: {}
+
+  canvas-roundrect-polyfill@0.0.1: {}
 
   ccount@2.0.1: {}
 
@@ -7110,11 +8374,39 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  chevrotain-allstar@0.3.1(chevrotain@11.0.3):
+    dependencies:
+      chevrotain: 11.0.3
+      lodash-es: 4.18.1
+
+  chevrotain@11.0.3:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 11.0.3
+      '@chevrotain/gast': 11.0.3
+      '@chevrotain/regexp-to-ast': 11.0.3
+      '@chevrotain/types': 11.0.3
+      '@chevrotain/utils': 11.0.3
+      lodash-es: 4.17.21
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
 
   classnames@2.5.1: {}
+
+  clsx@1.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -7130,6 +8422,8 @@ snapshots:
 
   commander@7.2.0: {}
 
+  commander@8.3.0: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -7140,6 +8434,14 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
@@ -7148,6 +8450,12 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.8.3
+
+  crc-32@0.3.0: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-fetch@3.2.0:
     dependencies:
@@ -7183,6 +8491,22 @@ snapshots:
       lru-cache: 11.2.5
 
   csstype@3.1.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
 
   d3-array@3.2.4:
     dependencies:
@@ -7249,6 +8573,8 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@1.0.9: {}
+
   d3-path@3.1.0: {}
 
   d3-polygon@3.0.1: {}
@@ -7256,6 +8582,11 @@ snapshots:
   d3-quadtree@3.0.1: {}
 
   d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
 
   d3-scale-chromatic@3.1.0:
     dependencies:
@@ -7271,6 +8602,10 @@ snapshots:
       d3-time-format: 4.1.0
 
   d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
 
   d3-shape@3.2.0:
     dependencies:
@@ -7336,6 +8671,11 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -7345,6 +8685,8 @@ snapshots:
     dependencies:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
+
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
@@ -7404,6 +8746,10 @@ snapshots:
 
   dompurify@3.1.7: {}
 
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
@@ -7457,6 +8803,10 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.47.0: {}
+
+  es6-promise-pool@2.5.0: {}
 
   es6-promise@4.2.8: {}
 
@@ -7678,6 +9028,8 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  fractional-indexing@3.2.0: {}
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -7700,6 +9052,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fuzzy@0.1.3: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -7762,11 +9116,15 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  glur@1.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
 
@@ -7901,16 +9259,28 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  image-blob-reduce@3.0.1:
+    dependencies:
+      pica: 7.1.1
+
+  immutable@4.3.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.4: {}
+
+  internmap@1.0.1: {}
 
   internmap@2.0.3: {}
 
@@ -7922,6 +9292,10 @@ snapshots:
       is-decimal: 2.0.1
 
   is-arrayish@0.2.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
 
   is-buffer@1.1.6: {}
 
@@ -7985,6 +9359,16 @@ snapshots:
   javascript-natural-sort@0.7.1: {}
 
   jiti@2.6.1: {}
+
+  jotai-scope@0.7.2(jotai@2.11.0(@types/react@19.2.2)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      jotai: 2.11.0(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+
+  jotai@2.11.0(@types/react@19.2.2)(react@19.2.0):
+    optionalDependencies:
+      '@types/react': 19.2.2
+      react: 19.2.0
 
   js-cookie@3.0.5: {}
 
@@ -8079,9 +9463,27 @@ snapshots:
 
   jwt-decode@4.0.0: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
+
+  langium@3.3.1:
+    dependencies:
+      chevrotain: 11.0.3
+      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   levn@0.4.1:
     dependencies:
@@ -8159,9 +9561,17 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.17.21: {}
+
+  lodash-es@4.18.1: {}
+
+  lodash.debounce@4.0.8: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
+
+  lodash.throttle@4.1.1: {}
 
   lodash@4.17.21: {}
 
@@ -8208,6 +9618,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@14.0.0: {}
+
+  marked@16.4.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -8375,6 +9787,30 @@ snapshots:
   memoize-one@5.2.1: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.8
+      es-toolkit: 1.47.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 11.1.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8609,7 +10045,16 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multimath@2.0.0:
+    dependencies:
+      glur: 1.1.2
+      object-assign: 4.1.1
+
   nanoid@3.3.11: {}
+
+  nanoid@3.3.3: {}
+
+  nanoid@4.0.2: {}
 
   natural-compare@1.4.0: {}
 
@@ -8624,11 +10069,15 @@ snapshots:
 
   node-releases@2.0.23: {}
 
+  normalize-path@3.0.0: {}
+
   nwsapi@2.2.22: {}
 
   oauth4webapi@2.17.0: {}
 
   object-assign@4.1.1: {}
+
+  open-color@1.9.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -8671,6 +10120,10 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  package-manager-detector@1.6.0: {}
+
+  pako@2.0.3: {}
+
   pako@2.1.0: {}
 
   parent-module@1.0.1:
@@ -8702,6 +10155,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-data-parser@0.1.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -8722,6 +10177,16 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  perfect-freehand@1.2.0: {}
+
+  pica@7.1.1:
+    dependencies:
+      glur: 1.1.2
+      inherits: 2.0.4
+      multimath: 2.0.0
+      object-assign: 4.1.1
+      webworkify: 1.5.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -8731,6 +10196,26 @@ snapshots:
   pify@4.0.1: {}
 
   pkce-challenge@4.1.0: {}
+
+  png-chunk-text@1.0.0: {}
+
+  png-chunks-encode@1.0.0:
+    dependencies:
+      crc-32: 0.3.0
+      sliced: 1.0.1
+
+  png-chunks-extract@1.0.0:
+    dependencies:
+      crc-32: 0.3.0
+
+  points-on-curve@0.2.0: {}
+
+  points-on-curve@1.0.1: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-value-parser@4.2.0: {}
 
@@ -8761,6 +10246,8 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  pwacompat@2.0.17: {}
 
   quansync@0.2.11: {}
 
@@ -8999,6 +10486,10 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -9093,6 +10584,20 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.4
       fsevents: 2.3.3
 
+  roughjs@4.6.4:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -9108,6 +10613,12 @@ snapshots:
       tslib: 2.8.1
 
   safer-buffer@2.1.2: {}
+
+  sass@1.51.0:
+    dependencies:
+      chokidar: 3.6.0
+      immutable: 4.3.8
+      source-map-js: 1.2.1
 
   saxes@6.0.0:
     dependencies:
@@ -9138,6 +10649,8 @@ snapshots:
       totalist: 3.0.1
 
   slash@3.0.0: {}
+
+  sliced@1.0.1: {}
 
   snake-case@3.0.4:
     dependencies:
@@ -9202,6 +10715,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -9235,6 +10750,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -9293,9 +10810,19 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
+  ts-dedent@2.2.0: {}
+
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tunnel-rat@0.1.2(@types/react@19.2.2)(react@19.2.0):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.2)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   type-check@0.4.0:
     dependencies:
@@ -9411,13 +10938,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@2.1.9(@types/node@20.12.7)(lightningcss@1.30.1):
+  vite-node@2.1.9(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9429,13 +10956,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@22.19.7)(lightningcss@1.30.1):
+  vite-node@2.1.9(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9447,36 +10974,36 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-compression@0.5.1(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)):
+  vite-plugin-compression@0.5.1(vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3
       fs-extra: 10.1.0
-      vite: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-compression@0.5.1(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)):
+  vite-plugin-compression@0.5.1(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3
       fs-extra: 10.1.0
-      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-svgr@4.3.0(rollup@4.52.4)(typescript@5.8.3)(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)):
+  vite-plugin-svgr@4.3.0(rollup@4.52.4)(typescript@5.8.3)(vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@5.4.20(@types/node@20.12.7)(lightningcss@1.30.1):
+  vite@5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -9485,8 +11012,9 @@ snapshots:
       '@types/node': 20.12.7
       fsevents: 2.3.3
       lightningcss: 1.30.1
+      sass: 1.51.0
 
-  vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1):
+  vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -9495,8 +11023,9 @@ snapshots:
       '@types/node': 22.19.7
       fsevents: 2.3.3
       lightningcss: 1.30.1
+      sass: 1.51.0
 
-  vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2):
+  vite@6.3.6(@types/node@20.12.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9509,9 +11038,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.1
+      sass: 1.51.0
       yaml: 2.8.2
 
-  vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.8.2):
+  vite@6.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.1)(sass@1.51.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9524,12 +11054,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.1
+      sass: 1.51.0
       yaml: 2.8.2
 
-  vitest@2.1.9(@types/node@20.12.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1):
+  vitest@2.1.9(@types/node@20.12.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@20.12.7)(lightningcss@1.30.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -9545,8 +11076,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)
-      vite-node: 2.1.9(@types/node@20.12.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0)
+      vite-node: 2.1.9(@types/node@20.12.7)(lightningcss@1.30.1)(sass@1.51.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.12.7
@@ -9563,10 +11094,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1):
+  vitest@2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -9582,8 +11113,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)
-      vite-node: 2.1.9(@types/node@22.19.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0)
+      vite-node: 2.1.9(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.7
@@ -9600,10 +11131,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@27.4.0)(lightningcss@1.30.1):
+  vitest@2.1.9(@types/node@22.19.7)(@vitest/ui@2.1.9)(jsdom@27.4.0)(lightningcss@1.30.1)(sass@1.51.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -9619,8 +11150,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)
-      vite-node: 2.1.9(@types/node@22.19.7)(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0)
+      vite-node: 2.1.9(@types/node@22.19.7)(lightningcss@1.30.1)(sass@1.51.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.7
@@ -9637,6 +11168,23 @@ snapshots:
       - supports-color
       - terser
 
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.0.8: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -9648,6 +11196,8 @@ snapshots:
   webidl-conversions@7.0.0: {}
 
   webidl-conversions@8.0.1: {}
+
+  webworkify@1.5.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -9708,5 +11258,12 @@ snapshots:
   yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@4.5.7(@types/react@19.2.2)(react@19.2.0):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      react: 19.2.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- add Drive-backed `.excalidraw` document creation and opening from the workspace explorer
- embed Excalidraw as a workspace document tab with debounced saves to Google Drive
- keep document identity on `local://file/<uuid>` and select the Excalidraw renderer via MIME metadata
- create new Excalidraw files local-first, matching regular notebook creation, then complete the Drive create through pending sync
- add generic Drive/local content helpers and focused tests
- document the design in `docs-dev/design/20260616_excalidraw_drive_documents.md` and user flow in `docs/05-google-drive-integration.md`

## Code review follow-up

- fixed a save-loss edge case where pending Excalidraw edits could be dropped on document switch, reload, or unmount before the debounce fired
- fixed Excalidraw creation lag by avoiding a synchronous Drive create before the explorer row appears

## Validation

- `pnpm -C app exec vitest run src/components/Workspace/WorkspaceExplorer.test.tsx src/storage/local.test.ts src/storage/drive.test.ts src/storage/excalidraw.test.ts`
- `pnpm -C app exec vitest run src/storage/excalidraw.test.ts src/storage/drive.test.ts src/lib/workspaceDocuments/workspaceDocumentController.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx src/components/SidePanel/SidePanel.test.tsx`
- `runme run build test`
- IAB manual setup: loaded `/Users/jlewi/secrets/aisre-gdrive-oai-test-8ba1a40f228e.json` with `credentials.google.setServiceAccountFromFilePath(...)`; `drive.authorize()` returned `status: authorized`, `authFlow: service_account`; visible app status showed `Google Drive: Syncing`

## Notes

This is a draft PR for review. Follow-ups called out in the design doc include save-error retry UX, lazy-loading the Excalidraw bundle, and conflict handling for concurrent Drive edits.