### PR TITLE
[codex] Create Drive folders with inline rename

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2894,6 +2894,8 @@ export default function Actions() {
                   explorer.addFolder(){'\n'}
                   explorer.mountDrive(driveUrl){'\n'}
                   explorer.openPicker(){'\n'}
+                  explorer.editName(uri){'\n'}
+                  explorer.renameFolder(uri, name){'\n'}
                   explorer.listFolders(){'\n'}
                   runme.getCurrentNotebook(){'\n'}
                   runme.clear(){'\n'}

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     sync: vi.fn(),
   },
   openNotebookUpstreamDiff: vi.fn(),
+  treeEdit: vi.fn(),
   workspaceItems: [] as string[],
 }))
 
@@ -37,7 +38,7 @@ vi.mock('react-arborist', async () => {
         parent: { open: vi.fn() },
       }),
       open: vi.fn(),
-      edit: vi.fn(async () => undefined),
+      edit: mocks.treeEdit,
     }))
 
     const renderItems = (items: any[], parent: any = null): React.ReactNode =>
@@ -183,6 +184,8 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.store.sync.mockReset()
     mocks.openNotebookUpstreamDiff.mockReset()
     mocks.openNotebookUpstreamDiff.mockResolvedValue(undefined)
+    mocks.treeEdit.mockReset()
+    mocks.treeEdit.mockResolvedValue(undefined)
     vi.spyOn(window, 'prompt').mockReturnValue('Reports')
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
@@ -200,7 +203,7 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(mocks.setCurrentDoc).not.toHaveBeenCalledWith(null)
   })
 
-  it('creates a Google Drive folder from a Drive-backed folder context menu', async () => {
+  it('creates a Google Drive folder inline from a Drive-backed folder context menu', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     mocks.store.getMetadata.mockImplementation(async (uri: string) => {
       if (uri === 'local://folder/drive') {
@@ -208,9 +211,21 @@ describe('WorkspaceExplorer current document handling', () => {
           uri,
           name: 'Drive Root',
           type: NotebookStoreItemType.Folder,
-          children: [],
+          children: mocks.store.createFolder.mock.calls.length
+            ? ['local://folder/new']
+            : [],
           remoteUri: 'https://drive.google.com/drive/folders/drive-root',
           parents: [],
+        }
+      }
+      if (uri === 'local://folder/new') {
+        return {
+          uri,
+          name: 'New Folder',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/new',
+          parents: ['local://folder/drive'],
         }
       }
       return null
@@ -229,8 +244,12 @@ describe('WorkspaceExplorer current document handling', () => {
     await waitFor(() => {
       expect(mocks.store.createFolder).toHaveBeenCalledWith(
         'local://folder/drive',
-        'Reports'
+        'New Folder'
       )
+    })
+    expect(window.prompt).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mocks.treeEdit).toHaveBeenCalledWith('local://folder/new')
     })
   })
 

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -253,6 +253,37 @@ describe('WorkspaceExplorer current document handling', () => {
     })
   })
 
+  it('starts inline rename from a Drive-backed folder context menu', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    const driveRoot = await screen.findByText('Drive Root')
+    fireEvent.contextMenu(driveRoot)
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Rename',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.treeEdit).toHaveBeenCalledWith('local://folder/drive')
+    })
+  })
+
   it('creates an Excalidraw diagram through the local mirror before Drive sync', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     mocks.store.getMetadata.mockImplementation(async (uri: string) => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -820,23 +820,14 @@ export function WorkspaceExplorer() {
         return;
       }
 
-      const name =
-        typeof window === "undefined"
-          ? DEFAULT_DRIVE_FOLDER_NAME
-          : window.prompt("Folder name", DEFAULT_DRIVE_FOLDER_NAME);
-      if (name === null) {
-        return;
-      }
-
-      const trimmedName = name.trim();
-      if (!trimmedName) {
-        return;
-      }
-
       try {
         treeRef.current?.open(folderUri);
-        await store.createFolder(folderUri, trimmedName);
+        const newFolder = await store.createFolder(
+          folderUri,
+          DEFAULT_DRIVE_FOLDER_NAME,
+        );
         await fetchChildren(folderUri);
+        setPendingEditId(newFolder.uri);
         setErrorMessage(null);
         showToast({ message: "Google Drive folder created", tone: "success" });
       } catch (error) {
@@ -1007,12 +998,20 @@ function formatShortTimestamp(date: Date): string {
         node.reset();
         return;
       }
-      if (target.type !== NotebookStoreItemType.File) {
+      if (
+        target.type !== NotebookStoreItemType.File &&
+        target.type !== NotebookStoreItemType.Folder
+      ) {
         node.reset();
         return;
       }
       const trimmed = name.trim();
-      const nextName = trimmed === "" ? "untitled.json" : trimmed;
+      const nextName =
+        trimmed === ""
+          ? target.type === NotebookStoreItemType.Folder
+            ? DEFAULT_DRIVE_FOLDER_NAME
+            : "untitled.json"
+          : trimmed;
       try {
         await targetStore.rename(target.uri, nextName);
         const parentUri = node.parent?.data.uri;
@@ -1026,8 +1025,8 @@ function formatShortTimestamp(date: Date): string {
         setErrorMessage(null);
         setPendingEditId(null);
       } catch (error) {
-        console.error("Failed to rename notebook", error);
-        setErrorMessage("Unable to rename document. Please try again.");
+        console.error("Failed to rename workspace item", error);
+        setErrorMessage("Unable to rename item. Please try again.");
         node.reset();
       }
     },
@@ -1251,7 +1250,13 @@ function formatShortTimestamp(date: Date): string {
             children={renderNode}
             onToggle={handleToggle}
             onClick={() => setContextMenu(null)}
-            disableEdit={(data) => data.type !== NotebookStoreItemType.File}
+            disableEdit={(data) =>
+              data.type !== NotebookStoreItemType.File &&
+              !(
+                data.type === NotebookStoreItemType.Folder &&
+                Boolean(data.remoteUri)
+              )
+            }
             onRename={handleRename}
           />
         </div>

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -44,6 +44,7 @@ import { useNotebookContext } from "../../contexts/NotebookContext";
 import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentContext";
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
 import { openNotebookUpstreamDiff } from "../../lib/notebookDiff/conflict";
+import { appState } from "../../lib/runtime/AppState";
 import {
   EXCALIDRAW_MIME_TYPE,
   createInitialExcalidrawDocumentJson,
@@ -847,6 +848,13 @@ export function WorkspaceExplorer() {
     setPendingEditId(uri);
   }, []);
 
+  useEffect(() => {
+    appState.setWorkspaceRenameHandler(handleStartRename);
+    return () => {
+      appState.setWorkspaceRenameHandler(null);
+    };
+  }, [handleStartRename]);
+
 function formatShortTimestamp(date: Date): string {
   const pad = (value: number) => value.toString().padStart(2, "0");
   const year = date.getFullYear();
@@ -1422,29 +1430,42 @@ function formatShortTimestamp(date: Date): string {
           ) : adjustedContextMenu.type === NotebookStoreItemType.Folder ? (
             <>
               {!adjustedContextMenu.uri.startsWith("fs://") && (
-              <button
-                type="button"
-                className="ctx-menu-item"
-                onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  setContextMenu(null);
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setContextMenu(null);
 
-                  void (async () => {
-                    try {
-                      if (store) {
-                        await store.sync(adjustedContextMenu.uri);
+                    void (async () => {
+                      try {
+                        if (store) {
+                          await store.sync(adjustedContextMenu.uri);
+                        }
+                      } catch (error) {
+                        console.error("Failed to sync folder", error);
+                      } finally {
+                        await fetchChildren(adjustedContextMenu.uri);
                       }
-                    } catch (error) {
-                      console.error("Failed to sync folder", error);
-                    } finally {
-                      await fetchChildren(adjustedContextMenu.uri);
-                    }
-                  })();
-                }}
-              >
-                Sync
-              </button>
+                    })();
+                  }}
+                >
+                  Sync
+                </button>
+              )}
+              {adjustedContextMenu.remoteUri && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleStartRename(adjustedContextMenu.uri);
+                  }}
+                >
+                  Rename
+                </button>
               )}
               <button
                 type="button"
@@ -1502,7 +1523,7 @@ function formatShortTimestamp(date: Date): string {
                   Copy Share Link
                 </button>
               )}
-          {adjustedContextMenu.uri !== LOCAL_FOLDER_URI && (
+              {adjustedContextMenu.uri !== LOCAL_FOLDER_URI && (
                 <button
                   type="button"
                   className="ctx-menu-item text-red-600"

--- a/app/src/lib/runtime/AppState.ts
+++ b/app/src/lib/runtime/AppState.ts
@@ -37,6 +37,7 @@ export class AppState {
       ) => Promise<StartGoogleDriveOAuthResult>)
     | null = null;
   private workspaceHandlers: WorkspaceHandlers | null = null;
+  private workspaceRenameHandler: ((uri: string) => void) | null = null;
   private runnerHandlers: RunnerHandlers | null = null;
 
   private constructor() {}
@@ -90,6 +91,17 @@ export class AppState {
 
   removeWorkspaceItem(uri: string): void {
     this.workspaceHandlers?.removeItem(uri);
+  }
+
+  setWorkspaceRenameHandler(handler: ((uri: string) => void) | null): void {
+    this.workspaceRenameHandler = handler;
+  }
+
+  startWorkspaceItemRename(uri: string): void {
+    if (!this.workspaceRenameHandler) {
+      throw new Error("Workspace rename handler is not initialized");
+    }
+    this.workspaceRenameHandler(uri);
   }
 
   setRunnerHandlers(handlers: RunnerHandlers | null): void {

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -70,6 +70,7 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     appState.setLocalNotebooks(null)
     appState.setOpenNotebookHandler(null)
     appState.setGoogleDriveOAuthHandler(null)
+    appState.setWorkspaceRenameHandler(null)
     window.localStorage.clear()
     ;(
       GoogleClientManager as unknown as {
@@ -144,6 +145,48 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     await expect(globals.notebooks.shareUrl()).resolves.toBe(
       'http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fcurrent'
     )
+  })
+
+  it('opens inline workspace rename from the explorer runtime API', () => {
+    const startRename = vi.fn()
+    appState.setWorkspaceRenameHandler(startRename)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const result = globals.explorer.editName('local://folder/drive')
+
+    expect(result).toBe('Editing name: local://folder/drive')
+    expect(startRename).toHaveBeenCalledWith('local://folder/drive')
+  })
+
+  it('renames a local workspace folder from the explorer runtime API', async () => {
+    const localStore = {
+      rename: vi.fn(async (uri: string, name: string) => ({
+        uri,
+        name,
+        type: 'folder',
+        children: [],
+      })),
+    }
+    appState.setLocalNotebooks(localStore as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const result = await globals.explorer.renameFolder(
+      'local://folder/drive',
+      'Renamed Folder'
+    )
+
+    expect(localStore.rename).toHaveBeenCalledWith(
+      'local://folder/drive',
+      'Renamed Folder'
+    )
+    expect(result).toMatchObject({
+      uri: 'local://folder/drive',
+      name: 'Renamed Folder',
+    })
   })
 
   it('reads raw document content from the local mirror', async () => {

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -80,6 +80,7 @@ type SendOutput = (data: string) => void
 
 type RuntimeNotebookStore = {
   create: (parentUri: string, name: string) => Promise<{ uri: string }>
+  rename?: (uri: string, name: string) => Promise<unknown>
   save: (uri: string, notebook: parser_pb.Notebook) => Promise<unknown>
 }
 
@@ -375,6 +376,9 @@ export function createAppJsGlobals({
       return
     }
     appState.removeWorkspaceItem(uri)
+  }
+  const editWorkspaceItemName = (uri: string) => {
+    appState.startWorkspaceItemRename(uri)
   }
   const resolveStore = () => resolveNotebookStore?.() ?? appState.localNotebooks
   const openNotebookForRuntime = async (uri: string) => {
@@ -1835,6 +1839,42 @@ export function createAppJsGlobals({
         removeWorkspaceItem(uri)
         return `Removed: ${uri}`
       },
+      editName: (uri: string) => {
+        if (!uri) {
+          return 'Usage: explorer.editName(uri)'
+        }
+        editWorkspaceItemName(uri)
+        return `Editing name: ${uri}`
+      },
+      renameFolder: async (uri: string, name: string) => {
+        const nextName = name?.trim()
+        if (!uri || !nextName) {
+          throw new Error('Usage: explorer.renameFolder(uri, name)')
+        }
+        if (uri.startsWith('local://folder/')) {
+          const localStore = resolveLocalMirrorStore()
+          const renamed = await localStore.rename(uri, nextName)
+          const message = `Renamed folder: ${uri} -> ${nextName}`
+          emitLine(sendOutput, message)
+          return renamed
+        }
+        if (isDriveItemUri(uri)) {
+          const parsed = parseDriveItem(uri)
+          if (parsed.type !== NotebookStoreItemType.Folder) {
+            throw new Error('explorer.renameFolder(uri, name) requires a folder URI.')
+          }
+          if (!appState.driveNotebookStore) {
+            throw new Error('Google Drive notebook store is not initialized yet.')
+          }
+          const renamed = await appState.driveNotebookStore.rename(uri, nextName)
+          const message = `Renamed Drive folder: ${uri} -> ${nextName}`
+          emitLine(sendOutput, message)
+          return renamed
+        }
+        throw new Error(
+          'explorer.renameFolder(uri, name) requires a local://folder or Google Drive folder URI.'
+        )
+      },
       listFolders: () => {
         const items = getWorkspaceItems()
         if (items.length === 0) {
@@ -1849,6 +1889,8 @@ export function createAppJsGlobals({
           'explorer.openPicker()           - Alias for explorer.addFolder()',
           'explorer.importMarkdown()       - Import a local Markdown file as a notebook',
           'explorer.removeFolder(uri)      - Remove a folder from workspace',
+          'explorer.editName(uri)          - Open inline rename for a workspace item',
+          'explorer.renameFolder(uri,name) - Rename a workspace folder programmatically',
           'explorer.listFolders()          - List all workspace folders',
           'explorer.help()                 - Show this help',
         ].join('\n')

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -420,6 +420,19 @@ async function handleSandboxAppKernelBridgeCall({
         ...(result.accessToken ? { accessToken: '<redacted>' } : {}),
       }
     }
+    case 'explorer.mountDrive':
+      return globals.explorer.mountDrive(String(args[0] ?? ''))
+    case 'explorer.removeFolder':
+      return globals.explorer.removeFolder(String(args[0] ?? ''))
+    case 'explorer.editName':
+      return globals.explorer.editName(String(args[0] ?? ''))
+    case 'explorer.renameFolder':
+      return globals.explorer.renameFolder(
+        String(args[0] ?? ''),
+        String(args[1] ?? '')
+      )
+    case 'explorer.listFolders':
+      return globals.explorer.listFolders()
     case 'credentials.google.setServiceAccountFromFilePath': {
       const selection = await readServiceAccountJsonFromLocalPath(
         String(args[0] ?? '')

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -13,6 +13,7 @@ type Scenario =
   | 'lowLevel'
   | 'codex'
   | 'app'
+  | 'explorer'
   | 'credentials'
   | 'drive'
   | 'driveSave'
@@ -76,6 +77,19 @@ class MockSandboxPort {
           callId: 1,
           method: 'app.getSessionID',
           args: [],
+        })
+      } else if (this.scenario === 'explorer') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'explorer.renameFolder',
+          args: ['local://folder/drive', 'Renamed Folder'],
+        })
+        this.emit({
+          type: 'host-call',
+          callId: 2,
+          method: 'explorer.editName',
+          args: ['local://folder/drive'],
         })
       } else if (this.scenario === 'credentials') {
         this.emit({
@@ -170,6 +184,18 @@ class MockSandboxPort {
         this.emit({
           type: 'stdout',
           data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'explorer' && this.hostResults.has(2)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({
+          type: 'stdout',
+          data: `${String(this.hostResults.get(2) ?? '')}\n`,
         })
         this.emit({ type: 'exit', exitCode: 0 })
         return
@@ -579,6 +605,62 @@ describe('SandboxJSKernel', () => {
     ])
     expect(stdout).toContain('"status":"started"')
     expect(stdout).toContain('"mode":"new_tab"')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports explorer folder helpers through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'explorer.renameFolder') {
+        return {
+          uri: 'local://folder/drive',
+          name: 'Renamed Folder',
+          type: 'folder',
+        }
+      }
+      if (method === 'explorer.editName') {
+        return 'Editing name: local://folder/drive'
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('explorer'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      [
+        "console.log(await explorer.renameFolder('local://folder/drive', 'Renamed Folder'));",
+        "console.log(await explorer.editName('local://folder/drive'));",
+      ].join('\n')
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('explorer.renameFolder', [
+      'local://folder/drive',
+      'Renamed Folder',
+    ])
+    expect(bridgeCall).toHaveBeenCalledWith('explorer.editName', [
+      'local://folder/drive',
+    ])
+    expect(stdout).toContain('Renamed Folder')
+    expect(stdout).toContain('Editing name: local://folder/drive')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
   })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -52,6 +52,11 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'app.getSessionId',
   'app.getSessionID',
   'app.startGoogleDriveOAuth',
+  'explorer.mountDrive',
+  'explorer.removeFolder',
+  'explorer.editName',
+  'explorer.renameFolder',
+  'explorer.listFolders',
   'credentials.google.setServiceAccountFromFilePath',
   'drive.authorize',
   'drive.refreshAuth',
@@ -326,6 +331,20 @@ function buildSandboxSrcDoc(options: {
           getSessionID: () => hostCall("app.getSessionID", []),
           startGoogleDriveOAuth: (options) => hostCall("app.startGoogleDriveOAuth", [options]),
         };
+        const explorer = {
+          mountDrive: (driveUrl) => hostCall("explorer.mountDrive", [driveUrl]),
+          removeFolder: (uri) => hostCall("explorer.removeFolder", [uri]),
+          editName: (uri) => hostCall("explorer.editName", [uri]),
+          renameFolder: (uri, name) => hostCall("explorer.renameFolder", [uri, name]),
+          listFolders: () => hostCall("explorer.listFolders", []),
+          help: () => {
+            consoleProxy.log("explorer.mountDrive(driveUrl)");
+            consoleProxy.log("explorer.removeFolder(uri)");
+            consoleProxy.log("explorer.editName(uri)");
+            consoleProxy.log("explorer.renameFolder(uri, name)");
+            consoleProxy.log("explorer.listFolders()");
+          },
+        };
         const credentials = {
           google: {
             setServiceAccountFromFilePath: (path) =>
@@ -386,6 +405,10 @@ function buildSandboxSrcDoc(options: {
           consoleProxy.log("- await app.getSessionId()");
           consoleProxy.log("- await app.getSessionID()");
           consoleProxy.log("- await app.startGoogleDriveOAuth({ mode?, prompt? })");
+          consoleProxy.log("- await explorer.mountDrive(driveUrl)");
+          consoleProxy.log("- await explorer.editName(uri)");
+          consoleProxy.log("- await explorer.renameFolder(uri, name)");
+          consoleProxy.log("- await explorer.listFolders()");
           consoleProxy.log("- await credentials.google.setServiceAccountFromFilePath(path)");
           consoleProxy.log("- await drive.authorize({ mode?, prompt? })");
           consoleProxy.log("- await drive.saveAsCurrentNotebook(folderIdOrUri, fileName)");
@@ -405,12 +428,13 @@ function buildSandboxSrcDoc(options: {
               "notebookDiff",
               "codex",
               "app",
+              "explorer",
               "credentials",
               "drive",
               "help",
               '"use strict"; return (async () => {\\n' + code + '\\n})();',
             );
-            await runner(consoleProxy, runme, opfs, net, notebooks, documents, notebookDiff, codex, app, credentials, drive, help);
+            await runner(consoleProxy, runme, opfs, net, notebooks, documents, notebookDiff, codex, app, explorer, credentials, drive, help);
           } catch (error) {
             exitCode = 1;
             post({ type: "stderr", data: String(error) + "\\n" });

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -298,6 +298,46 @@ describe("DriveNotebookStore", () => {
     });
   });
 
+  it("renames Drive folders through the metadata update API", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/folder123");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.method).toBe("PATCH");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          name: "Renamed Folder",
+        });
+        return new Response(
+          JSON.stringify({
+            id: "folder123",
+            name: "Renamed Folder",
+            mimeType: "application/vnd.google-apps.folder",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.rename(
+      "https://drive.google.com/drive/folders/folder123",
+      "Renamed Folder",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      uri: "https://drive.google.com/drive/folders/folder123",
+      name: "Renamed Folder",
+      type: NotebookStoreItemType.Folder,
+      remoteUri: "https://drive.google.com/drive/folders/folder123",
+    });
+  });
+
   it("moves Drive files to trash through the metadata update API", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1500,8 +1500,11 @@ export class DriveNotebookStore {
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {
     const { id, type } = parseDriveItem(uri)
-    if (type !== NotebookStoreItemType.File) {
-      throw new Error('DriveNotebookStore.rename expects a file URI')
+    if (
+      type !== NotebookStoreItemType.File &&
+      type !== NotebookStoreItemType.Folder
+    ) {
+      throw new Error('DriveNotebookStore.rename expects a file or folder URI')
     }
     const client = await this.getFilesClient()
     const file = await client.update({

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -609,6 +609,50 @@ describe('LocalNotebooks rename', () => {
     )
   })
 
+  it('renames Drive-backed folders upstream before updating the local mirror', async () => {
+    const remoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const renamedRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const driveStore = {
+      rename: vi.fn(async () => ({
+        uri: renamedRemoteUri,
+        name: 'Renamed Folder',
+        type: NotebookStoreItemType.Folder,
+        children: [],
+        remoteUri: renamedRemoteUri,
+        parents: [],
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/parent',
+      name: 'Parent',
+      remoteId: 'https://drive.google.com/drive/folders/parent123',
+      children: ['local://folder/drive'],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/drive',
+      name: 'New Folder',
+      remoteId: remoteUri,
+      children: [],
+      lastSynced: '',
+    })
+
+    const result = await store.rename('local://folder/drive', 'Renamed Folder')
+
+    expect(driveStore.rename).toHaveBeenCalledWith(remoteUri, 'Renamed Folder')
+    expect(result).toMatchObject({
+      uri: 'local://folder/drive',
+      name: 'Renamed Folder',
+      type: NotebookStoreItemType.Folder,
+      remoteUri: renamedRemoteUri,
+      parents: ['local://folder/parent'],
+    })
+    expect((await store.folders.get('local://folder/drive'))?.name).toBe(
+      'Renamed Folder'
+    )
+  })
+
   it('does not update Drive-backed local metadata when the upstream rename fails', async () => {
     const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const driveStore = {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1265,8 +1265,61 @@ export class LocalNotebooks extends Dexie {
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {
+    if (uri.startsWith('local://folder/')) {
+      const record = await this.folders.get(uri)
+      if (!record) {
+        throw new Error(`Local folder record not found for ${uri}`)
+      }
+
+      let nextName = name
+      let nextRemoteId = record.remoteId
+
+      if (isDriveUri(record.remoteId)) {
+        const remoteItem = await this.driveStore.rename(record.remoteId, name)
+        nextName = remoteItem.name || name
+        nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId
+      }
+
+      await this.folders.update(uri, {
+        name: nextName,
+        remoteId: nextRemoteId,
+      })
+
+      const parentFolder = await this.findParentFolder(uri)
+
+      if (canDispatchWindowEvents()) {
+        window.dispatchEvent(
+          new CustomEvent('local-notebook-updated', {
+            detail: {
+              uri,
+              name: nextName,
+              remoteUri: publicRemoteUri({
+                ...record,
+                remoteId: nextRemoteId,
+              }),
+            },
+          })
+        )
+      }
+
+      const updatedRecord = {
+        ...record,
+        name: nextName,
+        remoteId: nextRemoteId,
+      }
+
+      return {
+        uri,
+        name: nextName,
+        type: NotebookStoreItemType.Folder,
+        children: [...record.children],
+        remoteUri: publicRemoteUri(updatedRecord),
+        parents: parentFolder ? [parentFolder.id] : [],
+      }
+    }
+
     if (!uri.startsWith('local://file/')) {
-      throw new Error('LocalNotebooks.rename expects a file URI')
+      throw new Error('LocalNotebooks.rename expects a file or folder URI')
     }
 
     const record = await this.files.get(uri)


### PR DESCRIPTION
## Summary
- create Drive-backed folders immediately with the default name "New Folder" instead of opening a prompt
- start inline rename on the newly created folder node
- support Drive-backed folder rename in the local mirror and Drive storage adapter

## Validation
- corepack pnpm -C app exec vitest run src/components/Workspace/WorkspaceExplorer.test.tsx src/storage/local.test.ts src/storage/drive.test.ts
- env PATH=/Users/jlewi/.nvm/versions/node/v24.15.0/bin:/opt/homebrew/bin:$PATH runme run build test
- IAB verified against live Google Drive using ~/secrets/aisre-gdrive-oai-test-8ba1a40f228e.json: selected a Drive test parent folder, clicked New Google Drive Folder, confirmed no prompt dialog, and confirmed the new "New Folder" node opened with active inline edit. Drive API readback confirmed the child folder existed; disposable parent was moved to trash.