### PR TITLE
[codex] Persist tab session id across refresh

### DIFF
--- a/app/src/lib/tabIdentity.test.ts
+++ b/app/src/lib/tabIdentity.test.ts
@@ -16,6 +16,7 @@ describe('tab identity', () => {
 
   afterEach(() => {
     __resetTabIdForTests()
+    window.sessionStorage.clear()
     window.history.replaceState(null, '', '/')
     vi.restoreAllMocks()
     if (originalLocksDescriptor) {
@@ -25,28 +26,30 @@ describe('tab identity', () => {
     }
   })
 
-  it('replaces a copied session query parameter with the page session id', () => {
+  it('uses sessionStorage as the page-load session id source', async () => {
+    window.sessionStorage.setItem('runme/sessionId', 'session-from-storage')
     window.history.replaceState(null, '', '/?session=session-from-url#cell-a')
 
     const sessionId = ensureSessionQueryParam()
+    const claimed = await getClaimedSessionId()
 
-    expect(sessionId).toBeTruthy()
-    expect(sessionId).not.toBe('session-from-url')
-    expect(sessionId).toMatch(/^[a-z]+-[a-z]+$/)
+    expect(sessionId).toBe('session-from-storage')
+    expect(claimed).toBe(sessionId)
     expect(getSessionId()).toBe(sessionId)
-    expect(window.location.search).toBe(
-      `?session=${encodeURIComponent(sessionId)}`
-    )
+    expect(window.location.search).toBe('?session=session-from-storage')
     expect(window.location.hash).toBe('#cell-a')
   })
 
-  it('adds a session query parameter when the URL does not have one', () => {
+  it('adds a session query parameter when the URL does not have one', async () => {
     window.history.replaceState(null, '', '/?doc=local%3A%2F%2Fnote#section')
 
     const sessionId = ensureSessionQueryParam()
+    const claimed = await getClaimedSessionId()
 
     expect(sessionId).toBeTruthy()
+    expect(claimed).toBe(sessionId)
     expect(sessionId).toMatch(/^[a-z]+-[a-z]+$/)
+    expect(window.sessionStorage.getItem('runme/sessionId')).toBe(sessionId)
     expect(window.location.search).toContain('doc=local%3A%2F%2Fnote')
     expect(window.location.search).toContain(
       `session=${encodeURIComponent(sessionId)}`
@@ -87,6 +90,9 @@ describe('tab identity', () => {
 
     expect(initial).toBe('amber-anchor')
     expect(claimed).toBe('blue-beacon')
+    expect(window.sessionStorage.getItem('runme/sessionId')).toBe(
+      'blue-beacon'
+    )
     expect(window.location.search).toBe('?session=blue-beacon')
     expect(request).toHaveBeenCalledWith(
       'runme:session:amber-anchor',

--- a/app/src/lib/tabIdentity.ts
+++ b/app/src/lib/tabIdentity.ts
@@ -1,4 +1,5 @@
 export const SESSION_QUERY_PARAM = "session";
+const SESSION_STORAGE_KEY = "runme/sessionId";
 
 let sessionId: string | null = null;
 let claimedSessionId: string | null = null;
@@ -90,6 +91,55 @@ function createSessionId(): string {
     SESSION_PREFIXES[randomIndex(SESSION_PREFIXES.length)],
     SESSION_NOUNS[randomIndex(SESSION_NOUNS.length)],
   ].join("-");
+}
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readStoredSessionId(): string | null {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    return storage.getItem(SESSION_STORAGE_KEY)?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSessionId(id: string): void {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(SESSION_STORAGE_KEY, id);
+  } catch {
+    // Session identity still works in memory when storage is unavailable.
+  }
+}
+
+function initializeSessionId(): string {
+  const stored = readStoredSessionId();
+  if (stored) {
+    return stored;
+  }
+
+  const created = createSessionId();
+  writeStoredSessionId(created);
+  return created;
 }
 
 function hasWebLocks(): boolean {
@@ -187,6 +237,7 @@ async function claimSessionId(): Promise<string> {
     if (await tryClaimSessionId(candidate)) {
       sessionId = candidate;
       claimedSessionId = candidate;
+      writeStoredSessionId(candidate);
       updateSessionQueryParam(candidate);
       return candidate;
     }
@@ -195,6 +246,7 @@ async function claimSessionId(): Promise<string> {
   // If every readable name is actively locked, fall back to the current
   // candidate so the app still has a stable session label.
   claimedSessionId = getSessionId();
+  writeStoredSessionId(claimedSessionId);
   updateSessionQueryParam(claimedSessionId);
   return claimedSessionId;
 }
@@ -202,15 +254,14 @@ async function claimSessionId(): Promise<string> {
 /**
  * getSessionId returns the Runme browser session identifier for this page.
  *
- * The id is intentionally in memory only and generated per page load. Browser
- * tab duplication copies the URL and may copy sessionStorage, so neither is a
- * reliable source of tab identity. Web Locks remain the ownership authority for
- * editable notebook state; this id is metadata for Codex/browser-tab routing
- * and blocked-state UI.
+ * The id is scoped to sessionStorage so a page refresh preserves the same
+ * browser session. Browser tab duplication may copy both the URL and
+ * sessionStorage, so Web Locks remain the ownership authority and force a new
+ * persisted id when another live tab already owns the stored one.
  */
 export function getSessionId(): string {
   if (!sessionId) {
-    sessionId = createSessionId();
+    sessionId = initializeSessionId();
   }
   return sessionId;
 }


### PR DESCRIPTION
## Summary
- Persist Runme browser session identity in sessionStorage.
- Publish the stored session ID back into the URL on page load.
- Update tests to cover refresh persistence and Web Lock collision replacement.

## Root cause
The page-load path generated a fresh in-memory session ID and rewrote the URL, so refreshing a tab could change the visible session query parameter even though sessionStorage-backed tab state was unchanged.

## Validation
- corepack pnpm --dir app exec vitest run src/lib/tabIdentity.test.ts
- corepack pnpm run build
- corepack pnpm --filter @runmedev/react-console exec vitest run