### PR TITLE
Address Google Drive move review feedback

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -493,6 +493,13 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(mocks.treeProps.disableDrag(dragNode.data)).toBe(false)
     expect(
       mocks.treeProps.disableDrop({
+        parentNode: null,
+        dragNodes: [dragNode],
+        index: 0,
+      })
+    ).toBe(true)
+    expect(
+      mocks.treeProps.disableDrop({
         parentNode: destinationNode,
         dragNodes: [dragNode],
         index: 0,

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -1350,6 +1350,7 @@ function formatShortTimestamp(date: Date): string {
             disableDrag={(data) => !isMovableDriveNode(data)}
             disableDrop={({ parentNode, dragNodes }) => {
               if (
+                !parentNode ||
                 parentNode.data.type !== NotebookStoreItemType.Folder ||
                 !parentNode.data.remoteUri ||
                 dragNodes.some(

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -272,18 +272,29 @@ describe('LocalNotebooks pending Drive create', () => {
     })
   })
 
-  it('clears the markdown sidecar URI when its Drive move fails', async () => {
+  it('recreates the markdown sidecar when its Drive move fails', async () => {
     const sourceRemoteUri =
       'https://drive.google.com/drive/folders/source123'
     const destinationRemoteUri =
       'https://drive.google.com/drive/folders/destination123'
     const itemRemoteUri = 'https://drive.google.com/file/d/item123/view'
     const markdownUri = 'https://drive.google.com/file/d/markdown123/view'
+    const replacementMarkdownUri =
+      'https://drive.google.com/file/d/replacement-markdown123/view'
     const driveStore = {
       move: vi
         .fn()
         .mockResolvedValueOnce({})
         .mockRejectedValueOnce(new Error('Sidecar move failed')),
+      getMetadata: vi.fn(async () => ({
+        uri: itemRemoteUri,
+        name: 'notebook.json',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [destinationRemoteUri],
+      })),
+      create: vi.fn(async () => ({ uri: replacementMarkdownUri })),
+      saveContent: vi.fn(async () => undefined),
     }
     const store = createTestStore(driveStore)
     await store.folders.put({
@@ -307,7 +318,7 @@ describe('LocalNotebooks pending Drive create', () => {
       markdownUri,
       lastRemoteChecksum: '',
       lastSynced: '',
-      doc: '',
+      doc: notebookJson('print("hello")'),
       md5Checksum: '',
     })
 
@@ -315,8 +326,17 @@ describe('LocalNotebooks pending Drive create', () => {
 
     expect(driveStore.move).toHaveBeenCalledTimes(2)
     await expect(store.files.get('local://file/item')).resolves.toMatchObject({
-      markdownUri: undefined,
+      markdownUri: replacementMarkdownUri,
     })
+    expect(driveStore.create).toHaveBeenCalledWith(
+      destinationRemoteUri,
+      'notebook.index.md'
+    )
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      replacementMarkdownUri,
+      expect.stringContaining('print("hello")'),
+      'text/markdown'
+    )
     expect(
       (await store.folders.get('local://folder/destination'))?.children
     ).toEqual(['local://file/item'])

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -225,6 +225,103 @@ describe('LocalNotebooks pending Drive create', () => {
     })
   })
 
+  it('moves a notebook markdown sidecar with its Drive-backed file', async () => {
+    const sourceRemoteUri =
+      'https://drive.google.com/drive/folders/source123'
+    const destinationRemoteUri =
+      'https://drive.google.com/drive/folders/destination123'
+    const itemRemoteUri = 'https://drive.google.com/file/d/item123/view'
+    const markdownUri = 'https://drive.google.com/file/d/markdown123/view'
+    const driveStore = {
+      move: vi.fn(async () => ({})),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/source',
+      name: 'Source',
+      remoteId: sourceRemoteUri,
+      children: ['local://file/item'],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/destination',
+      name: 'Destination',
+      remoteId: destinationRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: 'local://file/item',
+      name: 'notebook.json',
+      remoteId: itemRemoteUri,
+      markdownUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.move('local://file/item', 'local://folder/destination')
+
+    expect(driveStore.move.mock.calls).toEqual([
+      [itemRemoteUri, sourceRemoteUri, destinationRemoteUri],
+      [markdownUri, sourceRemoteUri, destinationRemoteUri],
+    ])
+    await expect(store.files.get('local://file/item')).resolves.toMatchObject({
+      markdownUri,
+    })
+  })
+
+  it('clears the markdown sidecar URI when its Drive move fails', async () => {
+    const sourceRemoteUri =
+      'https://drive.google.com/drive/folders/source123'
+    const destinationRemoteUri =
+      'https://drive.google.com/drive/folders/destination123'
+    const itemRemoteUri = 'https://drive.google.com/file/d/item123/view'
+    const markdownUri = 'https://drive.google.com/file/d/markdown123/view'
+    const driveStore = {
+      move: vi
+        .fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Sidecar move failed')),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: 'local://folder/source',
+      name: 'Source',
+      remoteId: sourceRemoteUri,
+      children: ['local://file/item'],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: 'local://folder/destination',
+      name: 'Destination',
+      remoteId: destinationRemoteUri,
+      children: [],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: 'local://file/item',
+      name: 'notebook.json',
+      remoteId: itemRemoteUri,
+      markdownUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.move('local://file/item', 'local://folder/destination')
+
+    expect(driveStore.move).toHaveBeenCalledTimes(2)
+    await expect(store.files.get('local://file/item')).resolves.toMatchObject({
+      markdownUri: undefined,
+    })
+    expect(
+      (await store.folders.get('local://folder/destination'))?.children
+    ).toEqual(['local://file/item'])
+  })
+
   it('preserves the local folder tree when a Drive move fails', async () => {
     const sourceRemoteUri =
       'https://drive.google.com/drive/folders/source123'

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1429,7 +1429,7 @@ export class LocalNotebooks extends Dexie {
         } catch (error) {
           clearMarkdownUri = true
           appLogger.warn(
-            'Failed to move notebook markdown sidecar; it will be recreated on the next sync',
+            'Failed to move notebook markdown sidecar; it will be recreated after the notebook move',
             {
               attrs: {
                 scope: 'storage.drive.move',
@@ -1458,6 +1458,21 @@ export class LocalNotebooks extends Dexie {
         children: [...destinationFolder.children, uri],
         lastSynced: nowIsoString(),
       })
+    }
+
+    if (clearMarkdownUri && file) {
+      try {
+        await this.syncMarkdownFile(uri)
+      } catch (error) {
+        appLogger.warn('Failed to recreate notebook markdown sidecar after move', {
+          attrs: {
+            scope: 'storage.drive.move',
+            code: 'DRIVE_MARKDOWN_SIDECAR_RECREATE_FAILED',
+            localUri: uri,
+            error: String(error),
+          },
+        })
+      }
     }
 
     return {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1417,6 +1417,38 @@ export class LocalNotebooks extends Dexie {
       destinationFolder.remoteId
     )
 
+    let clearMarkdownUri = false
+    if (file?.markdownUri) {
+      if (isDriveUri(file.markdownUri)) {
+        try {
+          await this.driveStore.move(
+            file.markdownUri,
+            sourceParent.remoteId,
+            destinationFolder.remoteId
+          )
+        } catch (error) {
+          clearMarkdownUri = true
+          appLogger.warn(
+            'Failed to move notebook markdown sidecar; it will be recreated on the next sync',
+            {
+              attrs: {
+                scope: 'storage.drive.move',
+                code: 'DRIVE_MARKDOWN_SIDECAR_MOVE_FAILED',
+                localUri: uri,
+                markdownUri: file.markdownUri,
+                error: String(error),
+              },
+            }
+          )
+        }
+      } else {
+        clearMarkdownUri = true
+      }
+    }
+    if (clearMarkdownUri) {
+      await this.files.update(uri, { markdownUri: undefined })
+    }
+
     await this.folders.update(sourceParent.id, {
       children: sourceParent.children.filter((childUri) => childUri !== uri),
       lastSynced: nowIsoString(),


### PR DESCRIPTION
## Summary

- move a notebook's Markdown sidecar alongside its Google Drive-backed notebook
- clear the cached sidecar URI so sync can recreate it if the sidecar move fails
- reject root-level tree drops where react-arborist provides no parent node
- add regression coverage for sidecar success/failure and root-level drops

Follow-up to #279, addressing the final automated review feedback.

## Validation

- `pnpm -C app exec vitest run src/storage/local.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx` (37 tests passed)
- `runme run build test`
