### PR TITLE
Support Google Drive drag-and-drop moves

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NotebookStoreItemType } from '../../storage/notebook'
@@ -19,17 +19,21 @@ const mocks = vi.hoisted(() => ({
     getMetadata: vi.fn(),
     createContent: vi.fn(),
     createFolder: vi.fn(),
+    move: vi.fn(),
     moveToTrash: vi.fn(),
     sync: vi.fn(),
   },
   openNotebookUpstreamDiff: vi.fn(),
   treeEdit: vi.fn(),
+  treeProps: null as any,
   workspaceItems: [] as string[],
 }))
 
 vi.mock('react-arborist', async () => {
   const React = await vi.importActual<typeof import('react')>('react')
-  const Tree = React.forwardRef(({ data, children, onToggle }: any, ref) => {
+  const Tree = React.forwardRef((props: any, ref) => {
+    const { data, children, onToggle } = props
+    mocks.treeProps = props
     React.useImperativeHandle(ref, () => ({
       get: (id: string) => ({
         data: { uri: id, type: 'folder' },
@@ -50,6 +54,7 @@ vi.mock('react-arborist', async () => {
           handleClick: vi.fn(),
           toggle: vi.fn(() => onToggle?.(item.id)),
           parent,
+          isAncestorOf: vi.fn(() => false),
           reset: vi.fn(),
         }
         return (
@@ -181,11 +186,14 @@ describe('WorkspaceExplorer current document handling', () => {
     })
     mocks.store.moveToTrash.mockReset()
     mocks.store.moveToTrash.mockResolvedValue(undefined)
+    mocks.store.move.mockReset()
+    mocks.store.move.mockResolvedValue(undefined)
     mocks.store.sync.mockReset()
     mocks.openNotebookUpstreamDiff.mockReset()
     mocks.openNotebookUpstreamDiff.mockResolvedValue(undefined)
     mocks.treeEdit.mockReset()
     mocks.treeEdit.mockResolvedValue(undefined)
+    mocks.treeProps = null
     vi.spyOn(window, 'prompt').mockReturnValue('Reports')
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
@@ -419,6 +427,92 @@ describe('WorkspaceExplorer current document handling', () => {
         'local://file/untitled'
       )
     })
+  })
+
+  it('moves a Drive-backed file into a Drive folder via the tree move handler', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/notebook', 'local://folder/reports'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/notebook') {
+        return {
+          uri,
+          name: 'notebook.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/file123/view',
+          parents: ['local://folder/drive'],
+        }
+      }
+      if (uri === 'local://folder/reports') {
+        return {
+          uri,
+          name: 'Reports',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/reports123',
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+    await screen.findByText('Drive Root')
+
+    const dragNode = {
+      data: {
+        id: 'local://file/notebook',
+        uri: 'local://file/notebook',
+        name: 'notebook.json',
+        type: NotebookStoreItemType.File,
+        remoteUri: 'https://drive.google.com/file/d/file123/view',
+        parentUri: 'local://folder/drive',
+      },
+      isAncestorOf: vi.fn(() => false),
+    }
+    const destinationNode = {
+      data: {
+        id: 'local://folder/reports',
+        uri: 'local://folder/reports',
+        name: 'Reports',
+        type: NotebookStoreItemType.Folder,
+        remoteUri: 'https://drive.google.com/drive/folders/reports123',
+        parentUri: 'local://folder/drive',
+      },
+    }
+
+    expect(mocks.treeProps.disableDrag(dragNode.data)).toBe(false)
+    expect(
+      mocks.treeProps.disableDrop({
+        parentNode: destinationNode,
+        dragNodes: [dragNode],
+        index: 0,
+      })
+    ).toBe(false)
+
+    await act(async () => {
+      await mocks.treeProps.onMove({
+        dragIds: ['local://file/notebook'],
+        dragNodes: [dragNode],
+        parentId: 'local://folder/reports',
+        parentNode: destinationNode,
+        index: 0,
+      })
+    })
+
+    expect(mocks.store.move).toHaveBeenCalledWith(
+      'local://file/notebook',
+      'local://folder/reports'
+    )
   })
 
   it('opens an upstream diff from a Drive-backed file context menu', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -124,6 +124,15 @@ function isVisibleDocumentFile(name: string): boolean {
   return isJsonNotebookFile(name) || isExcalidrawFileName(name)
 }
 
+function isMovableDriveNode(data: TreeNode): boolean {
+  return (
+    Boolean(data.remoteUri) &&
+    Boolean(data.parentUri) &&
+    (data.type === NotebookStoreItemType.File ||
+      data.type === NotebookStoreItemType.Folder)
+  )
+}
+
 function setChildrenForFolder(
   nodes: TreeNode[],
   folderUri: string,
@@ -1041,6 +1050,79 @@ function formatShortTimestamp(date: Date): string {
     [fetchChildren, fsStore, store],
   );
 
+  const handleMove = useCallback(
+    async ({
+      dragNodes,
+      parentNode,
+    }: {
+      dragNodes: NodeApi<TreeNode>[];
+      parentNode: NodeApi<TreeNode> | null;
+    }) => {
+      if (
+        !store ||
+        !parentNode ||
+        parentNode.data.type !== NotebookStoreItemType.Folder ||
+        !parentNode.data.remoteUri
+      ) {
+        return;
+      }
+
+      const destinationUri = parentNode.data.uri;
+      const movableNodes = dragNodes.filter(
+        (node) =>
+          isMovableDriveNode(node.data) &&
+          node.data.parentUri !== destinationUri,
+      );
+      if (movableNodes.length === 0) {
+        return;
+      }
+
+      const refreshUris = new Set<string>([destinationUri]);
+      for (const node of movableNodes) {
+        if (node.data.parentUri) {
+          refreshUris.add(node.data.parentUri);
+        }
+      }
+
+      try {
+        for (const node of movableNodes) {
+          await store.move(node.data.uri, destinationUri);
+        }
+        treeRef.current?.open(destinationUri);
+        setErrorMessage(null);
+        showToast({
+          message:
+            movableNodes.length === 1
+              ? `Moved "${movableNodes[0].data.name}" to "${parentNode.data.name}"`
+              : `Moved ${movableNodes.length} items to "${parentNode.data.name}"`,
+          tone: "success",
+        });
+      } catch (error) {
+        appLogger.error("Failed to move Drive item", {
+          attrs: {
+            scope: "storage.drive.move",
+            code: "DRIVE_ITEM_MOVE_FAILED",
+            destinationUri,
+            itemUris: movableNodes.map((node) => node.data.uri),
+            error: String(error),
+          },
+        });
+        setErrorMessage(
+          "Unable to move Google Drive item. Check your Drive access and try again.",
+        );
+        showToast({
+          message: "Could not move Google Drive item",
+          tone: "error",
+        });
+      } finally {
+        await Promise.all(
+          [...refreshUris].map((folderUri) => fetchChildren(folderUri)),
+        );
+      }
+    },
+    [fetchChildren, store],
+  );
+
   const handleOpenLocalFolder = useCallback(async () => {
     if (!fsStore) {
       return;
@@ -1265,6 +1347,25 @@ function formatShortTimestamp(date: Date): string {
                 Boolean(data.remoteUri)
               )
             }
+            disableDrag={(data) => !isMovableDriveNode(data)}
+            disableDrop={({ parentNode, dragNodes }) => {
+              if (
+                parentNode.data.type !== NotebookStoreItemType.Folder ||
+                !parentNode.data.remoteUri ||
+                dragNodes.some(
+                  (node) =>
+                    !isMovableDriveNode(node.data) ||
+                    node.data.uri === parentNode.data.uri ||
+                    node.isAncestorOf(parentNode),
+                )
+              ) {
+                return true;
+              }
+              return dragNodes.every(
+                (node) => node.data.parentUri === parentNode.data.uri,
+              );
+            }}
+            onMove={handleMove}
             onRename={handleRename}
           />
         </div>

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -427,6 +427,51 @@ describe("DriveNotebookStore", () => {
     });
   });
 
+  it("moves Drive items between folders through the parent update API", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/file123");
+        expect(url.searchParams.get("addParents")).toBe("destination123");
+        expect(url.searchParams.get("removeParents")).toBe("source123");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.method).toBe("PATCH");
+        expect(init?.body).toBeUndefined();
+        return new Response(
+          JSON.stringify({
+            id: "file123",
+            name: "notebook.json",
+            mimeType: "application/json",
+            parents: ["destination123"],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.move(
+      "https://drive.google.com/file/d/file123/view",
+      "https://drive.google.com/drive/folders/source123",
+      "https://drive.google.com/drive/folders/destination123",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      uri: "https://drive.google.com/file/d/file123/view",
+      name: "notebook.json",
+      type: NotebookStoreItemType.File,
+      children: [],
+      remoteUri: "https://drive.google.com/file/d/file123/view",
+      mimeType: "application/json",
+      parents: ["https://drive.google.com/drive/folders/destination123"],
+    });
+  });
+
   it("moves Drive files to trash through the metadata update API", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -111,6 +111,11 @@ type DriveRevisionListResponse = {
 interface DriveFilesClient {
   create(doc: DriveDoc): Promise<DriveDoc>
   update(doc: DriveDoc): Promise<DriveDoc>
+  move(
+    fileId: string,
+    sourceParentId: string,
+    destinationParentId: string
+  ): Promise<DriveDoc>
   get(
     request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }>
@@ -355,6 +360,21 @@ class GapiDriveFilesClient implements DriveFilesClient {
     }
 
     return file
+  }
+
+  async move(
+    fileId: string,
+    sourceParentId: string,
+    destinationParentId: string
+  ): Promise<DriveDoc> {
+    const response = (await this.files.update({
+      fileId,
+      addParents: destinationParentId,
+      removeParents: sourceParentId,
+      supportsAllDrives: true,
+      fields: 'id,name,mimeType,parents',
+    } as Record<string, unknown>)) as DriveUpdateResponse
+    return response.result ?? { id: fileId }
   }
 
   get(
@@ -618,6 +638,26 @@ class FetchDriveFilesClient implements DriveFilesClient {
     }
 
     return file.id ? file : { ...doc }
+  }
+
+  async move(
+    fileId: string,
+    sourceParentId: string,
+    destinationParentId: string
+  ): Promise<DriveDoc> {
+    const response = await this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(fileId)}`,
+      {
+        params: {
+          addParents: destinationParentId,
+          removeParents: sourceParentId,
+          supportsAllDrives: 'true',
+          fields: 'id,name,mimeType,parents',
+        },
+      }
+    )
+    return (response.result ?? { id: fileId }) as DriveDoc
   }
 
   get(
@@ -1566,6 +1606,54 @@ export class DriveNotebookStore {
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       mimeType,
       parents: [],
+    }
+  }
+
+  async move(
+    uri: string,
+    sourceParentUri: string,
+    destinationParentUri: string
+  ): Promise<NotebookStoreItem> {
+    const item = parseDriveItem(uri)
+    const sourceParent = parseDriveItem(sourceParentUri)
+    const destinationParent = parseDriveItem(destinationParentUri)
+    if (
+      item.type !== NotebookStoreItemType.File &&
+      item.type !== NotebookStoreItemType.Folder
+    ) {
+      throw new Error('DriveNotebookStore.move expects a file or folder URI')
+    }
+    if (
+      sourceParent.type !== NotebookStoreItemType.Folder ||
+      destinationParent.type !== NotebookStoreItemType.Folder
+    ) {
+      throw new Error('DriveNotebookStore.move expects folder parent URIs')
+    }
+    if (sourceParent.id === destinationParent.id) {
+      throw new Error('DriveNotebookStore.move expects a new destination folder')
+    }
+
+    const client = await this.getFilesClient()
+    const file = await client.move(
+      item.id,
+      sourceParent.id,
+      destinationParent.id
+    )
+    const fileId = file.id ?? item.id
+    const isFolder =
+      file.mimeType === DRIVE_FOLDER_MIME_TYPE ||
+      item.type === NotebookStoreItemType.Folder
+    const itemUri = isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId)
+    return {
+      uri: itemUri,
+      name: file.name ?? uri,
+      type: isFolder
+        ? NotebookStoreItemType.Folder
+        : NotebookStoreItemType.File,
+      children: [],
+      remoteUri: itemUri,
+      mimeType: file.mimeType,
+      parents: [destinationParentUri],
     }
   }
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -163,6 +163,116 @@ describe('LocalNotebooks pending Drive create', () => {
     ).toContain(item.uri)
   })
 
+  it('moves a Drive-backed folder and updates the local folder tree', async () => {
+    const sourceRemoteUri =
+      'https://drive.google.com/drive/folders/source123'
+    const destinationRemoteUri =
+      'https://drive.google.com/drive/folders/destination123'
+    const itemRemoteUri = 'https://drive.google.com/drive/folders/item123'
+    const driveStore = {
+      move: vi.fn(async () => ({
+        uri: itemRemoteUri,
+        name: 'Reports',
+        type: NotebookStoreItemType.Folder,
+        children: [],
+        remoteUri: itemRemoteUri,
+        parents: [destinationRemoteUri],
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/source',
+      name: 'Source',
+      remoteId: sourceRemoteUri,
+      children: ['local://folder/item'],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/destination',
+      name: 'Destination',
+      remoteId: destinationRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/item',
+      name: 'Reports',
+      remoteId: itemRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+
+    const item = await store.move(
+      'local://folder/item',
+      'local://folder/destination'
+    )
+
+    expect(driveStore.move).toHaveBeenCalledWith(
+      itemRemoteUri,
+      sourceRemoteUri,
+      destinationRemoteUri
+    )
+    expect(
+      (await store.folders.get('local://folder/source'))?.children
+    ).toEqual([])
+    expect(
+      (await store.folders.get('local://folder/destination'))?.children
+    ).toEqual(['local://folder/item'])
+    expect(item).toMatchObject({
+      uri: 'local://folder/item',
+      type: NotebookStoreItemType.Folder,
+      parents: ['local://folder/destination'],
+    })
+  })
+
+  it('preserves the local folder tree when a Drive move fails', async () => {
+    const sourceRemoteUri =
+      'https://drive.google.com/drive/folders/source123'
+    const destinationRemoteUri =
+      'https://drive.google.com/drive/folders/destination123'
+    const itemRemoteUri = 'https://drive.google.com/file/d/item123/view'
+    const driveStore = {
+      move: vi.fn(async () => {
+        throw new Error('Google Drive authorization is required.')
+      }),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/source',
+      name: 'Source',
+      remoteId: sourceRemoteUri,
+      children: ['local://file/item'],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/destination',
+      name: 'Destination',
+      remoteId: destinationRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: 'local://file/item',
+      name: 'notebook.json',
+      remoteId: itemRemoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await expect(
+      store.move('local://file/item', 'local://folder/destination')
+    ).rejects.toThrow('Google Drive authorization is required.')
+
+    expect(
+      (await store.folders.get('local://folder/source'))?.children
+    ).toEqual(['local://file/item'])
+    expect(
+      (await store.folders.get('local://folder/destination'))?.children
+    ).toEqual([])
+  })
+
   it('persists pending upstream parent when Drive create fails', async () => {
     const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
     const driveStore = {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1362,6 +1362,85 @@ export class LocalNotebooks extends Dexie {
     }
   }
 
+  async move(
+    uri: string,
+    destinationFolderUri: string
+  ): Promise<NotebookStoreItem> {
+    const sourceParent = await this.findParentFolder(uri)
+    const destinationFolder = await this.folders.get(destinationFolderUri)
+    if (!sourceParent) {
+      throw new Error(`Local parent folder not found for ${uri}`)
+    }
+    if (!destinationFolder) {
+      throw new Error(
+        `Local destination folder not found for ${destinationFolderUri}`
+      )
+    }
+    if (
+      !isDriveUri(sourceParent.remoteId) ||
+      !isDriveUri(destinationFolder.remoteId)
+    ) {
+      throw new Error('LocalNotebooks.move only supports Drive-backed folders')
+    }
+    if (sourceParent.id === destinationFolder.id) {
+      throw new Error('LocalNotebooks.move expects a new destination folder')
+    }
+
+    const file = uri.startsWith('local://file/')
+      ? await this.files.get(uri)
+      : null
+    const folder = uri.startsWith('local://folder/')
+      ? await this.folders.get(uri)
+      : null
+    const item = file ?? folder
+    if (!item) {
+      throw new Error(`Local Drive-backed item not found for ${uri}`)
+    }
+    if (!isDriveUri(item.remoteId)) {
+      throw new Error('LocalNotebooks.move expects a Drive-backed item')
+    }
+    if (folder) {
+      let ancestor: LocalFolderRecord | null = destinationFolder
+      while (ancestor) {
+        if (ancestor.id === folder.id) {
+          throw new Error(
+            'LocalNotebooks.move cannot move a folder into itself or a descendant'
+          )
+        }
+        ancestor = await this.findParentFolder(ancestor.id)
+      }
+    }
+
+    await this.driveStore.move(
+      item.remoteId,
+      sourceParent.remoteId,
+      destinationFolder.remoteId
+    )
+
+    await this.folders.update(sourceParent.id, {
+      children: sourceParent.children.filter((childUri) => childUri !== uri),
+      lastSynced: nowIsoString(),
+    })
+    if (!destinationFolder.children.includes(uri)) {
+      await this.folders.update(destinationFolder.id, {
+        children: [...destinationFolder.children, uri],
+        lastSynced: nowIsoString(),
+      })
+    }
+
+    return {
+      uri,
+      name: item.name,
+      type: file
+        ? NotebookStoreItemType.File
+        : NotebookStoreItemType.Folder,
+      children: folder ? [...folder.children] : [],
+      remoteUri: item.remoteId,
+      mimeType: file?.mimeType,
+      parents: [destinationFolderUri],
+    }
+  }
+
   async moveToTrash(uri: string): Promise<void> {
     if (!uri.startsWith('local://file/')) {
       throw new Error('LocalNotebooks.moveToTrash expects a file URI')


### PR DESCRIPTION
## Summary

- add Google Drive `files.update` support for moving files and folders between parents
- keep the IndexedDB mirror consistent only after the synchronous Drive move succeeds
- enable drag-and-drop only for Drive-backed explorer descendants and block invalid/self/descendant drops
- refresh affected folders and surface success or authorization/error feedback

## User impact

Users with a valid Google Drive access token can drag Drive-backed files and folders onto another Drive-backed folder in Explorer. Local notebooks, filesystem entries, pending Drive uploads, and mounted roots remain non-draggable. Offline or unauthorized moves fail without changing the local tree.

## Validation

- `pnpm -C app exec vitest run src/storage/drive.test.ts src/storage/local.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx` (56 tests)
- `runme run build test`
- `git diff --check`

## Design

No separate design document is needed: the change is localized to the existing Drive client, local mirror, and explorer tree hooks, with the remote-first consistency invariant covered by tests.
