### PR TITLE
Allow read-only markdown source inspection

### DIFF
--- a/app/src/components/Actions/Editor.tsx
+++ b/app/src/components/Actions/Editor.tsx
@@ -172,11 +172,11 @@ const Editor = memo(
     useEffect(() => {
       const wasFocused = previousShouldFocusRef.current;
       previousShouldFocusRef.current = shouldFocus;
-      if (!shouldFocus || wasFocused || readOnly || !editorRef.current) {
+      if (!shouldFocus || wasFocused || !editorRef.current) {
         return;
       }
       editorRef.current.focus?.();
-    }, [readOnly, shouldFocus]);
+    }, [shouldFocus]);
 
     useEffect(() => {
       return () => {

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -14,11 +14,13 @@ vi.mock("./Editor", () => ({
     value,
     onChange,
     shouldFocus = false,
+    readOnly = false,
   }: {
     id: string;
     value: string;
     onChange: (value: string) => void;
     shouldFocus?: boolean;
+    readOnly?: boolean;
   }) => {
     const ref = React.useRef<HTMLTextAreaElement | null>(null);
     const previousShouldFocusRef = React.useRef(false);
@@ -38,6 +40,7 @@ vi.mock("./Editor", () => ({
         data-testid="mock-markdown-editor-input"
         id={id}
         value={value}
+        readOnly={readOnly}
         onChange={(event) => onChange(event.target.value)}
       />
     );
@@ -266,6 +269,39 @@ describe("MarkdownCell", () => {
     expect(document.activeElement).toBe(
       screen.getByTestId("mock-markdown-editor-input"),
     );
+  });
+
+  it("opens read-only markdown source without allowing changes", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-read-only",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "# Copy me",
+    });
+    const stub = new StubCellData(cell);
+
+    renderMarkdownCell(stub as unknown as CellData, { readOnly: true });
+
+    const rendered = screen.getByTestId("markdown-rendered");
+    expect(rendered.getAttribute("aria-label")).toContain(
+      "view read-only markdown source",
+    );
+    fireEvent.doubleClick(rendered);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const input = screen.getByTestId(
+      "mock-markdown-editor-input",
+    ) as HTMLTextAreaElement;
+    expect(input.readOnly).toBe(true);
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: "changed" } });
+    expect(stub.snapshot.value).toBe("# Copy me");
   });
 
   it("focuses rendered markdown when leaving editor mode with escape", async () => {

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -323,8 +323,30 @@ describe("MarkdownCell", () => {
     });
 
     const rendered = screen.getByTestId("markdown-rendered");
+    expect(rendered.getAttribute("role")).toBeNull();
+    expect(rendered.getAttribute("tabindex")).toBeNull();
+    expect(rendered.getAttribute("aria-label")).toBeNull();
     fireEvent.doubleClick(rendered);
     fireEvent.keyDown(rendered, { key: "Enter" });
+
+    expect(screen.getByTestId("markdown-rendered")).toBeTruthy();
+    expect(screen.queryByTestId("markdown-editor")).toBeNull();
+  });
+
+  it("starts inactive empty read-only markdown in rendered mode", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-read-only-empty-inactive",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "",
+    });
+
+    renderMarkdownCell(
+      new StubCellData(cell) as unknown as CellData,
+      { readOnly: true },
+    );
 
     expect(screen.getByTestId("markdown-rendered")).toBeTruthy();
     expect(screen.queryByTestId("markdown-editor")).toBeNull();

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -304,6 +304,32 @@ describe("MarkdownCell", () => {
     expect(stub.snapshot.value).toBe("# Copy me");
   });
 
+  it("keeps empty read-only markdown in rendered mode", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-read-only-empty",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "",
+    });
+    const stub = new StubCellData(cell);
+
+    renderMarkdownCell(stub as unknown as CellData, {
+      readOnly: true,
+      isActiveCell: true,
+      activeFocusRole: "editor",
+      isWindowFocused: true,
+    });
+
+    const rendered = screen.getByTestId("markdown-rendered");
+    fireEvent.doubleClick(rendered);
+    fireEvent.keyDown(rendered, { key: "Enter" });
+
+    expect(screen.getByTestId("markdown-rendered")).toBeTruthy();
+    expect(screen.queryByTestId("markdown-editor")).toBeNull();
+  });
+
   it("focuses rendered markdown when leaving editor mode with escape", async () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "md-escape-rendered",

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -220,6 +220,9 @@ const MarkdownCell = memo(
     // Start in rendered mode unless the cell is empty (new cell)
     const [rendered, setRendered] = useState(() => {
       const value = cell?.value ?? ''
+      if (readOnly) {
+        return true
+      }
       if (value.trim() && isActiveCell && activeFocusRole === 'editor') {
         return false
       }
@@ -232,6 +235,7 @@ const MarkdownCell = memo(
 
     // Get the current cell value
     const value = cell?.value ?? ''
+    const canOpenSource = !readOnly || Boolean(value.trim())
     const shouldOwnFocus = isActiveCell && isWindowFocused
     const tracksActiveCell = Boolean(onFocusRoleChange)
 
@@ -272,15 +276,15 @@ const MarkdownCell = memo(
         return
       }
       if (
-        (!readOnly && (activeFocusRole === 'editor' || !value.trim())) ||
-        (readOnly && activeFocusRole === 'editor' && Boolean(value.trim()))
+        (activeFocusRole === 'editor' && canOpenSource) ||
+        (!readOnly && !value.trim())
       ) {
         setRendered(false)
         return
       }
       setRendered(true)
       renderedRef.current?.focus()
-    }, [activeFocusRole, readOnly, shouldOwnFocus, value])
+    }, [activeFocusRole, canOpenSource, readOnly, shouldOwnFocus, value])
 
     useEffect(() => {
       if (!shouldOwnFocus || activeFocusRole !== 'rendered' || !rendered) {
@@ -300,13 +304,13 @@ const MarkdownCell = memo(
      * Handle switching to edit mode when user double-clicks rendered content.
      */
     const handleDoubleClick = useCallback(() => {
-      if (readOnly && !value.trim()) {
+      if (!canOpenSource) {
         return
       }
       setRendered(false)
       setEditorFocusIntent(true)
       onFocusRoleChange?.('editor')
-    }, [onFocusRoleChange, readOnly, value])
+    }, [canOpenSource, onFocusRoleChange])
 
     /**
      * Handle keyboard activation on the rendered container for accessibility.
@@ -321,7 +325,7 @@ const MarkdownCell = memo(
           return
         }
         if (event.key === 'Enter' || event.key === ' ') {
-          if (readOnly && !value.trim()) {
+          if (!canOpenSource) {
             return
           }
           event.preventDefault()
@@ -330,7 +334,7 @@ const MarkdownCell = memo(
           onFocusRoleChange?.('editor')
         }
       },
-      [onFocusRoleChange, readOnly, value]
+      [canOpenSource, onFocusRoleChange]
     )
 
     /**
@@ -417,15 +421,17 @@ const MarkdownCell = memo(
           <div
             id={`markdown-rendered-${cell.refId}`}
             className="cursor-text rounded-nb-md border border-transparent p-4 transition-[border-color,background-color,box-shadow] duration-200 hover:border-nb-border hover:bg-nb-surface-2/60 hover:shadow-nb-xs"
-            onDoubleClick={handleDoubleClick}
-            onKeyDown={handleRenderedKeyDown}
+            onDoubleClick={canOpenSource ? handleDoubleClick : undefined}
+            onKeyDown={canOpenSource ? handleRenderedKeyDown : undefined}
             ref={renderedRef}
-            tabIndex={0}
-            role="button"
+            tabIndex={canOpenSource ? 0 : undefined}
+            role={canOpenSource ? 'button' : undefined}
             aria-label={
-              readOnly
-                ? 'Double-click or press Enter to view read-only markdown source'
-                : 'Double-click or press Enter to edit markdown'
+              canOpenSource
+                ? readOnly
+                  ? 'Double-click or press Enter to view read-only markdown source'
+                  : 'Double-click or press Enter to edit markdown'
+                : undefined
             }
             data-testid="markdown-rendered"
             data-cell-focus-role="rendered"

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -179,7 +179,7 @@ interface MarkdownCellProps {
   isWindowFocused?: boolean
   /** Notify parent when markdown focus target changes explicitly */
   onFocusRoleChange?: (focusRole: CellFocusRole) => void
-  /** Render and inspect only; editing controls are disabled. */
+  /** Allow source inspection, but prevent content and metadata changes. */
   readOnly?: boolean
 }
 
@@ -220,9 +220,6 @@ const MarkdownCell = memo(
     // Start in rendered mode unless the cell is empty (new cell)
     const [rendered, setRendered] = useState(() => {
       const value = cell?.value ?? ''
-      if (readOnly) {
-        return true
-      }
       if (value.trim() && isActiveCell && activeFocusRole === 'editor') {
         return false
       }
@@ -274,7 +271,7 @@ const MarkdownCell = memo(
       if (!shouldOwnFocus || previouslyOwnedFocus) {
         return
       }
-      if (!readOnly && (activeFocusRole === 'editor' || !value.trim())) {
+      if (activeFocusRole === 'editor' || (!readOnly && !value.trim())) {
         setRendered(false)
         return
       }
@@ -300,13 +297,10 @@ const MarkdownCell = memo(
      * Handle switching to edit mode when user double-clicks rendered content.
      */
     const handleDoubleClick = useCallback(() => {
-      if (readOnly) {
-        return
-      }
       setRendered(false)
       setEditorFocusIntent(true)
       onFocusRoleChange?.('editor')
-    }, [onFocusRoleChange, readOnly])
+    }, [onFocusRoleChange])
 
     /**
      * Handle keyboard activation on the rendered container for accessibility.
@@ -321,16 +315,13 @@ const MarkdownCell = memo(
           return
         }
         if (event.key === 'Enter' || event.key === ' ') {
-          if (readOnly) {
-            return
-          }
           event.preventDefault()
           setRendered(false)
           setEditorFocusIntent(true)
           onFocusRoleChange?.('editor')
         }
       },
-      [onFocusRoleChange, readOnly]
+      [onFocusRoleChange]
     )
 
     /**
@@ -421,10 +412,10 @@ const MarkdownCell = memo(
             onKeyDown={handleRenderedKeyDown}
             ref={renderedRef}
             tabIndex={0}
-            role={readOnly ? undefined : 'button'}
+            role="button"
             aria-label={
               readOnly
-                ? 'Read-only markdown'
+                ? 'Double-click or press Enter to view read-only markdown source'
                 : 'Double-click or press Enter to edit markdown'
             }
             data-testid="markdown-rendered"
@@ -449,7 +440,6 @@ const MarkdownCell = memo(
               fontSize={fontSettings.fontSize}
               fontFamily={fontSettings.fontFamily}
               shouldFocus={
-                !readOnly &&
                 !rendered &&
                 ((shouldOwnFocus && activeFocusRole === 'editor') ||
                   editorFocusIntent)
@@ -476,9 +466,9 @@ const MarkdownCell = memo(
                 </select>
               </div>
               <div className="text-xs text-nb-text-muted">
-                Press{' '}
+                {readOnly && 'Read-only. '}Press{' '}
                 <kbd className="px-1 py-0.5 bg-nb-surface-3 rounded">Esc</kbd>{' '}
-                or run the cell to render
+                {readOnly ? 'to render' : 'or run the cell to render'}
               </div>
             </div>
           </div>

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -271,7 +271,10 @@ const MarkdownCell = memo(
       if (!shouldOwnFocus || previouslyOwnedFocus) {
         return
       }
-      if (activeFocusRole === 'editor' || (!readOnly && !value.trim())) {
+      if (
+        (!readOnly && (activeFocusRole === 'editor' || !value.trim())) ||
+        (readOnly && activeFocusRole === 'editor' && Boolean(value.trim()))
+      ) {
         setRendered(false)
         return
       }
@@ -297,10 +300,13 @@ const MarkdownCell = memo(
      * Handle switching to edit mode when user double-clicks rendered content.
      */
     const handleDoubleClick = useCallback(() => {
+      if (readOnly && !value.trim()) {
+        return
+      }
       setRendered(false)
       setEditorFocusIntent(true)
       onFocusRoleChange?.('editor')
-    }, [onFocusRoleChange])
+    }, [onFocusRoleChange, readOnly, value])
 
     /**
      * Handle keyboard activation on the rendered container for accessibility.
@@ -315,13 +321,16 @@ const MarkdownCell = memo(
           return
         }
         if (event.key === 'Enter' || event.key === ' ') {
+          if (readOnly && !value.trim()) {
+            return
+          }
           event.preventDefault()
           setRendered(false)
           setEditorFocusIntent(true)
           onFocusRoleChange?.('editor')
         }
       },
-      [onFocusRoleChange]
+      [onFocusRoleChange, readOnly, value]
     )
 
     /**


### PR DESCRIPTION
## Summary

- let Markdown cells in locked/read-only notebooks enter source mode via double-click, Enter, or Space
- keep the Monaco editor read-only and all Markdown metadata controls disabled
- focus the read-only source editor so users can immediately select and copy Markdown
- add regression coverage that verifies source mode opens without mutating cell content

## Root cause

`MarkdownCell` already passed `readOnly` to Monaco and guarded its change handler, but it also blocked every rendered-to-editor transition and suppressed focus for read-only editors.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run src/components/Actions/MarkdownCell.test.tsx`
- formatting and `git diff --check`
