### PR TITLE
Paginate Google Drive folder listings

### DIFF
--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -173,6 +173,67 @@ describe("DriveNotebookStore", () => {
     });
   });
 
+  it("paginates Drive folder listings beyond the first page", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const firstPageFiles = Array.from({ length: 100 }, (_, index) => ({
+      id: `dated-${index}`,
+      name: `20260715_notebook_${index}.json`,
+      mimeType: "application/json",
+    }));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files");
+        expect(url.searchParams.get("q")).toBe(
+          "'folder123' in parents and trashed = false",
+        );
+        expect(url.searchParams.get("includeItemsFromAllDrives")).toBe("true");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(url.searchParams.get("orderBy")).toBe("name");
+        expect(url.searchParams.get("pageSize")).toBe("1000");
+        expect(url.searchParams.get("fields")).toBe(
+          "nextPageToken,files(id,name,mimeType)",
+        );
+
+        const pageToken = url.searchParams.get("pageToken");
+        const body = pageToken
+          ? {
+              files: [
+                {
+                  id: "oncall-guide",
+                  name: "oncall_guide.json",
+                  mimeType: "application/json",
+                },
+              ],
+            }
+          : { files: firstPageFiles, nextPageToken: "page-2" };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.list(
+      "https://drive.google.com/drive/folders/folder123",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      new URL(String(fetchMock.mock.calls[0][0])).searchParams.get("pageToken"),
+    ).toBeNull();
+    expect(
+      new URL(String(fetchMock.mock.calls[1][0])).searchParams.get("pageToken"),
+    ).toBe("page-2");
+    expect(result).toHaveLength(101);
+    expect(result.at(-1)).toMatchObject({
+      uri: "https://drive.google.com/file/d/oncall-guide/view",
+      name: "oncall_guide.json",
+      type: NotebookStoreItemType.File,
+    });
+  });
+
   it("creates arbitrary Drive content with the provided MIME type", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1334,19 +1334,28 @@ export class DriveNotebookStore {
         'Google Drive URI must reference a folder to list contents'
       )
     }
-    const response = await this.search({
-      q: `'${id}' in parents and trashed = false`,
-      includeItemsFromAllDrives: true,
-      supportsAllDrives: true,
-      orderBy: 'name',
-      fields: 'files(id,name,mimeType)',
-    })
+    const files: DriveSearchFile[] = []
+    let pageToken: string | undefined
 
-    const files = response.files.filter(
+    do {
+      const response = await this.search({
+        q: `'${id}' in parents and trashed = false`,
+        includeItemsFromAllDrives: true,
+        supportsAllDrives: true,
+        orderBy: 'name',
+        pageSize: 1000,
+        pageToken,
+        fields: 'nextPageToken,files(id,name,mimeType)',
+      })
+      files.push(...response.files)
+      pageToken = response.nextPageToken
+    } while (pageToken)
+
+    const validFiles = files.filter(
       (file): file is DriveSearchFile & { id: string } => Boolean(file?.id)
     )
 
-    return files.map((file) => {
+    return validFiles.map((file) => {
       const isFolder = file.mimeType === DRIVE_FOLDER_MIME_TYPE
       return {
         uri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),


### PR DESCRIPTION
## Summary

- fetch every page when listing a Google Drive folder in Explorer
- request the maximum supported page size while continuing through nextPageToken
- add regression coverage for non-date notebooks returned after a 100-item first page

## Root cause

Explorer ordered Drive children by name but consumed only the first files.list page. Hidden Markdown sidecars still counted toward the 100-item default page, so the ft-oncall folder showed only date-prefixed JSON files while non-date notebooks remained on page two.

## Validation

- pnpm -C app exec vitest run src/storage/drive.test.ts (22 tests)
- pnpm -C app exec vitest run --silent (72 files, 652 tests)
- runme run build test
- development server opened at http://localhost:5173 in the in-app browser; app loaded without errors (localhost requires a separate Google login for live Drive verification)
- git diff --check