### PR TITLE
Surface notebook update operation failures

### DIFF
--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -657,6 +657,40 @@ describe('createNotebooksApi', () => {
     ])
   })
 
+  it('rejects invalid insert cell kinds before mutating the notebook', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const appendCell = vi.spyOn(model, 'appendCell')
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
+
+    await expect(
+      api.update({
+        target: { uri: 'local://one' },
+        operations: [
+          {
+            op: 'insert',
+            at: { index: -1 },
+            cells: [
+              { kind: 'markup', value: '# Valid cell' },
+              { kind: 'markdown', value: '# Invalid cell' } as any,
+            ],
+          },
+        ],
+      })
+    ).rejects.toThrow(
+      'Invalid notebooks.update insert cell kind at cells[1]: "markdown". Expected "code" or "markup"; use "markup" for Markdown cells.'
+    )
+
+    expect(appendCell).not.toHaveBeenCalled()
+    expect(model.updates).toEqual([])
+    expect(notebook.cells.map((cell) => cell.refId)).toEqual(['cell-a'])
+  })
+
   it('rejects notebooks.update without an explicit target', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [codeCell('cell-a', 'echo a')],

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -691,6 +691,41 @@ describe('createNotebooksApi', () => {
     expect(notebook.cells.map((cell) => cell.refId)).toEqual(['cell-a'])
   })
 
+  it('rejects invalid insert cell kinds before applying earlier operations', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
+
+    await expect(
+      api.update({
+        target: { uri: 'local://one' },
+        operations: [
+          {
+            op: 'update',
+            refId: 'cell-a',
+            patch: { value: 'echo updated' },
+          },
+          {
+            op: 'insert',
+            at: { index: -1 },
+            cells: [{ kind: 'markdown', value: '# Invalid cell' } as any],
+          },
+        ],
+      })
+    ).rejects.toThrow(
+      'Invalid notebooks.update insert cell kind at cells[0]: "markdown". Expected "code" or "markup"; use "markup" for Markdown cells.'
+    )
+
+    expect(model.updates).toEqual([])
+    expect(notebook.cells.map((cell) => cell.refId)).toEqual(['cell-a'])
+    expect(notebook.cells[0]?.value).toBe('echo a')
+  })
+
   it('rejects notebooks.update without an explicit target', async () => {
     const notebook = create(parser_pb.NotebookSchema, {
       cells: [codeCell('cell-a', 'echo a')],

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { RunmeMetadataKey, parser_pb } from '../../contexts/CellContext'
 import {
   type NotebookDataLike,
+  NotebookUpdateError,
   createNotebooksApi,
   createRunmeConsoleApi,
 } from './runmeConsole'
@@ -724,6 +725,66 @@ describe('createNotebooksApi', () => {
     expect(model.updates).toEqual([])
     expect(notebook.cells.map((cell) => cell.refId)).toEqual(['cell-a'])
     expect(notebook.cells[0]?.value).toBe('echo a')
+  })
+
+  it('reports applied, failed, and not-attempted operations on update failure', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a'), codeCell('cell-b', 'echo b')],
+    })
+    const model = new FakeNotebookData('local://one', 'One', notebook)
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      listNotebooks: () => [model],
+    })
+
+    let caught: unknown
+    try {
+      await api.update({
+        target: { uri: 'local://one' },
+        operations: [
+          {
+            op: 'update',
+            refId: 'cell-a',
+            patch: { value: 'echo updated' },
+          },
+          {
+            op: 'update',
+            refId: 'missing-cell',
+            patch: { value: 'echo missing' },
+          },
+          {
+            op: 'remove',
+            refIds: ['cell-b'],
+          },
+        ],
+      })
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(NotebookUpdateError)
+    const error = caught as NotebookUpdateError
+    expect(error.code).toBe('NOTEBOOK_UPDATE_FAILED')
+    expect(error.details.appliedOperationCount).toBe(1)
+    expect(error.details.failedOperationIndex).toBe(1)
+    expect(error.details.failedOperationError).toBe(
+      'Cell not found: missing-cell'
+    )
+    expect(error.details.operationStatuses).toEqual([
+      { index: 0, status: 'applied' },
+      { index: 1, status: 'failed', error: 'Cell not found: missing-cell' },
+      { index: 2, status: 'not_attempted' },
+    ])
+    expect(error.details.beforeHandle.uri).toBe('local://one')
+    expect(error.details.afterHandle.uri).toBe('local://one')
+    expect(error.details.afterHandle.revision).not.toBe(
+      error.details.beforeHandle.revision
+    )
+    expect(notebook.cells.map((cell) => cell.refId)).toEqual([
+      'cell-a',
+      'cell-b',
+    ])
+    expect(notebook.cells[0]?.value).toBe('echo updated')
   })
 
   it('rejects notebooks.update without an explicit target', async () => {

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -390,11 +390,7 @@ function addCellAfterForSpec(
   )
 }
 
-function insertCells(
-  notebook: NotebookDataLike,
-  at: CellLocation,
-  specs: InsertCellSpec[]
-): void {
+function assertValidInsertCellSpecs(specs: InsertCellSpec[]): void {
   if (!Array.isArray(specs) || specs.length === 0) {
     return
   }
@@ -408,6 +404,18 @@ function insertCells(
       )
     }
   }
+}
+
+function insertCells(
+  notebook: NotebookDataLike,
+  at: CellLocation,
+  specs: InsertCellSpec[]
+): void {
+  if (!Array.isArray(specs) || specs.length === 0) {
+    return
+  }
+
+  assertValidInsertCellSpecs(specs)
 
   if (
     typeof notebook.appendCell !== 'function' ||
@@ -631,6 +639,12 @@ export function createNotebooksApi({
             operations
           )}.`
         )
+      }
+
+      for (const operation of operations) {
+        if (operation.op === 'insert') {
+          assertValidInsertCellSpecs(operation.cells)
+        }
       }
 
       for (const [index, operation] of operations.entries()) {

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -398,6 +398,17 @@ function insertCells(
   if (!Array.isArray(specs) || specs.length === 0) {
     return
   }
+
+  for (const [index, spec] of specs.entries()) {
+    const kind = (spec as { kind?: unknown } | null)?.kind
+    if (kind !== 'code' && kind !== 'markup') {
+      throw new Error(
+        `Invalid notebooks.update insert cell kind at cells[${index}]: ${JSON.stringify(kind)}. ` +
+          'Expected "code" or "markup"; use "markup" for Markdown cells.'
+      )
+    }
+  }
+
   if (
     typeof notebook.appendCell !== 'function' ||
     typeof notebook.addCellBefore !== 'function' ||

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -110,6 +110,53 @@ export type NotebookMutation =
       refIds: string[]
     }
 
+export type NotebookUpdateOperationStatus =
+  | { index: number; status: 'applied' }
+  | { index: number; status: 'failed'; error: string }
+  | { index: number; status: 'not_attempted' }
+
+export type NotebookUpdateErrorDetails = {
+  method: 'notebooks.update'
+  code: 'NOTEBOOK_UPDATE_FAILED'
+  failedOperationIndex: number
+  failedOperation: unknown
+  failedOperationError: string
+  appliedOperationCount: number
+  operationStatuses: NotebookUpdateOperationStatus[]
+  beforeHandle: NotebookHandle
+  afterHandle: NotebookHandle
+}
+
+export class NotebookUpdateError extends Error {
+  readonly code = 'NOTEBOOK_UPDATE_FAILED'
+  readonly details: NotebookUpdateErrorDetails
+
+  constructor(details: NotebookUpdateErrorDetails) {
+    super(
+      `notebooks.update failed at operations[${details.failedOperationIndex}] ` +
+        `after applying ${details.appliedOperationCount} operation(s): ` +
+        details.failedOperationError
+    )
+    this.name = 'NotebookUpdateError'
+    this.details = details
+    Object.setPrototypeOf(this, NotebookUpdateError.prototype)
+  }
+
+  toJSON(): {
+    name: string
+    message: string
+    code: typeof this.code
+    details: NotebookUpdateErrorDetails
+  } {
+    return {
+      name: this.name,
+      message: this.message,
+      code: this.code,
+      details: this.details,
+    }
+  }
+}
+
 export type NotebookMethod = 'list' | 'get' | 'update' | 'delete' | 'execute'
 
 export type NotebooksApi = {
@@ -525,6 +572,66 @@ function formatNotebookMutationError(
   )
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function createOperationStatuses({
+  operationCount,
+  appliedOperationCount,
+  failedOperationIndex,
+  failedOperationError,
+}: {
+  operationCount: number
+  appliedOperationCount: number
+  failedOperationIndex: number
+  failedOperationError: string
+}): NotebookUpdateOperationStatus[] {
+  return Array.from({ length: operationCount }, (_value, index) => {
+    if (index < appliedOperationCount) {
+      return { index, status: 'applied' }
+    }
+    if (index === failedOperationIndex) {
+      return { index, status: 'failed', error: failedOperationError }
+    }
+    return { index, status: 'not_attempted' }
+  })
+}
+
+function createNotebookUpdateError({
+  operations,
+  failedOperationIndex,
+  error,
+  appliedOperationCount,
+  beforeHandle,
+  afterHandle,
+}: {
+  operations: NotebookMutation[]
+  failedOperationIndex: number
+  error: unknown
+  appliedOperationCount: number
+  beforeHandle: NotebookHandle
+  afterHandle: NotebookHandle
+}): NotebookUpdateError {
+  const failedOperationError = errorMessage(error)
+  return new NotebookUpdateError({
+    method: 'notebooks.update',
+    code: 'NOTEBOOK_UPDATE_FAILED',
+    failedOperationIndex,
+    failedOperation: operations[failedOperationIndex],
+    failedOperationError,
+    appliedOperationCount,
+    operationStatuses: createOperationStatuses({
+      operationCount: operations.length,
+      appliedOperationCount,
+      failedOperationIndex,
+      failedOperationError,
+    }),
+    beforeHandle,
+    afterHandle,
+  })
+}
+
 export function createNotebooksApi({
   resolveNotebook,
   listNotebooks,
@@ -641,31 +748,51 @@ export function createNotebooksApi({
         )
       }
 
-      for (const operation of operations) {
-        if (operation.op === 'insert') {
-          assertValidInsertCellSpecs(operation.cells)
+      for (const [index, operation] of operations.entries()) {
+        try {
+          if (operation.op === 'insert') {
+            assertValidInsertCellSpecs(operation.cells)
+          }
+        } catch (error) {
+          throw createNotebookUpdateError({
+            operations,
+            failedOperationIndex: index,
+            error,
+            appliedOperationCount: 0,
+            beforeHandle,
+            afterHandle: makeHandle(notebook),
+          })
         }
       }
 
+      let appliedOperationCount = 0
       for (const [index, operation] of operations.entries()) {
-        if (operation.op === 'insert') {
-          insertCells(notebook, operation.at, operation.cells)
-          continue
-        }
-        if (operation.op === 'update') {
-          updateCellPatch(notebook, operation.refId, operation.patch)
-          continue
-        }
-        if (operation.op === 'remove') {
-          if (typeof notebook.removeCell !== 'function') {
-            throw new Error('Notebook does not support remove operations.')
+        try {
+          if (operation.op === 'insert') {
+            insertCells(notebook, operation.at, operation.cells)
+          } else if (operation.op === 'update') {
+            updateCellPatch(notebook, operation.refId, operation.patch)
+          } else if (operation.op === 'remove') {
+            if (typeof notebook.removeCell !== 'function') {
+              throw new Error('Notebook does not support remove operations.')
+            }
+            for (const refId of operation.refIds ?? []) {
+              notebook.removeCell(refId)
+            }
+          } else {
+            throw new Error(formatNotebookMutationError(index, operation))
           }
-          for (const refId of operation.refIds ?? []) {
-            notebook.removeCell(refId)
-          }
-          continue
+          appliedOperationCount += 1
+        } catch (error) {
+          throw createNotebookUpdateError({
+            operations,
+            failedOperationIndex: index,
+            error,
+            appliedOperationCount,
+            beforeHandle,
+            afterHandle: makeHandle(notebook),
+          })
         }
-        throw new Error(formatNotebookMutationError(index, operation))
       }
 
       return makeDocument(notebook)

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest'
 
+import { NotebookUpdateError } from './runmeConsole'
 import {
   CODE_MODE_SANDBOX_ALLOWED_METHODS,
   SandboxJSKernel,
@@ -20,6 +21,7 @@ type Scenario =
   | 'driveSave'
   | 'documents'
   | 'notebooksCreate'
+  | 'notebooksUpdateError'
 
 class MockSandboxPort {
   onmessage: ((event: MessageEvent<any>) => void) | null = null
@@ -155,9 +157,23 @@ class MockSandboxPort {
           method: 'notebooks.appendCell',
           args: [
             {
-              target: { handle: { uri: 'local://file/comments-demo', revision: '1' } },
+              target: {
+                handle: { uri: 'local://file/comments-demo', revision: '1' },
+              },
               kind: 'markup',
               value: '# Comments demo',
+            },
+          ],
+        })
+      } else if (this.scenario === 'notebooksUpdateError') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'notebooks.update',
+          args: [
+            {
+              target: { uri: 'local://file/demo' },
+              operations: [],
             },
           ],
         })
@@ -295,6 +311,14 @@ class MockSandboxPort {
     }
 
     if (type === 'host-error') {
+      if (this.scenario === 'notebooksUpdateError') {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(message.error ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
       if (this.scenario === 'disallowed' || this.scenario === 'lowLevel') {
         this.emit({ type: 'stderr', data: String(message.error ?? '') + '\n' })
         this.emit({ type: 'exit', exitCode: 1 })
@@ -834,9 +858,9 @@ describe('SandboxJSKernel', () => {
     await kernel.run(
       [
         "const doc = await documents.get('local://file/test4');",
-        "const scene = JSON.parse(doc.content);",
+        'const scene = JSON.parse(doc.content);',
         "scene.elements.push({ id: 'label', type: 'text', text: 'Box A' });",
-        "console.log(await documents.update(doc.uri, JSON.stringify(scene), { mimeType: doc.mimeType }));",
+        'console.log(await documents.update(doc.uri, JSON.stringify(scene), { mimeType: doc.mimeType }));',
       ].join('\n')
     )
 
@@ -869,20 +893,23 @@ describe('SandboxJSKernel', () => {
       return null
     })
 
-    const kernel = new TestableSandboxJSKernel(new MockSandboxPort('driveSave'), {
-      bridge: { call: bridgeCall },
-      hooks: {
-        onStdout: (data) => {
-          stdout += data
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('driveSave'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
         },
-        onStderr: (data) => {
-          stderr += data
-        },
-        onExit: (code) => {
-          exitCode = code
-        },
-      },
-    })
+      }
+    )
 
     await kernel.run(
       "console.log(await drive.saveAsCurrentNotebook('root', 'Comments demo.ipynb'));"
@@ -945,7 +972,9 @@ describe('SandboxJSKernel', () => {
     ])
     expect(bridgeCall).toHaveBeenCalledWith('notebooks.appendCell', [
       {
-        target: { handle: { uri: 'local://file/comments-demo', revision: '1' } },
+        target: {
+          handle: { uri: 'local://file/comments-demo', revision: '1' },
+        },
         kind: 'markup',
         value: '# Comments demo',
       },
@@ -953,5 +982,81 @@ describe('SandboxJSKernel', () => {
     expect(stdout).toContain('cell-comments-demo')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
+  })
+
+  it('serializes structured notebook update errors through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async () => {
+      throw new NotebookUpdateError({
+        method: 'notebooks.update',
+        code: 'NOTEBOOK_UPDATE_FAILED',
+        failedOperationIndex: 1,
+        failedOperation: {
+          op: 'update',
+          refId: 'missing-cell',
+          patch: { value: 'echo missing' },
+        },
+        failedOperationError: 'Cell not found: missing-cell',
+        appliedOperationCount: 1,
+        operationStatuses: [
+          { index: 0, status: 'applied' },
+          {
+            index: 1,
+            status: 'failed',
+            error: 'Cell not found: missing-cell',
+          },
+        ],
+        beforeHandle: { uri: 'local://file/demo', revision: 'before' },
+        afterHandle: { uri: 'local://file/demo', revision: 'after' },
+      })
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('notebooksUpdateError'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run('await notebooks.update({ operations: [] });')
+
+    const serialized = JSON.parse(stdout)
+    expect(bridgeCall).toHaveBeenCalledWith('notebooks.update', [
+      {
+        target: { uri: 'local://file/demo' },
+        operations: [],
+      },
+    ])
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+    expect(serialized).toMatchObject({
+      name: 'NotebookUpdateError',
+      code: 'NOTEBOOK_UPDATE_FAILED',
+      details: {
+        failedOperationIndex: 1,
+        appliedOperationCount: 1,
+        operationStatuses: [
+          { index: 0, status: 'applied' },
+          {
+            index: 1,
+            status: 'failed',
+            error: 'Cell not found: missing-cell',
+          },
+        ],
+      },
+    })
   })
 })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -1,5 +1,6 @@
 import { appLogger } from '../logging/runtime'
 import { SANDBOX_NOTEBOOKS_API_METHODS } from './notebooksApiBridge'
+import { makeJsonSafe } from './runmeConsole'
 
 type KernelHooks = {
   onStdout?: (data: string) => void
@@ -13,6 +14,13 @@ type RunOptions = {
 
 type SandboxBridge = {
   call: (method: string, args: unknown[]) => Promise<unknown> | unknown
+}
+
+type SerializedHostError = {
+  name: string
+  message: string
+  code?: string
+  details?: unknown
 }
 
 type SandboxMessage =
@@ -31,6 +39,29 @@ type SandboxSession = {
 const SANDBOX_INIT_MESSAGE = 'runme-appkernel-sandbox-init'
 const LOAD_TIMEOUT_MS = 3_000
 const READY_TIMEOUT_MS = 3_000
+
+function serializeHostError(error: unknown): string | SerializedHostError {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!error || typeof error !== 'object') {
+    return message
+  }
+
+  const candidate = error as {
+    name?: unknown
+    code?: unknown
+    details?: unknown
+  }
+  if (typeof candidate.code !== 'string' && candidate.details === undefined) {
+    return message
+  }
+
+  return makeJsonSafe({
+    name: typeof candidate.name === 'string' ? candidate.name : 'Error',
+    message,
+    ...(typeof candidate.code === 'string' ? { code: candidate.code } : {}),
+    ...(candidate.details !== undefined ? { details: candidate.details } : {}),
+  })
+}
 
 const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'runme.clear',
@@ -251,6 +282,23 @@ function buildSandboxSrcDoc(options: {
             pending.set(callId, { resolve, reject });
             post({ type: "host-call", callId, method, args });
           });
+
+        const createHostError = (payload) => {
+          if (payload && typeof payload === "object") {
+            const error = new Error(String(payload.message ?? "Host call failed"));
+            if (typeof payload.name === "string") {
+              error.name = payload.name;
+            }
+            if (typeof payload.code === "string") {
+              error.code = payload.code;
+            }
+            if ("details" in payload) {
+              error.details = payload.details;
+            }
+            return error;
+          }
+          return new Error(String(payload ?? "Host call failed"));
+        };
 
         const consoleProxy = {
           log: (...args) => post({ type: "stdout", data: formatArgs(args) }),
@@ -475,7 +523,7 @@ function buildSandboxSrcDoc(options: {
                 return;
               }
               if (payload.type === "host-error") {
-                callbacks.reject(new Error(String(payload.error ?? "Host call failed")));
+                callbacks.reject(createHostError(payload.error));
               }
             };
             if (typeof port.start === "function") {
@@ -653,7 +701,7 @@ export class SandboxJSKernel {
       port.postMessage({
         type: 'host-error',
         callId,
-        error: String(error),
+        error: serializeHostError(error),
       })
     }
   }

--- a/app/test/browser/test-scenario-no-runner-logs.ts
+++ b/app/test/browser/test-scenario-no-runner-logs.ts
@@ -515,7 +515,13 @@ try {
   )
 }
 if (CUJ_ID_TOKEN) {
-  run(`agent-browser eval "localStorage.removeItem('oidc-auth'); 'ok'"`)
+  try {
+    run(`agent-browser eval "localStorage.removeItem('oidc-auth'); 'ok'"`)
+  } catch (error) {
+    // Auth cleanup is best-effort; browser teardown races should not mask
+    // the scenario assertions.
+    console.warn(`[WARN] Failed to clear OIDC auth token: ${String(error)}`)
+  }
 }
 if (!AGENT_BROWSER_KEEP_OPEN) {
   try {

--- a/docs-dev/design/20260702_notebook_update_structured_errors.md
+++ b/docs-dev/design/20260702_notebook_update_structured_errors.md
@@ -1,0 +1,112 @@
+# Structured Errors for Bulk Notebook Updates
+
+## Problem
+
+`notebooks.update` accepts multiple operations and applies them sequentially. If operation `K + 1` fails after the first `K` operations have mutated the notebook, the promise rejects with a plain `Error`. The caller receives a message, but not a structured answer to:
+
+- which operations were applied
+- which operation failed
+- which operations were not attempted
+- which notebook revision represents the partial state
+
+This is especially hard for Codex-driven WebMCP flows. Code executed through AppKernel crosses a sandbox host bridge. That bridge currently serializes host failures as `String(error)`, so custom fields on host-side errors are lost before Codex can inspect them.
+
+## Motivation
+
+Bulk updates are useful because Codex can make a multi-cell edit with one optimistic revision check. The failure mode must still be inspectable. If a later operation fails, Codex needs enough detail to decide whether to re-read the notebook, retry only the remaining operations, or report a partial edit.
+
+The API should not imply transactional behavior when the implementation is not fully transactional. It should state what happened.
+
+## Proposal
+
+`notebooks.update` will throw `NotebookUpdateError` when an operation inside a bulk update fails. The error will include a JSON-safe `details` object.
+
+```ts
+type NotebookUpdateOperationStatus =
+  | { index: number; status: 'applied' }
+  | { index: number; status: 'failed'; error: string }
+  | { index: number; status: 'not_attempted' }
+
+type NotebookUpdateErrorDetails = {
+  method: 'notebooks.update'
+  code: 'NOTEBOOK_UPDATE_FAILED'
+  failedOperationIndex: number
+  failedOperation: unknown
+  failedOperationError: string
+  appliedOperationCount: number
+  operationStatuses: NotebookUpdateOperationStatus[]
+  beforeHandle: NotebookHandle
+  afterHandle: NotebookHandle
+}
+
+class NotebookUpdateError extends Error {
+  name: 'NotebookUpdateError'
+  code: 'NOTEBOOK_UPDATE_FAILED'
+  details: NotebookUpdateErrorDetails
+}
+```
+
+The update loop stops at the first failed operation. Operations before the failed index are marked `applied`. The failed operation is marked `failed`. Later operations are marked `not_attempted`.
+
+The error includes `beforeHandle` and `afterHandle`. `beforeHandle` is the revision checked before mutation starts. `afterHandle` is the revision after the failure and any local rollback performed by the failed operation. Callers that need full state can call `notebooks.get({ handle: error.details.afterHandle })`.
+
+## Validation Failures
+
+Pre-apply validation errors use the same error shape. They report `appliedOperationCount: 0`, mark the invalid operation as `failed`, and mark every other operation as `not_attempted`.
+
+This preserves fail-closed behavior for invalid insert cell kinds while still giving callers the failed operation index.
+
+## WebMCP and AppKernel Surfacing
+
+The sandbox host bridge will send structured host errors instead of only `String(error)`.
+
+```ts
+type SerializedHostError = {
+  name: string
+  message: string
+  code?: string
+  details?: unknown
+}
+```
+
+When host-side `notebooks.update` throws `NotebookUpdateError`, the bridge posts:
+
+```ts
+{
+  type: "host-error",
+  callId,
+  error: {
+    name: "NotebookUpdateError",
+    message,
+    code: "NOTEBOOK_UPDATE_FAILED",
+    details
+  }
+}
+```
+
+The sandbox reconstructs an `Error`, then attaches `name`, `code`, and `details`. Code executed by Codex via WebMCP can inspect the error directly:
+
+```ts
+try {
+  await notebooks.update({ target, operations })
+} catch (error) {
+  if (error?.code === 'NOTEBOOK_UPDATE_FAILED') {
+    console.log(error.details.failedOperationIndex)
+    console.log(error.details.operationStatuses)
+  }
+}
+```
+
+Uncaught errors still render as stderr text. Structured details are available when Codex catches the error in the executed JavaScript.
+
+## Non-Goals
+
+This change does not make `notebooks.update` fully transactional. It reports partial application. Existing local rollback inside `insert` remains in place for inserted cells created by a failed insert operation.
+
+This change does not add per-operation success return values for successful updates. A successful update still returns `NotebookDocument`.
+
+## Risks
+
+The error may include caller-provided operation payloads in `failedOperation`. This is intentional for debugging, but the bridge must keep the payload JSON-safe.
+
+The details describe operations applied by the update loop. If a single operation partially mutates before throwing and does not roll itself back, the failed operation is still reported as `failed`, not `applied`.

--- a/docs-dev/design/20260702_notebook_update_structured_errors.md
+++ b/docs-dev/design/20260702_notebook_update_structured_errors.md
@@ -1,5 +1,49 @@
 # Structured Errors for Bulk Notebook Updates
 
+## Background
+
+Runme exposes notebook automation through AppKernel JavaScript. The sandbox design
+splits notebook behavior into one `NotebooksApi` contract with two
+implementations:
+
+- a host implementation backed by the live notebook model
+- a sandbox client implementation that forwards calls to the host
+
+Sandboxed AppKernel code runs in an iframe with a narrow helper surface. It does
+not receive direct access to host objects. Instead, helpers such as
+`notebooks.update(...)` call the host over a `MessageChannel` RPC path:
+
+```ts
+{ type: 'host-call', callId, method: 'notebooks.update', args }
+```
+
+The host validates the method against an allowlist, dispatches the call to the
+real host implementation, and replies with either:
+
+```ts
+{
+  type: ('host-result', callId, result)
+}
+```
+
+or:
+
+```ts
+{
+  type: ('host-error', callId, error)
+}
+```
+
+The `callId` maps each host reply back to the pending sandbox-side promise.
+Successful notebook results already flow through JSON-safe serialization before
+they cross back into the sandbox.
+
+WebMCP reuses this path. Runme registers an `ExecuteCode` browser tool. Codex
+calls that tool through the claimed Chrome tab, Runme executes the supplied code
+in AppKernel sandbox mode, and the tool returns the merged stdout/stderr output.
+This proposal does not add a WebMCP-specific notebook API or a new transport.
+It changes how the existing sandbox host bridge represents host-side errors.
+
 ## Problem
 
 `notebooks.update` accepts multiple operations and applies them sequentially. If operation `K + 1` fails after the first `K` operations have mutated the notebook, the promise rejects with a plain `Error`. The caller receives a message, but not a structured answer to:
@@ -99,6 +143,58 @@ try {
 
 Uncaught errors still render as stderr text. Structured details are available when Codex catches the error in the executed JavaScript.
 
+## Alternatives
+
+### Deserialize into concrete error classes
+
+The bridge could serialize a class discriminator and reconstruct concrete error
+classes in the sandbox, for example turning a host-side
+`NotebookUpdateError.toJSON()` payload back into a sandbox-side
+`NotebookUpdateError` instance.
+
+We will not do that now.
+
+Cross-realm JavaScript does not preserve prototypes reliably. The sandbox also
+does not need `instanceof NotebookUpdateError` or class methods. It needs stable
+machine-readable fields. A class registry would add versioning, fallback, and
+trust-boundary concerns for little immediate value.
+
+The bridge should treat errors as JSON data transfer objects:
+
+```ts
+type SerializedHostError = {
+  name: string
+  message: string
+  code?: string
+  details?: unknown
+}
+```
+
+Callers should branch on stable fields such as `error.code` and then inspect
+`error.details`. Unknown error codes still behave as ordinary `Error` instances
+with a message.
+
+### Rely only on native JSON serialization
+
+The bridge could rely on `JSON.stringify(error)` or structured clone behavior
+for host errors.
+
+We will not rely on that. Native `Error` properties are not consistently
+enumerable, and class-specific fields can be dropped or reshaped when crossing
+realms. The bridge should explicitly copy the fields it promises to preserve:
+`name`, `message`, `code`, and `details`.
+
+### Define a generic payload serialization framework
+
+The bridge could introduce a full serialization framework for all payloads,
+including type tags, schema versions, and class rehydration.
+
+That is too broad for this change. Successful host results already use JSON-safe
+payloads, and the current issue is limited to preserving structured error
+metadata. If more host APIs need typed error contracts, we can promote
+`SerializedHostError` into a shared bridge protocol type and add documented error
+codes without adding class rehydration.
+
 ## Non-Goals
 
 This change does not make `notebooks.update` fully transactional. It reports partial application. Existing local rollback inside `insert` remains in place for inserted cells created by a failed insert operation.
@@ -110,3 +206,27 @@ This change does not add per-operation success return values for successful upda
 The error may include caller-provided operation payloads in `failedOperation`. This is intentional for debugging, but the bridge must keep the payload JSON-safe.
 
 The details describe operations applied by the update loop. If a single operation partially mutates before throwing and does not roll itself back, the failed operation is still reported as `failed`, not `applied`.
+
+## References
+
+- [0310 AppKernel Sandbox](./20260311_appkernel_sandbox.md) defines the
+  sandboxed AppKernel execution model, the `NotebooksApi` host/sandbox split, and
+  the host broker policy boundary.
+- [Code Mode](./20260331_code_mode.md) describes `ExecuteCode`, the shared
+  AppKernel executor, and the Codex transport path.
+- [WebMCP Tool Support](./20260510_webmcp.md) describes the WebMCP `ExecuteCode`
+  registration and its reuse of the AppKernel sandbox executor.
+- [Codex Chrome And WebMCP](../../docs/codex-chrome-webmcp.md) describes the
+  external Codex desktop path that claims a Chrome tab and uses Runme WebMCP
+  tools.
+- [Agentic Search And Codex](../../docs/12-agentic-search-and-codex.md) contrasts
+  in-app chat with external Codex through Chrome and WebMCP.
+- [`sandboxJsKernel.ts`](../../app/src/lib/runtime/sandboxJsKernel.ts) implements
+  the sandbox iframe, `MessageChannel` bridge, `host-call`, `host-result`, and
+  `host-error` handling.
+- [`codeModeExecutor.ts`](../../app/src/lib/runtime/codeModeExecutor.ts) builds
+  the sandbox AppKernel runtime and dispatches sandbox host calls.
+- [`notebooksApiBridge.ts`](../../app/src/lib/runtime/notebooksApiBridge.ts)
+  routes sandbox notebook API calls to the host notebook API.
+- [`runmeConsole.ts`](../../app/src/lib/runtime/runmeConsole.ts) defines
+  `NotebooksApi`, `NotebookUpdateError`, and the bulk update application loop.

--- a/docs/09-appkernel-browser-runners.md
+++ b/docs/09-appkernel-browser-runners.md
@@ -30,3 +30,7 @@ Current runner identities:
   exists to tighten execution boundaries.
 - If the user wants fast local notebook manipulation without backend setup,
   AppKernel is often the right first choice.
+- When calling `notebooks.update` through WebMCP `ExecuteCode`, catch
+  `NOTEBOOK_UPDATE_FAILED` inside the executed JavaScript and print the
+  structured `error.details` fields. See
+  [codex-chrome-webmcp.md](codex-chrome-webmcp.md#handling-partial-notebook-update-failures).

--- a/docs/codex-chrome-webmcp.md
+++ b/docs/codex-chrome-webmcp.md
@@ -108,6 +108,8 @@ later notebook operations.
 Do not rely on "current notebook" after the initial resolution, because the user
 may switch notebooks while Codex is working.
 
+## Drive-backed notebook lookup
+
 When the user identifies a Drive-backed notebook by name or metadata rather
 than by URL, use Runme's AppKernel Drive API instead of searching the rendered
 page with DOM tools:
@@ -132,6 +134,106 @@ selection, and pagination. Include `id` and `mimeType` in `fields` so Runme can
 add a notebook-ready `uri` to each result. In WebMCP code mode, this call runs
 through the authenticated Runme AppKernel and does not require a separate
 Google Drive connector.
+
+## Handling partial notebook update failures
+
+Agents that mutate notebooks through WebMCP should run JavaScript with
+`ExecuteCode` and catch `notebooks.update` failures inside that JavaScript. The
+WebMCP tool returns merged stdout/stderr text, so structured failure details are
+only visible to the agent if the executed code catches the error and prints or
+otherwise returns the fields it needs.
+
+`notebooks.update` can apply multiple operations. If operation `K + 1` fails
+after the first `K` operations succeed, the promise rejects with an error whose
+`code` is `NOTEBOOK_UPDATE_FAILED`. The error includes `details` with:
+
+- `appliedOperationCount`: number of operations that completed before the
+  failure,
+- `failedOperationIndex`: zero-based index of the operation that failed,
+- `operationStatuses`: per-operation status values,
+- `beforeHandle`: notebook handle before the update started,
+- `afterHandle`: notebook handle after the failure.
+
+Use this pattern when calling `notebooks.update` from WebMCP `ExecuteCode`:
+
+```js
+const doc = await notebooks.get({ uri: 'local://file/demo.runme.md' })
+
+try {
+  const updated = await notebooks.update({
+    target: { handle: doc.handle },
+    operations: [
+      {
+        op: 'update',
+        refId: 'cell-a',
+        patch: { value: 'echo updated' },
+      },
+      {
+        op: 'update',
+        refId: 'missing-cell',
+        patch: { value: 'echo missing' },
+      },
+      {
+        op: 'remove',
+        refIds: ['cell-b'],
+      },
+    ],
+  })
+
+  console.log(
+    JSON.stringify({
+      status: 'ok',
+      handle: updated.handle,
+    })
+  )
+} catch (error) {
+  if (error?.code === 'NOTEBOOK_UPDATE_FAILED') {
+    console.log(
+      JSON.stringify({
+        status: 'partial_failure',
+        appliedOperationCount: error.details.appliedOperationCount,
+        failedOperationIndex: error.details.failedOperationIndex,
+        operationStatuses: error.details.operationStatuses,
+        afterHandle: error.details.afterHandle,
+      })
+    )
+  } else {
+    throw error
+  }
+}
+```
+
+For that example, the output tells the caller that operation `0` was applied,
+operation `1` failed, and operation `2` was not attempted:
+
+```json
+{
+  "status": "partial_failure",
+  "appliedOperationCount": 1,
+  "failedOperationIndex": 1,
+  "operationStatuses": [
+    { "index": 0, "status": "applied" },
+    { "index": 1, "status": "failed", "error": "Cell not found: missing-cell" },
+    { "index": 2, "status": "not_attempted" }
+  ],
+  "afterHandle": {
+    "uri": "local://file/demo.runme.md",
+    "revision": "..."
+  }
+}
+```
+
+After a partial failure, agents should use `afterHandle` when re-reading the
+notebook state. Inside the `NOTEBOOK_UPDATE_FAILED` catch branch:
+
+```js
+const current = await notebooks.get({ handle: error.details.afterHandle })
+console.log(JSON.stringify({ currentHandle: current.handle }))
+```
+
+Do not assume the whole update rolled back. `notebooks.update` reports which
+operations were applied; it does not make multi-operation updates fully
+transactional.
 
 ## Relationship to the chat panel
 


### PR DESCRIPTION
Summary: Adds a structured NotebookUpdateError for bulk notebooks.update failures, including applied/failed/not-attempted operation status, before/after handles, and failed operation details. Preserves fail-closed insert-kind validation. Serializes structured host errors across the sandbox bridge so WebMCP/AppKernel code can catch errors and inspect error.code plus error.details. Adds docs-dev/design/20260702_notebook_update_structured_errors.md. Tests: pnpm -C app exec vitest run src/lib/runtime/runmeConsole.test.ts; pnpm -C app exec vitest run src/lib/runtime/sandboxJsKernel.test.ts; pnpm run build; pnpm --filter @runmedev/react-console exec vitest run.