### PR TITLE
Add forced notebook lock release

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -30,6 +30,10 @@ const contextMocks = vi.hoisted(() => ({
     requestedUri?: string
     state?: 'loading' | 'loaded' | 'blocked' | 'error'
     readOnly?: boolean
+    releasePending?: boolean
+    writeAccessRequestState?: 'pending' | 'error'
+    writeAccessErrorMessage?: string
+    refreshErrorMessage?: string
     owner?: NotebookOwnershipRecord | null
   }>,
   currentDoc: null as string | null,
@@ -37,12 +41,15 @@ const contextMocks = vi.hoisted(() => ({
   showDocument: vi.fn(),
   closeWorkspaceDocument: vi.fn(),
   getNotebookData: vi.fn(),
+  requestWriteAccess: vi.fn(async () => undefined),
+  refreshReadOnlyNotebook: vi.fn(async () => undefined),
   notebookSnapshots: new Map<
     string,
     {
       uri: string
       loaded: boolean
       readOnly?: boolean
+      releasePending?: boolean
       notebook: parser_pb.Notebook
     }
   >(),
@@ -94,6 +101,8 @@ vi.mock('../../contexts/SettingsContext', () => ({
 vi.mock('../../contexts/NotebookContext', () => ({
   useNotebookContext: () => ({
     getNotebookData: contextMocks.getNotebookData,
+    requestWriteAccess: contextMocks.requestWriteAccess,
+    refreshReadOnlyNotebook: contextMocks.refreshReadOnlyNotebook,
     useNotebookSnapshot: (uri: string) =>
       contextMocks.notebookSnapshots.get(uri) ?? null,
   }),
@@ -280,6 +289,10 @@ beforeEach(() => {
   contextMocks.closeWorkspaceDocument.mockReset()
   contextMocks.getNotebookData.mockReset()
   contextMocks.getNotebookData.mockReturnValue(null)
+  contextMocks.requestWriteAccess.mockReset()
+  contextMocks.requestWriteAccess.mockResolvedValue(undefined)
+  contextMocks.refreshReadOnlyNotebook.mockReset()
+  contextMocks.refreshReadOnlyNotebook.mockResolvedValue(undefined)
   contextMocks.notebookSnapshots.clear()
   contextMocks.notebookStore = null
   conflictMocks.openNotebookConflictDiff.mockReset()
@@ -365,6 +378,91 @@ describe('Actions tabs', () => {
       screen.getByTestId('notebook-readonly-banner').textContent
     ).toContain('session calm-harbor')
     expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
+  it('requests write access from a read-only notebook banner', () => {
+    const uri = 'local://file/reference.runme.md'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'reference.runme.md',
+        state: 'loaded',
+        readOnly: true,
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      readOnly: true,
+      notebook: create(parser_pb.NotebookSchema, { metadata: {}, cells: [] }),
+    })
+
+    render(<Actions />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Request write access' })
+    )
+
+    expect(contextMocks.requestWriteAccess).toHaveBeenCalledWith(uri)
+  })
+
+  it('renders owner locked mode immediately without prompting', () => {
+    const uri = 'local://file/owned.runme.md'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'owned.runme.md',
+        state: 'loaded',
+        releasePending: true,
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      releasePending: true,
+      notebook: create(parser_pb.NotebookSchema, { metadata: {}, cells: [] }),
+    })
+
+    render(<Actions />)
+
+    expect(
+      screen.getByTestId('notebook-owner-locked-banner').textContent
+    ).toContain('Saving changes and switching this notebook to read-only')
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
+  it('surfaces a timeout and requires the user to retry', () => {
+    const uri = 'local://file/timeout.runme.md'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'timeout.runme.md',
+        state: 'loaded',
+        readOnly: true,
+        writeAccessRequestState: 'error',
+        writeAccessErrorMessage:
+          'The other session did not respond. The notebook is still read-only.',
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      readOnly: true,
+      notebook: create(parser_pb.NotebookSchema, { metadata: {}, cells: [] }),
+    })
+
+    render(<Actions />)
+
+    expect(
+      screen.getByTestId('notebook-readonly-banner').textContent
+    ).toContain('The other session did not respond')
+    expect(
+      screen.getByRole('button', { name: 'Request write access' })
+    ).toBeTruthy()
+    expect(contextMocks.requestWriteAccess).not.toHaveBeenCalled()
   })
 
   it('shows the owner session when a notebook is blocked by another tab', () => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1685,12 +1685,21 @@ function NotebookTabContent({
   isWindowFocused: boolean
   onCellFocus: (docUri: string, state: NotebookActiveCellState) => void
 }) {
-  const { getNotebookData, openNotebook, useNotebookSnapshot } =
-    useNotebookContext()
+  const {
+    getNotebookData,
+    refreshReadOnlyNotebook,
+    requestWriteAccess,
+    useNotebookSnapshot,
+  } = useNotebookContext()
   const { store } = useNotebookStore()
   const notebookSnapshot = useNotebookSnapshot(docUri)
   const syncState = useNotebookSyncState(docUri)
-  const readOnly = Boolean(entry.readOnly || notebookSnapshot?.readOnly)
+  const releasePending = Boolean(
+    entry.releasePending || notebookSnapshot?.releasePending
+  )
+  const readOnly = Boolean(
+    entry.readOnly || notebookSnapshot?.readOnly || releasePending
+  )
   const isDriveBacked = isDriveBackedNotebook(entry, syncState)
   const { commentsPanelOpen, openCommentsPanel, setCommentsPanelOpen } =
     useCommentsPanel()
@@ -1984,16 +1993,25 @@ function NotebookTabContent({
             </Text>
           )}
           <Text size="2" as="p">
-            Close this notebook in the other tab, then retry here.
+            Request write access to save the other tab and switch it to
+            read-only.
           </Text>
+          {entry.writeAccessErrorMessage && (
+            <Text size="2" as="p" color="red">
+              {entry.writeAccessErrorMessage}
+            </Text>
+          )}
         </div>
         <Button
           variant="soft"
+          disabled={entry.writeAccessRequestState === 'pending'}
           onClick={() => {
-            void openNotebook(docUri, { name: entry.name })
+            void requestWriteAccess(docUri)
           }}
         >
-          Retry
+          {entry.writeAccessRequestState === 'pending'
+            ? 'Requesting write access...'
+            : 'Request write access'}
         </Button>
       </div>
     )
@@ -2049,19 +2067,65 @@ function NotebookTabContent({
         {/* Full-width notebook column with horizontal padding for breathing room.
             Cells expand to fill the available width of the tab content area. */}
         <div id="notebook-column" className="w-full py-2 px-8">
-          {readOnly && (
+          {releasePending ? (
             <div
               className="mb-3 flex items-center gap-2 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
-              data-testid="notebook-readonly-banner"
+              data-testid="notebook-owner-locked-banner"
             >
               <LockClosedIcon className="h-4 w-4 text-nb-text-muted" />
               <span>
-                {ownerSessionId
-                  ? `Read-only. This notebook is open for editing in session ${ownerSessionId}.`
-                  : 'Read-only. This notebook is open for editing in another browser tab.'}
+                Another session requested write access. Saving changes and
+                switching this notebook to read-only.
               </span>
             </div>
-          )}
+          ) : readOnly ? (
+            <div
+              className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
+              data-testid="notebook-readonly-banner"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <LockClosedIcon className="h-4 w-4 shrink-0 text-nb-text-muted" />
+                <div className="min-w-0">
+                  <p>
+                    {ownerSessionId
+                      ? `Read-only. This notebook is open for editing in session ${ownerSessionId}.`
+                      : 'Read-only. This notebook is open for editing in another browser tab.'}
+                  </p>
+                  {entry.writeAccessErrorMessage && (
+                    <p className="mt-1 text-red-600">
+                      {entry.writeAccessErrorMessage}
+                    </p>
+                  )}
+                  {entry.refreshErrorMessage && (
+                    <p className="mt-1 text-red-600">
+                      {entry.refreshErrorMessage}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {entry.refreshErrorMessage && (
+                  <Button
+                    size="1"
+                    variant="soft"
+                    onClick={() => void refreshReadOnlyNotebook(docUri)}
+                  >
+                    Refresh
+                  </Button>
+                )}
+                <Button
+                  size="1"
+                  variant="soft"
+                  disabled={entry.writeAccessRequestState === 'pending'}
+                  onClick={() => void requestWriteAccess(docUri)}
+                >
+                  {entry.writeAccessRequestState === 'pending'
+                    ? 'Requesting...'
+                    : 'Request write access'}
+                </Button>
+              </div>
+            </div>
+          ) : null}
           {cellDatas.length === 0 ? (
             <div
               id="empty-notebook-prompt"
@@ -2228,6 +2292,10 @@ function renderWorkspaceDocument({
       name: document.title,
       state: document.state ?? 'loading',
       readOnly: document.readOnly,
+      releasePending: document.releasePending,
+      writeAccessRequestState: document.writeAccessRequestState,
+      writeAccessErrorMessage: document.writeAccessErrorMessage,
+      refreshErrorMessage: document.refreshErrorMessage,
       errorMessage: document.errorMessage,
       ...(document.owner !== undefined ? { owner: document.owner } : {}),
     }

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -30,6 +30,8 @@ type NotebookContextValue = {
   ) => Promise<OpenNotebookResult>;
   useNotebookSnapshot: (uri: string) => NotebookSnapshot | null;
   useNotebookList: () => OpenNotebookEntry[];
+  requestWriteAccess: (uri: string) => Promise<OpenNotebookResult>;
+  refreshReadOnlyNotebook: (uri: string) => Promise<void>;
   removeNotebook: (uri: string) => string | null;
 };
 
@@ -66,6 +68,16 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
 
   const removeNotebook = useCallback(
     (uri: string) => controller.closeNotebook(uri),
+    [controller],
+  );
+
+  const requestWriteAccess = useCallback(
+    (uri: string) => controller.requestWriteAccess(uri),
+    [controller],
+  );
+
+  const refreshReadOnlyNotebook = useCallback(
+    (uri: string) => controller.refreshReadOnlyNotebook(uri),
     [controller],
   );
 
@@ -142,12 +154,16 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
       openNotebook,
       useNotebookSnapshot,
       useNotebookList,
+      requestWriteAccess,
+      refreshReadOnlyNotebook,
       removeNotebook,
     }),
     [
       getNotebookData,
       openNotebook,
+      refreshReadOnlyNotebook,
       removeNotebook,
+      requestWriteAccess,
       useNotebookList,
       useNotebookSnapshot,
     ],

--- a/app/src/contexts/WorkspaceDocumentContext.tsx
+++ b/app/src/contexts/WorkspaceDocumentContext.tsx
@@ -58,6 +58,10 @@ export function WorkspaceDocumentProvider({
         requestedUri: notebook.requestedUri,
         state: notebook.state,
         readOnly: notebook.readOnly,
+        releasePending: notebook.releasePending,
+        writeAccessRequestState: notebook.writeAccessRequestState,
+        writeAccessErrorMessage: notebook.writeAccessErrorMessage,
+        refreshErrorMessage: notebook.refreshErrorMessage,
         errorMessage: notebook.errorMessage,
         owner: notebook.owner,
       })

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -591,9 +591,65 @@ describe("NotebookData persistence", () => {
       }),
     );
   });
+
+  it("propagates a final flush failure", async () => {
+    const save = vi.fn().mockRejectedValue(new Error("disk full"));
+    const model = new NotebookData({
+      notebook: create(parser_pb.NotebookSchema, { cells: [] }),
+      uri: "local://file/flush-failure.md",
+      name: "flush-failure.md",
+      notebookStore: { save },
+      loaded: true,
+    });
+
+    await expect(model.flushPendingPersist()).rejects.toThrow("disk full");
+  });
 });
 
 describe("NotebookData.runCodeCell", () => {
+  it("blocks mutations and cancels active streams during lock release", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-cancel",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "sleep 30",
+    });
+    const model = new NotebookData({
+      notebook: create(parser_pb.NotebookSchema, { cells: [cell] }),
+      uri: "local://file/cancel.md",
+      name: "cancel.md",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    const cellData = model.getCell(cell.refId);
+    model.runCodeCell(cell);
+    const stream = model.getActiveStream(cell.refId) as
+      | (StreamsLike & { close: ReturnType<typeof vi.fn> })
+      | undefined;
+    expect(stream).toBeTruthy();
+
+    model.setReleasePending(true);
+    await model.cancelActiveExecutions();
+
+    expect(stream?.close).toHaveBeenCalledTimes(1);
+    expect(
+      model.getCellSnapshot(cell.refId)?.metadata?.[RunmeMetadataKey.ExitCode],
+    ).toBe("130");
+    const stderr = (model.getCellSnapshot(cell.refId)?.outputs ?? [])
+      .flatMap((output) => output.items)
+      .filter((item) => item.mime === MimeType.VSCodeNotebookStdErr)
+      .map((item) => new TextDecoder().decode(item.data))
+      .join("");
+    expect(stderr).toContain("another session requested write access");
+    expect(cellData?.snapshot?.metadata?.[RunmeMetadataKey.ExitCode]).toBe(
+      "130",
+    );
+    expect(() => model.appendCell()).toThrow("releasing its write lock");
+  });
+
   it("returns empty run id when no runner is available", () => {
     getWithFallback.mockReturnValueOnce(undefined);
     const logError = vi.spyOn(appLogger, "error");

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -24,7 +24,10 @@ import {
   resolveAppKernelRunnerMode,
 } from './runtime/appKernel'
 import { JSKernel } from './runtime/jsKernel'
-import { buildJupyterChannelsWebSocketURL } from './runtime/jupyterManager'
+import {
+  buildJupyterChannelsWebSocketURL,
+  getJupyterManager,
+} from './runtime/jupyterManager'
 import {
   type NotebooksApiBridgeServer,
   createHostNotebooksApi,
@@ -58,6 +61,7 @@ export type NotebookSnapshot = {
   readonly notebook: parser_pb.Notebook
   readonly loaded: boolean
   readonly readOnly?: boolean
+  readonly releasePending?: boolean
 }
 
 const localTextEncoder = new TextEncoder()
@@ -425,13 +429,32 @@ export class NotebookData {
   private snapshotCache: NotebookSnapshot
   private loaded: boolean
   private readOnly: boolean
+  private releasePending = false
   private activeStreams: Map<string, StreamsLike> = new Map()
-  private activeJupyterSockets: Map<string, WebSocket> = new Map()
+  private activeJupyterSockets = new Map<
+    string,
+    {
+      socket: WebSocket
+      runnerName: string
+      serverName: string
+      kernelID: string
+    }
+  >()
+  private activeAppKernelExecutions = new Map<
+    string,
+    {
+      runID: string
+      generation: number
+      abortController: AbortController
+    }
+  >()
+  private executionGeneration = 0
 
   private refToCellData: Map<string, CellData> = new Map()
   // Debounce auto-save writes so keystrokes don't trigger a full disk write
   // (and in dev, a Vite page reload) on every change.
   private persistTimer: ReturnType<typeof setTimeout> | null = null
+  private persistInFlight: Promise<void> = Promise.resolve()
   private readonly persistDelayMs = 750
   private readonly resolveNotebookForAppKernel: (
     target?: unknown
@@ -518,12 +541,11 @@ export class NotebookData {
   }
 
   async flushPendingPersist(): Promise<void> {
-    if (!this.persistTimer) {
-      return
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer)
+      this.persistTimer = null
     }
-    clearTimeout(this.persistTimer)
-    this.persistTimer = null
-    await this.persist()
+    await this.persist({ throwOnError: true })
   }
 
   /**
@@ -559,6 +581,7 @@ export class NotebookData {
     { persist = true }: { persist?: boolean } = {}
   ): void {
     this.notebook = clone(parser_pb.NotebookSchema, notebook)
+    this.refToCellData.clear()
     this.rebuildIndex()
     this.validateCells()
     this.sequence = this.computeHighestSequence()
@@ -702,6 +725,111 @@ export class NotebookData {
     return this.readOnly
   }
 
+  setReleasePending(releasePending: boolean): void {
+    if (this.releasePending === releasePending) {
+      return
+    }
+    this.releasePending = releasePending
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+  }
+
+  isReleasePending(): boolean {
+    return this.releasePending
+  }
+
+  async cancelActiveExecutions(
+    message = 'Execution cancelled because another session requested write access.\n'
+  ): Promise<void> {
+    this.executionGeneration += 1
+    const activeRefIds = new Set<string>([
+      ...this.activeStreams.keys(),
+      ...this.activeJupyterSockets.keys(),
+      ...this.activeAppKernelExecutions.keys(),
+    ])
+
+    const streams = Array.from(this.activeStreams.values())
+    this.activeStreams.clear()
+    for (const stream of streams) {
+      try {
+        stream.close()
+      } catch {
+        // Cancellation is best-effort; a broken stream must not retain ownership.
+      }
+    }
+
+    const jupyterExecutions = Array.from(this.activeJupyterSockets.values())
+    this.activeJupyterSockets.clear()
+    const interruptControllers = jupyterExecutions.map(
+      () => new AbortController()
+    )
+    const interrupts = jupyterExecutions.map((execution, index) =>
+      getJupyterManager().interruptKernel(
+        execution.runnerName,
+        execution.serverName,
+        execution.kernelID,
+        { signal: interruptControllers[index]?.signal }
+      )
+    )
+    for (const execution of jupyterExecutions) {
+      const { socket } = execution
+      socket.onopen = null
+      socket.onmessage = null
+      socket.onerror = null
+      socket.onclose = null
+      try {
+        socket.close()
+      } catch {
+        // The kernel interrupt can still cancel execution if the socket is stale.
+      }
+    }
+
+    for (const execution of this.activeAppKernelExecutions.values()) {
+      execution.abortController.abort()
+    }
+    this.activeAppKernelExecutions.clear()
+
+    for (const refId of activeRefIds) {
+      const cell = this.getCellProto(refId)
+      if (!cell) {
+        continue
+      }
+      cell.metadata ??= {}
+      cell.metadata[RunmeMetadataKey.ExitCode] = '130'
+      delete cell.metadata[RunmeMetadataKey.Pid]
+      cell.outputs = [...cell.outputs, ...createStdTextOutputs('', message)]
+      const cellData = this.refToCellData.get(refId)
+      cellData?.updateCachedSnapshotFromNotebook(cell)
+      cellData?.emitContentChange()
+    }
+    if (activeRefIds.size > 0) {
+      this.snapshotCache = this.buildSnapshot()
+      this.emit()
+      this.schedulePersist()
+    }
+
+    if (interrupts.length > 0) {
+      let interruptTimeout: ReturnType<typeof setTimeout> | null = null
+      try {
+        await Promise.race([
+          Promise.allSettled(interrupts).then(() => undefined),
+          new Promise<void>((resolve) => {
+            interruptTimeout = setTimeout(() => {
+              for (const controller of interruptControllers) {
+                controller.abort()
+              }
+              resolve()
+            }, 2_000)
+          }),
+        ])
+      } finally {
+        if (interruptTimeout) {
+          clearTimeout(interruptTimeout)
+        }
+      }
+    }
+  }
+
   // Returns the runID if the cell was started successfully.
   // empty string otherwise
   runCodeCell(cell: parser_pb.Cell): string {
@@ -743,7 +871,7 @@ export class NotebookData {
     existing?.close()
     this.activeStreams.delete(cell.refId)
     const existingJupyterSocket = this.activeJupyterSockets.get(cell.refId)
-    existingJupyterSocket?.close()
+    existingJupyterSocket?.socket.close()
     this.activeJupyterSockets.delete(cell.refId)
 
     // Bump sequence and attach to metadata.
@@ -764,16 +892,17 @@ export class NotebookData {
     }
 
     const runID = genRunID()
+    const generation = this.executionGeneration
     cell.metadata[RunmeMetadataKey.LastRunID] = runID
     this.updateCell(cell)
 
     if (useAppKernel) {
-      this.runCodeCellWithAppKernel(cell, runID, appKernelMode)
+      this.runCodeCellWithAppKernel(cell, runID, appKernelMode, generation)
       return runID
     }
 
     if (useJupyterKernel) {
-      this.runCodeCellWithJupyterKernel(cell, runID, runner!)
+      this.runCodeCellWithJupyterKernel(cell, runID, runner!, generation)
       return runID
     }
 
@@ -782,6 +911,7 @@ export class NotebookData {
       runID,
       sequence: this.sequence,
       runner: runner!,
+      generation,
     })
     if (!streams) {
       return ''
@@ -884,7 +1014,13 @@ export class NotebookData {
       typeof seqValue === 'string' ? Number.parseInt(seqValue, 10) : Number.NaN
     const sequence = Number.isNaN(parsedSeq) ? this.sequence : parsedSeq
 
-    return this.createAndBindStreams({ cell, runID, sequence, runner })
+    return this.createAndBindStreams({
+      cell,
+      runID,
+      sequence,
+      runner,
+      generation: this.executionGeneration,
+    })
   }
 
   private createCell(
@@ -914,6 +1050,11 @@ export class NotebookData {
   }
 
   private assertWritable(): void {
+    if (this.releasePending) {
+      throw new Error(
+        `Notebook ${this.uri} is releasing its write lock for another session.`
+      )
+    }
     if (this.readOnly) {
       throw new Error(
         `Notebook ${this.uri} is open read-only in this browser tab.`
@@ -924,7 +1065,8 @@ export class NotebookData {
   private runCodeCellWithAppKernel(
     cell: parser_pb.Cell,
     runID: string,
-    mode: AppKernelRunnerMode
+    mode: AppKernelRunnerMode,
+    generation: number
   ): void {
     const refId = cell.refId
     const languageId = (cell.languageId ?? '').trim().toLowerCase()
@@ -948,6 +1090,14 @@ export class NotebookData {
     let stdout = ''
     let stderr = ''
     let finalExitCode = 0
+    const abortController = new AbortController()
+    const execution = { runID, generation, abortController }
+    this.activeAppKernelExecutions.get(refId)?.abortController.abort()
+    this.activeAppKernelExecutions.set(refId, execution)
+    const isCurrentExecution = () =>
+      this.activeAppKernelExecutions.get(refId) === execution &&
+      this.executionGeneration === generation &&
+      !this.releasePending
 
     appLogger.info('Starting AppKernel cell execution', {
       attrs: {
@@ -961,13 +1111,19 @@ export class NotebookData {
 
     const hooks = {
       onStdout: (data: string) => {
-        stdout += data
+        if (isCurrentExecution()) {
+          stdout += data
+        }
       },
       onStderr: (data: string) => {
-        stderr += data
+        if (isCurrentExecution()) {
+          stderr += data
+        }
       },
       onExit: (code: number) => {
-        finalExitCode = code
+        if (isCurrentExecution()) {
+          finalExitCode = code
+        }
       },
     }
 
@@ -986,7 +1142,7 @@ export class NotebookData {
                   ),
               },
               hooks,
-            }).run(source)
+            }).run(source, { signal: abortController.signal })
           : new JSKernel({
               globals: appGlobals,
               hooks,
@@ -1021,6 +1177,10 @@ export class NotebookData {
         stderr += `${String(error)}\n`
       })
       .finally(() => {
+        if (!isCurrentExecution()) {
+          return
+        }
+        this.activeAppKernelExecutions.delete(refId)
         const updated = this.getCellProto(refId)
         if (!updated) {
           return
@@ -1117,7 +1277,8 @@ export class NotebookData {
   private runCodeCellWithJupyterKernel(
     cell: parser_pb.Cell,
     runID: string,
-    runner: Runner
+    runner: Runner,
+    generation: number
   ): void {
     const refId = cell.refId
     const source = cell.value ?? ''
@@ -1182,7 +1343,16 @@ export class NotebookData {
     }
 
     const socket = new WebSocket(channelsURL)
-    this.activeJupyterSockets.set(refId, socket)
+    this.activeJupyterSockets.set(refId, {
+      socket,
+      runnerName: runner.name,
+      serverName,
+      kernelID: selectedKernelID,
+    })
+    const isCurrentExecution = () =>
+      this.executionGeneration === generation &&
+      this.activeJupyterSockets.get(refId)?.socket === socket &&
+      !this.releasePending
 
     const executeMsgID = crypto.randomUUID().replace(/-/g, '')
     const sessionID = crypto.randomUUID().replace(/-/g, '')
@@ -1328,6 +1498,9 @@ export class NotebookData {
     }
 
     const updateCellOutputs = (transient: boolean) => {
+      if (!isCurrentExecution()) {
+        return false
+      }
       const updated = this.getCellProto(refId)
       if (!updated) {
         return false
@@ -1358,7 +1531,7 @@ export class NotebookData {
     }
 
     const markCompleted = (code: number) => {
-      if (completed) {
+      if (completed || !isCurrentExecution()) {
         return
       }
       completed = true
@@ -1384,6 +1557,10 @@ export class NotebookData {
     }
 
     socket.onopen = () => {
+      if (!isCurrentExecution()) {
+        socket.close()
+        return
+      }
       const executeRequest = {
         channel: 'shell',
         header: {
@@ -1409,7 +1586,7 @@ export class NotebookData {
     }
 
     socket.onmessage = (event) => {
-      if (completed) {
+      if (completed || !isCurrentExecution()) {
         return
       }
       if (typeof event.data !== 'string') {
@@ -1502,7 +1679,7 @@ export class NotebookData {
     }
 
     socket.onerror = () => {
-      if (completed) {
+      if (completed || !isCurrentExecution()) {
         return
       }
       appendText(
@@ -1514,7 +1691,7 @@ export class NotebookData {
     }
 
     socket.onclose = () => {
-      if (completed) {
+      if (completed || !isCurrentExecution()) {
         return
       }
       // Long-running Jupyter executions can be quiet; completion is gated on
@@ -1553,11 +1730,13 @@ export class NotebookData {
     runID,
     sequence,
     runner,
+    generation,
   }: {
     cell: parser_pb.Cell
     runID: string
     sequence: number
     runner: Runner
+    generation: number
   }): StreamsLike | undefined {
     const streams = new Streams({
       knownID: `cell_${cell.refId}`,
@@ -1574,10 +1753,19 @@ export class NotebookData {
     bindStreamsToCell({
       refId: cell.refId,
       streams,
-      getCell: (ref) => this.getCellProto(ref),
-      updateCell: (next, options) => this.updateCell(next, options),
+      getCell: (ref) =>
+        this.executionGeneration === generation && !this.releasePending
+          ? this.getCellProto(ref)
+          : null,
+      updateCell: (next, options) => {
+        if (this.executionGeneration === generation && !this.releasePending) {
+          this.updateCell(next, options)
+        }
+      },
       onClose: (refId) => {
-        this.activeStreams.delete(refId)
+        if (this.activeStreams.get(refId) === streams) {
+          this.activeStreams.delete(refId)
+        }
       },
     })
 
@@ -1610,6 +1798,7 @@ export class NotebookData {
       name: this.name,
       loaded: this.loaded,
       readOnly: this.readOnly,
+      releasePending: this.releasePending,
       notebook: clone(parser_pb.NotebookSchema, this.notebook),
     }
   }
@@ -1624,18 +1813,29 @@ export class NotebookData {
     })
   }
 
-  private async persist(): Promise<void> {
+  private async persist({
+    throwOnError = false,
+  }: { throwOnError?: boolean } = {}): Promise<void> {
     if (this.readOnly || !this.notebookStore) {
       return
     }
-    try {
-      await this.notebookStore.save(this.uri, this.notebook)
-    } catch (error) {
+    const store = this.notebookStore
+    const save = this.persistInFlight
+      .catch(() => undefined)
+      .then(async () => {
+        await store.save(this.uri, this.notebook)
+      })
+    this.persistInFlight = save.catch((error) => {
       console.error('NotebookData failed to persist notebook', {
         uri: this.uri,
         error,
       })
+    })
+    if (throwOnError) {
+      await save
+      return
     }
+    await this.persistInFlight
   }
 
   private schedulePersist(): void {

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -1,6 +1,6 @@
 import { create } from '@bufbuild/protobuf'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { parser_pb } from '../contexts/CellContext'
 import type { LocalNotebooks } from '../storage/local'
@@ -11,7 +11,9 @@ import {
 } from './notebookDataController'
 import type {
   AcquireResult,
+  ForceReleaseRequest,
   NotebookOwnershipManager,
+  NotebookOwnershipMessage,
 } from './tabCoordination/notebookOwnership'
 
 vi.mock('@runmedev/renderers', () => ({
@@ -99,6 +101,7 @@ function createFakeOwnershipManager(
     tabId: 'tab-test',
     epoch: 'epoch-test',
     release: vi.fn(),
+    released: Promise.resolve(),
     isCurrentOwner: vi.fn(async () => true),
   }
   return {
@@ -117,9 +120,26 @@ function createFakeOwnershipManager(
     release: vi.fn(),
     getOwner: vi.fn(async () => null),
     subscribe: vi.fn(() => () => {}),
+    subscribeToMessages: vi.fn(() => () => {}),
+    setForceReleaseHandler: vi.fn(() => () => {}),
+    requestForceRelease: vi.fn(async () => ({ status: 'released' })),
     isCurrentOwner: vi.fn(async () => true),
     dispose: vi.fn(),
   } as unknown as NotebookOwnershipManager
+}
+
+function createForceReleaseRequest(notebookUri: string): ForceReleaseRequest {
+  const now = Date.now()
+  return {
+    type: 'force-release-request',
+    requestId: 'request-test',
+    notebookUri,
+    requesterTabId: 'tab-requester',
+    requesterLabel: 'Requester',
+    requesterUrl: 'http://localhost/requester',
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + 10_000).toISOString(),
+  }
 }
 
 describe('NotebookDataController', () => {
@@ -498,6 +518,7 @@ describe('NotebookDataController', () => {
           tabId: 'tab-test',
           epoch: 'epoch-test',
           release,
+          released: Promise.resolve(),
           isCurrentOwner: vi.fn(async () => true),
         },
       })
@@ -535,6 +556,7 @@ describe('NotebookDataController', () => {
           tabId: 'tab-test',
           epoch: 'epoch-test',
           release,
+          released: Promise.resolve(),
           isCurrentOwner: vi.fn(async () => true),
         },
       })
@@ -558,5 +580,351 @@ describe('NotebookDataController', () => {
       controller.getNotebookData('local://file/demo')?.getSnapshot().loaded
     ).toBe(true)
     expect(release).not.toHaveBeenCalled()
+  })
+
+  it('locks, flushes, and converts the owner to read-only before releasing', async () => {
+    const uri = 'local://file/owned'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'owned.json',
+      remoteId: uri,
+      notebook: createNotebook('before'),
+    })
+    let finishSave!: () => void
+    localStore.save.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSave = resolve
+        })
+    )
+    const release = vi.fn()
+    const lease = {
+      notebookUri: uri,
+      tabId: 'tab-owner',
+      epoch: 'epoch-owner',
+      release,
+      released: Promise.resolve(),
+      isCurrentOwner: vi.fn(async () => true),
+    }
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: 'acquired', lease })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+    const data = controller.getNotebookData(uri)!
+    const cancelExecutions = vi.spyOn(data, 'cancelActiveExecutions')
+
+    const releaseResult = controller.forceReleaseNotebook(
+      createForceReleaseRequest(uri)
+    )
+
+    await waitFor(() => {
+      expect(data.getSnapshot().releasePending).toBe(true)
+    })
+    expect(() => data.appendCell()).toThrow('releasing its write lock')
+    expect(cancelExecutions).toHaveBeenCalledTimes(1)
+    expect(release).not.toHaveBeenCalled()
+
+    finishSave()
+    await expect(releaseResult).resolves.toEqual({ status: 'released' })
+
+    expect(release).toHaveBeenCalledTimes(1)
+    expect(localStore.save.mock.invocationCallOrder[0]).toBeLessThan(
+      release.mock.invocationCallOrder[0]!
+    )
+    expect(data.getSnapshot()).toEqual(
+      expect.objectContaining({ readOnly: true, releasePending: false })
+    )
+    expect(controller.getOpenNotebooks()[0]).toEqual(
+      expect.objectContaining({ readOnly: true, releasePending: false })
+    )
+  })
+
+  it('keeps ownership when the final save fails', async () => {
+    const uri = 'local://file/save-failure'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'save-failure.json',
+      remoteId: uri,
+      notebook: createNotebook('before'),
+    })
+    localStore.save.mockRejectedValueOnce(new Error('disk full'))
+    const release = vi.fn()
+    const lease = {
+      notebookUri: uri,
+      tabId: 'tab-owner',
+      epoch: 'epoch-owner',
+      release,
+      released: Promise.resolve(),
+      isCurrentOwner: vi.fn(async () => true),
+    }
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: 'acquired', lease })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+
+    const result = await controller.forceReleaseNotebook(
+      createForceReleaseRequest(uri)
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({ status: 'failed', message: expect.any(String) })
+    )
+    expect(release).not.toHaveBeenCalled()
+    expect(controller.getNotebookData(uri)?.getSnapshot()).toEqual(
+      expect.objectContaining({ readOnly: false, releasePending: false })
+    )
+  })
+
+  it('reloads when the new owner acquires before release cleanup finishes', async () => {
+    const uri = 'local://file/release-race'
+    const localStore = createFakeLocalNotebooks()
+    const record = {
+      id: uri,
+      name: 'release-race.json',
+      remoteId: uri,
+      notebook: createNotebook('owner save'),
+    }
+    localStore.records.set(uri, record)
+    let finishRelease!: () => void
+    const released = new Promise<void>((resolve) => {
+      finishRelease = resolve
+    })
+    const lease = {
+      notebookUri: uri,
+      tabId: 'tab-owner',
+      epoch: 'epoch-owner',
+      release: vi.fn(),
+      released,
+      isCurrentOwner: vi.fn(async () => true),
+    }
+    const newOwner = {
+      notebookUri: uri,
+      ownerTabId: 'tab-requester',
+      ownerLabel: 'Requester',
+      ownerUrl: 'http://localhost/requester',
+      ownerStartedAt: new Date().toISOString(),
+      epoch: 'epoch-requester',
+    }
+    let messageListener: ((message: NotebookOwnershipMessage) => void) | null =
+      null
+    const manager = createFakeOwnershipManager({ status: 'acquired', lease })
+    vi.mocked(manager.subscribeToMessages).mockImplementation((listener) => {
+      messageListener = listener
+      return () => {
+        messageListener = null
+      }
+    })
+    vi.mocked(manager.getOwner).mockResolvedValue(newOwner)
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(manager)
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+
+    const result = controller.forceReleaseNotebook(
+      createForceReleaseRequest(uri)
+    )
+    await waitFor(() => expect(lease.release).toHaveBeenCalledTimes(1))
+    record.notebook = createNotebook('requester save')
+    messageListener?.({ type: 'owner-acquired', record: newOwner })
+    finishRelease()
+
+    await expect(result).resolves.toEqual({ status: 'released' })
+    expect(
+      controller.getNotebookData(uri)?.getCellSnapshot('cell-1')?.value
+    ).toBe('requester save')
+    expect(controller.getNotebookData(uri)?.isReadOnly()).toBe(true)
+    expect(controller.getOpenNotebooks()[0]?.owner).toEqual(newOwner)
+  })
+
+  it('reloads the owner save before the requester becomes editable', async () => {
+    const uri = 'local://file/takeover'
+    const localStore = createFakeLocalNotebooks()
+    const record = {
+      id: uri,
+      name: 'takeover.json',
+      remoteId: uri,
+      notebook: createNotebook('stale'),
+    }
+    localStore.records.set(uri, record)
+    const owner = {
+      notebookUri: uri,
+      ownerTabId: 'tab-owner',
+      ownerLabel: 'Owner',
+      ownerUrl: 'http://localhost/owner',
+      ownerStartedAt: new Date().toISOString(),
+      epoch: 'epoch-owner',
+    }
+    const manager = createFakeOwnershipManager()
+    vi.mocked(manager.acquire)
+      .mockResolvedValueOnce({ status: 'blocked', owner })
+      .mockResolvedValueOnce({ status: 'blocked', owner })
+      .mockResolvedValueOnce({
+        status: 'acquired',
+        lease: {
+          notebookUri: uri,
+          tabId: 'tab-requester',
+          epoch: 'epoch-requester',
+          release: vi.fn(),
+          released: Promise.resolve(),
+          isCurrentOwner: vi.fn(async () => true),
+        },
+      })
+    vi.mocked(manager.requestForceRelease).mockResolvedValue({
+      status: 'released',
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(manager)
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+    record.notebook = createNotebook('owner final save')
+
+    const result = await controller.requestWriteAccess(uri)
+
+    expect(manager.requestForceRelease).toHaveBeenCalledTimes(1)
+    expect(result.entry.readOnly).toBe(false)
+    expect(
+      controller.getNotebookData(uri)?.getCellSnapshot('cell-1')?.value
+    ).toBe('owner final save')
+  })
+
+  it('acquires immediately when stale owner metadata outlives the lock', async () => {
+    const uri = 'local://file/stale-owner'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'stale-owner.json',
+      remoteId: uri,
+      notebook: createNotebook('latest'),
+    })
+    const owner = {
+      notebookUri: uri,
+      ownerTabId: 'tab-gone',
+      ownerLabel: 'Gone owner',
+      ownerUrl: 'http://localhost/gone',
+      ownerStartedAt: new Date().toISOString(),
+      epoch: 'epoch-gone',
+    }
+    const manager = createFakeOwnershipManager()
+    vi.mocked(manager.acquire)
+      .mockResolvedValueOnce({ status: 'blocked', owner })
+      .mockResolvedValueOnce({
+        status: 'acquired',
+        lease: {
+          notebookUri: uri,
+          tabId: 'tab-requester',
+          epoch: 'epoch-requester',
+          release: vi.fn(),
+          released: Promise.resolve(),
+          isCurrentOwner: vi.fn(async () => true),
+        },
+      })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(manager)
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+
+    const result = await controller.requestWriteAccess(uri)
+
+    expect(result.entry.readOnly).toBe(false)
+    expect(manager.requestForceRelease).not.toHaveBeenCalled()
+  })
+
+  it('surfaces coordination errors instead of staying pending', async () => {
+    const uri = 'local://file/request-error'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'request-error.json',
+      remoteId: uri,
+      notebook: createNotebook('value'),
+    })
+    const owner = {
+      notebookUri: uri,
+      ownerTabId: 'tab-owner',
+      ownerLabel: 'Owner',
+      ownerUrl: 'http://localhost/owner',
+      ownerStartedAt: new Date().toISOString(),
+      epoch: 'epoch-owner',
+    }
+    const manager = createFakeOwnershipManager()
+    vi.mocked(manager.acquire).mockResolvedValue({ status: 'blocked', owner })
+    vi.mocked(manager.requestForceRelease).mockRejectedValue(
+      new Error('IndexedDB unavailable')
+    )
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(manager)
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+
+    const result = await controller.requestWriteAccess(uri)
+
+    expect(result.entry.writeAccessRequestState).toBe('error')
+    expect(result.entry.writeAccessErrorMessage).toContain(
+      'IndexedDB unavailable'
+    )
+  })
+
+  it('reloads a former owner read-only after another tab acquires', async () => {
+    const uri = 'local://file/former-owner'
+    const localStore = createFakeLocalNotebooks()
+    const record = {
+      id: uri,
+      name: 'former-owner.json',
+      remoteId: uri,
+      notebook: createNotebook('old'),
+    }
+    localStore.records.set(uri, record)
+    const owner = {
+      notebookUri: uri,
+      ownerTabId: 'tab-other',
+      ownerLabel: 'New owner',
+      ownerUrl: 'http://localhost/new-owner',
+      ownerStartedAt: new Date().toISOString(),
+      epoch: 'epoch-new-owner',
+    }
+    let messageListener: ((message: NotebookOwnershipMessage) => void) | null =
+      null
+    const manager = createFakeOwnershipManager({ status: 'blocked', owner })
+    vi.mocked(manager.subscribeToMessages).mockImplementation((listener) => {
+      messageListener = listener
+      return () => {
+        messageListener = null
+      }
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(manager)
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+    record.notebook = createNotebook('new writer save')
+
+    messageListener?.({ type: 'owner-acquired', record: owner })
+
+    await waitFor(() => {
+      expect(
+        controller.getNotebookData(uri)?.getCellSnapshot('cell-1')?.value
+      ).toBe('new writer save')
+    })
+    expect(controller.getNotebookData(uri)?.isReadOnly()).toBe(true)
+    expect(controller.getOpenNotebooks()[0]?.owner).toEqual(owner)
   })
 })

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -685,6 +685,102 @@ describe('NotebookDataController', () => {
     )
   })
 
+  it('does not reopen a notebook closed while the final save is pending', async () => {
+    const uri = 'local://file/closed-during-release'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'closed-during-release.json',
+      remoteId: uri,
+      notebook: createNotebook('before'),
+    })
+    let failSave!: (error: Error) => void
+    localStore.save.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          failSave = reject
+        })
+    )
+    const release = vi.fn()
+    const lease = {
+      notebookUri: uri,
+      tabId: 'tab-owner',
+      epoch: 'epoch-owner',
+      release,
+      released: Promise.resolve(),
+      isCurrentOwner: vi.fn(async () => true),
+    }
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: 'acquired', lease })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+
+    const result = controller.forceReleaseNotebook(
+      createForceReleaseRequest(uri)
+    )
+    await waitFor(() => expect(localStore.save).toHaveBeenCalledTimes(1))
+    controller.closeNotebook(uri)
+    failSave(new Error('disk full'))
+
+    await expect(result).resolves.toEqual(
+      expect.objectContaining({ status: 'failed' })
+    )
+    expect(release).toHaveBeenCalledTimes(1)
+    expect(controller.getOpenNotebooks()).toEqual([])
+    expect(controller.getNotebookData(uri)).toBeUndefined()
+  })
+
+  it('keeps a notebook closed when its pending final save succeeds', async () => {
+    const uri = 'local://file/closed-after-save'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'closed-after-save.json',
+      remoteId: uri,
+      notebook: createNotebook('before'),
+    })
+    let finishSave!: () => void
+    localStore.save.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSave = resolve
+        })
+    )
+    const release = vi.fn()
+    const lease = {
+      notebookUri: uri,
+      tabId: 'tab-owner',
+      epoch: 'epoch-owner',
+      release,
+      released: Promise.resolve(),
+      isCurrentOwner: vi.fn(async () => true),
+    }
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(
+      createFakeOwnershipManager({ status: 'acquired', lease })
+    )
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+
+    const result = controller.forceReleaseNotebook(
+      createForceReleaseRequest(uri)
+    )
+    await waitFor(() => expect(localStore.save).toHaveBeenCalledTimes(1))
+    controller.closeNotebook(uri)
+    finishSave()
+
+    await expect(result).resolves.toEqual({ status: 'released' })
+    expect(release).toHaveBeenCalledTimes(1)
+    expect(controller.getOpenNotebooks()).toEqual([])
+    expect(controller.getNotebookData(uri)).toBeUndefined()
+  })
+
   it('reloads when the new owner acquires before release cleanup finishes', async () => {
     const uri = 'local://file/release-race'
     const localStore = createFakeLocalNotebooks()

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -7,8 +7,11 @@ import { NotebookData, type NotebookSnapshot } from './notebookData'
 import { getNotebookSessionPersistence } from './notebookSessionPersistence'
 import type { NotebookDataLike } from './runtime/runmeConsole'
 import {
+  type ForceReleaseHandlerResult,
+  type ForceReleaseRequest,
   type NotebookLease,
   type NotebookOwnershipManager,
+  type NotebookOwnershipMessage,
   type NotebookOwnershipRecord,
   getNotebookOwnershipManager,
 } from './tabCoordination/notebookOwnership'
@@ -26,6 +29,10 @@ export interface OpenNotebookEntry {
   name: string
   state: NotebookTabState
   readOnly?: boolean
+  releasePending?: boolean
+  writeAccessRequestState?: 'pending' | 'error'
+  writeAccessErrorMessage?: string
+  refreshErrorMessage?: string
   errorMessage?: string
   owner?: NotebookOwnershipRecord | null
 }
@@ -98,6 +105,17 @@ export class NotebookDataController {
   private readonly listeners = new Set<() => void>()
   private snapshot: NotebookDataControllerSnapshot = { openNotebooks: [] }
   private restored = false
+  private readonly releasingNotebooks = new Set<string>()
+  private readonly writeAccessRequests = new Map<
+    string,
+    Promise<OpenNotebookResult>
+  >()
+  private unsubscribeOwnershipMessages: (() => void) | null = null
+  private unregisterForceReleaseHandler: (() => void) | null = null
+
+  private constructor() {
+    this.bindOwnershipManager()
+  }
 
   getSnapshot(): NotebookDataControllerSnapshot {
     this.ensureRestored()
@@ -116,8 +134,11 @@ export class NotebookDataController {
     this.ensureRestored()
     this.localNotebooks = options.localNotebooks
     for (const handle of this.notebooks.values()) {
+      const uri = handle.data.getUri()
       handle.data.setNotebookStore(
-        this.createOwnedNotebookStore(handle.data.getUri())
+        this.leases.has(uri) && !handle.data.isReadOnly()
+          ? this.createOwnedNotebookStore(uri)
+          : null
       )
     }
     if (this.localNotebooks) {
@@ -126,7 +147,9 @@ export class NotebookDataController {
   }
 
   configureOwnershipManager(manager: NotebookOwnershipManager): void {
+    this.unbindOwnershipManager()
     this.ownershipManager = manager
+    this.bindOwnershipManager()
   }
 
   async openNotebook(
@@ -147,6 +170,10 @@ export class NotebookDataController {
       name,
       state: 'loading',
       readOnly: false,
+      releasePending: false,
+      writeAccessRequestState: undefined,
+      writeAccessErrorMessage: undefined,
+      refreshErrorMessage: undefined,
       errorMessage: undefined,
       owner: undefined,
     })
@@ -214,14 +241,17 @@ export class NotebookDataController {
     }
     this.leases.set(localUri, acquireResult.lease)
 
+    const existingWasReadOnly =
+      this.notebooks.get(localUri)?.data.isReadOnly() ?? false
+
     const handle = this.ensureNotebookData({
       uri: localUri,
       name,
       loaded: false,
-      readOnly: false,
+      readOnly: existingWasReadOnly,
     })
 
-    if (handle.loaded) {
+    if (handle.loaded && !existingWasReadOnly) {
       handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
       handle.data.setReadOnly(false)
       entry = this.upsertOpenEntry({
@@ -229,6 +259,10 @@ export class NotebookDataController {
         name: handle.data.getName(),
         state: 'loaded',
         readOnly: false,
+        releasePending: false,
+        writeAccessRequestState: undefined,
+        writeAccessErrorMessage: undefined,
+        refreshErrorMessage: undefined,
         errorMessage: undefined,
         owner: undefined,
       })
@@ -238,15 +272,19 @@ export class NotebookDataController {
     if (this.localNotebooks) {
       try {
         const notebook = await this.localNotebooks.load(localUri)
+        handle.data.loadNotebook(notebook, { persist: false })
         handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
         handle.data.setReadOnly(false)
-        handle.data.loadNotebook(notebook, { persist: false })
         handle.loaded = true
         entry = this.upsertOpenEntry({
           ...entry,
           name: await this.resolveNotebookName(localUri, name),
           state: 'loaded',
           readOnly: false,
+          releasePending: false,
+          writeAccessRequestState: undefined,
+          writeAccessErrorMessage: undefined,
+          refreshErrorMessage: undefined,
           errorMessage: undefined,
           owner: undefined,
         })
@@ -288,6 +326,199 @@ export class NotebookDataController {
 
   getNotebookSnapshot(localUri: string): NotebookSnapshot | null {
     return this.getNotebookData(localUri)?.getSnapshot() ?? null
+  }
+
+  requestWriteAccess(localUri: string): Promise<OpenNotebookResult> {
+    const pending = this.writeAccessRequests.get(localUri)
+    if (pending) {
+      return pending
+    }
+    const request = this.requestWriteAccessInternal(localUri).finally(() => {
+      if (this.writeAccessRequests.get(localUri) === request) {
+        this.writeAccessRequests.delete(localUri)
+      }
+    })
+    this.writeAccessRequests.set(localUri, request)
+    return request
+  }
+
+  private async requestWriteAccessInternal(
+    localUri: string
+  ): Promise<OpenNotebookResult> {
+    this.ensureRestored()
+    const entry = this.openNotebooks.find((item) => item.uri === localUri)
+    if (!entry) {
+      throw new Error(`Notebook ${localUri} is not open.`)
+    }
+
+    this.upsertOpenEntry({
+      ...entry,
+      writeAccessRequestState: 'pending',
+      writeAccessErrorMessage: undefined,
+    })
+    try {
+      const immediate = await this.openNotebook(localUri, { name: entry.name })
+      if (!immediate.entry.readOnly && immediate.entry.state === 'loaded') {
+        return immediate
+      }
+      if (immediate.entry.state === 'error' && !immediate.entry.readOnly) {
+        return immediate
+      }
+      const currentEntry =
+        this.openNotebooks.find((item) => item.uri === localUri) ?? entry
+      this.upsertOpenEntry({
+        ...currentEntry,
+        writeAccessRequestState: 'pending',
+        writeAccessErrorMessage: undefined,
+      })
+
+      const result = await this.ownershipManager.requestForceRelease(localUri)
+      if (result.status !== 'released') {
+        return this.setWriteAccessError(localUri, currentEntry, result.message)
+      }
+
+      const reopened = await this.openNotebook(localUri, { name: entry.name })
+      if (reopened.entry.readOnly || reopened.entry.state !== 'loaded') {
+        return this.setWriteAccessError(
+          localUri,
+          reopened.entry,
+          'Write access was released, but another session acquired it first. Retry to request access again.'
+        )
+      }
+      return reopened
+    } catch (error) {
+      return this.setWriteAccessError(
+        localUri,
+        entry,
+        `Could not request write access: ${String(error)}`
+      )
+    }
+  }
+
+  private setWriteAccessError(
+    localUri: string,
+    fallbackEntry: OpenNotebookEntry,
+    message: string
+  ): OpenNotebookResult {
+    const nextEntry = this.openNotebooks.find((item) => item.uri === localUri)
+    const failedEntry = this.upsertOpenEntry({
+      ...(nextEntry ?? fallbackEntry),
+      writeAccessRequestState: 'error',
+      writeAccessErrorMessage: message,
+    })
+    return { localUri, entry: failedEntry }
+  }
+
+  async refreshReadOnlyNotebook(localUri: string): Promise<void> {
+    const entry = this.openNotebooks.find((item) => item.uri === localUri)
+    if (!entry?.readOnly) {
+      return
+    }
+    await this.reloadReadOnlyNotebook(localUri, entry.owner ?? null)
+  }
+
+  async forceReleaseNotebook(
+    request: ForceReleaseRequest
+  ): Promise<ForceReleaseHandlerResult> {
+    const localUri = request.notebookUri
+    const lease = this.leases.get(localUri)
+    if (!lease || !(await lease.isCurrentOwner())) {
+      return { status: 'not-owner' }
+    }
+    if (this.releasingNotebooks.has(localUri)) {
+      return {
+        status: 'busy',
+        message:
+          'The other session is already processing a write-access request.',
+      }
+    }
+
+    const handle = this.notebooks.get(localUri)
+    const entry = this.openNotebooks.find((item) => item.uri === localUri)
+    if (!handle || !entry) {
+      return {
+        status: 'failed',
+        message: 'The owning session no longer has the notebook open.',
+      }
+    }
+
+    this.releasingNotebooks.add(localUri)
+    try {
+      try {
+        handle.data.setReleasePending(true)
+        this.upsertOpenEntry({
+          ...entry,
+          releasePending: true,
+          writeAccessErrorMessage: undefined,
+        })
+        await handle.data.cancelActiveExecutions()
+        await handle.data.flushPendingPersist()
+      } catch (error) {
+        handle.data.setReleasePending(false)
+        handle.data.setReadOnly(false)
+        handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
+        const currentEntry =
+          this.openNotebooks.find((item) => item.uri === localUri) ?? entry
+        this.upsertOpenEntry({
+          ...currentEntry,
+          state: 'loaded',
+          readOnly: false,
+          releasePending: false,
+          writeAccessErrorMessage: `Could not save changes before releasing write access: ${String(error)}`,
+        })
+        return {
+          status: 'failed',
+          message: `The other session could not save changes before releasing the lock: ${String(error)}`,
+        }
+      }
+
+      // From this point onward the old session must never become writable again.
+      // Cleanup failures after release cannot restore an authoritative Web Lock.
+      lease.release()
+      try {
+        await lease.released
+      } catch (error) {
+        appLogger.error('Notebook lease cleanup failed after release', {
+          attrs: { scope: 'notebook-session', localUri, error },
+        })
+      }
+      if (this.leases.get(localUri) === lease) {
+        this.leases.delete(localUri)
+      }
+      handle.data.setNotebookStore(null)
+      handle.data.setReadOnly(true)
+      handle.data.setReleasePending(false)
+      const currentEntry =
+        this.openNotebooks.find((item) => item.uri === localUri) ?? entry
+      try {
+        this.upsertOpenEntry({
+          ...currentEntry,
+          state: 'loaded',
+          readOnly: true,
+          releasePending: false,
+          owner: null,
+          errorMessage: undefined,
+        })
+      } catch (error) {
+        appLogger.error('Failed to persist released notebook UI state', {
+          attrs: { scope: 'notebook-session', localUri, error },
+        })
+      }
+
+      try {
+        const newOwner = await this.ownershipManager.getOwner(localUri)
+        if (newOwner && newOwner.epoch !== lease.epoch) {
+          await this.reloadReadOnlyNotebook(localUri, newOwner)
+        }
+      } catch (error) {
+        appLogger.error('Failed to refresh notebook after ownership transfer', {
+          attrs: { scope: 'notebook-session', localUri, error },
+        })
+      }
+      return { status: 'released' }
+    } finally {
+      this.releasingNotebooks.delete(localUri)
+    }
   }
 
   private async resolveLocalUri(uri: string, name?: string): Promise<string> {
@@ -466,6 +697,82 @@ export class NotebookDataController {
     this.leases.delete(uri)
   }
 
+  private bindOwnershipManager(): void {
+    this.unregisterForceReleaseHandler =
+      this.ownershipManager.setForceReleaseHandler((request) =>
+        this.forceReleaseNotebook(request)
+      )
+    this.unsubscribeOwnershipMessages =
+      this.ownershipManager.subscribeToMessages((message) => {
+        this.handleOwnershipMessage(message)
+      })
+  }
+
+  private unbindOwnershipManager(): void {
+    this.unregisterForceReleaseHandler?.()
+    this.unregisterForceReleaseHandler = null
+    this.unsubscribeOwnershipMessages?.()
+    this.unsubscribeOwnershipMessages = null
+  }
+
+  private handleOwnershipMessage(message: NotebookOwnershipMessage): void {
+    if (message.type !== 'owner-acquired') {
+      return
+    }
+    if (this.leases.has(message.record.notebookUri)) {
+      return
+    }
+    const handle = this.notebooks.get(message.record.notebookUri)
+    if (!handle?.data.isReadOnly()) {
+      return
+    }
+    void this.reloadReadOnlyNotebook(message.record.notebookUri, message.record)
+  }
+
+  private async reloadReadOnlyNotebook(
+    localUri: string,
+    owner: NotebookOwnershipRecord | null
+  ): Promise<void> {
+    const handle = this.notebooks.get(localUri)
+    const entry = this.openNotebooks.find((item) => item.uri === localUri)
+    if (
+      !handle ||
+      !entry ||
+      !handle.data.isReadOnly() ||
+      this.leases.has(localUri) ||
+      !this.localNotebooks
+    ) {
+      return
+    }
+    try {
+      const notebook = await this.localNotebooks.load(localUri)
+      handle.data.setNotebookStore(null)
+      handle.data.setReleasePending(false)
+      handle.data.setReadOnly(true)
+      handle.data.loadNotebook(notebook, { persist: false })
+      handle.loaded = true
+      this.upsertOpenEntry({
+        ...entry,
+        name: await this.resolveNotebookName(localUri, entry.name),
+        state: 'loaded',
+        readOnly: true,
+        releasePending: false,
+        owner,
+        refreshErrorMessage: undefined,
+        errorMessage: undefined,
+      })
+    } catch (error) {
+      this.upsertOpenEntry({
+        ...entry,
+        state: 'loaded',
+        readOnly: true,
+        releasePending: false,
+        owner,
+        refreshErrorMessage: `Could not refresh the read-only notebook: ${String(error)}`,
+      })
+    }
+  }
+
   private async loadOpenNotebooks(): Promise<void> {
     if (!this.localNotebooks) {
       return
@@ -515,6 +822,7 @@ export class NotebookDataController {
   }
 
   private dispose(): void {
+    this.unbindOwnershipManager()
     for (const lease of this.leases.values()) {
       lease.release()
     }
@@ -525,6 +833,8 @@ export class NotebookDataController {
     this.notebooks.clear()
     this.openNotebooks = []
     this.listeners.clear()
+    this.releasingNotebooks.clear()
+    this.writeAccessRequests.clear()
     this.snapshot = { openNotebooks: [] }
     this.restored = false
     this.localNotebooks = null

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -454,22 +454,39 @@ export class NotebookDataController {
         await handle.data.cancelActiveExecutions()
         await handle.data.flushPendingPersist()
       } catch (error) {
-        handle.data.setReleasePending(false)
-        handle.data.setReadOnly(false)
-        handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
-        const currentEntry =
-          this.openNotebooks.find((item) => item.uri === localUri) ?? entry
-        this.upsertOpenEntry({
-          ...currentEntry,
-          state: 'loaded',
-          readOnly: false,
-          releasePending: false,
-          writeAccessErrorMessage: `Could not save changes before releasing write access: ${String(error)}`,
-        })
+        const currentEntry = this.openNotebooks.find(
+          (item) => item.uri === localUri
+        )
+        if (
+          currentEntry &&
+          this.notebooks.get(localUri) === handle &&
+          this.leases.get(localUri) === lease
+        ) {
+          handle.data.setReleasePending(false)
+          handle.data.setReadOnly(false)
+          handle.data.setNotebookStore(this.createOwnedNotebookStore(localUri))
+          this.upsertOpenEntry({
+            ...currentEntry,
+            state: 'loaded',
+            readOnly: false,
+            releasePending: false,
+            writeAccessErrorMessage: `Could not save changes before releasing write access: ${String(error)}`,
+          })
+        }
         return {
           status: 'failed',
           message: `The other session could not save changes before releasing the lock: ${String(error)}`,
         }
+      }
+
+      // Closing the notebook releases its lease. Do not let this asynchronous
+      // request mutate a notebook that was closed or subsequently reopened.
+      if (
+        !this.openNotebooks.some((item) => item.uri === localUri) ||
+        this.notebooks.get(localUri) !== handle ||
+        this.leases.get(localUri) !== lease
+      ) {
+        return { status: 'released' }
       }
 
       // From this point onward the old session must never become writable again.
@@ -485,11 +502,15 @@ export class NotebookDataController {
       if (this.leases.get(localUri) === lease) {
         this.leases.delete(localUri)
       }
+      const currentEntry = this.openNotebooks.find(
+        (item) => item.uri === localUri
+      )
+      if (!currentEntry || this.notebooks.get(localUri) !== handle) {
+        return { status: 'released' }
+      }
       handle.data.setNotebookStore(null)
       handle.data.setReadOnly(true)
       handle.data.setReleasePending(false)
-      const currentEntry =
-        this.openNotebooks.find((item) => item.uri === localUri) ?? entry
       try {
         this.upsertOpenEntry({
           ...currentEntry,

--- a/app/src/lib/runtime/jupyterManager.test.ts
+++ b/app/src/lib/runtime/jupyterManager.test.ts
@@ -150,4 +150,57 @@ describe("jupyterManager aliases", () => {
       }),
     ).rejects.toThrow('Kernel alias "openai2" already exists');
   });
+
+  it("interrupts a running kernel through the runner API", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/v1/jupyter/servers")) {
+        return jsonResponse([
+          { name: "port-8888", runner: "dev", base_url: "http://127.0.0.1:8888" },
+        ]);
+      }
+      if (url.endsWith("/v1/jupyter/servers/port-8888/kernels") && method === "GET") {
+        return jsonResponse([{ id: "kernel-1", name: "python3" }]);
+      }
+      if (
+        url.endsWith(
+          "/v1/jupyter/servers/port-8888/kernels/kernel-1:interrupt",
+        ) && method === "POST"
+      ) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.doMock("./runnersManager", () => ({
+      DEFAULT_RUNNER_PLACEHOLDER: "<default>",
+      getRunnersManager: () => ({
+        getDefaultRunnerName: () => "dev",
+        getWithFallback: () => ({ name: "dev", endpoint: "http://127.0.0.1:5191" }),
+      }),
+    }));
+    vi.doMock("../../token", () => ({
+      getAuthData: vi.fn(async () => null),
+    }));
+    vi.doMock("../../browserAdapter.client", () => ({
+      getBrowserAdapter: () => ({ simpleAuth: {} }),
+    }));
+
+    const { getJupyterManager } = await import("./jupyterManager");
+    const manager = getJupyterManager();
+    const abortController = new AbortController();
+    await manager.interruptKernel("dev", "port-8888", "kernel-1", {
+      signal: abortController.signal,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:5191/v1/jupyter/servers/port-8888/kernels/kernel-1:interrupt",
+      expect.objectContaining({
+        method: "POST",
+        signal: abortController.signal,
+      }),
+    );
+  });
 });

--- a/app/src/lib/runtime/jupyterManager.ts
+++ b/app/src/lib/runtime/jupyterManager.ts
@@ -576,6 +576,26 @@ class JupyterManager {
     this.bumpVersion();
   }
 
+  async interruptKernel(
+    runnerName: string,
+    serverName: string,
+    kernelID: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const effectiveRunner = this.normalizeRunnerName(runnerName);
+    if (!kernelID.trim()) {
+      throw new Error("Kernel ID is required.");
+    }
+    const baseURL = runnerEndpointToHttpBase(this.resolveRunnerEndpoint(effectiveRunner));
+    await this.fetchJSON<unknown>(
+      `${baseURL}/v1/jupyter/servers/${encodePathSegment(serverName)}/kernels/${encodePathSegment(kernelID)}:interrupt`,
+      {
+        method: "POST",
+        signal: options?.signal,
+      },
+    );
+  }
+
   async resolveKernelID(
     runnerName: string,
     serverName: string,

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -23,6 +23,7 @@ export type NotebookDataLike = {
   getName: () => string
   getNotebook: () => parser_pb.Notebook
   isReadOnly?: () => boolean
+  isReleasePending?: () => boolean
   flushPendingPersist?: () => Promise<void>
   loadNotebook?: (
     notebook: parser_pb.Notebook,
@@ -52,6 +53,7 @@ export type NotebookSummary = {
   name: string
   isOpen: boolean
   readOnly?: boolean
+  releasePending?: boolean
   source: 'local' | 'fs' | 'drive'
 }
 
@@ -271,6 +273,7 @@ function makeDocument(notebook: NotebookDataLike): NotebookDocument {
       name: notebook.getName(),
       isOpen: true,
       readOnly: notebook.isReadOnly?.() ?? false,
+      releasePending: notebook.isReleasePending?.() ?? false,
       source: inferNotebookSource(notebook.getUri()),
     },
     handle,
@@ -336,6 +339,11 @@ function assertNotebookWritable(
   method: 'update' | 'delete' | 'execute' | 'clear' | 'runAll' | 'rerun',
   notebook: NotebookDataLike
 ): void {
+  if (notebook.isReleasePending?.()) {
+    throw new Error(
+      `${method} is not allowed because notebook ${notebook.getUri()} is releasing its write lock for another session.`
+    )
+  }
   if (notebook.isReadOnly?.()) {
     throw new Error(
       `${method} is not allowed because notebook ${notebook.getUri()} is open read-only in this browser tab.`
@@ -705,6 +713,7 @@ export function createNotebooksApi({
         name: notebook.getName(),
         isOpen: true,
         readOnly: notebook.isReadOnly?.() ?? false,
+        releasePending: notebook.isReleasePending?.() ?? false,
         source: inferNotebookSource(notebook.getUri()),
       }))
       if (query?.uriPrefix) {

--- a/app/src/lib/tabCoordination/notebookOwnership.test.ts
+++ b/app/src/lib/tabCoordination/notebookOwnership.test.ts
@@ -51,6 +51,58 @@ type LockCallback = (
 
 const heldLocks = new Map<string, Promise<unknown>>()
 
+class FakeOwnershipChannelBus {
+  private readonly channels = new Set<FakeOwnershipChannel>()
+
+  createChannel(): FakeOwnershipChannel {
+    const channel = new FakeOwnershipChannel(this)
+    this.channels.add(channel)
+    return channel
+  }
+
+  post(sender: FakeOwnershipChannel, message: unknown): void {
+    queueMicrotask(() => {
+      for (const channel of this.channels) {
+        if (channel !== sender) {
+          channel.deliver(message)
+        }
+      }
+    })
+  }
+
+  close(channel: FakeOwnershipChannel): void {
+    this.channels.delete(channel)
+  }
+}
+
+class FakeOwnershipChannel {
+  private readonly listeners = new Set<(event: MessageEvent<unknown>) => void>()
+
+  constructor(private readonly bus: FakeOwnershipChannelBus) {}
+
+  addEventListener(
+    _type: 'message',
+    listener: (event: MessageEvent<unknown>) => void
+  ): void {
+    this.listeners.add(listener)
+  }
+
+  postMessage(message: unknown): void {
+    this.bus.post(this, message)
+  }
+
+  deliver(message: unknown): void {
+    for (const listener of this.listeners) {
+      listener(new MessageEvent('message', { data: message }))
+    }
+  }
+
+  close(): void {
+    this.listeners.clear()
+    this.bus.close(this)
+  }
+}
+
 function installFakeWebLocks(): void {
   Object.defineProperty(navigator, 'locks', {
     configurable: true,
@@ -199,5 +251,142 @@ describe('NotebookOwnershipManager', () => {
 
     await flushReleasedNotebookLocks()
     manager.dispose()
+  })
+
+  it('broadcasts by notebook and lets only the live owner release', async () => {
+    const bus = new FakeOwnershipChannelBus()
+    const first = new NotebookOwnershipManager({
+      dbName: 'force-release-test',
+      tabId: 'tab-owner',
+      channel: bus.createChannel(),
+    })
+    const requester = new NotebookOwnershipManager({
+      dbName: 'force-release-test',
+      tabId: 'tab-requester',
+      channel: bus.createChannel(),
+    })
+    const nonOwner = new NotebookOwnershipManager({
+      dbName: 'force-release-test',
+      tabId: 'tab-non-owner',
+      channel: bus.createChannel(),
+    })
+    const acquired = await first.acquire('local://file/a')
+    expect(acquired.status).toBe('acquired')
+    if (acquired.status !== 'acquired') {
+      return
+    }
+    const ownerHandler = vi.fn(async () => {
+      acquired.lease.release()
+      await acquired.lease.released
+      return { status: 'released' as const }
+    })
+    const nonOwnerHandler = vi.fn(async () => ({ status: 'released' as const }))
+    first.setForceReleaseHandler(ownerHandler)
+    nonOwner.setForceReleaseHandler(nonOwnerHandler)
+
+    await expect(
+      requester.requestForceRelease('local://file/a', { timeoutMs: 100 })
+    ).resolves.toEqual({ status: 'released' })
+
+    expect(ownerHandler).toHaveBeenCalledTimes(1)
+    expect(nonOwnerHandler).not.toHaveBeenCalled()
+    const requesterAcquire = await requester.acquire('local://file/a')
+    expect(requesterAcquire.status).toBe('acquired')
+    if (requesterAcquire.status === 'acquired') {
+      requesterAcquire.lease.release()
+      await requesterAcquire.lease.released
+    }
+    first.dispose()
+    requester.dispose()
+    nonOwner.dispose()
+  })
+
+  it('ignores expired force-release requests', async () => {
+    const bus = new FakeOwnershipChannelBus()
+    const ownerChannel = bus.createChannel()
+    const senderChannel = bus.createChannel()
+    const owner = new NotebookOwnershipManager({
+      dbName: 'expired-request-test',
+      tabId: 'tab-owner',
+      channel: ownerChannel,
+    })
+    const acquired = await owner.acquire('local://file/a')
+    expect(acquired.status).toBe('acquired')
+    const handler = vi.fn(async () => ({ status: 'released' as const }))
+    owner.setForceReleaseHandler(handler)
+
+    senderChannel.postMessage({
+      type: 'force-release-request',
+      requestId: 'expired',
+      notebookUri: 'local://file/a',
+      requesterTabId: 'tab-requester',
+      requesterLabel: 'Requester',
+      requesterUrl: 'http://localhost/requester',
+      createdAt: new Date(Date.now() - 20_000).toISOString(),
+      expiresAt: new Date(Date.now() - 10_000).toISOString(),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(handler).not.toHaveBeenCalled()
+    if (acquired.status === 'acquired') {
+      acquired.lease.release()
+      await acquired.lease.released
+    }
+    owner.dispose()
+    senderChannel.close()
+  })
+
+  it('ignores stale force-release requests with future expirations', async () => {
+    const bus = new FakeOwnershipChannelBus()
+    const ownerChannel = bus.createChannel()
+    const senderChannel = bus.createChannel()
+    const owner = new NotebookOwnershipManager({
+      dbName: 'stale-request-test',
+      tabId: 'tab-owner',
+      channel: ownerChannel,
+    })
+    const acquired = await owner.acquire('local://file/a')
+    expect(acquired.status).toBe('acquired')
+    const handler = vi.fn(async () => ({ status: 'released' as const }))
+    owner.setForceReleaseHandler(handler)
+
+    senderChannel.postMessage({
+      type: 'force-release-request',
+      requestId: 'stale',
+      notebookUri: 'local://file/a',
+      requesterTabId: 'tab-requester',
+      requesterLabel: 'Requester',
+      requesterUrl: 'http://localhost/requester',
+      createdAt: new Date(Date.now() - 120_000).toISOString(),
+      expiresAt: new Date(Date.now() + 10_000).toISOString(),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(handler).not.toHaveBeenCalled()
+    if (acquired.status === 'acquired') {
+      acquired.lease.release()
+      await acquired.lease.released
+    }
+    owner.dispose()
+    senderChannel.close()
+  })
+
+  it('returns a retryable timeout without automatically retrying', async () => {
+    const bus = new FakeOwnershipChannelBus()
+    const requester = new NotebookOwnershipManager({
+      dbName: 'force-release-timeout-test',
+      tabId: 'tab-requester',
+      channel: bus.createChannel(),
+    })
+
+    await expect(
+      requester.requestForceRelease('local://file/a', { timeoutMs: 5 })
+    ).resolves.toEqual({
+      status: 'timeout',
+      message:
+        'The other session did not respond. The notebook is still read-only.',
+    })
+
+    requester.dispose()
   })
 })

--- a/app/src/lib/tabCoordination/notebookOwnership.ts
+++ b/app/src/lib/tabCoordination/notebookOwnership.ts
@@ -22,7 +22,64 @@ export interface NotebookLease {
   tabId: string
   epoch: string
   release(): void
+  released: Promise<void>
   isCurrentOwner(): Promise<boolean>
+}
+
+export interface ForceReleaseRequest {
+  type: 'force-release-request'
+  requestId: string
+  notebookUri: string
+  requesterTabId: string
+  requesterSessionId?: string
+  requesterLabel: string
+  requesterUrl: string
+  createdAt: string
+  expiresAt: string
+  observedOwner?: NotebookOwnershipRecord | null
+}
+
+export type ForceReleaseHandlerResult =
+  | { status: 'released' }
+  | { status: 'not-owner' }
+  | { status: 'busy'; message: string }
+  | { status: 'failed'; message: string }
+
+export interface ForceReleaseResult {
+  type: 'force-release-result'
+  requestId: string
+  notebookUri: string
+  ownerTabId: string
+  ownerSessionId?: string
+  ownerEpoch: string
+  status: ForceReleaseHandlerResult['status']
+  message?: string
+  releasedAt?: string
+}
+
+export type NotebookOwnershipMessage =
+  | ForceReleaseRequest
+  | ForceReleaseResult
+  | {
+      type: 'owner-acquired' | 'owner-released'
+      record: NotebookOwnershipRecord
+    }
+
+export type ForceReleaseRequestResult =
+  | { status: 'released' }
+  | { status: 'busy' | 'failed' | 'timeout'; message: string }
+
+type ForceReleaseHandler = (
+  request: ForceReleaseRequest
+) => Promise<ForceReleaseHandlerResult>
+
+interface OwnershipChannel {
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<unknown>) => void
+  ): void
+  postMessage(message: unknown): void
+  close(): void
 }
 
 class NotebookOwnershipDatabase extends Dexie {
@@ -40,7 +97,18 @@ class NotebookOwnershipDatabase extends Dexie {
 type HeldLease = {
   record: NotebookOwnershipRecord
   release: () => void
+  released: Promise<void>
 }
+
+type PendingForceRelease = {
+  notebookUri: string
+  resolve: (result: ForceReleaseRequestResult) => void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+const FORCE_RELEASE_TIMEOUT_MS = 10_000
+const MAX_FORCE_RELEASE_REQUEST_AGE_MS = 60_000
+const MAX_PROCESSED_REQUEST_IDS = 1_000
 
 function buildLockName(notebookUri: string): string {
   return `runme:notebook:${notebookUri}`
@@ -78,16 +146,30 @@ export class NotebookOwnershipManager {
   private readonly tabId: string
   private readonly heldLeases = new Map<string, HeldLease>()
   private readonly listeners = new Set<() => void>()
-  private readonly channel: BroadcastChannel | null
+  private readonly messageListeners = new Set<
+    (message: NotebookOwnershipMessage) => void
+  >()
+  private readonly channel: OwnershipChannel | null
+  private readonly pendingForceReleases = new Map<string, PendingForceRelease>()
+  private readonly processedForceReleaseRequests = new Set<string>()
+  private forceReleaseHandler: ForceReleaseHandler | null = null
 
-  constructor(options?: { dbName?: string; tabId?: string }) {
+  constructor(options?: {
+    dbName?: string
+    tabId?: string
+    channel?: OwnershipChannel | null
+  }) {
     this.db = new NotebookOwnershipDatabase(options?.dbName)
     this.tabId = options?.tabId ?? getTabId()
     this.channel =
-      typeof BroadcastChannel === 'function'
-        ? new BroadcastChannel('runme-notebook-ownership')
-        : null
-    this.channel?.addEventListener('message', () => this.emit())
+      options && Object.prototype.hasOwnProperty.call(options, 'channel')
+        ? (options?.channel ?? null)
+        : typeof BroadcastChannel === 'function'
+          ? new BroadcastChannel('runme-notebook-ownership')
+          : null
+    this.channel?.addEventListener('message', (event) => {
+      this.handleMessage(event.data)
+    })
   }
 
   async acquire(notebookUri: string): Promise<AcquireResult> {
@@ -105,6 +187,10 @@ export class NotebookOwnershipManager {
     const lockName = buildLockName(notebookUri)
     return new Promise<AcquireResult>((resolve) => {
       let settled = false
+      let markReleased!: () => void
+      const lockReleased = new Promise<void>((release) => {
+        markReleased = release
+      })
       const settle = (result: AcquireResult) => {
         if (settled) {
           return
@@ -141,6 +227,7 @@ export class NotebookOwnershipManager {
           this.heldLeases.set(notebookUri, {
             record,
             release: releaseLock,
+            released: lockReleased,
           })
           this.broadcast('owner-acquired', record)
           this.emit()
@@ -155,7 +242,11 @@ export class NotebookOwnershipManager {
           this.broadcast('owner-released', record)
           this.emit()
         })
+        .then(() => {
+          markReleased()
+        })
         .catch(async () => {
+          markReleased()
           settle({
             status: 'blocked',
             owner: await this.getOwner(notebookUri),
@@ -184,6 +275,76 @@ export class NotebookOwnershipManager {
     }
   }
 
+  subscribeToMessages(
+    listener: (message: NotebookOwnershipMessage) => void
+  ): () => void {
+    this.messageListeners.add(listener)
+    return () => {
+      this.messageListeners.delete(listener)
+    }
+  }
+
+  setForceReleaseHandler(handler: ForceReleaseHandler | null): () => void {
+    this.forceReleaseHandler = handler
+    return () => {
+      if (this.forceReleaseHandler === handler) {
+        this.forceReleaseHandler = null
+      }
+    }
+  }
+
+  async requestForceRelease(
+    notebookUri: string,
+    options?: { timeoutMs?: number }
+  ): Promise<ForceReleaseRequestResult> {
+    if (!this.channel) {
+      return {
+        status: 'failed',
+        message: 'Cross-tab notebook coordination is unavailable.',
+      }
+    }
+
+    const timeoutMs = options?.timeoutMs ?? FORCE_RELEASE_TIMEOUT_MS
+    const now = Date.now()
+    const request: ForceReleaseRequest = {
+      type: 'force-release-request',
+      requestId: crypto.randomUUID(),
+      notebookUri,
+      requesterTabId: this.tabId,
+      requesterSessionId: await getClaimedSessionId(),
+      requesterLabel: getOwnerLabel(),
+      requesterUrl: getOwnerUrl(),
+      createdAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + timeoutMs).toISOString(),
+    }
+
+    return new Promise<ForceReleaseRequestResult>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.pendingForceReleases.delete(request.requestId)
+        resolve({
+          status: 'timeout',
+          message:
+            'The other session did not respond. The notebook is still read-only.',
+        })
+      }, timeoutMs)
+      this.pendingForceReleases.set(request.requestId, {
+        notebookUri,
+        resolve,
+        timeout,
+      })
+      try {
+        this.channel?.postMessage(request)
+      } catch (error) {
+        clearTimeout(timeout)
+        this.pendingForceReleases.delete(request.requestId)
+        resolve({
+          status: 'failed',
+          message: `Could not request write access: ${String(error)}`,
+        })
+      }
+    })
+  }
+
   async isCurrentOwner(notebookUri: string, epoch?: string): Promise<boolean> {
     const held = this.heldLeases.get(notebookUri)
     if (!held) {
@@ -199,7 +360,17 @@ export class NotebookOwnershipManager {
     for (const uri of Array.from(this.heldLeases.keys())) {
       this.release(uri)
     }
+    for (const pending of this.pendingForceReleases.values()) {
+      clearTimeout(pending.timeout)
+      pending.resolve({
+        status: 'failed',
+        message: 'Notebook ownership manager was disposed.',
+      })
+    }
+    this.pendingForceReleases.clear()
     this.listeners.clear()
+    this.messageListeners.clear()
+    this.forceReleaseHandler = null
     this.channel?.close()
     void this.db.close()
   }
@@ -210,6 +381,8 @@ export class NotebookOwnershipManager {
       tabId: record.ownerTabId,
       epoch: record.epoch,
       release: () => this.release(record.notebookUri),
+      released:
+        this.heldLeases.get(record.notebookUri)?.released ?? Promise.resolve(),
       isCurrentOwner: () =>
         this.isCurrentOwner(record.notebookUri, record.epoch),
     }
@@ -231,7 +404,154 @@ export class NotebookOwnershipManager {
     type: 'owner-acquired' | 'owner-released',
     record: NotebookOwnershipRecord
   ): void {
-    this.channel?.postMessage({ type, record })
+    try {
+      this.channel?.postMessage({ type, record })
+    } catch {
+      // A closing tab can dispose the channel before lock cleanup finishes.
+    }
+  }
+
+  private handleMessage(value: unknown): void {
+    const message = parseOwnershipMessage(value)
+    if (!message) {
+      return
+    }
+
+    this.emitMessage(message)
+    this.emit()
+    if (message.type === 'force-release-request') {
+      this.handleForceReleaseRequest(message)
+      return
+    }
+    if (message.type === 'force-release-result') {
+      this.handleForceReleaseResult(message)
+      return
+    }
+    if (message.type === 'owner-released') {
+      this.resolveReleasedNotebookRequests(message.record.notebookUri)
+    }
+  }
+
+  private handleForceReleaseRequest(request: ForceReleaseRequest): void {
+    const now = Date.now()
+    const createdAt = Date.parse(request.createdAt)
+    const expiresAt = Date.parse(request.expiresAt)
+    if (
+      !Number.isFinite(createdAt) ||
+      !Number.isFinite(expiresAt) ||
+      createdAt < now - MAX_FORCE_RELEASE_REQUEST_AGE_MS ||
+      expiresAt <= now ||
+      expiresAt <= createdAt ||
+      expiresAt > createdAt + MAX_FORCE_RELEASE_REQUEST_AGE_MS ||
+      createdAt > now + 60_000 ||
+      this.processedForceReleaseRequests.has(request.requestId)
+    ) {
+      return
+    }
+
+    const held = this.heldLeases.get(request.notebookUri)
+    const handler = this.forceReleaseHandler
+    if (!held || !handler) {
+      return
+    }
+    this.rememberProcessedRequest(request.requestId)
+
+    void handler(request)
+      .then((result) => {
+        if (result.status === 'not-owner') {
+          return
+        }
+        const response: ForceReleaseResult = {
+          type: 'force-release-result',
+          requestId: request.requestId,
+          notebookUri: request.notebookUri,
+          ownerTabId: held.record.ownerTabId,
+          ownerSessionId: held.record.ownerSessionId,
+          ownerEpoch: held.record.epoch,
+          status: result.status,
+          ...(result.status === 'released'
+            ? { releasedAt: new Date().toISOString() }
+            : { message: result.message }),
+        }
+        try {
+          this.channel?.postMessage(response)
+        } catch {
+          // The requester will time out if the response cannot be delivered.
+        }
+      })
+      .catch((error) => {
+        const response: ForceReleaseResult = {
+          type: 'force-release-result',
+          requestId: request.requestId,
+          notebookUri: request.notebookUri,
+          ownerTabId: held.record.ownerTabId,
+          ownerSessionId: held.record.ownerSessionId,
+          ownerEpoch: held.record.epoch,
+          status: 'failed',
+          message: String(error),
+        }
+        try {
+          this.channel?.postMessage(response)
+        } catch {
+          // The requester will time out if the response cannot be delivered.
+        }
+      })
+  }
+
+  private handleForceReleaseResult(result: ForceReleaseResult): void {
+    const pending = this.pendingForceReleases.get(result.requestId)
+    if (!pending || pending.notebookUri !== result.notebookUri) {
+      return
+    }
+    if (result.status === 'not-owner') {
+      return
+    }
+    clearTimeout(pending.timeout)
+    this.pendingForceReleases.delete(result.requestId)
+    if (result.status === 'released') {
+      pending.resolve({ status: 'released' })
+      return
+    }
+    pending.resolve({
+      status: result.status,
+      message:
+        result.message ??
+        (result.status === 'busy'
+          ? 'The other session is already processing a write-access request.'
+          : 'The other session could not release the notebook.'),
+    })
+  }
+
+  private resolveReleasedNotebookRequests(notebookUri: string): void {
+    for (const [requestId, pending] of this.pendingForceReleases) {
+      if (pending.notebookUri !== notebookUri) {
+        continue
+      }
+      clearTimeout(pending.timeout)
+      this.pendingForceReleases.delete(requestId)
+      pending.resolve({ status: 'released' })
+    }
+  }
+
+  private rememberProcessedRequest(requestId: string): void {
+    this.processedForceReleaseRequests.add(requestId)
+    if (this.processedForceReleaseRequests.size <= MAX_PROCESSED_REQUEST_IDS) {
+      return
+    }
+    const oldest = this.processedForceReleaseRequests.values().next().value
+    if (oldest) {
+      this.processedForceReleaseRequests.delete(oldest)
+    }
+  }
+
+  private emitMessage(message: NotebookOwnershipMessage): void {
+    for (const listener of this.messageListeners) {
+      try {
+        listener(message)
+      } catch {
+        // Ignore listener failures so ownership messages continue to flow.
+      }
+    }
   }
 
   private emit(): void {
@@ -243,6 +563,47 @@ export class NotebookOwnershipManager {
       }
     }
   }
+}
+
+function parseOwnershipMessage(
+  value: unknown
+): NotebookOwnershipMessage | null {
+  if (!value || typeof value !== 'object' || !('type' in value)) {
+    return null
+  }
+  const message = value as Partial<NotebookOwnershipMessage>
+  if (
+    (message.type === 'owner-acquired' || message.type === 'owner-released') &&
+    'record' in message &&
+    message.record &&
+    typeof message.record.notebookUri === 'string'
+  ) {
+    return message as NotebookOwnershipMessage
+  }
+  if (
+    message.type === 'force-release-request' &&
+    typeof message.requestId === 'string' &&
+    typeof message.notebookUri === 'string' &&
+    typeof message.requesterTabId === 'string' &&
+    typeof message.createdAt === 'string' &&
+    typeof message.expiresAt === 'string'
+  ) {
+    return message as ForceReleaseRequest
+  }
+  if (
+    message.type === 'force-release-result' &&
+    typeof message.requestId === 'string' &&
+    typeof message.notebookUri === 'string' &&
+    typeof message.ownerTabId === 'string' &&
+    typeof message.ownerEpoch === 'string' &&
+    (message.status === 'released' ||
+      message.status === 'not-owner' ||
+      message.status === 'busy' ||
+      message.status === 'failed')
+  ) {
+    return message as ForceReleaseResult
+  }
+  return null
 }
 
 let manager: NotebookOwnershipManager = new NotebookOwnershipManager()

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -155,6 +155,10 @@ export class WorkspaceDocumentController {
       mimeType: options?.mimeType,
       state: options?.state,
       readOnly: options?.readOnly,
+      releasePending: options?.releasePending,
+      writeAccessRequestState: options?.writeAccessRequestState,
+      writeAccessErrorMessage: options?.writeAccessErrorMessage,
+      refreshErrorMessage: options?.refreshErrorMessage,
       errorMessage: options?.errorMessage,
       owner: options?.owner,
     }
@@ -169,6 +173,12 @@ export class WorkspaceDocumentController {
         existing?.mimeType === nextDocument.mimeType &&
         existing?.state === nextDocument.state &&
         existing?.readOnly === nextDocument.readOnly &&
+        existing?.releasePending === nextDocument.releasePending &&
+        existing?.writeAccessRequestState ===
+          nextDocument.writeAccessRequestState &&
+        existing?.writeAccessErrorMessage ===
+          nextDocument.writeAccessErrorMessage &&
+        existing?.refreshErrorMessage === nextDocument.refreshErrorMessage &&
         existing?.errorMessage === nextDocument.errorMessage &&
         existing?.owner === nextDocument.owner
       ) {

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -16,6 +16,10 @@ export interface WorkspaceDocument {
   mimeType?: string
   state?: NotebookTabState
   readOnly?: boolean
+  releasePending?: boolean
+  writeAccessRequestState?: 'pending' | 'error'
+  writeAccessErrorMessage?: string
+  refreshErrorMessage?: string
   errorMessage?: string
   owner?: NotebookOwnershipRecord | null
 }

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -1,5 +1,22 @@
 import { vi } from "vitest";
 
+// Excalidraw's browser bundle depends on canvas and extensionless ESM imports
+// that are unavailable in Vitest's Node environment. Tests that need the real
+// component can explicitly unmock it.
+vi.mock("@excalidraw/excalidraw", () => ({
+  CaptureUpdateAction: { NEVER: "never" },
+  Excalidraw: () => null,
+  restore: (data: any) => ({
+    elements: data?.elements ?? [],
+    appState: data?.appState ?? {},
+    files: data?.files ?? {},
+  }),
+  serializeAsJSON: (elements: unknown[], appState: unknown, files: unknown) =>
+    JSON.stringify({ type: "excalidraw", elements, appState, files }),
+}));
+
+vi.mock("@excalidraw/excalidraw/index.css", () => ({}));
+
 // Shared Vitest setup run before every test suite.
 // Provide minimal browser globals so modules that expect `window`/`document`
 // don't crash in Node.

--- a/docs-dev/design/20260702_forced_notebook_lock_release.md
+++ b/docs-dev/design/20260702_forced_notebook_lock_release.md
@@ -1,0 +1,461 @@
+# Forced Notebook Lock Release
+
+Date: 2026-07-02
+
+Builds on:
+
+- `docs-dev/design/20260520_multi_tab_support.md`
+- `docs-dev/design/20260603_readonly_secondary_notebook_tabs.md`
+
+## Summary
+
+Add a cooperative takeover path for notebooks that are already open for writing
+in another browser session.
+
+The current ownership model is correct but incomplete. Web Locks prevent two
+same-origin tabs from editing the same notebook at the same time, and secondary
+tabs can open the notebook read-only. A user cannot currently ask the owner tab
+to give up its write lease. That creates friction when Codex loses track of the
+browser tab that owns the notebook lock.
+
+We will add a "Request write access" action in the read-only tab. The action
+sends a same-origin coordination message for the notebook URI. Every live
+session receives the message, and only the session that currently holds the
+notebook lease responds. That owner session saves pending notebook changes,
+releases its Web Lock lease, and keeps the notebook open read-only. The
+requester then retries ownership acquisition and becomes the writer if the lock
+is available.
+
+This is a cooperative force, not lock stealing. The owner tab still performs the
+save before release, which preserves the single-writer invariant and avoids
+data loss.
+
+## Current State
+
+`NotebookDataController.openNotebook()` resolves every requested notebook to a
+stable `local://file/...` URI before ownership is evaluated.
+
+For write access, the controller asks `NotebookOwnershipManager.acquire()` for
+an exclusive Web Lock. If acquisition succeeds, the controller creates an
+editable `NotebookData` model and wraps its save store with an ownership check.
+Autosave is debounced in `NotebookData`, and `flushPendingPersist()` can force a
+pending save before a transition.
+
+If acquisition is blocked, the controller opens the notebook read-only by
+default. Read-only notebooks can be inspected by the UI and AppKernel read APIs,
+but notebook mutations, runs, deletes, and persistence are rejected.
+
+`NotebookOwnershipManager` writes descriptive owner metadata to IndexedDB:
+
+```ts
+interface NotebookOwnershipRecord {
+  notebookUri: string
+  ownerTabId: string
+  ownerSessionId?: string
+  ownerLabel: string
+  ownerUrl: string
+  ownerStartedAt: string
+  epoch: string
+}
+```
+
+The Web Lock remains the ownership authority. IndexedDB metadata is only used to
+explain who appears to own the notebook. It is not used to route or authorize
+force-release requests because it may be stale.
+
+## Goals
+
+- Let a user in one session request write access from the session that currently
+  owns the notebook.
+- Save the owner session's pending notebook changes before it releases the
+  ownership lease.
+- Keep the owner session open read-only after release when possible.
+- Reload the former owner's read-only view after the requester acquires the
+  lease so both sessions show the latest persisted notebook state.
+- Preserve the single-writer guarantee.
+- Keep the takeover protocol same-origin and browser-local.
+- Make failure modes visible when the owner tab cannot release the lock.
+
+## Non-Goals
+
+- Do not add collaborative editing or live document synchronization.
+- Do not use IndexedDB metadata as a fallback lock.
+- Do not build a server-side lock broker.
+- Do not add live synchronization or merge edits into stale read-only views.
+  The former owner performs one full reload after ownership transfers.
+- Do not use Web Locks `steal` in v1. Stealing can revoke the authoritative lock
+  before the owner has saved or updated its local state.
+
+## Decision
+
+Use `BroadcastChannel` for notebook-targeted cooperative force-release requests
+and acknowledgments.
+
+The requester broadcasts a request for `notebookUri`. Every session receives
+the message. Each session asks its local `NotebookOwnershipManager` whether it
+currently holds the lease for that URI. Only the current owner accepts the
+request. It then:
+
+1. blocks new notebook mutations and new executions for that notebook
+2. cancels active executions for that notebook
+3. flushes pending notebook persistence while the lease is still valid
+4. releases the ownership lease
+5. converts its local `NotebookData` model to read-only
+6. broadcasts a release result
+
+The requester waits for the release result or for an `owner-released` ownership
+message, then calls `openNotebook(localUri)` again. Normal Web Lock acquisition
+decides whether takeover succeeded.
+
+This keeps Web Locks as the only authority. Stale IndexedDB metadata cannot
+cause a request to miss the real owner or target the wrong session. The
+coordination protocol only asks the current owner to take actions it could
+already take locally by closing or reopening the notebook.
+
+## Protocol
+
+Reuse the existing `runme-notebook-ownership` `BroadcastChannel`, or replace it
+with a small typed wrapper around that channel. The protocol should be explicit
+because the channel will carry more than owner-acquired and owner-released hints.
+
+```ts
+type NotebookOwnershipMessage =
+  | {
+      type: 'force-release-request'
+      requestId: string
+      notebookUri: string
+      requesterTabId: string
+      requesterSessionId?: string
+      requesterLabel: string
+      requesterUrl: string
+      createdAt: string
+      expiresAt: string
+      observedOwner?: NotebookOwnershipRecord | null
+    }
+  | {
+      type: 'force-release-result'
+      requestId: string
+      notebookUri: string
+      ownerTabId: string
+      ownerSessionId?: string
+      ownerEpoch: string
+      status: 'released' | 'not-owner' | 'busy' | 'failed'
+      message?: string
+      releasedAt?: string
+    }
+  | {
+      type: 'owner-acquired' | 'owner-released'
+      record: NotebookOwnershipRecord
+    }
+```
+
+The request targets only the notebook. `observedOwner` is optional diagnostic
+context captured when the requester sends the message. It can help the UI render
+useful labels, but it must not decide which session handles the request.
+
+The result includes the releasing owner's `ownerTabId`, `ownerSessionId`, and
+`ownerEpoch` so the requester can correlate the release with the owner it last
+observed. These fields are response metadata, not routing inputs.
+
+Every message should be ignored when:
+
+- `notebookUri` does not match a local open notebook
+- `requestId` has already been processed
+- `createdAt` / `expiresAt` is outside the accepted clock window
+
+The owner should additionally ignore a request when the current tab does not
+hold a live lease for `notebookUri`. If the tab holds a lease, the current lease
+epoch is the epoch used in the result. The request does not need to name that
+epoch.
+
+The owner should process at most one force-release request per notebook at a
+time.
+
+## Requester Flow
+
+The UI should offer `Request write access` when the current notebook is
+read-only because another tab owns it. Owner metadata improves the label, but
+it is not required.
+
+Flow:
+
+1. User clicks `Request write access`.
+2. The requester retries normal Web Lock acquisition once. If the lock is
+   already free, it reloads persisted state and becomes editable without
+   broadcasting a force-release request.
+3. If acquisition is still blocked, the requester reads the latest owner
+   metadata from `NotebookOwnershipManager.getOwner(localUri)` for display and
+   diagnostics. Missing metadata does not block the request.
+4. The requester sends `force-release-request` for `localUri`.
+5. The UI shows a pending state such as `Requesting write access from
+   <ownerLabel>...` when owner metadata exists, or `Requesting write access...`
+   when it does not.
+6. The requester waits for:
+   - `force-release-result` with `status: "released"`
+   - `owner-released` for the same notebook
+   - a timeout
+7. On release, the requester calls `openNotebook(localUri)` and selects the tab.
+8. If acquisition succeeds, the notebook becomes editable.
+   Its `owner-acquired` message tells the former owner to reload the notebook
+   from persisted storage in read-only mode.
+9. If acquisition is still blocked, the tab remains read-only and shows the
+   latest owner metadata.
+10. If the request times out, the tab remains read-only and shows an error with
+   an explicit retry action.
+
+The timeout should be short enough to avoid trapping the user in a spinner. Ten
+seconds is a reasonable initial value. The timeout does not imply lock
+ownership. The requester should not automatically retry after timeout. The user
+must click retry or request write access again.
+
+The requester always retries normal acquisition once before broadcasting. This
+handles a crashed owner whose Web Lock was released while its IndexedDB metadata
+remained stale.
+
+## Owner Flow
+
+`NotebookDataController` should expose a focused method for this path:
+
+```ts
+interface ForceReleaseRequest {
+  requestId: string
+  notebookUri: string
+  requesterLabel: string
+  createdAt: string
+  expiresAt: string
+}
+
+type ForceReleaseResult =
+  | { status: "released" }
+  | { status: "not-owner" }
+  | { status: "busy"; message: string } // another release is already in progress
+  | { status: "failed"; message: string }
+
+forceReleaseNotebook(request: ForceReleaseRequest): Promise<ForceReleaseResult>
+```
+
+The method should:
+
+1. Verify the current tab holds a live lease for `notebookUri`.
+2. Mark the notebook as `releasePending` so UI controls and runtime APIs reject
+   new mutations immediately.
+3. Cancel active executions for the target notebook.
+4. Call `NotebookData.flushPendingPersist()`.
+5. Release the lease through `NotebookLease.release()`.
+6. Remove the write save store from the model.
+7. Mark the model and open entry `readOnly: true`.
+8. Preserve the open tab and current selection in the owner session.
+9. Broadcast `force-release-result` with the released lease epoch and let the
+   existing `owner-released` message fire from the ownership manager.
+10. When a different session later broadcasts `owner-acquired` for the same
+    notebook, reload the notebook from persisted storage and keep it read-only.
+
+The save must happen before the lease is released. The current save wrapper
+checks `lease.isCurrentOwner()`, so releasing first would cause the flush to fail
+or silently skip the only durable write opportunity.
+
+`releasePending` should be separate from `readOnly`. During release, the tab is
+still the owner and can save, but user and AppKernel mutations should already be
+blocked. The UI should render this state as locked mode.
+
+The owner should not show a confirmation prompt before entering locked mode.
+Force release is an explicit action from another same-origin session, and the
+feature is meant to recover from lost sessions. Prompting the owner would fail
+the recovery case when the owner tab is alive but not visible to the user or
+Codex.
+
+The post-transfer reload is triggered by the authoritative acquisition path,
+not by the force-release result. The former owner handles `owner-acquired` only
+when it no longer holds a lease and its local model is read-only. It replaces
+the model contents from the local notebook store while preserving the existing
+tab and selection. The reload must not call `acquire()` or install a save store.
+If the reload fails, the tab remains read-only and shows a refresh error; it
+must not fall back to the former in-memory model as editable state.
+
+## Active Execution Policy
+
+Forced release cancels active executions for the target notebook.
+
+Rules:
+
+- The owner closes active runner streams and aborts AppKernel executions for the
+  target notebook.
+- For Jupyter executions, the owner requests a kernel interrupt and closes the
+  channels socket. Interrupt is best-effort and bounded to two seconds so an
+  unreachable runner cannot indefinitely block takeover.
+- The owner records a clear terminal output or status message on affected cells
+  before the final flush when possible.
+- After cancellation starts, execution callbacks must not append more outputs.
+- The owner then flushes and releases.
+
+This makes takeover bounded and predictable. It may interrupt work in the owner
+session, but the action is explicitly a forced release and is meant to recover
+from lost sessions.
+
+## UI Contract
+
+Read-only banner:
+
+```text
+This notebook is read-only because <ownerLabel> has write access.
+
+[Request write access]
+```
+
+Pending request:
+
+```text
+Requesting write access from <ownerLabel>...
+```
+
+Owner locked mode:
+
+```text
+Another session requested write access. Saving changes and switching this
+notebook to read-only.
+```
+
+Locked mode should render the notebook with all editing and execution controls
+disabled. It should show the latest in-memory notebook contents while the owner
+cancels executions and flushes pending saves. After the lease is released, the
+same tab remains open and renders the notebook read-only.
+
+Failure states:
+
+- `The other session did not respond. The notebook is still read-only.`
+- `The other session is already processing a write-access request.`
+- `The other session could not save changes before releasing the lock.`
+
+If the owner metadata contains `ownerSessionId`, the UI may display it in
+diagnostic details. The primary user-facing label should remain human-readable:
+for example `Runme tab opened at 10:42 AM` or the existing `ownerLabel`.
+
+## Runtime Contract
+
+Runtime and AppKernel mutations must reject while `releasePending` is true.
+`releasePending` is the runtime state behind the owner tab's locked mode.
+
+The rejection message should be explicit:
+
+```text
+Notebook local://file/... is releasing its write lock for another session.
+```
+
+Read APIs remain allowed during `releasePending` and after the notebook becomes
+read-only.
+
+`notebooks.list()` should expose enough state for Codex to understand the mode:
+
+```ts
+interface NotebookSummary {
+  uri: string
+  name: string
+  readOnly: boolean
+  releasePending?: boolean
+  owner?: NotebookOwnershipRecord | null
+}
+```
+
+## Failure Modes
+
+Owner tab is closed or crashed:
+
+- The Web Lock is released by the browser.
+- The requester retry succeeds once the lock is available.
+- Stale IndexedDB owner metadata must not block acquisition.
+
+Owner tab exists but Codex cannot find it:
+
+- The owner still receives the BroadcastChannel request if the page is alive.
+- The owner saves, releases, and becomes read-only without Codex needing to
+  control that tab.
+
+Owner metadata is stale:
+
+- The requester still broadcasts by notebook URI.
+- The live owner self-identifies by checking its current lease.
+- Sessions that do not hold the lease ignore the request.
+
+Owner tab is alive but does not run the new protocol:
+
+- The requester times out and remains read-only.
+- The user can close the owner tab manually or reload it after the feature ships.
+
+Owner save fails:
+
+- The owner keeps the write lease.
+- The owner returns `status: "failed"`.
+- The requester remains read-only.
+
+Requester loses the race after release:
+
+- Another tab may acquire the lock first.
+- The requester handles this through the normal blocked/read-only path.
+- The former owner reloads after whichever session broadcasts the successful
+  `owner-acquired` event.
+
+Former owner reload fails:
+
+- The former owner remains read-only.
+- The UI shows an error and offers a manual refresh.
+- The new owner keeps the lease; reload failure does not affect ownership.
+
+## Implementation Plan
+
+1. Add typed ownership-channel helpers and message tests.
+2. Extend `NotebookOwnershipManager` with `requestForceRelease()` and a
+   subscription path for force-release requests.
+3. Add `releasePending` to notebook snapshots and open notebook entries.
+4. Add `NotebookDataController.forceReleaseNotebook()`.
+5. Add a `NotebookData` execution-cancel API for runner streams, AppKernel
+   executions, and Jupyter kernel interrupts/channels sockets.
+6. Block UI and AppKernel mutations while `releasePending` is true.
+7. Add the read-only banner `Request write access` action.
+8. Add pending, timeout-error, busy, and failed states in the read-only UI.
+9. Add owner-side locked-mode UI.
+10. Reload the former owner's read-only model after another session acquires
+    the notebook.
+11. Add tests for request, release, retry acquisition, post-transfer reload,
+    timeout, and save failure.
+
+## Test Plan
+
+Unit tests:
+
+- force-release request is ignored by tabs that do not hold the notebook lease
+- force-release request is ignored when it is expired
+- owner flushes pending persistence before releasing the lease
+- owner keeps the lease when flush fails
+- owner marks the notebook read-only after successful release
+- owner enters locked mode immediately without showing a confirmation prompt
+- owner cancels active executions before flushing and releasing
+- execution callbacks cannot append outputs after cancellation starts
+- requester retries `openNotebook(localUri)` after a release result
+- former owner reloads persisted contents after another session acquires the
+  released notebook and remains read-only
+- former owner ignores `owner-acquired` reload hints while it holds the lease
+- former owner remains read-only and exposes a refresh error when reload fails
+- requester remains read-only and shows a retryable error after timeout
+- stale owner metadata does not block reacquisition
+- `releasePending` rejects notebook mutations and execution starts
+
+Browser tests:
+
+- open a notebook editable in tab A and read-only in tab B
+- request write access from tab B
+- verify tab A saves, releases, and becomes read-only
+- verify tab A renders locked mode during release without prompting
+- verify tab B becomes editable
+- verify tab A reloads tab B's persisted state and remains read-only
+- verify a non-responsive owner produces a timeout error and requires user retry
+- verify active executions are canceled before release
+
+## Recommendation
+
+Implement cooperative forced release over `BroadcastChannel`. Keep Web Locks as
+the authority, save before release, and convert the old owner to read-only after
+the lease is dropped. Broadcast requests by notebook URI and let the live owner
+self-identify through its current lease. For v1, cancel active executions during
+forced release so the recovery path is bounded and useful for lost Browser-tab
+sessions. Reload the former owner's read-only view after the new writer acquires
+the lease.


### PR DESCRIPTION
## Summary

- add a notebook-targeted BroadcastChannel protocol that lets the live Web Lock owner self-identify and cooperatively release its lease
- cancel active runner, AppKernel, and Jupyter executions; flush pending changes before release; and keep the former owner open in locked/read-only mode
- let the requester retry normal acquisition, surface timeout/failure states without automatic retries, and reload the former owner after the new writer acquires
- document the mechanism and resolved design decisions in `docs-dev/design/20260702_forced_notebook_lock_release.md`
- add a shared Excalidraw test boundary mock so the complete Vitest suite can run in Node without loading its canvas/browser bundle

## Why

A notebook can currently be edited in only one browser session, but a lost or inaccessible session can retain the write lock. Stale IndexedDB owner metadata cannot safely identify that owner, so force-release requests are broadcast by notebook URI and only the session holding the authoritative Web Lock responds.

## Validation

- `corepack pnpm -C app exec vitest run` (72 files, 639 tests)
- `runme run build test`
- ESLint on all changed source files (0 errors)
- two-session browser verification:
  - requester became editable and former owner became read-only
  - debounced edits were saved during takeover
  - the former owner reloaded persisted content with editing controls disabled
