### PR TITLE
Add conflict resolution cell shortcuts

### DIFF
--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -113,6 +113,46 @@ describe('NotebookDiffContent', () => {
     ).toBeTruthy()
   })
 
+  it('shows a remove affordance for cells that exist only locally', () => {
+    const upstreamNotebook = create(parser_pb.NotebookSchema, {
+      cells: [],
+      metadata: {},
+    })
+    const localNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'local-only',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('remove me')",
+        }),
+      ],
+      metadata: {},
+    })
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(upstreamNotebook, localNotebook),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={{} as unknown as LocalNotebooks}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Remove cell from local notebook',
+      })
+    ).toBeTruthy()
+  })
+
   it('loads an older Drive revision from the Base revision selector', async () => {
     const upstreamNotebook = notebook("print('upstream')")
     const olderNotebook = notebook("print('older')")
@@ -220,6 +260,11 @@ describe('NotebookDiffContent', () => {
         name: 'Insert upstream cell into local notebook',
       })
     ).toBeNull()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Remove cell from local notebook',
+      })
+    ).toBeNull()
     expect(screen.getByLabelText('Compare against')).toBeTruthy()
   })
 
@@ -302,5 +347,81 @@ describe('NotebookDiffContent', () => {
       'remote-only',
     ])
     expect(screen.getByText('0 deleted')).toBeTruthy()
+  })
+
+  it('removes a local-only cell from the local notebook and refreshes the diff', async () => {
+    const upstreamNotebook = create(parser_pb.NotebookSchema, {
+      cells: [],
+      metadata: {},
+    })
+    const localNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'local-only',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('remove me')",
+        }),
+      ],
+      metadata: {},
+    })
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const localStore = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(upstreamNotebook, localNotebook),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={localStore}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Remove cell from local notebook',
+      })
+    )
+
+    await waitFor(() => {
+      expect(localStore.save).toHaveBeenCalledTimes(1)
+      expect(
+        screen.queryByRole('button', {
+          name: 'Remove cell from local notebook',
+        })
+      ).toBeNull()
+    })
+    const savedNotebook = fromJsonString(parser_pb.NotebookSchema, record.doc, {
+      ignoreUnknownFields: true,
+    })
+    expect(savedNotebook.cells).toHaveLength(0)
+    expect(screen.getByText('0 inserted')).toBeTruthy()
   })
 })

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -14,6 +14,7 @@ import type {
 import {
   openNotebookDriveRevisionDiff,
   refreshNotebookConflictDiff,
+  removeInsertedConflictCell,
   restoreDeletedConflictCell,
 } from '../../lib/notebookDiff/conflict'
 import type { DriveRevision } from '../../storage/drive'
@@ -261,6 +262,63 @@ function RestoreDeletedCellButton({
   )
 }
 
+function RemoveInsertedCellButton({
+  localUri,
+  row,
+  onRemoved,
+}: {
+  localUri: string
+  row: CellDiff
+  onRemoved: (document: NotebookDiffDocument) => void
+}) {
+  const { store } = useNotebookStore()
+  const [isRemoving, setIsRemoving] = useState(false)
+
+  const removeCell = async () => {
+    if (!store) {
+      return
+    }
+    setIsRemoving(true)
+    try {
+      const notebookData = getNotebookDataController().getNotebookData(localUri)
+      await notebookData?.flushPendingPersist()
+      const result = await removeInsertedConflictCell(store, localUri, row, {
+        localNotebook: notebookData?.getSnapshot().notebook,
+      })
+      notebookData?.loadNotebook(result.localNotebook, { persist: false })
+      onRemoved(result.document)
+      showToast({
+        message: 'Removed local-only cell from the local notebook.',
+        tone: 'success',
+      })
+    } catch {
+      showToast({
+        message: 'Unable to remove local-only cell. Please try again.',
+        tone: 'error',
+      })
+    } finally {
+      setIsRemoving(false)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      size="1"
+      color="red"
+      variant="soft"
+      disabled={!store || isRemoving}
+      aria-label="Remove cell from local notebook"
+      title="Remove cell from local notebook"
+      onClick={() => {
+        void removeCell()
+      }}
+    >
+      {isRemoving ? 'Removing...' : 'Remove local'}
+    </Button>
+  )
+}
+
 function revisionLabel(revision: DriveRevision): string {
   const modified = revision.modifiedTime
     ? new Date(revision.modifiedTime).toLocaleString()
@@ -434,6 +492,13 @@ function DiffRow({
             localUri={conflictLocalUri}
             row={row}
             onRestored={onConflictDocumentChanged}
+          />
+        )}
+        {conflictLocalUri && row.kind === 'inserted' && (
+          <RemoveInsertedCellButton
+            localUri={conflictLocalUri}
+            row={row}
+            onRemoved={onConflictDocumentChanged}
           />
         )}
       </div>

--- a/app/src/lib/notebookDiff/conflict.test.ts
+++ b/app/src/lib/notebookDiff/conflict.test.ts
@@ -6,6 +6,7 @@ import type LocalNotebooks from '../../storage/local'
 import {
   openNotebookDriveRevisionDiff,
   openNotebookUpstreamDiff,
+  removeInsertedConflictCell,
   restoreDeletedConflictCell,
 } from './conflict'
 import { computeNotebookDiff } from './diff'
@@ -164,6 +165,69 @@ describe('restoreDeletedConflictCell', () => {
       'c',
     ])
     expect(saved?.cells[0]?.value).toBe('unsaved a edit')
+  })
+})
+
+describe('removeInsertedConflictCell', () => {
+  it('removes a local-only cell while preserving other live notebook edits', async () => {
+    const upstreamNotebook = notebook([
+      cell({ refId: 'a', value: 'a' }),
+      cell({ refId: 'c', value: 'c' }),
+    ])
+    const staleLocalNotebook = notebook([
+      cell({ refId: 'a', value: 'stale a' }),
+      cell({ refId: 'local-only', value: 'remove me' }),
+      cell({ refId: 'c', value: 'c' }),
+    ])
+    const liveLocalNotebook = notebook([
+      cell({ refId: 'a', value: 'unsaved a edit' }),
+      cell({ refId: 'local-only', value: 'remove me' }),
+      cell({ refId: 'c', value: 'c' }),
+    ])
+    const diff = computeNotebookDiff(upstreamNotebook, staleLocalNotebook)
+    const insertedRow = diff.cells.find(
+      (row) => row.compareCell?.refId === 'local-only'
+    )
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      remoteId: 'https://drive.google.com/file/d/file123/view',
+      lastRemoteChecksum: 'base',
+      lastSynced: '',
+      doc: serialize(staleLocalNotebook),
+      md5Checksum: 'local',
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+
+    const result = await removeInsertedConflictCell(
+      store,
+      'local://file/conflict',
+      insertedRow!,
+      { localNotebook: liveLocalNotebook }
+    )
+
+    expect(store.save).toHaveBeenCalledTimes(1)
+    expect(
+      result.localNotebook.cells.map((savedCell) => savedCell.refId)
+    ).toEqual(['a', 'c'])
+    expect(result.localNotebook.cells[0]?.value).toBe('unsaved a edit')
+    expect(result.document.diff.summary.insertedCells).toBe(0)
   })
 })
 

--- a/app/src/lib/notebookDiff/conflict.test.ts
+++ b/app/src/lib/notebookDiff/conflict.test.ts
@@ -229,6 +229,52 @@ describe('removeInsertedConflictCell', () => {
     expect(result.localNotebook.cells[0]?.value).toBe('unsaved a edit')
     expect(result.document.diff.summary.insertedCells).toBe(0)
   })
+
+  it('removes the indexed local-only cell when refIds are duplicated', async () => {
+    const upstreamNotebook = notebook([
+      cell({ refId: 'duplicate', value: 'upstream value' }),
+    ])
+    const localNotebook = notebook([
+      cell({ refId: 'duplicate', value: 'keep me' }),
+      cell({ refId: 'duplicate', value: 'remove me' }),
+    ])
+    const diff = computeNotebookDiff(upstreamNotebook, localNotebook)
+    const insertedRow = diff.cells.find(
+      (row) => row.kind === 'inserted' && row.compareCell?.value === 'remove me'
+    )
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+
+    const result = await removeInsertedConflictCell(
+      store,
+      'local://file/conflict',
+      insertedRow!
+    )
+
+    expect(result.localNotebook.cells).toHaveLength(1)
+    expect(result.localNotebook.cells[0]?.value).toBe('keep me')
+    expect(result.document.diff.summary.insertedCells).toBe(0)
+  })
 })
 
 describe('Drive upstream diff documents', () => {

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -14,14 +14,19 @@ import {
   registerNotebookDiffDocument,
 } from './registry'
 
-export interface RestoredConflictCellResult {
+export interface ConflictCellMutationResult {
   document: NotebookDiffDocument
   localNotebook: parser_pb.Notebook
 }
 
-export interface RestoreDeletedConflictCellOptions {
+export type RestoredConflictCellResult = ConflictCellMutationResult
+
+export interface ConflictCellMutationOptions {
   localNotebook?: parser_pb.Notebook
 }
+
+export type RestoreDeletedConflictCellOptions = ConflictCellMutationOptions
+export type RemoveInsertedConflictCellOptions = ConflictCellMutationOptions
 
 type DriveDiffResolutionKind = NonNullable<
   NotebookDiffDocument['resolution']
@@ -311,6 +316,86 @@ export async function restoreDeletedConflictCell(
     row.baseIndex ?? localCells.length
   )
   localNotebook.cells.splice(insertIndex, 0, restoredCell)
+
+  await store.save(localUri, localNotebook)
+
+  const updatedRecord = await store.files.get(localUri)
+  if (!updatedRecord) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+  return {
+    document: await registerConflictDiffDocument(
+      store,
+      localUri,
+      updatedRecord,
+      record.conflict
+    ),
+    localNotebook,
+  }
+}
+
+function findInsertedCellIndex(
+  localNotebook: parser_pb.Notebook,
+  row: CellDiff
+): number {
+  const localCells = localNotebook.cells ?? []
+  const refId = row.compareCell?.refId
+  if (refId) {
+    const matchingIndexes = localCells.flatMap((cell, index) =>
+      cell.refId === refId ? [index] : []
+    )
+    if (matchingIndexes.length === 1) {
+      return matchingIndexes[0]
+    }
+    if (matchingIndexes.length > 1) {
+      throw new Error(`Local notebook has duplicate cell refId ${refId}.`)
+    }
+    throw new Error(`Local cell ${refId} is no longer present.`)
+  }
+
+  const compareCell = row.compareCell
+  const compareIndex = row.compareIndex
+  if (compareCell && compareIndex !== undefined) {
+    const candidate = localCells[compareIndex]
+    if (
+      candidate &&
+      !candidate.refId &&
+      candidate.kind === compareCell.kind &&
+      candidate.languageId === compareCell.languageId &&
+      candidate.value === compareCell.value
+    ) {
+      return compareIndex
+    }
+  }
+
+  throw new Error('Local cell is no longer present at the expected position.')
+}
+
+export async function removeInsertedConflictCell(
+  store: LocalNotebooks,
+  localUri: string,
+  row: CellDiff,
+  options: RemoveInsertedConflictCellOptions = {}
+): Promise<ConflictCellMutationResult> {
+  if (row.kind !== 'inserted' || !row.compareCell) {
+    throw new Error(
+      'Only cells present exclusively in the local notebook can be removed.'
+    )
+  }
+
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+  if (!record.conflict) {
+    throw new Error(`Local notebook ${localUri} does not have a conflict`)
+  }
+
+  const localNotebook = options.localNotebook
+    ? clone(parser_pb.NotebookSchema, options.localNotebook)
+    : parseNotebookJson(record.doc ?? '', 'local')
+  const removeIndex = findInsertedCellIndex(localNotebook, row)
+  localNotebook.cells.splice(removeIndex, 1)
 
   await store.save(localUri, localNotebook)
 

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -339,6 +339,8 @@ function findInsertedCellIndex(
   row: CellDiff
 ): number {
   const localCells = localNotebook.cells ?? []
+  const compareCell = row.compareCell
+  const compareIndex = row.compareIndex
   const refId = row.compareCell?.refId
   if (refId) {
     const matchingIndexes = localCells.flatMap((cell, index) =>
@@ -348,13 +350,23 @@ function findInsertedCellIndex(
       return matchingIndexes[0]
     }
     if (matchingIndexes.length > 1) {
+      const indexedCandidate =
+        compareIndex === undefined ? undefined : localCells[compareIndex]
+      if (
+        compareIndex !== undefined &&
+        indexedCandidate?.refId === refId &&
+        compareCell &&
+        indexedCandidate.kind === compareCell.kind &&
+        indexedCandidate.languageId === compareCell.languageId &&
+        indexedCandidate.value === compareCell.value
+      ) {
+        return compareIndex
+      }
       throw new Error(`Local notebook has duplicate cell refId ${refId}.`)
     }
     throw new Error(`Local cell ${refId} is no longer present.`)
   }
 
-  const compareCell = row.compareCell
-  const compareIndex = row.compareIndex
   if (compareCell && compareIndex !== undefined) {
     const candidate = localCells[compareIndex]
     if (


### PR DESCRIPTION
## Summary

- add a **Remove local** shortcut for cells present locally but absent upstream
- keep the existing **Insert →** shortcut for upstream cells deleted locally
- persist the selected resolution into the live local notebook and refresh the conflict diff immediately
- hide mutation shortcuts while viewing historical Drive revisions

## Why

Conflict resolution already allowed restoring an upstream-only cell, but resolving the opposite case required leaving the diff and manually deleting the local-only cell. The new symmetric action makes both deletion conflicts resolvable directly from the diff.

## User impact

Users can now resolve both kinds of cell-presence conflicts inline without losing unrelated live notebook edits.

## Validation

- `pnpm -C app test --run` (72 files, 644 tests)
- `runme run build test`
- focused conflict helper and UI tests (17 tests)
