### PR TITLE
[codex] Use session storage for drive link intents

### DIFF
--- a/app/src/lib/driveLinkCoordinator.test.ts
+++ b/app/src/lib/driveLinkCoordinator.test.ts
@@ -1,9 +1,26 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   isDriveAuthError,
   isDriveMissingOrAccessDeniedError,
 } from "./driveLinkCoordinator";
+
+const STORAGE_KEY = "runme/drive-link-intents";
+
+function createStoredIntent(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "drive-intent-test",
+    remoteUri: "https://drive.google.com/file/d/file123/view",
+    action: "open_shared_file",
+    source: "url",
+    status: "pending",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    retryCount: 0,
+    ...overrides,
+  };
+}
 
 describe("isDriveAuthError", () => {
   it("treats popup blocked auth failures as auth errors", () => {
@@ -54,5 +71,76 @@ describe("isDriveMissingOrAccessDeniedError", () => {
         new Error("Redirecting to Google OAuth for Drive authorization."),
       ),
     ).toBe(false);
+  });
+});
+
+describe("driveLinkCoordinator intent storage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("does not restore legacy localStorage intents and clears them", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([createStoredIntent()]),
+    );
+
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+
+    expect(driveLinkCoordinator.getSnapshot().intents).toEqual([]);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("restores pending intents from sessionStorage for the current tab", async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([createStoredIntent({ status: "processing" })]),
+    );
+
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+
+    expect(driveLinkCoordinator.getSnapshot().intents).toEqual([
+      expect.objectContaining({
+        id: "drive-intent-test",
+        remoteUri: "https://drive.google.com/file/d/file123/view",
+        status: "pending",
+      }),
+    ]);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("persists auth-blocked intents in sessionStorage only", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+
+    driveLinkCoordinator.configure({
+      ensureAccessToken: vi.fn(async () => {
+        throw new Error("Google Drive authorization is required.");
+      }),
+      updateFolder: vi.fn(),
+      addFile: vi.fn(),
+      addWorkspaceItem: vi.fn(),
+      removeWorkspaceItem: vi.fn(),
+      getWorkspaceItems: vi.fn(() => []),
+      openNotebook: vi.fn(),
+    });
+
+    await driveLinkCoordinator.enqueue(remoteUri, "manual");
+
+    const stored = JSON.parse(
+      window.sessionStorage.getItem(STORAGE_KEY) ?? "[]",
+    );
+    expect(stored).toEqual([
+      expect.objectContaining({
+        remoteUri,
+        action: "open_shared_file",
+        status: "waiting_for_auth",
+        retryCount: 1,
+      }),
+    ]);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 });

--- a/app/src/lib/driveLinkCoordinator.ts
+++ b/app/src/lib/driveLinkCoordinator.ts
@@ -102,13 +102,40 @@ function toDriveLinkAccessErrorMessage(remoteUri: string): string {
   return `Failed to load shared Drive link (${remoteUri}). The file may not exist or you may not have permission to access it.`;
 }
 
+function getIntentStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function clearLegacyLocalIntents(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore cleanup failures. Session-scoped intent storage remains primary.
+  }
+}
+
 function loadIntents(): DriveLinkIntent[] {
-  if (typeof window === "undefined" || !window.localStorage) {
+  clearLegacyLocalIntents();
+
+  const storage = getIntentStorage();
+  if (!storage) {
     return [];
   }
 
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = storage.getItem(STORAGE_KEY);
     if (!raw) {
       return [];
     }
@@ -126,7 +153,7 @@ function loadIntents(): DriveLinkIntent[] {
       )
       .map((intent) => ({
         ...intent,
-        // "processing" can be left behind in localStorage after reload/crash.
+        // "processing" can be left behind in sessionStorage after reload/crash.
         // Treat it as pending so the coordinator can resume it.
         status: intent.status === "processing" ? "pending" : intent.status,
       }));
@@ -136,16 +163,19 @@ function loadIntents(): DriveLinkIntent[] {
 }
 
 function persistIntents(intents: DriveLinkIntent[]): void {
-  if (typeof window === "undefined" || !window.localStorage) {
+  clearLegacyLocalIntents();
+
+  const storage = getIntentStorage();
+  if (!storage) {
     return;
   }
 
   try {
     if (intents.length === 0) {
-      window.localStorage.removeItem(STORAGE_KEY);
+      storage.removeItem(STORAGE_KEY);
       return;
     }
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(intents));
+    storage.setItem(STORAGE_KEY, JSON.stringify(intents));
   } catch {
     // Ignore persistence failures.
   }


### PR DESCRIPTION
## Summary
- Store Drive link intents in per-tab sessionStorage instead of shared localStorage.
- Clear the legacy localStorage queue so stale Drive intents do not leak into unrelated Runme tabs.
- Add jsdom coverage for legacy cleanup, same-tab restore, and auth-blocked intent persistence.

## Review
- Fixed a review issue before commit: legacy localStorage cleanup now accesses localStorage inside a try/catch, so storage-restricted browsers do not throw during coordinator startup.

## Validation
- git diff --check
- pnpm -C app test app/src/lib/driveLinkCoordinator.test.ts --run (blocked before test execution: pnpm install fails because @buf/googleapis_googleapis.bufbuild_es lockfile entry has no tarball integrity field)
- runme run build test (blocked by the same pnpm lockfile integrity issue)