### PR TITLE
Connect explorer rows to Drive drag handling

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
     sync: vi.fn(),
   },
   openNotebookUpstreamDiff: vi.fn(),
+  dragHandle: vi.fn(),
   treeEdit: vi.fn(),
   treeProps: null as any,
   workspaceItems: [] as string[],
@@ -62,6 +63,7 @@ vi.mock('react-arborist', async () => {
             {children({
               node,
               style: {},
+              dragHandle: mocks.dragHandle,
             })}
             {item.children?.length ? renderItems(item.children, node) : null}
           </div>
@@ -190,6 +192,7 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.store.move.mockResolvedValue(undefined)
     mocks.store.sync.mockReset()
     mocks.openNotebookUpstreamDiff.mockReset()
+    mocks.dragHandle.mockReset()
     mocks.openNotebookUpstreamDiff.mockResolvedValue(undefined)
     mocks.treeEdit.mockReset()
     mocks.treeEdit.mockResolvedValue(undefined)
@@ -467,6 +470,17 @@ describe('WorkspaceExplorer current document handling', () => {
 
     render(<WorkspaceExplorer />)
     await screen.findByText('Drive Root')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    await screen.findByText('notebook.json')
+
+    expect(
+      mocks.dragHandle.mock.calls.some(
+        ([element]) =>
+          element instanceof HTMLElement &&
+          element.dataset.nodeId === 'local://file/notebook'
+      )
+    ).toBe(true)
 
     const dragNode = {
       data: {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -7,7 +7,12 @@ import {
   type CSSProperties,
   type MouseEvent,
 } from "react";
-import { Tree, type NodeApi, type TreeApi } from "react-arborist";
+import {
+  Tree,
+  type NodeApi,
+  type NodeRendererProps,
+  type TreeApi,
+} from "react-arborist";
 import { ChevronRightIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
 import { CloudArrowUpIcon, DocumentTextIcon, FolderIcon, FolderPlusIcon } from "@heroicons/react/24/outline";
 import useResizeObserver from "use-resize-observer";
@@ -875,13 +880,7 @@ function formatShortTimestamp(date: Date): string {
 }
 
   const renderNode = useCallback(
-    ({
-      node,
-      style,
-    }: {
-      node: NodeApi<TreeNode, unknown>;
-      style: CSSProperties;
-    }) => {
+    ({ node, style, dragHandle }: NodeRendererProps<TreeNode>) => {
       if (node.isEditing) {
         return <EditableTreeNode node={node} style={style} />;
       }
@@ -906,6 +905,7 @@ function formatShortTimestamp(date: Date): string {
       };
       return (
         <div
+          ref={dragHandle}
           style={style}
           className="flex h-full items-center gap-1.5 overflow-hidden px-2 text-sm"
           data-node-id={data.uri}


### PR DESCRIPTION
## Summary

- attach the react-arborist drag handle to each rendered explorer row
- add regression coverage that verifies a Drive-backed file row receives the connector
- preserve the existing Google Drive-only eligibility and synchronous move behavior

## Root cause

PR #279 added the Drive move API and tree move callbacks, but the custom node renderer ignored react-arborist’s dragHandle ref. The drag backend therefore had no DOM source from which to begin a drag.

## Validation

- pnpm -C app exec vitest run src/components/Workspace/WorkspaceExplorer.test.tsx (8 passed)
- pnpm -C app exec vitest run --silent (72 files, 652 tests passed)
- runme run build test
- development app in the in-app browser: explorer rows expose draggable=true and no new browser errors

Follow-up to #279 and #280.