### PR TITLE
Negotiate cell execution start and resume

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -663,6 +663,23 @@ export function Action({
   const [exitCode, setExitCode] = useState<number | null>(null)
 
   useEffect(() => {
+    const rawPid = cell?.metadata?.[RunmeMetadataKey.Pid]
+    const parsedPid =
+      typeof rawPid === 'string' ? Number.parseInt(rawPid, 10) : Number.NaN
+    setPid(Number.isNaN(parsedPid) ? null : parsedPid)
+
+    const rawExitCode = cell?.metadata?.[RunmeMetadataKey.ExitCode]
+    const parsedExitCode =
+      typeof rawExitCode === 'string'
+        ? Number.parseInt(rawExitCode, 10)
+        : Number.NaN
+    setExitCode(Number.isNaN(parsedExitCode) ? null : parsedExitCode)
+  }, [
+    cell?.metadata?.[RunmeMetadataKey.ExitCode],
+    cell?.metadata?.[RunmeMetadataKey.Pid],
+  ])
+
+  useEffect(() => {
     const fallbackUri = docUri.trim() || null
     if (!store || !docUri.startsWith('local://')) {
       setShareTarget({ docUri, targetUri: fallbackUri })

--- a/app/src/contexts/CellContext.tsx
+++ b/app/src/contexts/CellContext.tsx
@@ -3,6 +3,7 @@ import { create } from "@bufbuild/protobuf";
 import {
   AgentMetadataKey,
   MimeType,
+  RunmeExecutionState,
   RunmeMetadataKey,
   parser_pb,
 } from "../runme/client";
@@ -62,4 +63,11 @@ const TypingCell = create(parser_pb.CellSchema, {
 });
 
 // eslint-disable-next-line react-refresh/only-export-components
-export { parser_pb, TypingCell, MimeType, RunmeMetadataKey, AgentMetadataKey };
+export {
+  parser_pb,
+  TypingCell,
+  MimeType,
+  RunmeMetadataKey,
+  RunmeExecutionState,
+  AgentMetadataKey,
+};

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -1,4 +1,5 @@
 import { create } from "@bufbuild/protobuf";
+import { Code } from "@buf/googleapis_googleapis.bufbuild_es/google/rpc/code_pb";
 import type { StreamsLike } from "@runmedev/renderers";
 import { Subject } from "rxjs";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -338,7 +339,7 @@ type FakeStreams = StreamsLike & {
   exitCode$: Subject<number>;
   pid$: Subject<number>;
   mimeType$: Subject<string>;
-  errors$: Subject<Error>;
+  errors$: Subject<Error | { code: Code; message: string }>;
 };
 
 function makeFakeStreams(): FakeStreams {
@@ -347,7 +348,7 @@ function makeFakeStreams(): FakeStreams {
   const exitCode$ = new Subject<number>();
   const pid$ = new Subject<number>();
   const mimeType$ = new Subject<string>();
-  const errors$ = new Subject<Error>();
+  const errors$ = new Subject<Error | { code: Code; message: string }>();
 
   return {
     stdout: stdout$,
@@ -477,7 +478,7 @@ describe("bindStreamsToCell", () => {
     );
   });
 
-  it("marks the outcome unknown when monitoring fails after a pid", () => {
+  it("keeps the outcome running after a non-authoritative monitoring error", () => {
     const refId = "cell-monitor-failed";
     const cell = create(parser_pb.CellSchema, {
       refId,
@@ -500,7 +501,39 @@ describe("bindStreamsToCell", () => {
     });
 
     fake.pid$.next(123);
-    fake.errors$.next(new Error("run is no longer available"));
+    fake.errors$.next(new Error("runner is temporarily unreachable"));
+
+    expect(current.metadata?.[RunmeMetadataKey.Pid]).toBe("123");
+    expect(current.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
+    expect(current.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Running,
+    );
+  });
+
+  it("marks the outcome unknown when the runner no longer has the run", () => {
+    const refId = "cell-run-not-found";
+    const cell = create(parser_pb.CellSchema, {
+      refId,
+      kind: parser_pb.CellKind.CODE,
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "run-not-found",
+      },
+    });
+
+    let current = cell;
+    const fake = makeFakeStreams();
+    bindStreamsToCell({
+      refId,
+      streams: fake,
+      getCell: () => current,
+      updateCell: (next) => {
+        current = next;
+      },
+    });
+
+    fake.pid$.next(123);
+    fake.errors$.next({ code: Code.NOT_FOUND, message: "run not found" });
 
     expect(current.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
     expect(current.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
@@ -765,13 +798,16 @@ describe("NotebookData.runCodeCell", () => {
     const stream = model.getActiveStream(cell.refId) as
       | (StreamsLike & {
           pid: Subject<number>;
-          errors: Subject<Error>;
+          errors: Subject<Error | { code: Code; message: string }>;
         })
       | undefined;
     expect(stream).toBeTruthy();
 
     stream!.pid.next(123);
-    stream!.errors.next(new Error("execution record expired"));
+    stream!.errors.next({
+      code: Code.NOT_FOUND,
+      message: "execution record expired",
+    });
     await run;
 
     const updated = model.getCellSnapshot(cell.refId);

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -59,6 +59,10 @@ vi.mock("@runmedev/renderers", () => {
   return {
     Streams: FakeStreams,
     Heartbeat: { INITIAL: "INITIAL" },
+    RunIntent: {
+      START: "RUN_INTENT_START",
+      RESUME: "RUN_INTENT_RESUME",
+    },
     genRunID: () => "run-generated",
     ClientMessages: {},
     setContext: vi.fn(),
@@ -513,7 +517,7 @@ describe("bindStreamsToCell", () => {
 });
 
 describe("NotebookData.getActiveStream", () => {
-  it("does not treat a persisted pid as proof of a live run", () => {
+  it("negotiates resume for persisted running metadata", () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-recover",
       kind: parser_pb.CellKind.CODE,
@@ -533,19 +537,23 @@ describe("NotebookData.getActiveStream", () => {
       loaded: true,
     });
 
-    expect(model.getActiveStream(cell.refId)).toBeUndefined();
-    const reconciled = model.getCellSnapshot(cell.refId);
-    expect(reconciled?.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
-    expect(reconciled?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
-    expect(reconciled?.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+    const stream = model.getActiveStream(cell.refId) as unknown as {
+      runID: string;
+      sequence: number;
+      options: { initialIntent: string };
+    };
+    expect(stream).toBeDefined();
+    expect(stream.runID).toBe("existing-run");
+    expect(stream.sequence).toBe(7);
+    expect(stream.options.initialIntent).toBe("RUN_INTENT_RESUME");
+    expect(model.getActiveStream(cell.refId)).toBe(stream);
+
+    const current = model.getCellSnapshot(cell.refId);
+    expect(current?.metadata?.[RunmeMetadataKey.Pid]).toBe("1234");
+    expect(current?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
+    expect(current?.metadata?.[RunmeMetadataKey.ExecutionState]).not.toBe(
       RunmeExecutionState.Unknown,
     );
-    const stderr = reconciled?.outputs
-      .flatMap((output) => output.items)
-      .find((item) => item.mime === MimeType.VSCodeNotebookStdErr);
-    expect(
-      new TextDecoder().decode(stderr?.data ?? new Uint8Array()),
-    ).toContain("process may still be running");
   });
 
   it("does not recover when exit code metadata is present", () => {

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -3,7 +3,12 @@ import type { StreamsLike } from "@runmedev/renderers";
 import { Subject } from "rxjs";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { MimeType, RunmeMetadataKey, parser_pb } from "../contexts/CellContext";
+import {
+  MimeType,
+  RunmeExecutionState,
+  RunmeMetadataKey,
+  parser_pb,
+} from "../contexts/CellContext";
 import { LOCAL_FOLDER_URI } from "../storage/local";
 import { appLogger } from "./logging/runtime";
 import { appState } from "./runtime/AppState";
@@ -463,11 +468,52 @@ describe("bindStreamsToCell", () => {
 
     expect(current.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
     expect(current.metadata?.[RunmeMetadataKey.ExitCode]).toBe("0");
+    expect(current.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Completed,
+    );
+  });
+
+  it("marks the outcome unknown when monitoring fails after a pid", () => {
+    const refId = "cell-monitor-failed";
+    const cell = create(parser_pb.CellSchema, {
+      refId,
+      kind: parser_pb.CellKind.CODE,
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "run-monitor-failed",
+      },
+    });
+
+    let current = cell;
+    const fake = makeFakeStreams();
+    bindStreamsToCell({
+      refId,
+      streams: fake,
+      getCell: () => current,
+      updateCell: (next) => {
+        current = next;
+      },
+    });
+
+    fake.pid$.next(123);
+    fake.errors$.next(new Error("run is no longer available"));
+
+    expect(current.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
+    expect(current.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
+    expect(current.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Unknown,
+    );
+    const stderr = current.outputs
+      .flatMap((output) => output.items)
+      .find((item) => item.mime === MimeType.VSCodeNotebookStdErr);
+    expect(
+      new TextDecoder().decode(stderr?.data ?? new Uint8Array()),
+    ).toContain("Execution monitoring was interrupted");
   });
 });
 
 describe("NotebookData.getActiveStream", () => {
-  it("recovers stream when metadata indicates an active run", () => {
+  it("does not treat a persisted pid as proof of a live run", () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-recover",
       kind: parser_pb.CellKind.CODE,
@@ -487,40 +533,19 @@ describe("NotebookData.getActiveStream", () => {
       loaded: true,
     });
 
-    const stream = model.getActiveStream(cell.refId) as any;
-    expect(stream).toBeTruthy();
-    expect(stream.runID).toBe("existing-run");
-    expect(stream.sequence).toBe(7);
-  });
-
-  it("clears recovered streams after the run exits", () => {
-    const cell = create(parser_pb.CellSchema, {
-      refId: "cell-finished",
-      kind: parser_pb.CellKind.CODE,
-      outputs: [],
-      metadata: {
-        [RunmeMetadataKey.Pid]: "1234",
-        [RunmeMetadataKey.LastRunID]: "existing-run",
-        [RunmeMetadataKey.Sequence]: "7",
-      },
-    });
-    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
-    const model = new NotebookData({
-      notebook,
-      uri: "nb://test",
-      name: "test",
-      notebookStore: null,
-      loaded: true,
-    });
-
-    const stream = model.getActiveStream(cell.refId) as {
-      exitCode: Subject<number>;
-    };
-    expect(stream).toBeTruthy();
-
-    stream.exitCode.next(0);
-
     expect(model.getActiveStream(cell.refId)).toBeUndefined();
+    const reconciled = model.getCellSnapshot(cell.refId);
+    expect(reconciled?.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
+    expect(reconciled?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
+    expect(reconciled?.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Unknown,
+    );
+    const stderr = reconciled?.outputs
+      .flatMap((output) => output.items)
+      .find((item) => item.mime === MimeType.VSCodeNotebookStdErr);
+    expect(
+      new TextDecoder().decode(stderr?.data ?? new Uint8Array()),
+    ).toContain("process may still be running");
   });
 
   it("does not recover when exit code metadata is present", () => {
@@ -707,6 +732,46 @@ describe("NotebookData.runCodeCell", () => {
 
     const runID = model.runCodeCell(cell);
     expect(runID).toBe("");
+  });
+
+  it("resolves CellData.run when execution monitoring becomes unknown", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-monitor-interrupted",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "sleep 30",
+    });
+    const model = new NotebookData({
+      notebook: create(parser_pb.NotebookSchema, { cells: [cell] }),
+      uri: "nb://test",
+      name: "test",
+      notebookStore: null,
+      loaded: true,
+    });
+    const cellData = model.getCell(cell.refId);
+    expect(cellData).toBeTruthy();
+
+    const run = cellData!.run();
+    const stream = model.getActiveStream(cell.refId) as
+      | (StreamsLike & {
+          pid: Subject<number>;
+          errors: Subject<Error>;
+        })
+      | undefined;
+    expect(stream).toBeTruthy();
+
+    stream!.pid.next(123);
+    stream!.errors.next(new Error("execution record expired"));
+    await run;
+
+    const updated = model.getCellSnapshot(cell.refId);
+    expect(updated?.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
+    expect(updated?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined();
+    expect(updated?.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Unknown,
+    );
   });
 
   it("executes javascript locally with appkernel and records stdout + exit code", async () => {

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -7,7 +7,12 @@ import {
 } from '@runmedev/renderers'
 
 import { getBrowserAdapter } from '../browserAdapter.client'
-import { MimeType, RunmeMetadataKey, parser_pb } from '../contexts/CellContext'
+import {
+  MimeType,
+  RunmeExecutionState,
+  RunmeMetadataKey,
+  parser_pb,
+} from '../contexts/CellContext'
 import { isHtmlLanguageId } from './cellContent'
 import {
   IOPUB_INCOMPLETE_METADATA_KEY,
@@ -114,6 +119,11 @@ const JUPYTER_LIMITS = {
 
 const RUNNER_BACKEND_UNAVAILABLE_MESSAGE =
   'Runme backend server is not running. Please start it and try again.'
+
+const EXECUTION_MONITOR_INTERRUPTED_MESSAGE =
+  'Execution monitoring was interrupted before Runme received a final exit code. ' +
+  'The process may still be running, but this client cannot confirm its state. ' +
+  'Check the runner before re-running commands that are not idempotent.\n'
 
 function decodeBase64ToBytes(value: string): Uint8Array {
   try {
@@ -363,12 +373,16 @@ export const bindStreamsToCell: StreamBinder = ({
       const updated = getCell(refId)
       if (!updated || !updated.metadata) return
       updated.metadata[RunmeMetadataKey.Pid] = pid.toString()
+      updated.metadata[RunmeMetadataKey.ExecutionState] =
+        RunmeExecutionState.Running
       updateCell(updated, { transient: true })
     }),
     streams.exitCode.subscribe((code) => {
       const updated = getCell(refId)
       if (!updated || !updated.metadata) return
       updated.metadata[RunmeMetadataKey.ExitCode] = code.toString()
+      updated.metadata[RunmeMetadataKey.ExecutionState] =
+        RunmeExecutionState.Completed
       delete updated.metadata[RunmeMetadataKey.Pid]
       updateCell(updated)
       flushStdoutBuffer()
@@ -387,6 +401,20 @@ export const bindStreamsToCell: StreamBinder = ({
           error: String(err),
         },
       })
+      const updated = getCell(refId)
+      if (
+        updated?.metadata &&
+        typeof updated.metadata[RunmeMetadataKey.ExitCode] !== 'string'
+      ) {
+        delete updated.metadata[RunmeMetadataKey.Pid]
+        updated.metadata[RunmeMetadataKey.ExecutionState] =
+          RunmeExecutionState.Unknown
+        updated.outputs = [
+          ...updated.outputs,
+          ...createStdTextOutputs('', EXECUTION_MONITOR_INTERRUPTED_MESSAGE),
+        ]
+        updateCell(updated)
+      }
       flushStdoutBuffer()
       finalizeIopubStream()
       finish()
@@ -488,6 +516,8 @@ export class NotebookData {
     this.readOnly = readOnly
     this.sequence = this.computeHighestSequence()
     this.rebuildIndex()
+    const reconciledInterruptedExecutions =
+      this.reconcileInterruptedExecutions()
     this.snapshotCache = this.buildSnapshot()
     this.resolveNotebookForAppKernel =
       resolveNotebookForAppKernel ??
@@ -502,6 +532,52 @@ export class NotebookData {
       (() => {
         return [this]
       })
+    if (reconciledInterruptedExecutions && !this.readOnly) {
+      this.schedulePersist()
+    }
+  }
+
+  /**
+   * A persisted PID records that a process once started. It does not prove the
+   * process is still live after this browser model has been recreated. The
+   * current runner protocol cannot distinguish attaching to a live run from
+   * creating an empty multiplexer for an expired run ID, so claiming that such
+   * cells are still running would be unsafe.
+   */
+  private reconcileInterruptedExecutions(): boolean {
+    let changed = false
+    for (const cell of this.notebook.cells) {
+      const metadata = cell.metadata ?? {}
+      const hasPid =
+        typeof metadata[RunmeMetadataKey.Pid] === 'string' &&
+        metadata[RunmeMetadataKey.Pid].length > 0
+      const hasExitCode =
+        typeof metadata[RunmeMetadataKey.ExitCode] === 'string' &&
+        metadata[RunmeMetadataKey.ExitCode].length > 0
+      const monitoredHere =
+        this.activeStreams.has(cell.refId) ||
+        this.activeJupyterSockets.has(cell.refId) ||
+        this.activeAppKernelExecutions.has(cell.refId)
+
+      if (!hasPid || hasExitCode || monitoredHere) {
+        continue
+      }
+
+      delete metadata[RunmeMetadataKey.Pid]
+      if (
+        metadata[RunmeMetadataKey.ExecutionState] !==
+        RunmeExecutionState.Unknown
+      ) {
+        cell.outputs = [
+          ...cell.outputs,
+          ...createStdTextOutputs('', EXECUTION_MONITOR_INTERRUPTED_MESSAGE),
+        ]
+      }
+      metadata[RunmeMetadataKey.ExecutionState] = RunmeExecutionState.Unknown
+      cell.metadata = metadata
+      changed = true
+    }
+    return changed
   }
 
   private matchesNotebookTarget(target: unknown): boolean {
@@ -585,10 +661,12 @@ export class NotebookData {
     this.rebuildIndex()
     this.validateCells()
     this.sequence = this.computeHighestSequence()
+    const reconciledInterruptedExecutions =
+      this.reconcileInterruptedExecutions()
     this.loaded = true
     this.snapshotCache = this.buildSnapshot()
     this.emit()
-    if (persist && !this.readOnly) {
+    if ((persist || reconciledInterruptedExecutions) && !this.readOnly) {
       this.schedulePersist()
     }
   }
@@ -796,6 +874,8 @@ export class NotebookData {
       }
       cell.metadata ??= {}
       cell.metadata[RunmeMetadataKey.ExitCode] = '130'
+      cell.metadata[RunmeMetadataKey.ExecutionState] =
+        RunmeExecutionState.Completed
       delete cell.metadata[RunmeMetadataKey.Pid]
       cell.outputs = [...cell.outputs, ...createStdTextOutputs('', message)]
       const cellData = this.refToCellData.get(refId)
@@ -879,6 +959,7 @@ export class NotebookData {
     cell.metadata ??= {}
     delete cell.metadata[RunmeMetadataKey.ExitCode]
     delete cell.metadata[RunmeMetadataKey.Pid]
+    cell.metadata[RunmeMetadataKey.ExecutionState] = RunmeExecutionState.Running
     cell.metadata[RunmeMetadataKey.Sequence] = this.sequence.toString()
 
     // Clear outputs on each execution start for Jupyter/IPython; for other
@@ -985,42 +1066,7 @@ export class NotebookData {
       return existing
     }
 
-    // Check if the cell has metadata indicating an active run we can recover.
-    // If there is a PID and lastRunID is set but no exit code we interpret that
-    // as an active run.
-
-    const hasPid =
-      typeof metadata[RunmeMetadataKey.Pid] === 'string' &&
-      metadata[RunmeMetadataKey.Pid].length > 0
-    const runID =
-      typeof metadata[RunmeMetadataKey.LastRunID] === 'string'
-        ? metadata[RunmeMetadataKey.LastRunID]
-        : ''
-
-    if (!cell || !hasPid || hasExitCode || !runID) {
-      return undefined
-    }
-
-    const runner = this.getRunner(cell)
-    if (!runner || !runner.endpoint) {
-      console.warn('Cannot recover stream; no runner available', {
-        refId,
-      })
-      return undefined
-    }
-    console.log('Trying to resume streams for cell', { refId, runID })
-    const seqValue = metadata[RunmeMetadataKey.Sequence]
-    const parsedSeq =
-      typeof seqValue === 'string' ? Number.parseInt(seqValue, 10) : Number.NaN
-    const sequence = Number.isNaN(parsedSeq) ? this.sequence : parsedSeq
-
-    return this.createAndBindStreams({
-      cell,
-      runID,
-      sequence,
-      runner,
-      generation: this.executionGeneration,
-    })
+    return undefined
   }
 
   private createCell(
@@ -1196,6 +1242,8 @@ export class NotebookData {
 
         updated.metadata ??= {}
         updated.metadata[RunmeMetadataKey.ExitCode] = `${finalExitCode}`
+        updated.metadata[RunmeMetadataKey.ExecutionState] =
+          RunmeExecutionState.Completed
         delete updated.metadata[RunmeMetadataKey.Pid]
 
         // AppKernel runs are not terminal-stream based. Drop stale terminal MIME
@@ -1313,6 +1361,8 @@ export class NotebookData {
       if (updated) {
         updated.metadata ??= {}
         updated.metadata[RunmeMetadataKey.ExitCode] = '1'
+        updated.metadata[RunmeMetadataKey.ExecutionState] =
+          RunmeExecutionState.Completed
         delete updated.metadata[RunmeMetadataKey.Pid]
         updated.outputs = createStdTextOutputs(
           '',
@@ -1341,6 +1391,8 @@ export class NotebookData {
       if (updated) {
         updated.metadata ??= {}
         updated.metadata[RunmeMetadataKey.ExitCode] = '1'
+        updated.metadata[RunmeMetadataKey.ExecutionState] =
+          RunmeExecutionState.Completed
         delete updated.metadata[RunmeMetadataKey.Pid]
         updated.outputs = createStdTextOutputs(
           '',
@@ -1553,6 +1605,8 @@ export class NotebookData {
         if (currentRunID === runID) {
           updated.metadata ??= {}
           updated.metadata[RunmeMetadataKey.ExitCode] = `${code}`
+          updated.metadata[RunmeMetadataKey.ExecutionState] =
+            RunmeExecutionState.Completed
           delete updated.metadata[RunmeMetadataKey.Pid]
           this.updateCell(updated)
         }
@@ -2076,6 +2130,12 @@ export class CellData {
     }
     const activeRunID = snap.metadata?.[RunmeMetadataKey.LastRunID]
     const exitCode = snap.metadata?.[RunmeMetadataKey.ExitCode]
-    return activeRunID !== runID || typeof exitCode === 'string'
+    const executionState = snap.metadata?.[RunmeMetadataKey.ExecutionState]
+    return (
+      activeRunID !== runID ||
+      typeof exitCode === 'string' ||
+      executionState === RunmeExecutionState.Completed ||
+      executionState === RunmeExecutionState.Unknown
+    )
   }
 }

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -1,3 +1,4 @@
+import { Code } from '@buf/googleapis_googleapis.bufbuild_es/google/rpc/code_pb'
 import { clone, create } from '@bufbuild/protobuf'
 import {
   Heartbeat,
@@ -123,8 +124,17 @@ const RUNNER_BACKEND_UNAVAILABLE_MESSAGE =
 
 const EXECUTION_MONITOR_INTERRUPTED_MESSAGE =
   'Execution monitoring was interrupted before Runme received a final exit code. ' +
-  'The process may still be running, but this client cannot confirm its state. ' +
-  'Check the runner before re-running commands that are not idempotent.\n'
+  'The runner no longer has this execution. Its final exit code is unknown. ' +
+  'Check external effects before re-running commands that are not idempotent.\n'
+
+function isRunNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === Code.NOT_FOUND
+  )
+}
 
 function decodeBase64ToBytes(value: string): Uint8Array {
   try {
@@ -404,6 +414,7 @@ export const bindStreamsToCell: StreamBinder = ({
       })
       const updated = getCell(refId)
       if (
+        isRunNotFoundError(err) &&
         updated?.metadata &&
         typeof updated.metadata[RunmeMetadataKey.ExitCode] !== 'string'
       ) {

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -1,6 +1,7 @@
 import { clone, create } from '@bufbuild/protobuf'
 import {
   Heartbeat,
+  RunIntent,
   Streams,
   type StreamsLike,
   genRunID,
@@ -516,8 +517,6 @@ export class NotebookData {
     this.readOnly = readOnly
     this.sequence = this.computeHighestSequence()
     this.rebuildIndex()
-    const reconciledInterruptedExecutions =
-      this.reconcileInterruptedExecutions()
     this.snapshotCache = this.buildSnapshot()
     this.resolveNotebookForAppKernel =
       resolveNotebookForAppKernel ??
@@ -532,52 +531,6 @@ export class NotebookData {
       (() => {
         return [this]
       })
-    if (reconciledInterruptedExecutions && !this.readOnly) {
-      this.schedulePersist()
-    }
-  }
-
-  /**
-   * A persisted PID records that a process once started. It does not prove the
-   * process is still live after this browser model has been recreated. The
-   * current runner protocol cannot distinguish attaching to a live run from
-   * creating an empty multiplexer for an expired run ID, so claiming that such
-   * cells are still running would be unsafe.
-   */
-  private reconcileInterruptedExecutions(): boolean {
-    let changed = false
-    for (const cell of this.notebook.cells) {
-      const metadata = cell.metadata ?? {}
-      const hasPid =
-        typeof metadata[RunmeMetadataKey.Pid] === 'string' &&
-        metadata[RunmeMetadataKey.Pid].length > 0
-      const hasExitCode =
-        typeof metadata[RunmeMetadataKey.ExitCode] === 'string' &&
-        metadata[RunmeMetadataKey.ExitCode].length > 0
-      const monitoredHere =
-        this.activeStreams.has(cell.refId) ||
-        this.activeJupyterSockets.has(cell.refId) ||
-        this.activeAppKernelExecutions.has(cell.refId)
-
-      if (!hasPid || hasExitCode || monitoredHere) {
-        continue
-      }
-
-      delete metadata[RunmeMetadataKey.Pid]
-      if (
-        metadata[RunmeMetadataKey.ExecutionState] !==
-        RunmeExecutionState.Unknown
-      ) {
-        cell.outputs = [
-          ...cell.outputs,
-          ...createStdTextOutputs('', EXECUTION_MONITOR_INTERRUPTED_MESSAGE),
-        ]
-      }
-      metadata[RunmeMetadataKey.ExecutionState] = RunmeExecutionState.Unknown
-      cell.metadata = metadata
-      changed = true
-    }
-    return changed
   }
 
   private matchesNotebookTarget(target: unknown): boolean {
@@ -661,12 +614,10 @@ export class NotebookData {
     this.rebuildIndex()
     this.validateCells()
     this.sequence = this.computeHighestSequence()
-    const reconciledInterruptedExecutions =
-      this.reconcileInterruptedExecutions()
     this.loaded = true
     this.snapshotCache = this.buildSnapshot()
     this.emit()
-    if ((persist || reconciledInterruptedExecutions) && !this.readOnly) {
+    if (persist && !this.readOnly) {
       this.schedulePersist()
     }
   }
@@ -1066,7 +1017,37 @@ export class NotebookData {
       return existing
     }
 
-    return undefined
+    const hasPid =
+      typeof metadata[RunmeMetadataKey.Pid] === 'string' &&
+      metadata[RunmeMetadataKey.Pid].length > 0
+    const runID =
+      typeof metadata[RunmeMetadataKey.LastRunID] === 'string'
+        ? metadata[RunmeMetadataKey.LastRunID]
+        : ''
+
+    if (!cell || !hasPid || hasExitCode || !runID) {
+      return undefined
+    }
+
+    const runner = this.getRunner(cell)
+    if (!runner || !runner.endpoint) {
+      console.warn('Cannot resume stream; no runner available', { refId })
+      return undefined
+    }
+
+    const seqValue = metadata[RunmeMetadataKey.Sequence]
+    const parsedSeq =
+      typeof seqValue === 'string' ? Number.parseInt(seqValue, 10) : Number.NaN
+    const sequence = Number.isNaN(parsedSeq) ? this.sequence : parsedSeq
+
+    return this.createAndBindStreams({
+      cell,
+      runID,
+      sequence,
+      runner,
+      generation: this.executionGeneration,
+      intent: RunIntent.RESUME,
+    })
   }
 
   private createCell(
@@ -1794,12 +1775,14 @@ export class NotebookData {
     sequence,
     runner,
     generation,
+    intent = RunIntent.START,
   }: {
     cell: parser_pb.Cell
     runID: string
     sequence: number
     runner: Runner
     generation: number
+    intent?: RunIntent
   }): StreamsLike | undefined {
     const streams = new Streams({
       knownID: `cell_${cell.refId}`,
@@ -1809,6 +1792,7 @@ export class NotebookData {
         runnerEndpoint: runner.endpoint,
         interceptors: runner.interceptors ?? [],
         autoReconnect: runner.reconnect ?? true,
+        initialIntent: intent,
       },
     })
     this.activeStreams.set(cell.refId, streams)

--- a/app/src/lib/notebookDiff/diff.ts
+++ b/app/src/lib/notebookDiff/diff.ts
@@ -34,6 +34,7 @@ const TRANSIENT_METADATA_KEYS = new Set<string>([
   RunmeMetadataKey.LastRunID,
   RunmeMetadataKey.Pid,
   RunmeMetadataKey.ExitCode,
+  RunmeMetadataKey.ExecutionState,
 ]);
 
 type IndexedCell = {

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -210,6 +210,7 @@ describe('createRunmeConsoleApi', () => {
             [RunmeMetadataKey.LastRunID]: 'run-cell-a',
             [RunmeMetadataKey.Pid]: '42',
             [RunmeMetadataKey.ExitCode]: '0',
+            [RunmeMetadataKey.ExecutionState]: 'completed',
           },
         }),
         codeCell('cell-b', 'echo bye'),
@@ -229,6 +230,7 @@ describe('createRunmeConsoleApi', () => {
     expect(updated?.metadata?.[RunmeMetadataKey.LastRunID]).toBeUndefined()
     expect(updated?.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined()
     expect(updated?.metadata?.[RunmeMetadataKey.ExitCode]).toBeUndefined()
+    expect(updated?.metadata?.[RunmeMetadataKey.ExecutionState]).toBeUndefined()
     expect(model.updates).toHaveLength(1)
   })
 

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -876,6 +876,7 @@ function clearCellRunMetadata(cell: parser_pb.Cell): void {
   delete cell.metadata[RunmeMetadataKey.LastRunID]
   delete cell.metadata[RunmeMetadataKey.Pid]
   delete cell.metadata[RunmeMetadataKey.ExitCode]
+  delete cell.metadata[RunmeMetadataKey.ExecutionState]
 }
 
 export function createRunmeConsoleApi({
@@ -905,7 +906,8 @@ export function createRunmeConsoleApi({
       const hasRunMetadata =
         typeof cell.metadata?.[RunmeMetadataKey.LastRunID] === 'string' ||
         typeof cell.metadata?.[RunmeMetadataKey.Pid] === 'string' ||
-        typeof cell.metadata?.[RunmeMetadataKey.ExitCode] === 'string'
+        typeof cell.metadata?.[RunmeMetadataKey.ExitCode] === 'string' ||
+        typeof cell.metadata?.[RunmeMetadataKey.ExecutionState] === 'string'
       if (!hasOutputs && !hasRunMetadata) {
         continue
       }

--- a/app/src/runme/client.ts
+++ b/app/src/runme/client.ts
@@ -25,10 +25,17 @@ export enum RunmeMetadataKey {
   LastRunID = "runme.dev/lastRunID",
   Pid = "runme.dev/pid",
   ExitCode = "runme.dev/exitCode",
+  ExecutionState = "runme.dev/executionState",
   RunnerName = "runme.dev/runnerName",
   JupyterServerName = "runme.dev/jupyterServerName",
   JupyterKernelName = "runme.dev/jupyterKernelName",
   JupyterKernelID = "runme.dev/jupyterKernelID",
+}
+
+export enum RunmeExecutionState {
+  Running = "running",
+  Completed = "completed",
+  Unknown = "unknown",
 }
 
 export enum AgentMetadataKey {

--- a/app/test/browser/README.md
+++ b/app/test/browser/README.md
@@ -59,14 +59,13 @@ The hello-world scenario validates an end-to-end flow:
 - run the first cell
 - assert executed cell outputs contain `hello world`
 
-The no-runner logs scenario validates failure diagnostics:
+The no-runner logs scenario validates unreachable-runner semantics:
 
 - remove configured runners
-- minimize the bottom pane before execution
 - attempt to execute a code cell
-- re-expand the bottom pane
+- assert the execution remains running without a terminal result
 - open the Logs tab
-- assert the no-runner error is visible in logs
+- assert transport failure did not synthesize a terminal backend error
 
 Run it with:
 

--- a/app/test/browser/test-scenario-no-runner-logs.ts
+++ b/app/test/browser/test-scenario-no-runner-logs.ts
@@ -276,6 +276,7 @@ for (const file of [
   'scenario-no-runner-logs-03-runner-state.txt',
   'scenario-no-runner-logs-04-opened-notebook.txt',
   'scenario-no-runner-logs-05-after-run.txt',
+  'scenario-no-runner-logs-05b-execution-state.txt',
   'scenario-no-runner-logs-06-logs-pane.txt',
   'scenario-no-runner-logs-07-logs-visible.png',
   'scenario-no-runner-logs-auth-seed.txt',
@@ -452,6 +453,48 @@ if (runTrigger.status === 0 && runTrigger.stdout.includes('ok')) {
 snapshot = run('agent-browser snapshot -i').stdout
 writeArtifact('scenario-no-runner-logs-05-after-run.txt', snapshot)
 
+const executionStateProbe = run(
+  `agent-browser eval "(async () => {
+    const ln = window.app?.localNotebooks;
+    if (!ln) return 'missing-local-notebooks';
+    const record = await ln.files.get('local://file/${SCENARIO_NOTEBOOK_NAME}');
+    if (!record) return 'missing-notebook-record';
+    const notebook = JSON.parse(record.doc || '{}');
+    const cell = Array.isArray(notebook.cells)
+      ? notebook.cells.find((candidate) => candidate?.refId === 'cell_no_runner')
+      : null;
+    const metadata = cell?.metadata && typeof cell.metadata === 'object'
+      ? cell.metadata
+      : {};
+    const executionState = metadata['runme.dev/executionState'];
+    const lastRunID = metadata['runme.dev/lastRunID'];
+    const exitCode = metadata['runme.dev/exitCode'];
+    if (
+      executionState === 'running' &&
+      typeof lastRunID === 'string' &&
+      lastRunID.length > 0 &&
+      typeof exitCode !== 'string'
+    ) {
+      return 'running-without-terminal-result';
+    }
+    return JSON.stringify({ executionState, lastRunID, exitCode });
+  })()"`
+)
+const executionStateResult =
+  `${executionStateProbe.stdout}\n${executionStateProbe.stderr}`.trim()
+writeArtifact(
+  'scenario-no-runner-logs-05b-execution-state.txt',
+  executionStateResult
+)
+if (
+  executionStateProbe.status === 0 &&
+  executionStateResult.includes('running-without-terminal-result')
+) {
+  pass('Kept execution running while the runner was unreachable')
+} else {
+  fail('Execution did not remain running while the runner was unreachable')
+}
+
 let logsTabVisible = false
 const tabAttemptStates: string[] = []
 for (let attempt = 0; attempt < 8; attempt += 1) {
@@ -495,13 +538,13 @@ const logsText = run(
 ).stdout
 writeArtifact('scenario-no-runner-logs-06-logs-pane.txt', logsText)
 if (
-  logsText.includes(
+  !logsText.includes(
     'Runme backend server is not running. Please start it and try again.'
   )
 ) {
-  pass('Observed backend-unavailable error in Logs tab')
+  pass('Did not synthesize a terminal error for an unreachable runner')
 } else {
-  fail('Logs tab did not show backend-unavailable execution error')
+  fail('Unreachable runner was incorrectly treated as a terminal error')
 }
 
 run('agent-browser wait 1500')

--- a/docs-dev/design/20260715_execution_monitoring.md
+++ b/docs-dev/design/20260715_execution_monitoring.md
@@ -2,23 +2,30 @@
 
 ## Status
 
-The client-side safety fix is implemented in this change. The runner protocol
-is unchanged. The protocol section below is a possible future improvement for
-restoring reliable cross-session resume; it is not part of this change.
+This design is implemented by coordinated draft changes to the Runme runner and
+Runme Web. It replaces the earlier client-only proposal that disabled
+cross-session resume.
+
+The first version distinguishes starting a run from resuming one. Retaining and
+replaying a completed run's terminal result remains a future protocol extension.
 
 ## Decision
 
-We will not treat a persisted PID as proof that a cell is still running.
+The first application message on a new execution WebSocket will declare whether
+the client intends to start a new run or resume an existing run. The runner will
+acknowledge that intent before the client sends execute requests or heartbeats.
 
-When a notebook model is recreated with a PID but no exit code, the web client
-will clear the PID and record the execution outcome as `unknown`. It will not
-attach a new stream for that run. The cell will explain that the process may
-still be running and that the user should check the runner before repeating a
-non-idempotent command.
+- `START` creates a new execution and fails if its `runID` already exists.
+- `RESUME` attaches to an active execution and fails if its `runID` is unknown.
+- A legacy client that does not send the negotiation message keeps the existing
+  create-or-attach behavior.
 
-This change does not attempt cross-session resume. A future runner protocol
-could restore that capability by distinguishing a new execution from a resume
-attempt and replaying a retained terminal outcome.
+`runID` identifies an execution across connections. `streamID` identifies one
+WebSocket connection to that execution and is regenerated on reconnect.
+
+This removes the ambiguity that caused stale cells to appear to run forever. A
+resume request can no longer create an empty multiplexer for an execution that
+has already disappeared.
 
 ## Incident
 
@@ -30,175 +37,169 @@ finished. Each cell contained:
 - no `runme.dev/exitCode`
 
 The operating-system processes no longer existed. Clearing the PIDs stopped the
-running indicators, which confirmed that the UI was rendering persisted
-execution metadata rather than live process state.
+running indicators, confirming that the UI was rendering persisted execution
+metadata rather than live process state.
 
-This state is reproducible without a real process:
+The state is reproducible without a live process:
 
 1. Start a backend cell execution.
 2. Deliver and persist its PID.
-3. Interrupt the browser-to-runner connection before the exit response arrives.
+3. Disconnect the browser before the exit response arrives.
 4. Let the process finish and let the runner remove its `runID`.
-5. Recreate the browser notebook model.
+5. Recreate the browser notebook model and reconnect with the old `runID`.
 
-The old client interprets the PID as an active run and opens a WebSocket with
-the old `runID`. The runner no longer has that run, so it creates a new, empty
-multiplexer. That multiplexer answers heartbeats but has no process and no exit
-event. The cell therefore remains active until another failure or manual
-metadata repair.
+Previously, the runner treated that unknown `runID` as a request to create a
+new multiplexer. It answered heartbeats, but the multiplexer had no process and
+would never produce an exit event. The cell therefore remained active.
 
-## Current Contract
+## Existing Contract and Ambiguity
 
-The web client persists three facts:
+The web client persists three relevant facts:
 
 - `lastRunID` identifies an execution attempt.
 - `pid` records that the runner reported a process.
 - `exitCode` records an observed terminal process result.
 
-The client currently derives liveness from `pid && !exitCode`. That inference is
-valid only while the same in-memory stream owns the execution.
+The runner previously used one operation for two meanings:
 
-The runner's WebSocket handler has different semantics:
+- a connection for an existing `runID` joined its multiplexer;
+- a connection for an unknown `runID` created a multiplexer.
 
-- a connection for an existing `runID` joins its multiplexer;
-- a connection for an unknown `runID` creates a multiplexer;
-- a completed run is removed from the in-memory map;
-- responses are broadcast live and are not replayed to later connections;
-- heartbeat pongs prove transport health, not process liveness.
+Completed runs are removed from the in-memory map, and responses are broadcast
+live rather than replayed to later connections. After reconnecting, the client
+therefore could not distinguish a quiet running process from a completed,
+forgotten, or runner-lost process. Heartbeat success only proved transport
+health; it did not prove process liveness.
 
-The client therefore cannot distinguish these cases after reconnecting:
+No browser timeout can resolve this ambiguity because a valid process may be
+quiet for an arbitrary amount of time.
 
-1. a quiet process is still running;
-2. the process finished, but the client missed its exit response;
-3. the runner restarted and forgot the execution;
-4. a new empty multiplexer was created for an expired `runID`.
+## Protocol
 
-No client timeout can resolve this ambiguity. A timeout would classify a valid,
-quiet process as dead.
-
-## Execution State
-
-The web client will persist `runme.dev/executionState` with these values:
-
-| State       | Meaning                                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------------------------- |
-| `running`   | This browser model owns a live monitor and has not observed a terminal result.                                |
-| `completed` | The monitor observed an exit code.                                                                            |
-| `unknown`   | Monitoring ended or the model was recreated before an exit code was observed. The process outcome is unknown. |
-
-`unknown` is terminal for the browser operation that awaited the run, but it is
-not a process exit status. We will not synthesize exit code `0` or `1` because
-either value would make an unsupported claim about the command.
-
-The PID remains useful for display and diagnostics while an in-memory monitor
-owns the run. It is cleared when that ownership is lost.
-
-```mermaid
-stateDiagram-v2
-    [*] --> running: execution starts
-    running --> completed: exit code observed
-    running --> unknown: monitor fails
-    running --> unknown: notebook model recreated
-    completed --> running: user reruns cell
-    unknown --> running: user reruns cell
-```
-
-## Client Safety Fix
-
-`NotebookData` will reconcile interrupted executions when it is constructed or
-loads a replacement notebook:
-
-1. Find cells with a PID and no exit code.
-2. Preserve cells that have an execution monitor owned by this model.
-3. Clear every other PID.
-4. Set `executionState=unknown`.
-5. Append a warning without changing the prior command output.
-6. Persist the repaired metadata.
-
-Stream errors use the same transition. This prevents `CellData.run()` and
-AppKernel notebook helpers from waiting forever after monitoring has become
-terminally unavailable.
-
-This fix intentionally disables cross-session backend execution resume. The
-current protocol cannot implement that feature without sometimes reporting
-false liveness.
-
-## Behavior Without a Runner Protocol Change
-
-Normal execution monitoring is unchanged while the original in-memory notebook
-model owns the stream. The cell shows as running after receiving a PID, streams
-output, and becomes completed when it observes the exit code. Transient stream
-reconnection can also continue while that live monitor retains its execution
-context.
-
-Once that ownership is lost, the client favors an honest loss-of-knowledge
-state over a false running state:
-
-- Loading a notebook with a PID but no exit code changes the execution to
-  `unknown`; it does not open a stream for the persisted `runID`.
-- A terminal monitoring error changes the execution to `unknown` and resolves
-  callers waiting for the run.
-- The stale PID is cleared, so the cell no longer shows a running indicator or
-  accepts input for that execution.
-- Existing output is preserved and a warning explains that the outcome is
-  unknown. The client does not synthesize a successful or failed exit code.
-- The underlying process might already have exited or might still be running
-  without a client monitor. The user must inspect its effects or runner state
-  before deciding whether it is safe to run the cell again.
-
-Consequently, this change fixes indefinite false-running UI but does not provide
-cross-session resume or recovery of a missed exit result. New executions are
-unaffected.
-
-## Possible Future Runner Protocol Improvement
-
-The following is a suggested future design. It is not implemented or required
-by the client safety fix in this change.
-
-A future protocol could separate creation from attachment and retain terminal
-state for a bounded period.
-
-For example, the connection intent could be explicit:
-
-```text
-ws://runner/ws?id=<stream-id>&runID=<run-id>&mode=start
-ws://runner/ws?id=<stream-id>&runID=<run-id>&mode=resume
-```
-
-- `mode=start` creates a run and fails if the `runID` already exists.
-- `mode=resume` attaches to an existing or retained run and never creates one.
-- an unknown resume target returns a terminal `not_found` result.
-
-The first response could describe authoritative execution state:
+The WebSocket request and response envelopes add an open-run exchange:
 
 ```proto
-message ExecutionSnapshot {
-  enum State {
-    STATE_UNSPECIFIED = 0;
-    STATE_RUNNING = 1;
-    STATE_COMPLETED = 2;
-    STATE_UNKNOWN = 3;
-  }
+enum RunIntent {
+  RUN_INTENT_UNSPECIFIED = 0;
+  RUN_INTENT_START = 1;
+  RUN_INTENT_RESUME = 2;
+}
 
-  string run_id = 1;
-  State state = 2;
-  optional int64 pid = 3;
-  optional int32 exit_code = 4;
+enum RunState {
+  RUN_STATE_UNSPECIFIED = 0;
+  RUN_STATE_CREATED = 1;
+  RUN_STATE_RUNNING = 2;
+}
+
+message OpenRunRequest {
+  RunIntent intent = 1;
+}
+
+message OpenRunResponse {
+  RunState state = 1;
 }
 ```
 
-Such a protocol would need to retain at least the terminal snapshot for longer
-than the browser's reconnect window. Replaying stdout and stderr would be useful
-but is not necessary to fix liveness; replaying `state`, `pid`, and `exit_code`
-would be.
+For a negotiating client, `OpenRunRequest` must be the first application
+message. The runner validates authorization and identity before acting on the
+intent. The result matrix is:
 
-With that possible contract, the client could safely use these transitions:
+| Intent   | Runner state          | Result                                     |
+| -------- | --------------------- | ------------------------------------------ |
+| `START`  | `runID` is unknown    | Create it; reply `CREATED`                 |
+| `START`  | `runID` exists        | Return `ALREADY_EXISTS`                    |
+| `RESUME` | active `runID` exists | Attach to it; reply `RUNNING`              |
+| `RESUME` | `runID` is unknown    | Return `NOT_FOUND`; do not create anything |
 
-- resumed `running` snapshot: restore the running UI;
-- resumed `completed` snapshot: persist the real exit code;
-- `not_found` after the retention window: record `unknown`;
-- transport failure: show `reconnecting` without changing process state until
-  the retry policy is exhausted.
+After a successful response, reconnects for that `Streams` instance use
+`RESUME`. A second negotiation message on the same WebSocket is rejected.
+
+The client waits for `OpenRunResponse` before releasing queued execute requests
+or starting heartbeat traffic. This guarantees that the first operation has an
+unambiguous meaning.
+
+### Legacy Clients
+
+Backward compatibility is server-side. If the first request is not
+`OpenRunRequest`, the runner processes it with the old create-or-attach
+semantics. Clients that know nothing about negotiation therefore continue to
+work against the new runner without changes.
+
+The inverse is not guaranteed: an old runner does not understand the new first
+message. Deployment must therefore be runner-first.
+
+| Client     | Runner | Behavior                                 |
+| ---------- | ------ | ---------------------------------------- |
+| Legacy     | New    | Existing create-or-attach behavior       |
+| Negotiated | New    | Explicit `START`/`RESUME` behavior       |
+| Negotiated | Legacy | Unsupported; deploy the new runner first |
+
+Putting intent in the WebSocket query string was rejected because a legacy
+runner could ignore an unknown query argument and silently retain the ambiguous
+behavior. An application-level request produces an explicit response or an
+explicit protocol failure.
+
+## Web Client Behavior
+
+The web client persists `runme.dev/executionState` with these values:
+
+| State       | Meaning                                                         |
+| ----------- | --------------------------------------------------------------- |
+| `running`   | The runner acknowledged the run and no terminal result arrived. |
+| `completed` | The client observed an exit code.                               |
+| `unknown`   | Monitoring ended without an authoritative terminal result.      |
+
+When a notebook model is recreated with a PID, a `lastRunID`, and no exit code,
+it creates a stream using `RESUME` instead of assuming that the PID proves
+liveness or immediately discarding the run:
+
+- `RUNNING`: retain the PID and continue monitoring the same execution;
+- `NOT_FOUND`: clear the PID, set `executionState=unknown`, preserve prior
+  output, and explain that the result is unknown;
+- terminal transport/protocol failure: use the same `unknown` transition after
+  reconnect policy is exhausted.
+
+`unknown` is terminal for the browser operation waiting on the run, but it is
+not a process exit status. The client does not synthesize exit code `0` or `1`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> negotiating: START or RESUME
+    negotiating --> running: CREATED or RUNNING
+    negotiating --> unknown: NOT_FOUND or terminal error
+    running --> completed: exit code observed
+    running --> negotiating: WebSocket reconnect
+    running --> unknown: terminal monitoring failure
+    completed --> negotiating: user starts another run
+    unknown --> negotiating: user starts another run
+```
+
+### Ten-hour Execution and Browser Refresh
+
+Suppose a cell starts a ten-hour command and the browser refreshes after five
+hours. The notebook reloads the persisted `runID` and opens a WebSocket with a
+new `streamID`. Its first message is `RESUME` for the original `runID`.
+
+If the runner still has that active execution, it replies `RUNNING`, attaches
+the new stream to the existing multiplexer, and the browser resumes monitoring
+the same process. It does not start the command again.
+
+If the execution finished while the browser was absent, this version of the
+runner has already discarded it and returns `NOT_FOUND`. The browser records
+`unknown` rather than displaying a false running state. Recovering the actual
+exit code in that case requires terminal-state retention.
+
+## Future: Terminal-State Retention
+
+This first protocol fix authoritatively answers whether a run is active. It does
+not yet preserve completed results. A future version should retain a bounded
+execution snapshot containing at least `runID`, terminal state, PID, and exit
+code for longer than the expected reconnect window.
+
+With that extension, `RESUME` could return `COMPLETED` and replay the real exit
+code when the process ended during disconnection. Output replay would be useful
+but is not required to fix liveness. Retention limits, runner restarts, and
+snapshot persistence need a separate design decision.
 
 ## Rejected Alternatives
 
@@ -207,41 +208,50 @@ With that possible contract, the client could safely use these transitions:
 PIDs are runner-local. The browser cannot test them portably, and PID reuse can
 produce false positives.
 
-### Mark interrupted executions successful
+### Mark interrupted executions successful or failed
 
-The missing exit event may represent either success or failure. Writing exit
-code `0` corrupts execution history.
-
-### Mark interrupted executions failed
-
-A transport or browser failure is not a process failure. Writing exit code `1`
-also corrupts execution history.
+A missing exit event supports neither conclusion. Synthesizing exit code `0` or
+`1` would corrupt execution history.
 
 ### Use a quiet-period timeout
 
 Long-running commands can produce no output for an arbitrary period. Silence is
 not a terminal protocol event.
 
-### Keep reconnecting to the old `runID`
+### Keep reconnecting with implicit semantics
 
-The current runner creates an empty multiplexer for an unknown `runID`, so a
-successful heartbeat does not confirm that the old process exists.
+The old runner creates an empty multiplexer for an unknown `runID`, so a
+successful heartbeat does not confirm that the original process exists.
+
+## Rollout
+
+1. Deploy the backward-compatible runner implementation.
+2. Verify that legacy clients continue to execute and reconnect.
+3. Deploy the negotiating web client.
+4. Consider terminal-state retention as a follow-up protocol change.
+
+The web implementation currently serializes the small negotiation envelope
+directly because the published Buf package does not yet contain the new schema.
+It should switch to the generated message types after the runner proto is
+published.
 
 ## Tests
 
-The client regression suite covers:
+Runner coverage verifies:
 
-- PID followed by exit code becomes `completed` and clears the PID;
-- PID followed by a terminal stream error becomes `unknown`, clears the PID,
-  and preserves an explanatory stderr output;
-- loading persisted PID-without-exit metadata does not create a stream and
-  becomes `unknown`;
+- negotiated `START` creates a run and returns `CREATED`;
+- duplicate `START` returns `ALREADY_EXISTS`;
+- negotiated `RESUME` attaches to the active run and returns `RUNNING`;
+- `RESUME` for an unknown run returns `NOT_FOUND` without creating a run;
+- legacy first messages retain create-or-attach behavior;
+- existing round-trip and inactivity behavior remains intact.
+
+Web coverage verifies:
+
+- a `START` negotiation is the first message;
+- execute requests remain queued until `CREATED` is received;
+- persisted PID-without-exit metadata negotiates `RESUME` with the saved
+  `runID`;
+- stream errors become `unknown`, clear the PID, and preserve an explanatory
+  stderr output;
 - `CellData.run()` resolves when monitoring becomes `unknown`.
-
-If a future runner protocol adopts these semantics, its integration coverage
-should include reconnecting:
-
-- while a quiet process is running;
-- after a process exits while the client is disconnected;
-- after terminal-state retention expires;
-- after a runner restart.

--- a/docs-dev/design/20260715_execution_monitoring.md
+++ b/docs-dev/design/20260715_execution_monitoring.md
@@ -1,82 +1,100 @@
-# 2026-07-15: Cell Execution Monitoring Semantics
+# Cell Execution Monitoring Across Reconnects
 
-## Status
+- **Author:** Jeremy Lewi
+- **Date:** 2026-07-15
+- **Status:** Draft
 
-This design is implemented by coordinated draft changes to the Runme runner and
-Runme Web. It replaces the earlier client-only proposal that disabled
-cross-session resume.
+## TL;DR
 
-The first version distinguishes starting a run from resuming one. Retaining and
-replaying a completed run's terminal result remains a future protocol extension.
+Runme Web can show a cell as running after its process has exited. The bug
+occurs when the browser misses the exit response and reconnects with a `runID`
+that the runner no longer knows. The old runner interprets the unknown `runID`
+as a new execution and creates an empty multiplexer. That multiplexer answers
+heartbeats but never produces an exit event.
 
-## Decision
+We will add an `OpenRunRequest` as the first WebSocket application message. Its
+intent is either `START` or `RESUME`. `RESUME` will attach only to an active run
+and return `NOT_FOUND` rather than create a new one. The runner will retain its
+legacy create-or-attach behavior for clients that do not send
+`OpenRunRequest`.
 
-The first application message on a new execution WebSocket will declare whether
-the client intends to start a new run or resume an existing run. The runner will
-acknowledge that intent before the client sends execute requests or heartbeats.
+This change restores active-run recovery after a browser refresh. It does not
+retain completed results. If a run finishes while the browser is disconnected,
+the client will record the outcome as `unknown`. Retaining terminal results is
+a future protocol extension.
 
-- `START` creates a new execution and fails if its `runID` already exists.
-- `RESUME` attaches to an active execution and fails if its `runID` is unknown.
-- A legacy client that does not send the negotiation message keeps the existing
-  create-or-attach behavior.
+## Motivation
 
-`runID` identifies an execution across connections. `streamID` identifies one
-WebSocket connection to that execution and is regenerated on reconnect.
+### Bug
 
-This removes the ambiguity that caused stale cells to appear to run forever. A
-resume request can no longer create an empty multiplexer for an execution that
-has already disappeared.
-
-## Incident
-
-Three cells in a local notebook showed as running after their commands had
-finished. Each cell contained:
+Three cells in a local notebook remained in the running state after their
+commands had finished. Each cell had:
 
 - `runme.dev/lastRunID`
 - `runme.dev/pid`
 - no `runme.dev/exitCode`
 
-The operating-system processes no longer existed. Clearing the PIDs stopped the
-running indicators, confirming that the UI was rendering persisted execution
-metadata rather than live process state.
+The operating-system processes no longer existed. Clearing the persisted PIDs
+removed the running indicators.
 
-The state is reproducible without a live process:
+The failure is reproducible:
 
 1. Start a backend cell execution.
-2. Deliver and persist its PID.
-3. Disconnect the browser before the exit response arrives.
-4. Let the process finish and let the runner remove its `runID`.
-5. Recreate the browser notebook model and reconnect with the old `runID`.
+2. Persist the PID and `runID`.
+3. Disconnect the browser before it receives the exit response.
+4. Let the process finish and let the runner remove the `runID`.
+5. Reload the notebook and reconnect with the persisted `runID`.
 
-Previously, the runner treated that unknown `runID` as a request to create a
-new multiplexer. It answered heartbeats, but the multiplexer had no process and
-would never produce an exit event. The cell therefore remained active.
+The old runner uses one operation for two intents:
 
-## Existing Contract and Ambiguity
+- an existing `runID` attaches the connection to its multiplexer;
+- an unknown `runID` creates a multiplexer.
 
-The web client persists three relevant facts:
+Step 5 therefore creates an empty multiplexer. Heartbeats succeed, but no
+process is attached and no exit response will arrive. The cell remains active
+indefinitely.
 
-- `lastRunID` identifies an execution attempt.
-- `pid` records that the runner reported a process.
-- `exitCode` records an observed terminal process result.
+### Why the client cannot infer liveness
 
-The runner previously used one operation for two meanings:
+The client persists three observations:
 
-- a connection for an existing `runID` joined its multiplexer;
-- a connection for an unknown `runID` created a multiplexer.
+- `lastRunID` identifies an execution attempt;
+- `pid` records that the runner reported a process;
+- `exitCode` records an observed terminal result.
 
-Completed runs are removed from the in-memory map, and responses are broadcast
-live rather than replayed to later connections. After reconnecting, the client
-therefore could not distinguish a quiet running process from a completed,
-forgotten, or runner-lost process. Heartbeat success only proved transport
-health; it did not prove process liveness.
+A PID without an exit code does not prove that the process is still running.
+PIDs are runner-local and can be reused. A heartbeat proves transport health,
+not process liveness. A silence timeout is also unsafe because a valid process
+can produce no output for hours.
 
-No browser timeout can resolve this ambiguity because a valid process may be
-quiet for an arbitrary amount of time.
+After reconnecting, the client cannot distinguish:
 
-## Protocol
+1. an active but quiet process;
+2. a process that finished while the client was disconnected;
+3. a run lost because the runner restarted;
+4. an empty multiplexer created for an expired `runID`.
 
-The WebSocket request and response envelopes add an open-run exchange:
+The runner must resolve this ambiguity.
+
+### Requirements
+
+The design must:
+
+- reconnect to an active execution after a browser refresh;
+- never create a run when the client intends to resume;
+- stop showing a cell as running when the resume target does not exist;
+- preserve the existing behavior for legacy clients;
+- avoid inventing a successful or failed exit code;
+- distinguish the execution identifier from the WebSocket identifier.
+
+This version does not retain completed results or survive loss of the runner's
+in-memory run registry.
+
+## Proposal
+
+### Protocol
+
+The WebSocket envelopes will add an explicit open-run exchange:
 
 ```proto
 enum RunIntent {
@@ -100,48 +118,36 @@ message OpenRunResponse {
 }
 ```
 
-For a negotiating client, `OpenRunRequest` must be the first application
-message. The runner validates authorization and identity before acting on the
-intent. The result matrix is:
+`OpenRunRequest` must be the first application message from a negotiating
+client. The runner will validate authorization, `runID`, and `knownID` before
+acting on the intent.
+
+The client must wait for `OpenRunResponse` before sending execute requests or
+heartbeats. A second `OpenRunRequest` on the same WebSocket will fail with
+`FAILED_PRECONDITION`.
+
+`runID` identifies one execution across connections. `streamID` identifies one
+WebSocket connection and changes on every reconnect.
+
+### Runner behavior
 
 | Intent   | Runner state          | Result                                     |
 | -------- | --------------------- | ------------------------------------------ |
-| `START`  | `runID` is unknown    | Create it; reply `CREATED`                 |
+| `START`  | `runID` is unknown    | Create it and return `CREATED`             |
 | `START`  | `runID` exists        | Return `ALREADY_EXISTS`                    |
-| `RESUME` | active `runID` exists | Attach to it; reply `RUNNING`              |
+| `RESUME` | active `runID` exists | Attach to it and return `RUNNING`          |
 | `RESUME` | `runID` is unknown    | Return `NOT_FOUND`; do not create anything |
 
-After a successful response, reconnects for that `Streams` instance use
-`RESUME`. A second negotiation message on the same WebSocket is rejected.
+After a successful `START`, later connections for the same client-side stream
+will use `RESUME`.
 
-The client waits for `OpenRunResponse` before releasing queued execute requests
-or starting heartbeat traffic. This guarantees that the first operation has an
-unambiguous meaning.
+If the first request is not `OpenRunRequest`, the runner will use the legacy
+create-or-attach path. This preserves compatibility with clients that do not
+know the new protocol.
 
-### Legacy Clients
+### Web client behavior
 
-Backward compatibility is server-side. If the first request is not
-`OpenRunRequest`, the runner processes it with the old create-or-attach
-semantics. Clients that know nothing about negotiation therefore continue to
-work against the new runner without changes.
-
-The inverse is not guaranteed: an old runner does not understand the new first
-message. Deployment must therefore be runner-first.
-
-| Client     | Runner | Behavior                                 |
-| ---------- | ------ | ---------------------------------------- |
-| Legacy     | New    | Existing create-or-attach behavior       |
-| Negotiated | New    | Explicit `START`/`RESUME` behavior       |
-| Negotiated | Legacy | Unsupported; deploy the new runner first |
-
-Putting intent in the WebSocket query string was rejected because a legacy
-runner could ignore an unknown query argument and silently retain the ambiguous
-behavior. An application-level request produces an explicit response or an
-explicit protocol failure.
-
-## Web Client Behavior
-
-The web client persists `runme.dev/executionState` with these values:
+Runme Web will persist `runme.dev/executionState`:
 
 | State       | Meaning                                                         |
 | ----------- | --------------------------------------------------------------- |
@@ -149,109 +155,140 @@ The web client persists `runme.dev/executionState` with these values:
 | `completed` | The client observed an exit code.                               |
 | `unknown`   | Monitoring ended without an authoritative terminal result.      |
 
-When a notebook model is recreated with a PID, a `lastRunID`, and no exit code,
-it creates a stream using `RESUME` instead of assuming that the PID proves
-liveness or immediately discarding the run:
+A new execution will send `START` and wait for `CREATED` before releasing its
+queued execute request.
 
-- `RUNNING`: retain the PID and continue monitoring the same execution;
-- `NOT_FOUND`: clear the PID, set `executionState=unknown`, preserve prior
-  output, and explain that the result is unknown;
-- terminal transport/protocol failure: use the same `unknown` transition after
-  reconnect policy is exhausted.
+When a notebook is reloaded with a PID, `lastRunID`, and no exit code, the
+client will send `RESUME` for the persisted `runID`:
 
-`unknown` is terminal for the browser operation waiting on the run, but it is
-not a process exit status. The client does not synthesize exit code `0` or `1`.
+- `RUNNING`: retain the PID and continue monitoring;
+- `NOT_FOUND`: clear the PID, set `executionState=unknown`, preserve existing
+  output, and append an explanatory warning;
+- terminal transport or protocol failure: use the same `unknown` transition
+  after reconnect attempts are exhausted.
 
-```mermaid
-stateDiagram-v2
-    [*] --> negotiating: START or RESUME
-    negotiating --> running: CREATED or RUNNING
-    negotiating --> unknown: NOT_FOUND or terminal error
-    running --> completed: exit code observed
-    running --> negotiating: WebSocket reconnect
-    running --> unknown: terminal monitoring failure
-    completed --> negotiating: user starts another run
-    unknown --> negotiating: user starts another run
-```
+`unknown` is not an exit status. The client will not synthesize exit code `0`
+or `1`.
 
-### Ten-hour Execution and Browser Refresh
+### Browser refresh during a long execution
 
-Suppose a cell starts a ten-hour command and the browser refreshes after five
-hours. The notebook reloads the persisted `runID` and opens a WebSocket with a
-new `streamID`. Its first message is `RESUME` for the original `runID`.
+Consider a ten-hour command followed by a browser refresh after five hours.
+The reloaded notebook opens a WebSocket with a new `streamID` and sends
+`RESUME` for the original `runID`.
 
-If the runner still has that active execution, it replies `RUNNING`, attaches
-the new stream to the existing multiplexer, and the browser resumes monitoring
-the same process. It does not start the command again.
+If the runner still owns the execution, it returns `RUNNING` and attaches the
+new connection to the existing multiplexer. The browser resumes monitoring the
+same process without executing the command again.
 
-If the execution finished while the browser was absent, this version of the
-runner has already discarded it and returns `NOT_FOUND`. The browser records
-`unknown` rather than displaying a false running state. Recovering the actual
-exit code in that case requires terminal-state retention.
+If the run finished while the browser was disconnected, the runner has already
+removed it and returns `NOT_FOUND`. The browser records `unknown` rather than
+displaying false liveness.
 
-## Future: Terminal-State Retention
+### Compatibility and rollout
 
-This first protocol fix authoritatively answers whether a run is active. It does
-not yet preserve completed results. A future version should retain a bounded
-execution snapshot containing at least `runID`, terminal state, PID, and exit
-code for longer than the expected reconnect window.
+Backward compatibility is runner-side:
 
-With that extension, `RESUME` could return `COMPLETED` and replay the real exit
-code when the process ended during disconnection. Output replay would be useful
-but is not required to fix liveness. Retention limits, runner restarts, and
-snapshot persistence need a separate design decision.
+| Client     | Runner | Behavior                               |
+| ---------- | ------ | -------------------------------------- |
+| Legacy     | New    | Existing create-or-attach behavior     |
+| Negotiated | New    | Explicit `START` and `RESUME` behavior |
+| Negotiated | Legacy | Unsupported                            |
 
-## Rejected Alternatives
+We will deploy the runner before the web client:
 
-### Check the PID from the browser
-
-PIDs are runner-local. The browser cannot test them portably, and PID reuse can
-produce false positives.
-
-### Mark interrupted executions successful or failed
-
-A missing exit event supports neither conclusion. Synthesizing exit code `0` or
-`1` would corrupt execution history.
-
-### Use a quiet-period timeout
-
-Long-running commands can produce no output for an arbitrary period. Silence is
-not a terminal protocol event.
-
-### Keep reconnecting with implicit semantics
-
-The old runner creates an empty multiplexer for an unknown `runID`, so a
-successful heartbeat does not confirm that the original process exists.
-
-## Rollout
-
-1. Deploy the backward-compatible runner implementation.
-2. Verify that legacy clients continue to execute and reconnect.
+1. Deploy the runner with negotiation and the legacy fallback.
+2. Verify existing clients still execute and reconnect.
 3. Deploy the negotiating web client.
-4. Consider terminal-state retention as a follow-up protocol change.
 
-The web implementation currently serializes the small negotiation envelope
-directly because the published Buf package does not yet contain the new schema.
-It should switch to the generated message types after the runner proto is
-published.
+The web client currently serializes the small negotiation envelope directly
+because the published Buf package does not contain the new schema. It will use
+the generated message types after the runner proto is published.
 
-## Tests
+### Validation
 
-Runner coverage verifies:
+Runner tests verify:
 
-- negotiated `START` creates a run and returns `CREATED`;
+- `START` creates a run and returns `CREATED`;
 - duplicate `START` returns `ALREADY_EXISTS`;
-- negotiated `RESUME` attaches to the active run and returns `RUNNING`;
-- `RESUME` for an unknown run returns `NOT_FOUND` without creating a run;
+- `RESUME` attaches to an active run and returns `RUNNING`;
+- missing `RESUME` returns `NOT_FOUND` without creating a run;
 - legacy first messages retain create-or-attach behavior;
 - existing round-trip and inactivity behavior remains intact.
 
-Web coverage verifies:
+Web tests verify:
 
-- a `START` negotiation is the first message;
-- execute requests remain queued until `CREATED` is received;
-- persisted PID-without-exit metadata negotiates `RESUME` with the saved
-  `runID`;
-- stream errors become `unknown`, clear the PID, and preserve an explanatory
+- `START` is the first message;
+- execute requests remain queued until `CREATED`;
+- persisted running metadata sends `RESUME` with the saved `runID`;
+- `NOT_FOUND` becomes a terminal monitoring error;
+- monitoring errors set `unknown`, clear the PID, and preserve an explanatory
   stderr output;
-- `CellData.run()` resolves when monitoring becomes `unknown`.
+- callers waiting for the run resolve when monitoring becomes `unknown`.
+
+### Future terminal-state retention
+
+A later protocol version should retain a bounded terminal snapshot containing
+at least `runID`, state, PID, and exit code. `RESUME` could then return
+`COMPLETED` when the process finished during disconnection.
+
+Output replay is useful but not required to resolve liveness. Retention limits,
+runner restarts, and snapshot persistence require a separate design.
+
+## Alternatives
+
+### Put intent in the WebSocket query
+
+An old runner could ignore an unknown query parameter and retain the ambiguous
+behavior. A first application message requires an explicit response or an
+explicit protocol failure.
+
+### Mark persisted executions `unknown` without reconnecting
+
+This client-only fix prevents false liveness but abandons active executions
+after a browser refresh. Explicit `RESUME` preserves recovery without allowing
+an unknown run to be created.
+
+### Check the PID from the browser
+
+The PID belongs to the runner host. The browser cannot inspect it portably, and
+PID reuse can produce false positives.
+
+### Use a quiet-period timeout
+
+A long-running command may be silent indefinitely. Silence is not a terminal
+protocol event.
+
+### Mark an interrupted execution successful or failed
+
+A missing exit response supports neither conclusion. Synthesizing exit code
+`0` or `1` would corrupt execution history.
+
+### Keep the implicit reconnect behavior
+
+The old behavior creates an empty multiplexer for an unknown `runID`.
+Successful heartbeats from that multiplexer do not prove that the original
+process exists.
+
+## References
+
+- [Runner protocol draft PR](https://github.com/runmedev/runme/pull/1247) —
+  adds `OpenRunRequest`, implements negotiated runner behavior, and covers
+  start, resume, error, and legacy paths.
+- [Runme Web draft PR](https://github.com/runmedev/web/pull/282) — implements
+  client negotiation, persisted-run recovery, execution-state repair, and web
+  regression tests.
+- [WebSocket protocol schema](https://github.com/runmedev/runme/blob/codex/run-intent-negotiation/api/proto/runme/stream/v1/websockets.proto) —
+  defines the `RunIntent`, `RunState`, `OpenRunRequest`, and `OpenRunResponse`
+  wire types.
+- [Web stream implementation](https://github.com/runmedev/web/blob/codex/fix-stale-cell-execution/packages/renderers/src/streams.ts) —
+  sends the negotiation request and gates heartbeat and execution traffic on
+  the response.
+- [Notebook execution state implementation](https://github.com/runmedev/web/blob/codex/fix-stale-cell-execution/app/src/lib/notebookData.ts) —
+  restores persisted runs with `RESUME` and records `unknown` after terminal
+  monitoring failures.
+- [Stale cell execution investigation notebook](https://drive.google.com/file/d/1OTZffhR0d2GX2x5gVJ43qiIHa7bTfUkX/view) —
+  summarizes the observed failure, selected protocol fix, refresh behavior,
+  and implementation links.
+- [Codex investigation and implementation thread](codex://threads/019f4dd8-eff5-7dd1-be50-392508c916b0) —
+  records the protocol discussion, compatibility analysis, implementation,
+  and validation.

--- a/docs-dev/design/20260715_execution_monitoring.md
+++ b/docs-dev/design/20260715_execution_monitoring.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Proposed. The client-side safety fix is implemented in this change. Reliable
-cross-session resume requires the runner protocol change described below.
+The client-side safety fix is implemented in this change. The runner protocol
+is unchanged. The protocol section below is a possible future improvement for
+restoring reliable cross-session resume; it is not part of this change.
 
 ## Decision
 
@@ -15,8 +16,9 @@ attach a new stream for that run. The cell will explain that the process may
 still be running and that the user should check the runner before repeating a
 non-idempotent command.
 
-We will re-enable cross-session resume only after the runner can distinguish a
-new execution from a resume attempt and can replay a retained terminal outcome.
+This change does not attempt cross-session resume. A future runner protocol
+could restore that capability by distinguishing a new execution from a resume
+attempt and replaying a retained terminal outcome.
 
 ## Incident
 
@@ -121,12 +123,42 @@ This fix intentionally disables cross-session backend execution resume. The
 current protocol cannot implement that feature without sometimes reporting
 false liveness.
 
-## Runner Protocol Fix
+## Behavior Without a Runner Protocol Change
 
-The runner should separate creation from attachment and retain terminal state
-for a bounded period.
+Normal execution monitoring is unchanged while the original in-memory notebook
+model owns the stream. The cell shows as running after receiving a PID, streams
+output, and becomes completed when it observes the exit code. Transient stream
+reconnection can also continue while that live monitor retains its execution
+context.
 
-The connection intent should be explicit:
+Once that ownership is lost, the client favors an honest loss-of-knowledge
+state over a false running state:
+
+- Loading a notebook with a PID but no exit code changes the execution to
+  `unknown`; it does not open a stream for the persisted `runID`.
+- A terminal monitoring error changes the execution to `unknown` and resolves
+  callers waiting for the run.
+- The stale PID is cleared, so the cell no longer shows a running indicator or
+  accepts input for that execution.
+- Existing output is preserved and a warning explains that the outcome is
+  unknown. The client does not synthesize a successful or failed exit code.
+- The underlying process might already have exited or might still be running
+  without a client monitor. The user must inspect its effects or runner state
+  before deciding whether it is safe to run the cell again.
+
+Consequently, this change fixes indefinite false-running UI but does not provide
+cross-session resume or recovery of a missed exit result. New executions are
+unaffected.
+
+## Possible Future Runner Protocol Improvement
+
+The following is a suggested future design. It is not implemented or required
+by the client safety fix in this change.
+
+A future protocol could separate creation from attachment and retain terminal
+state for a bounded period.
+
+For example, the connection intent could be explicit:
 
 ```text
 ws://runner/ws?id=<stream-id>&runID=<run-id>&mode=start
@@ -137,7 +169,7 @@ ws://runner/ws?id=<stream-id>&runID=<run-id>&mode=resume
 - `mode=resume` attaches to an existing or retained run and never creates one.
 - an unknown resume target returns a terminal `not_found` result.
 
-The first response should describe authoritative execution state:
+The first response could describe authoritative execution state:
 
 ```proto
 message ExecutionSnapshot {
@@ -155,11 +187,12 @@ message ExecutionSnapshot {
 }
 ```
 
-The runner should retain at least the terminal snapshot for longer than the
-browser's reconnect window. Replaying stdout and stderr is useful but not
-required to fix liveness. Replaying `state`, `pid`, and `exit_code` is required.
+Such a protocol would need to retain at least the terminal snapshot for longer
+than the browser's reconnect window. Replaying stdout and stderr would be useful
+but is not necessary to fix liveness; replaying `state`, `pid`, and `exit_code`
+would be.
 
-With that contract, the client can safely use these transitions:
+With that possible contract, the client could safely use these transitions:
 
 - resumed `running` snapshot: restore the running UI;
 - resumed `completed` snapshot: persist the real exit code;
@@ -205,7 +238,8 @@ The client regression suite covers:
   becomes `unknown`;
 - `CellData.run()` resolves when monitoring becomes `unknown`.
 
-The future runner change should add integration coverage for reconnecting:
+If a future runner protocol adopts these semantics, its integration coverage
+should include reconnecting:
 
 - while a quiet process is running;
 - after a process exits while the client is disconnected;

--- a/docs-dev/design/20260715_execution_monitoring.md
+++ b/docs-dev/design/20260715_execution_monitoring.md
@@ -188,11 +188,11 @@ know the new protocol.
 
 Runme Web will persist `runme.dev/executionState`:
 
-| State       | Meaning                                                         |
-| ----------- | --------------------------------------------------------------- |
-| `running`   | The runner acknowledged the run and no terminal result arrived. |
-| `completed` | The client observed an exit code.                               |
-| `unknown`   | Monitoring ended without an authoritative terminal result.      |
+| State       | Meaning                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `running`   | The client has no authoritative terminal result.           |
+| `completed` | The client observed an exit code.                          |
+| `unknown`   | The runner reported that it no longer retains the `runID`. |
 
 A new execution will send `START` and wait for `CREATED` before releasing its
 queued execute request.
@@ -203,11 +203,29 @@ client will send `RESUME` for the persisted `runID`:
 - `RUNNING`: retain the PID and continue monitoring;
 - `NOT_FOUND`: clear the PID, set `executionState=unknown`, preserve existing
   output, and append an explanatory warning;
-- terminal transport or protocol failure: use the same `unknown` transition
-  after reconnect attempts are exhausted.
+- transport failure: retain the PID and `running` state and keep reconnecting.
 
 `unknown` is not an exit status. The client will not synthesize exit code `0`
 or `1`.
+
+### Unreachable runners and user recovery
+
+Connection failure is not a terminal execution result. The client will keep the
+cell in the running state until it receives an exit response or the runner
+returns `NOT_FOUND`. This can leave a cell running indefinitely when its runner
+was on a VM that no longer exists, but it avoids turning a network outage into
+a false execution result.
+
+Users can select another runner and rerun the cell. The rerun creates a new
+`runID` and stops monitoring the old one. If the old runner is unreachable, the
+client cannot guarantee that its process stopped, so users must treat
+non-idempotent commands carefully.
+
+A future UI should let users explicitly abandon an unreachable run. Abandoning
+will clear local running state and record `unknown`; it will not claim that the
+remote process was cancelled. Confirmed remote cancellation requires a runner
+connection and a separate cancellation acknowledgement, which this protocol
+does not add.
 
 ### Browser refresh during a long execution
 
@@ -260,8 +278,9 @@ Web tests verify:
 - execute requests remain queued until `CREATED`;
 - persisted running metadata sends `RESUME` with the saved `runID`;
 - `NOT_FOUND` becomes a terminal monitoring error;
-- monitoring errors set `unknown`, clear the PID, and preserve an explanatory
+- `NOT_FOUND` sets `unknown`, clears the PID, and preserves an explanatory
   stderr output;
+- transport failures preserve the PID and running state while reconnecting;
 - callers waiting for the run resolve when monitoring becomes `unknown`.
 
 ### Future terminal-state retention

--- a/docs-dev/design/20260715_execution_monitoring.md
+++ b/docs-dev/design/20260715_execution_monitoring.md
@@ -90,6 +90,48 @@ The design must:
 This version does not retain completed results or survive loss of the runner's
 in-memory run registry.
 
+## Background
+
+### Execution and connection identifiers
+
+Runme uses different identifiers for an execution and for a connection to that
+execution:
+
+| Identifier | Scope                    | Lifetime                                                            |
+| ---------- | ------------------------ | ------------------------------------------------------------------- |
+| `runID`    | One command execution    | Stable from execution start through every reconnect                 |
+| `streamID` | One WebSocket connection | Generated when the socket is opened and discarded when it is closed |
+
+The web client generates `runID` as `run_<ULID>`. The runner uses it as the key
+for the multiplexer that owns an execution. The client persists the value as
+`runme.dev/lastRunID` so a reloaded notebook can refer to the same execution.
+
+The client generates `streamID` as a UUID without dashes for each connection.
+The runner uses it to add and remove that connection from the run's
+multiplexer. One `runID` can therefore have several `streamID` values over its
+lifetime, and more than one client can connect to the same run. Reconnecting
+after a browser refresh means using the original `runID` with a new
+`streamID`.
+
+### Current WebSocket request
+
+The web client opens the runner WebSocket with this URL shape:
+
+```text
+<runnerEndpoint>?id=<streamID>&runID=<runID>
+```
+
+`id` and `runID` are the only query arguments that the `Streams` client adds.
+If the configured runner endpoint already contains other query arguments, the
+client preserves them; it sets or replaces `id` and `runID`. The runner
+requires both values before upgrading the connection.
+
+After the upgrade, application messages contain `knownId`, `runId`, and, when
+available, `authorization`. `knownId` identifies the notebook cell rather than
+an execution. The proposed `OpenRunRequest.intent` is also an application
+message field. None of these fields is added as a query argument. `runID` is
+currently present both in the WebSocket URL and in application messages.
+
 ## Proposal
 
 ### Protocol
@@ -125,9 +167,6 @@ acting on the intent.
 The client must wait for `OpenRunResponse` before sending execute requests or
 heartbeats. A second `OpenRunRequest` on the same WebSocket will fail with
 `FAILED_PRECONDITION`.
-
-`runID` identifies one execution across connections. `streamID` identifies one
-WebSocket connection and changes on every reconnect.
 
 ### Runner behavior
 

--- a/docs-dev/design/20260715_execution_monitoring.md
+++ b/docs-dev/design/20260715_execution_monitoring.md
@@ -1,0 +1,213 @@
+# 2026-07-15: Cell Execution Monitoring Semantics
+
+## Status
+
+Proposed. The client-side safety fix is implemented in this change. Reliable
+cross-session resume requires the runner protocol change described below.
+
+## Decision
+
+We will not treat a persisted PID as proof that a cell is still running.
+
+When a notebook model is recreated with a PID but no exit code, the web client
+will clear the PID and record the execution outcome as `unknown`. It will not
+attach a new stream for that run. The cell will explain that the process may
+still be running and that the user should check the runner before repeating a
+non-idempotent command.
+
+We will re-enable cross-session resume only after the runner can distinguish a
+new execution from a resume attempt and can replay a retained terminal outcome.
+
+## Incident
+
+Three cells in a local notebook showed as running after their commands had
+finished. Each cell contained:
+
+- `runme.dev/lastRunID`
+- `runme.dev/pid`
+- no `runme.dev/exitCode`
+
+The operating-system processes no longer existed. Clearing the PIDs stopped the
+running indicators, which confirmed that the UI was rendering persisted
+execution metadata rather than live process state.
+
+This state is reproducible without a real process:
+
+1. Start a backend cell execution.
+2. Deliver and persist its PID.
+3. Interrupt the browser-to-runner connection before the exit response arrives.
+4. Let the process finish and let the runner remove its `runID`.
+5. Recreate the browser notebook model.
+
+The old client interprets the PID as an active run and opens a WebSocket with
+the old `runID`. The runner no longer has that run, so it creates a new, empty
+multiplexer. That multiplexer answers heartbeats but has no process and no exit
+event. The cell therefore remains active until another failure or manual
+metadata repair.
+
+## Current Contract
+
+The web client persists three facts:
+
+- `lastRunID` identifies an execution attempt.
+- `pid` records that the runner reported a process.
+- `exitCode` records an observed terminal process result.
+
+The client currently derives liveness from `pid && !exitCode`. That inference is
+valid only while the same in-memory stream owns the execution.
+
+The runner's WebSocket handler has different semantics:
+
+- a connection for an existing `runID` joins its multiplexer;
+- a connection for an unknown `runID` creates a multiplexer;
+- a completed run is removed from the in-memory map;
+- responses are broadcast live and are not replayed to later connections;
+- heartbeat pongs prove transport health, not process liveness.
+
+The client therefore cannot distinguish these cases after reconnecting:
+
+1. a quiet process is still running;
+2. the process finished, but the client missed its exit response;
+3. the runner restarted and forgot the execution;
+4. a new empty multiplexer was created for an expired `runID`.
+
+No client timeout can resolve this ambiguity. A timeout would classify a valid,
+quiet process as dead.
+
+## Execution State
+
+The web client will persist `runme.dev/executionState` with these values:
+
+| State       | Meaning                                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------------------------- |
+| `running`   | This browser model owns a live monitor and has not observed a terminal result.                                |
+| `completed` | The monitor observed an exit code.                                                                            |
+| `unknown`   | Monitoring ended or the model was recreated before an exit code was observed. The process outcome is unknown. |
+
+`unknown` is terminal for the browser operation that awaited the run, but it is
+not a process exit status. We will not synthesize exit code `0` or `1` because
+either value would make an unsupported claim about the command.
+
+The PID remains useful for display and diagnostics while an in-memory monitor
+owns the run. It is cleared when that ownership is lost.
+
+```mermaid
+stateDiagram-v2
+    [*] --> running: execution starts
+    running --> completed: exit code observed
+    running --> unknown: monitor fails
+    running --> unknown: notebook model recreated
+    completed --> running: user reruns cell
+    unknown --> running: user reruns cell
+```
+
+## Client Safety Fix
+
+`NotebookData` will reconcile interrupted executions when it is constructed or
+loads a replacement notebook:
+
+1. Find cells with a PID and no exit code.
+2. Preserve cells that have an execution monitor owned by this model.
+3. Clear every other PID.
+4. Set `executionState=unknown`.
+5. Append a warning without changing the prior command output.
+6. Persist the repaired metadata.
+
+Stream errors use the same transition. This prevents `CellData.run()` and
+AppKernel notebook helpers from waiting forever after monitoring has become
+terminally unavailable.
+
+This fix intentionally disables cross-session backend execution resume. The
+current protocol cannot implement that feature without sometimes reporting
+false liveness.
+
+## Runner Protocol Fix
+
+The runner should separate creation from attachment and retain terminal state
+for a bounded period.
+
+The connection intent should be explicit:
+
+```text
+ws://runner/ws?id=<stream-id>&runID=<run-id>&mode=start
+ws://runner/ws?id=<stream-id>&runID=<run-id>&mode=resume
+```
+
+- `mode=start` creates a run and fails if the `runID` already exists.
+- `mode=resume` attaches to an existing or retained run and never creates one.
+- an unknown resume target returns a terminal `not_found` result.
+
+The first response should describe authoritative execution state:
+
+```proto
+message ExecutionSnapshot {
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    STATE_RUNNING = 1;
+    STATE_COMPLETED = 2;
+    STATE_UNKNOWN = 3;
+  }
+
+  string run_id = 1;
+  State state = 2;
+  optional int64 pid = 3;
+  optional int32 exit_code = 4;
+}
+```
+
+The runner should retain at least the terminal snapshot for longer than the
+browser's reconnect window. Replaying stdout and stderr is useful but not
+required to fix liveness. Replaying `state`, `pid`, and `exit_code` is required.
+
+With that contract, the client can safely use these transitions:
+
+- resumed `running` snapshot: restore the running UI;
+- resumed `completed` snapshot: persist the real exit code;
+- `not_found` after the retention window: record `unknown`;
+- transport failure: show `reconnecting` without changing process state until
+  the retry policy is exhausted.
+
+## Rejected Alternatives
+
+### Check the PID from the browser
+
+PIDs are runner-local. The browser cannot test them portably, and PID reuse can
+produce false positives.
+
+### Mark interrupted executions successful
+
+The missing exit event may represent either success or failure. Writing exit
+code `0` corrupts execution history.
+
+### Mark interrupted executions failed
+
+A transport or browser failure is not a process failure. Writing exit code `1`
+also corrupts execution history.
+
+### Use a quiet-period timeout
+
+Long-running commands can produce no output for an arbitrary period. Silence is
+not a terminal protocol event.
+
+### Keep reconnecting to the old `runID`
+
+The current runner creates an empty multiplexer for an unknown `runID`, so a
+successful heartbeat does not confirm that the old process exists.
+
+## Tests
+
+The client regression suite covers:
+
+- PID followed by exit code becomes `completed` and clears the PID;
+- PID followed by a terminal stream error becomes `unknown`, clears the PID,
+  and preserves an explanatory stderr output;
+- loading persisted PID-without-exit metadata does not create a stream and
+  becomes `unknown`;
+- `CellData.run()` resolves when monitoring becomes `unknown`.
+
+The future runner change should add integration coverage for reconnecting:
+
+- while a quiet process is running;
+- after a process exits while the client is disconnected;
+- after terminal-state retention expires;
+- after a runner restart.

--- a/packages/renderers/src/index.ts
+++ b/packages/renderers/src/index.ts
@@ -3,7 +3,7 @@ import { getContext, setContext } from './messaging'
 import { ClientMessages } from './types'
 
 export { default as Streams, type Authorization } from './streams'
-export { genRunID, Heartbeat, type StreamError } from './streams'
+export { genRunID, Heartbeat, RunIntent, type StreamError } from './streams'
 
 export {
   ConsoleView,

--- a/packages/renderers/src/streams.test.ts
+++ b/packages/renderers/src/streams.test.ts
@@ -2,7 +2,7 @@ import { ExecuteRequestSchema } from '@buf/runmedev_runme.bufbuild_es/runme/runn
 import { create } from '@bufbuild/protobuf'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import Streams, { Heartbeat } from './streams'
+import Streams, { Heartbeat, RunIntent } from './streams'
 
 class MockWebSocket extends EventTarget {
   static readonly CONNECTING = 0
@@ -37,6 +37,12 @@ class MockWebSocket extends EventTarget {
   open(): void {
     this.readyState = MockWebSocket.OPEN
     this.dispatchEvent(new Event('open'))
+  }
+
+  receive(data: object): void {
+    this.dispatchEvent(
+      new MessageEvent('message', { data: JSON.stringify(data) })
+    )
   }
 }
 
@@ -90,10 +96,95 @@ describe('Streams', () => {
 
     expect(
       MockWebSocket.instances[1].sent.some((message) =>
+        message.includes('RUN_INTENT_START')
+      )
+    ).toBe(true)
+    expect(
+      MockWebSocket.instances[1].sent.some((message) =>
+        message.includes('executeRequest')
+      )
+    ).toBe(false)
+
+    MockWebSocket.instances[1].receive({
+      openRunResponse: { state: 'RUN_STATE_CREATED' },
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(
+      MockWebSocket.instances[1].sent.some((message) =>
         message.includes('executeRequest')
       )
     ).toBe(true)
     expect(errors).toEqual([])
+
+    errorSubscription.unsubscribe()
+    streams.close()
+  })
+
+  it('uses resume intent before reconnecting a persisted run', async () => {
+    const streams = new Streams({
+      knownID: 'cell-resume',
+      runID: 'run-resume',
+      sequence: 7,
+      options: {
+        runnerEndpoint: 'ws://localhost:9977/ws',
+        interceptors: [],
+        autoReconnect: true,
+        initialIntent: RunIntent.RESUME,
+      },
+    })
+
+    streams.connect(Heartbeat.INITIAL).subscribe()
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    MockWebSocket.instances[0].open()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(
+      MockWebSocket.instances[0].sent.some((message) =>
+        message.includes('RUN_INTENT_RESUME')
+      )
+    ).toBe(true)
+
+    MockWebSocket.instances[0].receive({
+      openRunResponse: { state: 'RUN_STATE_RUNNING' },
+    })
+    await Promise.resolve()
+
+    streams.close()
+  })
+
+  it('reports a missing resumed run as a terminal protocol error', async () => {
+    const streams = new Streams({
+      knownID: 'cell-missing',
+      runID: 'run-missing',
+      sequence: 8,
+      options: {
+        runnerEndpoint: 'ws://localhost:9977/ws',
+        interceptors: [],
+        autoReconnect: true,
+        initialIntent: RunIntent.RESUME,
+      },
+    })
+    const errors: unknown[] = []
+    const errorSubscription = streams.errors.subscribe((error) => {
+      errors.push(error)
+    })
+
+    streams.connect(Heartbeat.INITIAL).subscribe({ error: () => undefined })
+    MockWebSocket.instances[0].open()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    MockWebSocket.instances[0].receive({
+      status: { code: 'NOT_FOUND', message: 'run not found' },
+    })
+    await Promise.resolve()
+
+    expect(errors).toHaveLength(1)
+    expect(MockWebSocket.instances).toHaveLength(1)
 
     errorSubscription.unsubscribe()
     streams.close()

--- a/packages/renderers/src/streams.test.ts
+++ b/packages/renderers/src/streams.test.ts
@@ -122,6 +122,38 @@ describe('Streams', () => {
     streams.close()
   })
 
+  it('keeps retrying when the runner is unreachable', async () => {
+    const streams = new Streams({
+      knownID: 'cell-unreachable',
+      runID: 'run-unreachable',
+      sequence: 2,
+      options: {
+        runnerEndpoint: 'ws://localhost:9977/ws',
+        interceptors: [],
+        autoReconnect: true,
+        initialIntent: RunIntent.RESUME,
+      },
+    })
+    const errors: unknown[] = []
+    const errorSubscription = streams.errors.subscribe((error) => {
+      errors.push(error)
+    })
+
+    streams.connect(Heartbeat.INITIAL).subscribe()
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      expect(MockWebSocket.instances).toHaveLength(attempt + 1)
+      MockWebSocket.instances[attempt].failConnection()
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+
+    expect(MockWebSocket.instances).toHaveLength(5)
+    expect(errors).toEqual([])
+
+    errorSubscription.unsubscribe()
+    streams.close()
+  })
+
   it('uses resume intent before reconnecting a persisted run', async () => {
     const streams = new Streams({
       knownID: 'cell-resume',

--- a/packages/renderers/src/streams.ts
+++ b/packages/renderers/src/streams.ts
@@ -67,6 +67,13 @@ export enum Heartbeat {
   INITIAL = 'INITIAL',
 }
 
+export enum RunIntent {
+  START = 'RUN_INTENT_START',
+  RESUME = 'RUN_INTENT_RESUME',
+}
+
+type OpenRunState = 'RUN_STATE_CREATED' | 'RUN_STATE_RUNNING'
+
 export type Authorization = {
   bearerToken: string | undefined
 }
@@ -91,6 +98,7 @@ type StreamsProps = {
     runnerEndpoint: string
     interceptors: Interceptor[]
     autoReconnect: boolean
+    initialIntent?: RunIntent
   }
 }
 
@@ -179,6 +187,7 @@ class Streams {
   private readonly runnerEndpoint: string
   private readonly interceptors: Interceptor[]
   private readonly autoReconnect: boolean
+  private nextIntent: RunIntent
 
   // Track consecutive connection failures to detect unreachable backend
   private connectionFailures: number[] = []
@@ -193,6 +202,7 @@ class Streams {
     this.runnerEndpoint = options.runnerEndpoint
     this.interceptors = options.interceptors
     this.autoReconnect = options.autoReconnect
+    this.nextIntent = options.initialIntent ?? RunIntent.START
 
     // Turn the connectables into hot observables
     this._latenciesConnectable.connect()
@@ -324,8 +334,10 @@ class Streams {
       url.searchParams.set('runID', this.runID)
       const socket = new WebSocket(url.toString())
       let opened = false
+      let negotiationComplete = false
       let failureRecorded = false
       let terminalFailure = false
+      const intent = this.nextIntent
 
       const recordConnectionFailure = (requiredFailures: number) => {
         if (failureRecorded) {
@@ -392,26 +404,61 @@ class Streams {
           console.warn('Unexpected WebSocket message type:', typeof event.data)
           return
         }
+
+        let rawMessage: { openRunResponse?: { state?: OpenRunState } }
+        try {
+          rawMessage = JSON.parse(event.data)
+        } catch (err) {
+          console.error('Failed to parse WebsocketResponse:', err)
+          return
+        }
+
+        if (rawMessage.openRunResponse) {
+          const state = rawMessage.openRunResponse.state
+          const expectedState =
+            intent === RunIntent.START
+              ? 'RUN_STATE_CREATED'
+              : 'RUN_STATE_RUNNING'
+          if (state !== expectedState) {
+            terminalFailure = true
+            observer.error(
+              new Error(
+                `Runner returned ${state ?? 'an unspecified state'} for ${intent}`
+              )
+            )
+            return
+          }
+
+          negotiationComplete = true
+          opened = true
+          this.connectionFailures = []
+          this.nextIntent = RunIntent.RESUME
+          observer.next(socket)
+          return
+        }
+
         let message: pb.WebsocketResponse
         try {
           message = parseWebsocketResponse(event.data)
         } catch (err) {
           console.error('Failed to parse WebsocketResponse:', err)
+          return
         }
 
-        const status = message!.status
+        const status = message.status
         if (status && status.code !== Code.OK) {
+          terminalFailure = true
           observer.error(status)
           return
         }
 
         // Pong is noop
-        if (message!.pong) {
+        if (message.pong) {
           // We could measure latency here
           return
         }
 
-        const response = message!.payload.value as ExecuteResponse
+        const response = message.payload.value as ExecuteResponse
         if (response.stdoutData && response.stdoutData.length > 0) {
           this.callback?.({
             type: ClientMessages.terminalStdout,
@@ -451,11 +498,18 @@ class Streams {
       }
 
       const onOpen = () => {
-        // Reset failure tracking on successful connection
-        this.connectionFailures = []
-        opened = true
-
-        observer.next(socket)
+        void sendOpenRunRequest({
+          intent,
+          interceptors: this.interceptors,
+          socket,
+          knownID: this.knownID,
+          runID: this.runID,
+        }).catch((err) => {
+          if (!negotiationComplete) {
+            terminalFailure = true
+            observer.error(err)
+          }
+        })
       }
 
       // Attach event listeners
@@ -647,29 +701,13 @@ function parseWebsocketResponse(data: string): pb.WebsocketResponse {
   return fromJson(pb.WebsocketResponseSchema, parsed)
 }
 
-// Sends a WebsocketRequest over a WebSocket after adding knownId, runId, and authorization.
-async function sendWebsocketRequest({
-  req,
+async function resolveAuthorization({
   interceptors,
   socket,
-  knownID,
-  runID,
 }: {
-  req: pb.WebsocketRequest
   interceptors: Interceptor[]
   socket: WebSocket
-  knownID?: string
-  runID?: string
-}) {
-  // knownID tracks the origin cell/cell of the request.
-  if (knownID) {
-    req.knownId = knownID
-  }
-  // runID identifies the specific execution of the request.
-  if (runID) {
-    req.runId = runID
-  }
-
+}): Promise<string | null> {
   // Create a dummy unary request for interceptor compatibility
   const authzReq: UnaryRequest = {
     stream: false,
@@ -704,9 +742,59 @@ async function sendWebsocketRequest({
   // Call the final interceptor chain
   const appliedAuthzResp = await next(authzReq)
 
+  return appliedAuthzResp.header.get('Authorization')
+}
+
+async function sendOpenRunRequest({
+  intent,
+  interceptors,
+  socket,
+  knownID,
+  runID,
+}: {
+  intent: RunIntent
+  interceptors: Interceptor[]
+  socket: WebSocket
+  knownID: string
+  runID: string
+}) {
+  const authorization = await resolveAuthorization({ interceptors, socket })
+  socket.send(
+    JSON.stringify({
+      openRunRequest: { intent },
+      ...(authorization ? { authorization } : {}),
+      knownId: knownID,
+      runId: runID,
+    })
+  )
+}
+
+// Sends a WebsocketRequest over a WebSocket after adding knownId, runId, and authorization.
+async function sendWebsocketRequest({
+  req,
+  interceptors,
+  socket,
+  knownID,
+  runID,
+}: {
+  req: pb.WebsocketRequest
+  interceptors: Interceptor[]
+  socket: WebSocket
+  knownID?: string
+  runID?: string
+}) {
+  // knownID tracks the origin cell/cell of the request.
+  if (knownID) {
+    req.knownId = knownID
+  }
+  // runID identifies the specific execution of the request.
+  if (runID) {
+    req.runId = runID
+  }
+
   // Websockets do not support authorization headers directly, so we add it to the request.
   // However, going the HTTP header route allows reusing interceptors across Connect and WebSockets.
-  const authorization = appliedAuthzResp.header.get('Authorization')
+  const authorization = await resolveAuthorization({ interceptors, socket })
   if (authorization && req) {
     req.authorization = authorization
   }

--- a/packages/renderers/src/streams.ts
+++ b/packages/renderers/src/streams.ts
@@ -51,8 +51,6 @@ const HEARTBEAT_INTERVAL_MS = 5_000
 const MONITOR_INTERVAL_MS = 1_000
 const MAX_LATENCY_DEADLINE_MS = 4_000
 const RECONNECT_THROTTLE_MS = 1_000
-const MAX_CONSECUTIVE_FAILURES = 3
-const FAILURE_WINDOW_MS = 5_000
 
 export type StreamError = Error | pb.WebsocketStatus
 
@@ -181,7 +179,6 @@ class Streams {
   // Identifiers for the cell/console associated with this stream
   private readonly knownID: string
   private readonly runID: string
-  private readonly sequence: number
 
   // Configuration
   private readonly runnerEndpoint: string
@@ -189,14 +186,10 @@ class Streams {
   private readonly autoReconnect: boolean
   private nextIntent: RunIntent
 
-  // Track consecutive connection failures to detect unreachable backend
-  private connectionFailures: number[] = []
-
-  constructor({ knownID, runID, sequence, options }: StreamsProps) {
+  constructor({ knownID, runID, options }: StreamsProps) {
     // Set the identifiers
     this.knownID = knownID
     this.runID = runID
-    this.sequence = sequence
 
     // Assign configuration
     this.runnerEndpoint = options.runnerEndpoint
@@ -333,38 +326,9 @@ class Streams {
       url.searchParams.set('id', streamID)
       url.searchParams.set('runID', this.runID)
       const socket = new WebSocket(url.toString())
-      let opened = false
       let negotiationComplete = false
-      let failureRecorded = false
       let terminalFailure = false
       const intent = this.nextIntent
-
-      const recordConnectionFailure = (requiredFailures: number) => {
-        if (failureRecorded) {
-          return false
-        }
-        failureRecorded = true
-
-        const now = Date.now()
-        this.connectionFailures.push(now)
-        this.connectionFailures = this.connectionFailures.filter(
-          (t) => now - t < FAILURE_WINDOW_MS
-        )
-
-        if (this.connectionFailures.length < requiredFailures) {
-          return false
-        }
-
-        this.connectionFailures = []
-        this._errors.next(
-          new Error(
-            `Unable to connect to Runme backend server for cell ${this.knownID} (#${this.sequence}).`
-          )
-        )
-        terminalFailure = true
-        observer.error(new Error('WebSocket connection failed'))
-        return true
-      }
 
       // Define event handlers
       const onClose = (event: CloseEvent) => {
@@ -374,11 +338,8 @@ class Streams {
         }
 
         if (this.autoReconnect) {
-          if (!opened) {
-            const shouldStop = recordConnectionFailure(MAX_CONSECUTIVE_FAILURES)
-            if (shouldStop || terminalFailure) {
-              return
-            }
+          if (terminalFailure) {
+            return
           }
           // This infinite loop is throttled by the reconnect subject.
           this.connect()
@@ -393,10 +354,8 @@ class Streams {
           return
         }
 
-        const shouldStop = recordConnectionFailure(MAX_CONSECUTIVE_FAILURES)
-        if (shouldStop || terminalFailure) {
-          return
-        }
+        // A transport failure says nothing about the execution. The close event
+        // will reconnect without clearing the persisted run state.
       }
 
       const onMessage = (event: MessageEvent) => {
@@ -430,8 +389,6 @@ class Streams {
           }
 
           negotiationComplete = true
-          opened = true
-          this.connectionFailures = []
           this.nextIntent = RunIntent.RESUME
           observer.next(socket)
           return


### PR DESCRIPTION
## Summary

- negotiate explicit `START` or `RESUME` intent as the first WebSocket application message
- wait for the runner acknowledgement before releasing execute requests or starting heartbeats
- restore a persisted active cell by resuming its saved `runID`
- mark the execution `unknown` only when the runner returns authoritative `NOT_FOUND`
- preserve the running state and keep reconnecting when the runner is unreachable
- document the protocol semantics, compatibility matrix, recovery behavior, runner-first rollout, and future terminal-state retention

## Root cause

The old runner could not distinguish a new execution from a reconnect. Connecting with an unknown historical `runID` created an empty multiplexer that answered heartbeats but had no process and would never emit an exit event. A persisted PID therefore left the cell displaying as running indefinitely.

## Behavior

`runID` continues to identify the execution; each WebSocket gets a fresh `streamID`.

- New run: send `START`, expect `CREATED`.
- Reconnect or browser refresh: send `RESUME`, expect `RUNNING`.
- Missing/expired run: receive `NOT_FOUND`, clear the stale PID, and record `unknown`.
- Unreachable runner: retain the PID and running state and keep reconnecting because transport failure is not a terminal execution result.
- Legacy clients remain supported by the new runner’s existing create-or-attach path.

Users may select another runner and rerun the cell, which creates a new `runID` and stops monitoring the old one. If the old runner remains unreachable, the client cannot guarantee that its process stopped. A future explicit abandon action can clear local running state without claiming remote cancellation.

Completed terminal results are not retained in this version. If a run finishes while the browser is disconnected, reconnect returns `NOT_FOUND`; retaining and replaying the exit result is documented as a future protocol extension.

Coordinated runner change: https://github.com/runmedev/runme/pull/1247

Design doc: https://github.com/runmedev/web/blob/codex/fix-stale-cell-execution/docs-dev/design/20260715_execution_monitoring.md

## Validation

- `pnpm --filter @runmedev/renderers exec vitest run src/streams.test.ts`
- `pnpm --filter @runmedev/app exec vitest run src/lib/notebookData.test.ts`
- `runme run build test`
