### PR TITLE
[codex] Add Google Drive query search to AppConsole

### DIFF
--- a/app/src/lib/driveTransfer.test.ts
+++ b/app/src/lib/driveTransfer.test.ts
@@ -7,6 +7,7 @@ import {
   createDriveFile,
   listDriveFolderItems,
   saveNotebookAsDriveCopy,
+  searchDriveFiles,
   updateDriveFileBytes,
 } from "./driveTransfer";
 import { parser_pb } from "../runme/client";
@@ -69,6 +70,42 @@ describe("driveTransfer", () => {
       "https://drive.google.com/drive/folders/folder123",
     );
     expect(items).toHaveLength(1);
+  });
+
+  it("forwards Google Drive files.list search requests", async () => {
+    const request = {
+      q: "name = 'eval_read.json' and trashed = false",
+      pageSize: 25,
+      fields: "nextPageToken,files(id,name,mimeType)",
+    };
+    const expected = {
+      files: [
+        {
+          id: "abc123",
+          name: "eval_read.json",
+          mimeType: "application/json",
+          uri: "https://drive.google.com/file/d/abc123/view",
+        },
+      ],
+      nextPageToken: "next-page",
+    };
+    const search = vi.fn().mockResolvedValue(expected);
+    appState.setDriveNotebookStore({ search } as any);
+
+    const result = await searchDriveFiles(request);
+
+    expect(search).toHaveBeenCalledWith(request);
+    expect(result).toEqual(expected);
+  });
+
+  it("rejects non-object Drive search requests", async () => {
+    appState.setDriveNotebookStore({ search: vi.fn() } as any);
+
+    await expect(
+      searchDriveFiles("name = 'eval_read.json'" as any),
+    ).rejects.toThrow(
+      "drive.search requires a Google Drive files.list request object",
+    );
   });
 
   it("copies a notebook file to another drive folder", async () => {

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -1,5 +1,6 @@
 import { appState } from "./runtime/AppState";
 import {
+  type DriveSearchResult,
   driveFileUrl,
   driveFolderUrl,
   parseDriveItem,
@@ -108,6 +109,47 @@ export async function listDriveFolderItems(folder: string) {
       attrs: {
         scope: "drive.transfer",
         folderRef,
+        error: String(error),
+      },
+    });
+    throw error;
+  }
+}
+
+/**
+ * Executes a Google Drive files.list request through the authenticated Drive
+ * store. The request remains unmodified so App Console and WebMCP callers can
+ * use the complete Drive query grammar and list parameter surface.
+ */
+export async function searchDriveFiles(
+  request: Record<string, unknown>,
+): Promise<DriveSearchResult> {
+  if (!request || typeof request !== "object" || Array.isArray(request)) {
+    throw new Error("drive.search requires a Google Drive files.list request object");
+  }
+
+  appLogger.info("Searching Google Drive files", {
+    attrs: {
+      scope: "drive.transfer",
+      hasQuery: typeof request.q === "string" && request.q.length > 0,
+      hasPageToken: typeof request.pageToken === "string" && request.pageToken.length > 0,
+    },
+  });
+  try {
+    const result = await ensureDriveStore().search(request);
+    appLogger.info("Searched Google Drive files", {
+      attrs: {
+        scope: "drive.transfer",
+        count: result.files.length,
+        hasNextPage: Boolean(result.nextPageToken),
+        incompleteSearch: result.incompleteSearch === true,
+      },
+    });
+    return result;
+  } catch (error) {
+    appLogger.error("Failed to search Google Drive files", {
+      attrs: {
+        scope: "drive.transfer",
         error: String(error),
       },
     });

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -1034,6 +1034,7 @@ describe("NotebookData.runCodeCell", () => {
       value: [
         'console.log(typeof drive);',
         'console.log(typeof drive.create);',
+        'console.log(typeof drive.search);',
         'console.log(typeof drive.saveAsCurrentNotebook);',
         'console.log(typeof drive.listPendingSync);',
         'console.log(typeof drive.requeuePendingSync);',

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -383,6 +383,40 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     expect(output.join('')).toContain('Google Drive OAuth authorized.')
   })
 
+  it('searches Google Drive with native files.list parameters', async () => {
+    const request = {
+      q: "name = 'eval_read.json' and trashed = false",
+      orderBy: 'modifiedTime desc',
+      fields: 'nextPageToken,files(id,name,mimeType)',
+    }
+    const search = vi.fn(async () => ({
+      files: [
+        {
+          id: 'file123',
+          name: 'eval_read.json',
+          mimeType: 'application/json',
+          uri: 'https://drive.google.com/file/d/file123/view',
+        },
+      ],
+      nextPageToken: 'page-2',
+    }))
+    const output: string[] = []
+    appState.setDriveNotebookStore({ search } as any)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+      sendOutput: (data) => output.push(data),
+    })
+
+    const result = await globals.drive.search(request)
+
+    expect(search).toHaveBeenCalledWith(request)
+    expect(result.nextPageToken).toBe('page-2')
+    expect(result.files[0]?.uri).toBe(
+      'https://drive.google.com/file/d/file123/view'
+    )
+    expect(output.join('')).toContain('Found 1 Drive item(s)')
+  })
+
   it('moves Google Drive files to trash from browser AppKernel drive globals', async () => {
     const remoteUri = 'https://drive.google.com/file/d/file123/view'
     const moveToTrash = vi.fn(async () => ({

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -34,6 +34,7 @@ import {
   listDriveFolderItems,
   moveDriveFileToTrash,
   saveNotebookAsDriveCopy,
+  searchDriveFiles,
   updateDriveFileBytes,
 } from '../driveTransfer'
 import { googleClientManager } from '../googleClientManager'
@@ -1968,6 +1969,11 @@ export function createAppJsGlobals({
         emitLine(sendOutput, `Listed ${items.length} Drive item(s)`)
         return items
       },
+      search: async (request: Record<string, unknown>) => {
+        const result = await searchDriveFiles(request)
+        emitLine(sendOutput, `Found ${result.files.length} Drive item(s)`)
+        return result
+      },
       create: async (folder: string, name: string) => {
         const id = await createDriveFile(folder, name)
         emitLine(sendOutput, `Created Drive file ${id}`)
@@ -2056,6 +2062,7 @@ export function createAppJsGlobals({
       help: () => {
         return [
           'drive.list(folder)            - List Drive items in a folder',
+          'drive.search(request)         - Run a Google Drive files.list request with native q/list parameters',
           'drive.authorize(options?)      - Start a fresh Google Drive OAuth flow; options: { mode?, prompt? }',
           'drive.refreshAuth(options?)    - Alias for drive.authorize(options?)',
           'drive.create(folder, name)     - Create a Drive file in folder; returns file id',

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -6,6 +6,7 @@ import {
   createDriveFile,
   listDriveFolderItems,
   saveNotebookAsDriveCopy,
+  searchDriveFiles,
   updateDriveFileBytes,
 } from '../driveTransfer'
 import { appState } from './AppState'
@@ -460,6 +461,8 @@ async function handleSandboxAppKernelBridgeCall({
     }
     case 'drive.list':
       return listDriveFolderItems(String(args[0] ?? ''))
+    case 'drive.search':
+      return searchDriveFiles(args[0] as Record<string, unknown>)
     case 'drive.create':
       return createDriveFile(String(args[0] ?? ''), String(args[1] ?? ''))
     case 'drive.update': {

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -16,6 +16,7 @@ type Scenario =
   | 'explorer'
   | 'credentials'
   | 'drive'
+  | 'driveSearch'
   | 'driveSave'
   | 'documents'
   | 'notebooksCreate'
@@ -105,6 +106,18 @@ class MockSandboxPort {
           method: 'drive.authorize',
           args: [{ mode: 'new_tab' }],
         })
+      } else if (this.scenario === 'driveSearch') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'drive.search',
+          args: [
+            {
+              q: "name = 'eval_read.json' and trashed = false",
+              pageSize: 25,
+            },
+          ],
+        })
       } else if (this.scenario === 'driveSave') {
         this.emit({
           type: 'host-call',
@@ -173,6 +186,14 @@ class MockSandboxPort {
         return
       }
       if (this.scenario === 'drive' && this.hostResults.has(1)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'driveSearch' && this.hostResults.has(1)) {
         this.emit({
           type: 'stdout',
           data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
@@ -605,6 +626,61 @@ describe('SandboxJSKernel', () => {
     ])
     expect(stdout).toContain('"status":"started"')
     expect(stdout).toContain('"mode":"new_tab"')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('passes native Drive search requests through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'drive.search') {
+        return {
+          files: [
+            {
+              id: 'file123',
+              name: 'eval_read.json',
+              mimeType: 'application/json',
+              uri: 'https://drive.google.com/file/d/file123/view',
+            },
+          ],
+          nextPageToken: 'page-2',
+        }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('driveSearch'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      "console.log(await drive.search({ q: \"name = 'eval_read.json' and trashed = false\", pageSize: 25 }));"
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('drive.search', [
+      {
+        q: "name = 'eval_read.json' and trashed = false",
+        pageSize: 25,
+      },
+    ])
+    expect(stdout).toContain('eval_read.json')
+    expect(stdout).toContain('page-2')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
   })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -61,6 +61,7 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'drive.authorize',
   'drive.refreshAuth',
   'drive.list',
+  'drive.search',
   'drive.create',
   'drive.update',
   'drive.saveAsCurrentNotebook',
@@ -355,6 +356,7 @@ function buildSandboxSrcDoc(options: {
           authorize: (options) => hostCall("drive.authorize", [options]),
           refreshAuth: (options) => hostCall("drive.refreshAuth", [options]),
           list: (folder) => hostCall("drive.list", [folder]),
+          search: (request) => hostCall("drive.search", [request]),
           create: (folder, name) => hostCall("drive.create", [folder, name]),
           update: (idOrUri, bytes) => hostCall("drive.update", [idOrUri, bytes]),
           saveAsCurrentNotebook: (folder, name) =>
@@ -363,6 +365,7 @@ function buildSandboxSrcDoc(options: {
             consoleProxy.log("drive.authorize({ mode?, prompt? })");
             consoleProxy.log("drive.refreshAuth({ mode?, prompt? })");
             consoleProxy.log("drive.list(folderIdOrUri)");
+            consoleProxy.log("drive.search(filesListRequest)");
             consoleProxy.log("drive.create(folderIdOrUri, name)");
             consoleProxy.log("drive.update(fileIdOrUri, bytes)");
             consoleProxy.log("drive.saveAsCurrentNotebook(folderIdOrUri, name)");

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -84,6 +84,95 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("forwards native Drive files.list search parameters and returns paging metadata", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files");
+        expect(url.searchParams.get("q")).toBe(
+          "name = 'eval_read.json' and trashed = false",
+        );
+        expect(url.searchParams.get("corpora")).toBe("drive");
+        expect(url.searchParams.get("driveId")).toBe("shared-drive-1");
+        expect(url.searchParams.get("includeItemsFromAllDrives")).toBe("true");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(url.searchParams.get("orderBy")).toBe("modifiedTime desc");
+        expect(url.searchParams.get("pageSize")).toBe("25");
+        expect(url.searchParams.get("pageToken")).toBe("page-1");
+        expect(url.searchParams.get("fields")).toBe(
+          "nextPageToken,incompleteSearch,files(id,name,mimeType,modifiedTime)",
+        );
+        return new Response(
+          JSON.stringify({
+            files: [
+              {
+                id: "file123",
+                name: "eval_read.json",
+                mimeType: "application/json",
+                modifiedTime: "2026-07-02T00:00:00Z",
+              },
+              {
+                id: "folder123",
+                name: "Evaluation notebooks",
+                mimeType: "application/vnd.google-apps.folder",
+              },
+              {
+                id: "metadata123",
+                name: "Metadata without MIME type",
+              },
+            ],
+            nextPageToken: "page-2",
+            incompleteSearch: true,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.search({
+      q: "name = 'eval_read.json' and trashed = false",
+      corpora: "drive",
+      driveId: "shared-drive-1",
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+      orderBy: "modifiedTime desc",
+      pageSize: 25,
+      pageToken: "page-1",
+      fields:
+        "nextPageToken,incompleteSearch,files(id,name,mimeType,modifiedTime)",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      files: [
+        {
+          id: "file123",
+          name: "eval_read.json",
+          mimeType: "application/json",
+          modifiedTime: "2026-07-02T00:00:00Z",
+          uri: "https://drive.google.com/file/d/file123/view",
+        },
+        {
+          id: "folder123",
+          name: "Evaluation notebooks",
+          mimeType: "application/vnd.google-apps.folder",
+          uri: "https://drive.google.com/drive/folders/folder123",
+        },
+        {
+          id: "metadata123",
+          name: "Metadata without MIME type",
+        },
+      ],
+      nextPageToken: "page-2",
+      incompleteSearch: true,
+    });
+  });
+
   it("creates arbitrary Drive content with the provided MIME type", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -39,6 +39,17 @@ export type DriveDoc = {
   trashed?: boolean
 }
 
+export type DriveSearchFile = DriveDoc &
+  Record<string, unknown> & {
+    uri?: string
+  }
+
+export type DriveSearchResult = {
+  files: DriveSearchFile[]
+  nextPageToken?: string
+  incompleteSearch?: boolean
+}
+
 type Drive = {
   id?: string
   name?: string
@@ -86,7 +97,13 @@ interface GapiGlobal {
 type DriveCreateResponse = { result?: DriveDoc }
 type DriveUpdateResponse = { result?: DriveDoc }
 type DriveGetResponse = { result?: Drive }
-type DriveListResponse = { result?: { files?: DriveDoc[] } }
+type DriveListResponse = {
+  result?: {
+    files?: DriveSearchFile[]
+    nextPageToken?: string
+    incompleteSearch?: boolean
+  }
+}
 type DriveRevisionListResponse = {
   result?: { revisions?: DriveRevision[]; nextPageToken?: string }
 }
@@ -1277,8 +1294,7 @@ export class DriveNotebookStore {
         'Google Drive URI must reference a folder to list contents'
       )
     }
-    const client = await this.getFilesClient()
-    const response = await client.list({
+    const response = await this.search({
       q: `'${id}' in parents and trashed = false`,
       includeItemsFromAllDrives: true,
       supportsAllDrives: true,
@@ -1286,8 +1302,8 @@ export class DriveNotebookStore {
       fields: 'files(id,name,mimeType)',
     })
 
-    const files = (response.result?.files ?? []).filter(
-      (file): file is DriveDoc & { id: string } => Boolean(file?.id)
+    const files = response.files.filter(
+      (file): file is DriveSearchFile & { id: string } => Boolean(file?.id)
     )
 
     return files.map((file) => {
@@ -1304,6 +1320,31 @@ export class DriveNotebookStore {
         parents: [],
       }
     })
+  }
+
+  /**
+   * Runs a Google Drive files.list request without narrowing its query surface.
+   * The request is forwarded as-is so callers can use the complete Drive `q`
+   * grammar and list parameters. Returned files retain their Drive metadata and
+   * gain a Runme-compatible URI when the response includes an id and MIME type.
+   */
+  async search(request: Record<string, unknown>): Promise<DriveSearchResult> {
+    const client = await this.getFilesClient()
+    const response = await client.list(request)
+    const result = response.result ?? {}
+    return {
+      ...result,
+      files: (result.files ?? []).map((file) => {
+        if (!file.id || !file.mimeType) {
+          return { ...file }
+        }
+        const isFolder = file.mimeType === DRIVE_FOLDER_MIME_TYPE
+        return {
+          ...file,
+          uri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
+        }
+      }),
+    }
   }
 
   async listComments(uri: string): Promise<DriveComment[]> {

--- a/docs-dev/design/20260403_drive_agentic_search.md
+++ b/docs-dev/design/20260403_drive_agentic_search.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Draft proposal.
+Draft proposal. Modified on 2026-07-03 to clarify alternatives around direct
+`gapi` exposure and the current `drive.search` implementation direction.
 
 ## Problem
 
@@ -93,12 +94,21 @@ References:
 
 ## Proposed Agent Interface
 
-Expose a read-only `drive` namespace to AppKernel / code mode with two
-functions:
+The current MVP, implemented by PR #274, exposes `drive.search(...)` in the
+existing AppKernel `drive` namespace. `drive.search` is a Runme wrapper around
+Google Drive v3 `files.list`: it accepts the native list request shape, forwards
+the request to Drive, preserves paging metadata, and adds a Runme-compatible
+`uri` to returned files when the caller includes `id` and `mimeType` in the
+requested fields.
+
+The longer-term read-oriented agent surface should add `drive.open(...)`,
+query-building helpers, sidecar resolution helpers, and stronger guardrails.
 
 ```ts
-type DriveQueryRequest = {
-  q: string;
+type DriveSearchRequest = {
+  // Native Google Drive v3 files.list parameters.
+  q?: string;
+  fields?: string;
   pageSize?: number;
   pageToken?: string;
   orderBy?: string;
@@ -107,20 +117,22 @@ type DriveQueryRequest = {
   includeItemsFromAllDrives?: boolean;
   supportsAllDrives?: boolean;
   spaces?: string;
+  [key: string]: unknown;
 };
 
-type DriveQueryMatch = {
-  uri: string;
-  id: string;
-  name: string;
-  mimeType: string;
+type DriveSearchFile = {
+  uri?: string;
+  id?: string;
+  name?: string;
+  mimeType?: string;
   modifiedTime?: string;
-  parents: string[];
+  parents?: string[];
   webViewLink?: string;
+  [key: string]: unknown;
 };
 
-type DriveQueryResponse = {
-  matches: DriveQueryMatch[];
+type DriveSearchResponse = {
+  files: DriveSearchFile[];
   nextPageToken?: string;
   incompleteSearch?: boolean;
 };
@@ -144,34 +156,50 @@ type DriveOpenResponse = {
 };
 
 interface DriveAgentApi {
-  query(request: DriveQueryRequest): Promise<DriveQueryResponse>;
+  search(request: DriveSearchRequest): Promise<DriveSearchResponse>;
+
+  // Future follow-up.
   open(request: DriveOpenRequest): Promise<DriveOpenResponse>;
 }
 ```
 
-### `drive.query`
+### `drive.search`
 
-`drive.query` should pass the caller's `q` expression directly to Drive
-`files.list` after applying only safety guardrails that do not reduce query
-expressiveness.
+`drive.search` should pass the caller's request directly to Drive `files.list`
+so App Console, WebMCP, and Codex code mode can use Drive's native `q`
+expression, field masks, shared-drive parameters, pagination, and ordering.
+
+PR #274 intentionally keeps the request surface close to `files.list` rather
+than inventing a custom search DSL. It does, however, keep Drive client details
+behind Runme's Drive store and enriches results with Runme URIs.
 
 Recommended behavior:
 
-- Always use a fixed response field mask that returns only read-only metadata
-  needed by `open` and UI/debugging.
-- Cap `pageSize` to a safe maximum (for example 100).
-- Default `supportsAllDrives=true` and `includeItemsFromAllDrives=true` so
-  shared-drive notebooks are discoverable.
-- Preserve caller-supplied `corpora`, `driveId`, `spaces`, and `orderBy`.
-- Return stable canonical Drive URIs built from file IDs, not path-like names.
+- Preserve caller-supplied `q`, `fields`, `pageSize`, `pageToken`,
+  `corpora`, `driveId`, `spaces`, shared-drive options, and `orderBy`.
+- Add stable canonical Drive URIs built from file IDs when results include
+  `id` and `mimeType`.
+- Encourage callers to request explicit fields such as
+  `nextPageToken,incompleteSearch,files(id,name,mimeType,parents,modifiedTime)`.
+- In a follow-up, cap `pageSize` to a safe maximum and consider a conservative
+  default `fields` value when callers omit one.
+- In a follow-up, default `supportsAllDrives=true` and
+  `includeItemsFromAllDrives=true` if that proves more ergonomic for shared
+  Drive notebooks.
+
+`drive.list(folderIdOrUri)` is separate from `drive.search(...)`.
+`drive.list` is a folder-browsing convenience API for the Explorer and returns
+`NotebookStoreItem` objects. Internally it can be implemented using
+`drive.search` with a fixed parent-folder query, but callers should use
+`drive.search` when they need the general Drive query/list surface.
 
 ### Query builder helpers
 
 Instead of a `mode` argument, query shaping should happen before calling
-`drive.query(...)` using composable helpers that return native Drive `q`
+`drive.search(...)` using composable helpers that return native Drive `q`
 strings.
 
-This keeps `drive.query` itself aligned with Drive's API while still making
+This keeps `drive.search` itself aligned with Drive's API while still making
 common query patterns easy to express and chain.
 
 Example helper API:
@@ -183,7 +211,7 @@ const q = drive.q
   .restrictToMarkdownSidecars()
   .build();
 
-const result = await drive.query({
+const result = await drive.search({
   q,
   orderBy: "modifiedTime desc",
   pageSize: 20,
@@ -193,7 +221,7 @@ const result = await drive.query({
 Equivalent functional style:
 
 ```ts
-const result = await drive.query({
+const result = await drive.search({
   q: drive.q.restrictToMarkdownSidecars(
     "fullText contains 'SLO burn rate' and modifiedTime >= '2026-01-01T00:00:00'",
   ),
@@ -237,7 +265,7 @@ const q = drive.q
   .restrictToMarkdownSidecars()
   .build();
 
-const result = await drive.query({
+const result = await drive.search({
   q,
   corpora: "drive",
   driveId: "<shared-drive-id>",
@@ -275,7 +303,7 @@ Recommended behavior:
 
 ## Sidecar Resolution Design
 
-Query result post-processing should also be separate from `drive.query(...)`.
+Query result post-processing should also be separate from `drive.search(...)`.
 That avoids mixing "what Drive should search" with "how Runme interprets the
 matches".
 
@@ -283,21 +311,21 @@ Proposed helper:
 
 ```ts
 type DriveNotebookMatch = {
-  notebook: DriveQueryMatch;
-  sidecar: DriveQueryMatch;
+  notebook: DriveSearchFile;
+  sidecar: DriveSearchFile;
   resolution: "resolved" | "missing" | "ambiguous";
-  candidates?: DriveQueryMatch[];
+  candidates?: DriveSearchFile[];
 };
 
 interface DriveResultResolvers {
-  resolveNotebookSidecars(matches: DriveQueryMatch[]): Promise<DriveNotebookMatch[]>;
+  resolveNotebookSidecars(files: DriveSearchFile[]): Promise<DriveNotebookMatch[]>;
 }
 ```
 
 Example:
 
 ```ts
-const sidecarMatches = await drive.query({
+const sidecarMatches = await drive.search({
   q: drive.q.restrictToMarkdownSidecars(
     "fullText contains 'feature flag cleanup'",
   ),
@@ -305,7 +333,7 @@ const sidecarMatches = await drive.query({
 });
 
 const notebookMatches = await drive.results.resolveNotebookSidecars(
-  sidecarMatches.matches,
+  sidecarMatches.files,
 );
 
 for (const match of notebookMatches) {
@@ -360,6 +388,36 @@ notebook files deterministically without relying on sibling-name inference.
 
 ## Alternatives Considered
 
+### Expose the raw `gapi.client.drive.files.list` API
+
+Another option is to make the dynamically loaded Google API client directly
+available in App Console and code mode, for example by exposing
+`gapi.client.drive.files.list(...)` to agent-authored JavaScript.
+
+That approach is not the right default for Runme:
+
+- It leaks the implementation detail that the current browser Drive client is
+  backed by Google's dynamically generated `gapi` client. Runme also uses
+  fetch-backed Drive clients in tests and service-account flows, and the
+  AppKernel API should not force callers to know which client is active.
+- It exposes a broad generated client object rather than a small, reviewed
+  Runme-owned surface. That makes it easier to accidentally expose write,
+  share, copy, or delete methods alongside read-only search.
+- It does not return Runme-native identifiers. Search results still need
+  post-processing to add stable Drive file/folder URIs that can be passed to
+  `notebooks.show(...)`, sidecar resolution helpers, and other Runme APIs.
+- It gives Runme no clean place to add logging, auth refresh behavior, response
+  size limits, field-mask defaults, or future safety guardrails.
+- It couples agent examples and user docs to a generated third-party API shape
+  rather than a stable Runme API.
+
+Current recommendation:
+
+- Keep `gapi` and other Drive clients behind `DriveNotebookStore` and expose a
+  small Runme API such as `drive.search(...)`.
+- Preserve the native Drive `files.list` request shape at that boundary so the
+  agent still gets Drive's full query expressiveness.
+
 ### Use the built-in Google Drive connector in the Responses API
 
 OpenAI's Responses API supports first-party connectors, including Google Drive,
@@ -392,7 +450,7 @@ Main downside of the Runme-owned JS API approach:
 
 Current recommendation:
 
-- Prefer the Runme-owned `drive.query`, `drive.q`, `drive.results`, and
+- Prefer the Runme-owned `drive.search`, `drive.q`, `drive.results`, and
   `drive.open` AppKernel API as the primary design.
 - Keep the built-in Responses Google Drive connector as a fallback or future
   implementation option if we discover that maintaining a custom agentic Drive
@@ -400,41 +458,56 @@ Current recommendation:
 
 ## Safety and Policy
 
-This interface should be intentionally read-only.
+The long-term agent-facing interface should be intentionally read-oriented.
+PR #274 adds a read-oriented `drive.search` method to the existing AppKernel
+`drive` namespace, but that namespace also contains broader App Console helpers
+for user-driven Drive operations. Future Codex-specific or policy-specific
+exposure should keep the agent's default Drive surface narrower than the full
+App Console surface.
 
 - Do not expose `create`, `save`, `saveContent`, `rename`, `copy`, `share`, or
-  `delete` through the agent-facing `drive` namespace.
+  `delete` through a default agent-facing read surface.
 - Use the user's existing Drive auth context and request only read scopes for
   agent search/open.
 - Do not let `open` fetch arbitrary URLs; only Drive file IDs/URLs accepted by
   the existing Drive parser should be allowed.
-- Cap `pageSize`, response bytes, and `open.maxBytes` so a broad search or a
-  large notebook cannot flood the tool response.
-- Keep a fixed metadata field mask so the model cannot use `fields` to ask for
-  unexpected Drive resource fields.
+- Preserve Drive's native `files.list` request expressiveness for
+  `drive.search`, but add practical limits in a follow-up: cap `pageSize`, set
+  a conservative default `fields` mask when omitted, and cap returned output
+  bytes.
+- Cap `open.maxBytes` so a large notebook cannot flood the tool response.
 - Emit structured errors for malformed `q`, unsupported MIME types, folder
   content reads, missing files, and permission-denied responses.
 
 ## Implementation Plan
 
-1. Add a small read-only Drive client method layer around the existing
-   Drive files client:
-   - `queryFiles(request)` -> `files.list`
+1. Add a small Drive client method layer around the existing Drive files client:
+   - `searchFiles(request)` / `drive.search(request)` -> `files.list`
    - `openFileMetadata(uri)` -> `files.get(fields=...)`
    - `openFileText(uri, maxBytes)` -> `files.get(alt=media)`
-2. Add sidecar-aware query resolution:
+2. PR #274 implements the first search/list part:
+   - forward the native Drive `files.list` request shape,
+   - preserve `nextPageToken` and `incompleteSearch`,
+   - add Runme `uri` values when returned files include `id` and `mimeType`,
+   - expose the method in App Console and WebMCP/code-mode sandbox as
+     `drive.search(...)`.
+3. Add sidecar-aware query resolution:
    - implement `drive.q.restrictToMarkdownSidecars(...)`,
    - implement `drive.results.resolveNotebookSidecars(...)`,
    - start with naming-based sidecar-to-notebook resolution.
-3. Expose a read-only `drive.query` and `drive.open` AppKernel API for
-   code-mode agent flows.
-4. Update agent instructions/tool docs to teach this pattern:
+4. Add `drive.open(...)` for read-only metadata/text/notebook JSON fetches.
+5. Add follow-up guardrails for the agent-facing path:
+   - cap `pageSize`,
+   - default or constrain `fields` where appropriate,
+   - cap returned output bytes,
+   - keep write helpers out of the default agent read surface.
+6. Update agent instructions/tool docs to teach this pattern:
    - use Drive `q` directly,
    - search Markdown sidecars for notebook text,
    - open canonical notebook files for final inspection.
-5. Add tests against the fake Drive server and at least one manual Drive CUJ
+7. Add tests against the fake Drive server and at least one manual Drive CUJ
    notebook covering sidecar search and notebook open.
-6. Consider a v1 sidecar schema migration to persist reciprocal Drive
+8. Consider a v1 sidecar schema migration to persist reciprocal Drive
    `appProperties` links and remove naming-based ambiguity.
 
 ## Test Plan
@@ -448,7 +521,7 @@ This interface should be intentionally read-only.
 - Manual CUJ test against real Drive:
   - create/save a Drive notebook,
   - wait for sidecar sync,
-  - search by notebook body text through `drive.query`,
+  - search by notebook body text through `drive.search`,
   - open the returned notebook through `drive.open`,
   - verify no write operation is available from the agent API.
 
@@ -460,7 +533,7 @@ This interface should be intentionally read-only.
   when notebook resolution fails, or return sidecar hits with explicit
   ambiguity metadata?
 - Do we want a dedicated `drive.queryNotebookText(...)` convenience wrapper, or
-  is `drive.query(...)` plus `drive.results.resolveNotebookSidecars(...)`
+  is `drive.search(...)` plus `drive.results.resolveNotebookSidecars(...)`
   enough?
 - Should AppKernel expose this as direct JS helpers only, or also generate
   first-class MCP tools from a proto contract?

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -138,6 +138,7 @@ drive.help()
 await drive.authorize()
 await drive.refreshAuth()
 drive.list(folderIdOrUri)
+drive.search(filesListRequest)
 drive.create(folderIdOrUri, "name.json")
 drive.trash(fileIdOrUri)
 drive.saveAsCurrentNotebook(folderIdOrUri, "name.json")
@@ -145,6 +146,71 @@ drive.copyNotebook(sourceIdOrUri, targetFolderIdOrUri, "name.json")
 drive.listPendingSync()
 drive.requeuePendingSync()
 ```
+
+### Search Drive with native query syntax
+
+`drive.search(request)` passes `request` directly to the Google Drive v3
+[`files.list`](https://developers.google.com/drive/api/reference/rest/v3/files/list)
+API. Use the native Drive `q` grammar and list parameters, including `corpora`,
+`driveId`, `spaces`, `orderBy`, `pageSize`, `pageToken`, and `fields`:
+
+```js
+const result = await drive.search({
+  q: "name = 'eval_read.json' and trashed = false",
+  orderBy: 'modifiedTime desc',
+  pageSize: 100,
+  fields:
+    'nextPageToken,incompleteSearch,files(id,name,mimeType,parents,modifiedTime)',
+})
+
+console.table(result.files)
+```
+
+Runme preserves the file metadata requested in `fields` and adds a `uri` to
+each result when `id` and `mimeType` are present. That URI can be passed to the
+notebook APIs without constructing a Drive URL:
+
+```js
+if (result.files.length !== 1) {
+  throw new Error(`Expected one notebook, found ${result.files.length}`)
+}
+await notebooks.show(result.files[0].uri)
+```
+
+Use `nextPageToken` to retrieve every matching file:
+
+```js
+const files = []
+let pageToken
+
+do {
+  const page = await drive.search({
+    q: "mimeType != 'application/vnd.google-apps.folder' and trashed = false",
+    pageSize: 1000,
+    pageToken,
+    fields: 'nextPageToken,files(id,name,mimeType)',
+  })
+  files.push(...page.files)
+  pageToken = page.nextPageToken
+} while (pageToken)
+```
+
+For a shared drive, use the same parameters required by the Drive API:
+
+```js
+const result = await drive.search({
+  q: "name contains 'evaluation' and trashed = false",
+  corpora: 'drive',
+  driveId: '<shared-drive-id>',
+  includeItemsFromAllDrives: true,
+  supportsAllDrives: true,
+  fields: 'nextPageToken,files(id,name,mimeType,parents)',
+})
+```
+
+`drive.list(folderIdOrUri)` remains the simpler choice for listing one known
+folder. Use `drive.search` when the caller needs Drive query expressions,
+pagination, ordering, shared-drive scoping, or additional file metadata.
 
 `drive.authorize()` starts a fresh Google Drive OAuth flow. It first clears any
 locally stored Drive OAuth handoff state from a previous redirect or new-tab

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -149,6 +149,25 @@ Google OAuth flow. They are useful when the Drive status button does not appear
 to launch auth, or when a human or agent needs an explicit auth refresh from App
 Console.
 
+Search Google Drive with the complete Drive v3 `files.list` request surface:
+
+```js
+const result = await drive.search({
+  q: "name = 'example.runme.md' and trashed = false",
+  orderBy: 'modifiedTime desc',
+  pageSize: 100,
+  fields:
+    'nextPageToken,incompleteSearch,files(id,name,mimeType,parents,modifiedTime)',
+})
+console.table(result.files)
+await notebooks.show(result.files[0].uri)
+```
+
+The request is passed through unchanged, so use Google Drive's native `q`,
+corpora, shared-drive, ordering, pagination, spaces, and fields parameters.
+Include `id` and `mimeType` in `fields` when the returned file should have a
+Runme-ready `uri`. Continue with `result.nextPageToken` when it is present.
+
 App config:
 
 ```js
@@ -178,3 +197,6 @@ app.harness.setDefault('configured-harness-name')
   `shareUrl`, and replacement-ready `markdownLink`.
 - Use `notebooks.show(reference)` when Codex needs one command that opens a
   local notebook tab or hands a Drive reference to shared-link coordination.
+- Prefer `drive.search(...)` over DOM inspection when Codex knows a Drive file
+  name or can express the intended file with the Drive query grammar. Resolve a
+  unique result, then pass its `uri` to `notebooks.show(...)`.

--- a/docs/codex-chrome-webmcp.md
+++ b/docs/codex-chrome-webmcp.md
@@ -108,6 +108,31 @@ later notebook operations.
 Do not rely on "current notebook" after the initial resolution, because the user
 may switch notebooks while Codex is working.
 
+When the user identifies a Drive-backed notebook by name or metadata rather
+than by URL, use Runme's AppKernel Drive API instead of searching the rendered
+page with DOM tools:
+
+```js
+const result = await drive.search({
+  q: "name = 'eval_read.json' and trashed = false",
+  orderBy: 'modifiedTime desc',
+  pageSize: 100,
+  fields: 'nextPageToken,files(id,name,mimeType,modifiedTime)',
+})
+
+if (result.files.length !== 1) {
+  throw new Error(`Expected one notebook, found ${result.files.length}`)
+}
+await notebooks.show(result.files[0].uri)
+```
+
+`drive.search` accepts the native Google Drive v3 `files.list` request,
+including the full `q` grammar, shared-drive parameters, ordering, field
+selection, and pagination. Include `id` and `mimeType` in `fields` so Runme can
+add a notebook-ready `uri` to each result. In WebMCP code mode, this call runs
+through the authenticated Runme AppKernel and does not require a separate
+Google Drive connector.
+
 ## Relationship to the chat panel
 
 Do not confuse this mode with the Runme AI Chat panel:


### PR DESCRIPTION
## Summary
- add drive.search as a pass-through to Google Drive v3 files.list
- expose native Drive queries through AppConsole and the WebMCP sandbox
- preserve paging metadata and add Runme-ready URIs when id and MIME type are requested
- document query syntax, pagination, shared-drive search, and opening a unique notebook result

## Validation
- runme run build test
- focused App tests: 81 passed across Drive storage, transfer, AppConsole globals, AppKernel exposure, and sandbox bridging
- pnpm -C app run build
- targeted ESLint: no errors; one pre-existing unused-variable warning