### PR TITLE
Fix first cell execution during runner startup

### DIFF
--- a/packages/renderers/src/streams.test.ts
+++ b/packages/renderers/src/streams.test.ts
@@ -1,0 +1,101 @@
+import { ExecuteRequestSchema } from '@buf/runmedev_runme.bufbuild_es/runme/runner/v2/runner_pb'
+import { create } from '@bufbuild/protobuf'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Streams, { Heartbeat } from './streams'
+
+class MockWebSocket extends EventTarget {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  static instances: MockWebSocket[] = []
+
+  readonly sent: string[] = []
+  readyState = MockWebSocket.CONNECTING
+
+  constructor(readonly url: string) {
+    super()
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+  }
+
+  failConnection(): void {
+    this.dispatchEvent(new Event('error'))
+    this.readyState = MockWebSocket.CLOSED
+    this.dispatchEvent(new CloseEvent('close', { code: 1006 }))
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.dispatchEvent(new Event('open'))
+  }
+}
+
+describe('Streams', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('keeps the first execute request queued while the runner starts', async () => {
+    const streams = new Streams({
+      knownID: 'cell-first-run',
+      runID: 'run-first-run',
+      sequence: 1,
+      options: {
+        runnerEndpoint: 'ws://localhost:9977/ws',
+        interceptors: [],
+        autoReconnect: true,
+      },
+    })
+    const errors: unknown[] = []
+    const errorSubscription = streams.errors.subscribe((error) => {
+      errors.push(error)
+    })
+
+    streams.connect(Heartbeat.INITIAL).subscribe()
+    streams.sendExecuteRequest(
+      create(ExecuteRequestSchema, {
+        config: {
+          languageId: 'bash',
+        },
+      })
+    )
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    MockWebSocket.instances[0].failConnection()
+    expect(errors).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    MockWebSocket.instances[1].open()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(
+      MockWebSocket.instances[1].sent.some((message) =>
+        message.includes('executeRequest')
+      )
+    ).toBe(true)
+    expect(errors).toEqual([])
+
+    errorSubscription.unsubscribe()
+    streams.close()
+  })
+})

--- a/packages/renderers/src/streams.ts
+++ b/packages/renderers/src/streams.ts
@@ -53,7 +53,6 @@ const MAX_LATENCY_DEADLINE_MS = 4_000
 const RECONNECT_THROTTLE_MS = 1_000
 const MAX_CONSECUTIVE_FAILURES = 3
 const FAILURE_WINDOW_MS = 5_000
-const INITIAL_CONNECT_FAILURES = 1
 
 export type StreamError = Error | pb.WebsocketStatus
 
@@ -183,7 +182,6 @@ class Streams {
 
   // Track consecutive connection failures to detect unreachable backend
   private connectionFailures: number[] = []
-  private hasConnectedOnce = false
 
   constructor({ knownID, runID, sequence, options }: StreamsProps) {
     // Set the identifiers
@@ -365,11 +363,7 @@ class Streams {
 
         if (this.autoReconnect) {
           if (!opened) {
-            const shouldStop = recordConnectionFailure(
-              this.hasConnectedOnce
-                ? MAX_CONSECUTIVE_FAILURES
-                : INITIAL_CONNECT_FAILURES
-            )
+            const shouldStop = recordConnectionFailure(MAX_CONSECUTIVE_FAILURES)
             if (shouldStop || terminalFailure) {
               return
             }
@@ -387,9 +381,7 @@ class Streams {
           return
         }
 
-        const shouldStop = recordConnectionFailure(
-          opened ? MAX_CONSECUTIVE_FAILURES : INITIAL_CONNECT_FAILURES
-        )
+        const shouldStop = recordConnectionFailure(MAX_CONSECUTIVE_FAILURES)
         if (shouldStop || terminalFailure) {
           return
         }
@@ -461,7 +453,6 @@ class Streams {
       const onOpen = () => {
         // Reset failure tracking on successful connection
         this.connectionFailures = []
-        this.hasConnectedOnce = true
         opened = true
 
         observer.next(socket)


### PR DESCRIPTION
## Summary

- retry transient initial runner WebSocket failures instead of abandoning the first cell execution
- keep the original execute request buffered until a retry connects
- add a transport regression test covering a runner that becomes available after the first connection attempt

## Root cause

Initial WebSocket connections used a one-failure budget, while reconnects after a successful connection allowed three failures. If a cell was run while the dev runner was still starting, the first refused connection terminated the stream and stranded the queued execute request. A second Run click created a new stream after the runner was ready, so it appeared that cells always had to be run twice.

## Verification

- Browser reproduction before the fix: first click during runner startup produced no output; second click produced the expected output
- `pnpm -C packages/renderers exec vitest run src/streams.test.ts`
- `runme run build test`
- hello-world browser CUJ: 10/10 assertions passed, including one Run click and observed `hello world` output
