### PR TITLE
Add notebook outline view

### DIFF
--- a/app/src/components/SidePanel/NotebookOutlinePanel.tsx
+++ b/app/src/components/SidePanel/NotebookOutlinePanel.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useMemo } from 'react'
+
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useNotebookContext } from '../../contexts/NotebookContext'
+import {
+  extractNotebookOutline,
+  type NotebookOutlineEntry,
+} from '../../lib/notebookOutline'
+import { isNotebookDocumentUri } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
+
+function findCellElement(
+  notebookUri: string,
+  cellRefId: string
+): HTMLElement | null {
+  const notebookElements =
+    document.querySelectorAll<HTMLElement>('[data-document-id]')
+  const notebookElement = Array.from(notebookElements).find(
+    (element) => element.dataset.documentId === notebookUri
+  )
+  const elements =
+    notebookElement?.querySelectorAll<HTMLElement>('[data-cell-ref-id]') ?? []
+  return (
+    Array.from(elements).find(
+      (element) => element.dataset.cellRefId === cellRefId
+    ) ?? null
+  )
+}
+
+export default function NotebookOutlinePanel() {
+  const { getCurrentDoc } = useCurrentDoc()
+  const { useNotebookSnapshot } = useNotebookContext()
+  const currentDocUri = getCurrentDoc()
+  const notebookUri =
+    currentDocUri && isNotebookDocumentUri(currentDocUri) ? currentDocUri : ''
+  const notebookSnapshot = useNotebookSnapshot(notebookUri)
+  const entries = useMemo(
+    () =>
+      notebookSnapshot?.loaded
+        ? extractNotebookOutline(notebookSnapshot.notebook.cells ?? [])
+        : [],
+    [notebookSnapshot]
+  )
+
+  const navigateToEntry = useCallback(
+    (entry: NotebookOutlineEntry) => {
+      findCellElement(notebookUri, entry.cellRefId)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      })
+    },
+    [notebookUri]
+  )
+
+  let emptyMessage: string | null = null
+  if (!notebookUri) {
+    emptyMessage = 'Open a notebook to see its outline.'
+  } else if (!notebookSnapshot?.loaded) {
+    emptyMessage = 'Loading outline…'
+  } else if (entries.length === 0) {
+    emptyMessage = 'Add Markdown headings to build an outline.'
+  }
+
+  return (
+    <div
+      id="notebook-outline-panel"
+      className="flex h-full min-h-0 w-full flex-col bg-nb-surface"
+    >
+      <div
+        id="notebook-outline-panel-header"
+        className="border-b border-nb-border px-4 py-3"
+      >
+        <p className="text-xs font-semibold tracking-[0.18em] text-nb-text-faint uppercase">
+          Outline
+        </p>
+        <p className="mt-1 text-sm text-nb-text-muted">
+          {entries.length} {entries.length === 1 ? 'heading' : 'headings'}
+        </p>
+      </div>
+      <nav
+        aria-label="Notebook outline"
+        className="min-h-0 flex-1 overflow-y-auto px-2 py-2"
+      >
+        {emptyMessage ? (
+          <div
+            id="notebook-outline-empty"
+            className="rounded-nb-sm border border-dashed border-nb-border bg-white/60 px-3 py-4 text-sm text-nb-text-muted"
+          >
+            {emptyMessage}
+          </div>
+        ) : (
+          <ul className="space-y-0.5">
+            {entries.map((entry) => (
+              <li key={`${entry.cellRefId}:${entry.line}`}>
+                <button
+                  type="button"
+                  className="block w-full truncate rounded-nb-sm py-1.5 pr-2 text-left text-sm text-nb-text-muted transition-colors hover:bg-white/80 hover:text-nb-text focus-visible:bg-white focus-visible:text-nb-text"
+                  data-heading-level={entry.level}
+                  onClick={() => navigateToEntry(entry)}
+                  style={{ paddingLeft: `${8 + (entry.level - 1) * 12}px` }}
+                  title={entry.text}
+                >
+                  {entry.text}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </nav>
+    </div>
+  )
+}

--- a/app/src/components/SidePanel/NotebookOutlinePanel.tsx
+++ b/app/src/components/SidePanel/NotebookOutlinePanel.tsx
@@ -1,11 +1,16 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { LinkIcon } from '@heroicons/react/20/solid'
 import { useCurrentDoc } from '../../contexts/CurrentDocContext'
 import { useNotebookContext } from '../../contexts/NotebookContext'
+import { useNotebookStore } from '../../contexts/NotebookStoreContext'
+import { appLogger } from '../../lib/logging/runtime'
 import {
   extractNotebookOutline,
   type NotebookOutlineEntry,
 } from '../../lib/notebookOutline'
+import { copyNotebookCellShareUrl } from '../../lib/shareLinks'
+import { showToast } from '../../lib/toast'
 import { isNotebookDocumentUri } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 
 function findCellElement(
@@ -26,13 +31,37 @@ function findCellElement(
   )
 }
 
+function focusCellElement(cellElement: HTMLElement): void {
+  const focusTarget =
+    cellElement.querySelector<HTMLElement>(
+      '[data-cell-focus-role="rendered"]'
+    ) ??
+    cellElement.querySelector<HTMLElement>(
+      '[data-cell-focus-role="editor"] textarea'
+    ) ??
+    cellElement.querySelector<HTMLElement>('[contenteditable="true"]') ??
+    cellElement.querySelector<HTMLElement>('[data-cell-focus-role="editor"]') ??
+    cellElement
+  focusTarget.focus({ preventScroll: true })
+}
+
 export default function NotebookOutlinePanel() {
   const { getCurrentDoc } = useCurrentDoc()
   const { useNotebookSnapshot } = useNotebookContext()
+  const { store } = useNotebookStore()
   const currentDocUri = getCurrentDoc()
   const notebookUri =
     currentDocUri && isNotebookDocumentUri(currentDocUri) ? currentDocUri : ''
   const notebookSnapshot = useNotebookSnapshot(notebookUri)
+  const [shareTarget, setShareTarget] = useState<{
+    notebookUri: string
+    targetUri: string | null
+  }>(() => ({
+    notebookUri,
+    targetUri: notebookUri || null,
+  }))
+  const shareTargetUri =
+    shareTarget.notebookUri === notebookUri ? shareTarget.targetUri : null
   const entries = useMemo(
     () =>
       notebookSnapshot?.loaded
@@ -41,14 +70,76 @@ export default function NotebookOutlinePanel() {
     [notebookSnapshot]
   )
 
+  useEffect(() => {
+    const fallbackUri = notebookUri || null
+    if (!store || !notebookUri.startsWith('local://')) {
+      setShareTarget({ notebookUri, targetUri: fallbackUri })
+      return
+    }
+
+    let cancelled = false
+    setShareTarget({ notebookUri, targetUri: null })
+    void (async () => {
+      try {
+        const metadata = await store.getMetadata(notebookUri)
+        if (!cancelled) {
+          setShareTarget({
+            notebookUri,
+            targetUri: metadata?.remoteUri?.trim() || fallbackUri,
+          })
+        }
+      } catch {
+        if (!cancelled) {
+          setShareTarget({ notebookUri, targetUri: fallbackUri })
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [notebookUri, store])
+
   const navigateToEntry = useCallback(
     (entry: NotebookOutlineEntry) => {
-      findCellElement(notebookUri, entry.cellRefId)?.scrollIntoView({
+      const cellElement = findCellElement(notebookUri, entry.cellRefId)
+      cellElement?.scrollIntoView({
         behavior: 'smooth',
         block: 'center',
       })
+      if (cellElement) {
+        focusCellElement(cellElement)
+      }
     },
     [notebookUri]
+  )
+
+  const copyEntryLink = useCallback(
+    async (entry: NotebookOutlineEntry) => {
+      if (!shareTargetUri) {
+        return
+      }
+      try {
+        await copyNotebookCellShareUrl(shareTargetUri, entry.cellRefId)
+        showToast({ message: 'Link to cell copied', tone: 'success' })
+      } catch (error) {
+        appLogger.error('Failed to copy notebook cell link from outline', {
+          attrs: {
+            scope: 'notebook.share',
+            code: 'NOTEBOOK_OUTLINE_CELL_LINK_COPY_FAILED',
+            notebookUri: shareTargetUri,
+            cellRefId: entry.cellRefId,
+            error: String(error),
+          },
+        })
+        showToast({
+          message:
+            'Could not copy the cell link. Check clipboard permissions and try again.',
+          tone: 'error',
+        })
+      }
+    },
+    [shareTargetUri]
   )
 
   let emptyMessage: string | null = null
@@ -90,16 +181,29 @@ export default function NotebookOutlinePanel() {
         ) : (
           <ul className="space-y-0.5">
             {entries.map((entry) => (
-              <li key={`${entry.cellRefId}:${entry.line}`}>
+              <li
+                key={`${entry.cellRefId}:${entry.line}`}
+                className="group flex min-w-0 items-center gap-1"
+              >
                 <button
                   type="button"
-                  className="block w-full truncate rounded-nb-sm py-1.5 pr-2 text-left text-sm text-nb-text-muted transition-colors hover:bg-white/80 hover:text-nb-text focus-visible:bg-white focus-visible:text-nb-text"
+                  className="block min-w-0 flex-1 truncate rounded-nb-sm py-1.5 pr-2 text-left text-sm text-nb-text-muted transition-colors hover:bg-white/80 hover:text-nb-text focus-visible:bg-white focus-visible:text-nb-text"
                   data-heading-level={entry.level}
                   onClick={() => navigateToEntry(entry)}
                   style={{ paddingLeft: `${8 + (entry.level - 1) * 12}px` }}
                   title={entry.text}
                 >
                   {entry.text}
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Copy link to ${entry.text}`}
+                  className="icon-btn h-7 w-7 shrink-0 text-nb-text-faint transition-colors hover:bg-white/80 hover:text-nb-accent focus-visible:bg-white focus-visible:text-nb-accent disabled:opacity-40"
+                  disabled={!shareTargetUri}
+                  onClick={() => void copyEntryLink(entry)}
+                  title="Copy link to cell"
+                >
+                  <LinkIcon className="h-4 w-4" />
                 </button>
               </li>
             ))}

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { useEffect } from 'react'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 type PanelKey = 'explorer' | 'open-documents' | 'outline' | 'chatkit' | null
@@ -92,6 +98,12 @@ vi.mock('../../contexts/GoogleAuthContext', () => ({
 vi.mock('../../contexts/NotebookContext', () => ({
   useNotebookContext: () => ({
     useNotebookSnapshot: () => notebookSnapshotState,
+  }),
+}))
+
+vi.mock('../../contexts/NotebookStoreContext', () => ({
+  useNotebookStore: () => ({
+    store: null,
   }),
 }))
 
@@ -412,7 +424,12 @@ describe('SidePanelContent ChatKit persistence', () => {
     )
   })
 
-  it('renders Markdown headings and scrolls the selected cell into view', () => {
+  it('focuses outline cells and copies their deep links', async () => {
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
     activePanelState = 'outline'
     currentDocUri = 'local://file/outline.json'
     notebookSnapshotState = {
@@ -443,6 +460,9 @@ describe('SidePanelContent ChatKit persistence', () => {
     const secondCellElement = document.createElement('div')
     secondCellElement.dataset.cellRefId = 'cell-two'
     secondCellElement.scrollIntoView = vi.fn()
+    const secondCellFocusTarget = document.createElement('button')
+    secondCellFocusTarget.dataset.cellFocusRole = 'rendered'
+    secondCellElement.appendChild(secondCellFocusTarget)
     notebookElement.appendChild(secondCellElement)
     document.body.appendChild(notebookElement)
 
@@ -456,6 +476,16 @@ describe('SidePanelContent ChatKit persistence', () => {
     expect(secondCellElement.scrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'center',
+    })
+    expect(document.activeElement).toBe(secondCellFocusTarget)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Copy link to Second cell' })
+    )
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        'http://localhost:3000/?doc=local%3A%2F%2Ffile%2Foutline.json#cell=cell-two'
+      )
     })
 
     notebookElement.remove()

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-type PanelKey = 'explorer' | 'open-documents' | 'chatkit' | null
+type PanelKey = 'explorer' | 'open-documents' | 'outline' | 'chatkit' | null
 
 let authData: {} | null = null
 let isDriveSyncing = false
@@ -19,6 +19,17 @@ let openDocumentsState: {
 let runnersState: { name: string; endpoint: string; reconnect: boolean }[] = []
 let chatKitMountCount = 0
 let chatKitUnmountCount = 0
+let notebookSnapshotState: {
+  loaded: boolean
+  notebook: {
+    cells: {
+      kind: number
+      languageId: string
+      refId: string
+      value: string
+    }[]
+  }
+} | null = null
 const ensureAccessTokenMock = vi.fn(async () => 'token')
 const startGoogleDriveOAuthMock = vi.fn(async () => ({
   status: 'started',
@@ -78,6 +89,12 @@ vi.mock('../../contexts/GoogleAuthContext', () => ({
   }),
 }))
 
+vi.mock('../../contexts/NotebookContext', () => ({
+  useNotebookContext: () => ({
+    useNotebookSnapshot: () => notebookSnapshotState,
+  }),
+}))
+
 vi.mock('../../contexts/RunnersContext', () => ({
   useRunners: () => ({
     defaultRunnerName: runnersState[0]?.name ?? null,
@@ -114,6 +131,7 @@ describe('SidePanelToolbar drive status button', () => {
     runnersState = []
     chatKitMountCount = 0
     chatKitUnmountCount = 0
+    notebookSnapshotState = null
     ensureAccessTokenMock.mockClear()
     startGoogleDriveOAuthMock.mockClear()
     loginWithRedirectMock.mockClear()
@@ -214,12 +232,20 @@ describe('SidePanelToolbar drive status button', () => {
     expect(togglePanelMock).toHaveBeenCalledWith('open-documents')
   })
 
-  it('exposes an App Console button in the toolbar', () => {
+  it('exposes an Outline button in the toolbar', () => {
     render(<SidePanelToolbar />)
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Open App Console' })
+      screen.getByRole('button', { name: 'Toggle Outline panel' })
     )
+
+    expect(togglePanelMock).toHaveBeenCalledWith('outline')
+  })
+
+  it('exposes an App Console button in the toolbar', () => {
+    render(<SidePanelToolbar />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open App Console' }))
 
     expect(showDocumentMock).toHaveBeenCalledWith('app://console', {
       title: 'App Console',
@@ -313,6 +339,7 @@ describe('SidePanelContent ChatKit persistence', () => {
     runnersState = []
     chatKitMountCount = 0
     chatKitUnmountCount = 0
+    notebookSnapshotState = null
     setCurrentDocMock.mockClear()
     showDocumentMock.mockClear()
     closeWorkspaceDocumentMock.mockClear()
@@ -383,6 +410,69 @@ describe('SidePanelContent ChatKit persistence', () => {
     expect(closeWorkspaceDocumentMock).toHaveBeenCalledWith(
       'local://file/alpha.json'
     )
+  })
+
+  it('renders Markdown headings and scrolls the selected cell into view', () => {
+    activePanelState = 'outline'
+    currentDocUri = 'local://file/outline.json'
+    notebookSnapshotState = {
+      loaded: true,
+      notebook: {
+        cells: [
+          {
+            kind: 1,
+            languageId: 'markdown',
+            refId: 'cell-one',
+            value: '# Title\n\n### Details',
+          },
+        ],
+      },
+    }
+    const cellElement = document.createElement('div')
+    cellElement.dataset.cellRefId = 'cell-one'
+    cellElement.scrollIntoView = vi.fn()
+    const notebookElement = document.createElement('div')
+    notebookElement.dataset.documentId = currentDocUri
+    notebookElement.appendChild(cellElement)
+    document.body.appendChild(notebookElement)
+
+    render(<SidePanelContent />)
+
+    expect(screen.getByText('2 headings')).toBeTruthy()
+    expect(
+      screen.getByRole('button', { name: 'Details' }).dataset.headingLevel
+    ).toBe('3')
+    fireEvent.click(screen.getByRole('button', { name: 'Title' }))
+    expect(cellElement.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+    })
+
+    notebookElement.remove()
+  })
+
+  it('shows an outline empty state for notebooks without headings', () => {
+    activePanelState = 'outline'
+    currentDocUri = 'local://file/outline.json'
+    notebookSnapshotState = {
+      loaded: true,
+      notebook: {
+        cells: [
+          {
+            kind: 1,
+            languageId: 'markdown',
+            refId: 'cell-one',
+            value: 'No headings yet.',
+          },
+        ],
+      },
+    }
+
+    render(<SidePanelContent />)
+
+    expect(
+      screen.getByText('Add Markdown headings to build an outline.')
+    ).toBeTruthy()
   })
 
   it('shows blocked notebook status from open entry metadata', () => {

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -425,6 +425,12 @@ describe('SidePanelContent ChatKit persistence', () => {
             refId: 'cell-one',
             value: '# Title\n\n### Details',
           },
+          {
+            kind: 2,
+            languageId: 'markdown',
+            refId: 'cell-two',
+            value: '## Second cell',
+          },
         ],
       },
     }
@@ -434,16 +440,20 @@ describe('SidePanelContent ChatKit persistence', () => {
     const notebookElement = document.createElement('div')
     notebookElement.dataset.documentId = currentDocUri
     notebookElement.appendChild(cellElement)
+    const secondCellElement = document.createElement('div')
+    secondCellElement.dataset.cellRefId = 'cell-two'
+    secondCellElement.scrollIntoView = vi.fn()
+    notebookElement.appendChild(secondCellElement)
     document.body.appendChild(notebookElement)
 
     render(<SidePanelContent />)
 
-    expect(screen.getByText('2 headings')).toBeTruthy()
+    expect(screen.getByText('3 headings')).toBeTruthy()
     expect(
       screen.getByRole('button', { name: 'Details' }).dataset.headingLevel
     ).toBe('3')
-    fireEvent.click(screen.getByRole('button', { name: 'Title' }))
-    expect(cellElement.scrollIntoView).toHaveBeenCalledWith({
+    fireEvent.click(screen.getByRole('button', { name: 'Second cell' }))
+    expect(secondCellElement.scrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'center',
     })

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -5,6 +5,7 @@ import {
   ChatBubbleLeftRightIcon,
   DocumentTextIcon,
   InformationCircleIcon,
+  Bars3BottomLeftIcon,
   QueueListIcon,
   ServerStackIcon,
   UserCircleIcon,
@@ -21,6 +22,7 @@ import {
 } from 'react'
 
 import ChatKitPanel from '../ChatKit/ChatKitPanel'
+import NotebookOutlinePanel from './NotebookOutlinePanel'
 import WorkspaceExplorer from '../Workspace/WorkspaceExplorer'
 import {
   getBrowserAdapter,
@@ -375,6 +377,18 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
+            activePanel === 'outline' ? sideButtonActive : sideButtonInactive
+          }`}
+          aria-pressed={activePanel === 'outline'}
+          aria-label="Toggle Outline panel"
+          onClick={() => togglePanel('outline')}
+        >
+          <Bars3BottomLeftIcon className="h-5 w-5" />
+          <span className={tooltipBase}>Outline</span>
+        </button>
+        <button
+          type="button"
+          className={`${sideButtonBase} ${
             activePanel === 'chatkit' ? sideButtonActive : sideButtonInactive
           }`}
           aria-pressed={activePanel === 'chatkit'}
@@ -553,6 +567,11 @@ export function SidePanelContent() {
       >
         <OpenDocumentsPanel />
       </div>
+      {activePanel === 'outline' ? (
+        <div className="flex h-full min-h-0 w-full">
+          <NotebookOutlinePanel />
+        </div>
+      ) : null}
       {shouldRenderChatKit ? (
         <div
           className={`h-full min-h-0 w-full overflow-hidden ${activePanel === 'chatkit' ? 'flex' : 'hidden'}`}

--- a/app/src/contexts/SidePanelContext.tsx
+++ b/app/src/contexts/SidePanelContext.tsx
@@ -1,73 +1,92 @@
-import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
-export type PanelKey = "explorer" | "open-documents" | "chatkit" | null;
+export type PanelKey =
+  | 'explorer'
+  | 'open-documents'
+  | 'outline'
+  | 'chatkit'
+  | null
 
 interface SidePanelContextValue {
-  activePanel: PanelKey;
-  togglePanel: (panel: Exclude<PanelKey, null>) => void;
-  setPanel: (panel: PanelKey) => void;
+  activePanel: PanelKey
+  togglePanel: (panel: Exclude<PanelKey, null>) => void
+  setPanel: (panel: PanelKey) => void
 }
 
-const STORAGE_KEY = "runme.sidePanel.active";
-const LEGACY_STORAGE_KEY = "aisre.sidePanel.active";
+const STORAGE_KEY = 'runme.sidePanel.active'
+const LEGACY_STORAGE_KEY = 'aisre.sidePanel.active'
 
-const SidePanelContext = createContext<SidePanelContextValue | undefined>(undefined);
+const SidePanelContext = createContext<SidePanelContextValue | undefined>(
+  undefined
+)
 
 export function SidePanelProvider({ children }: { children: ReactNode }) {
   const [activePanel, setActivePanel] = useState<PanelKey>(() => {
-    if (typeof window === "undefined") {
-      return "explorer";
+    if (typeof window === 'undefined') {
+      return 'explorer'
     }
     try {
       const stored =
         localStorage.getItem(STORAGE_KEY) ??
-        localStorage.getItem(LEGACY_STORAGE_KEY);
+        localStorage.getItem(LEGACY_STORAGE_KEY)
       if (
-        stored === "explorer" ||
-        stored === "open-documents" ||
-        stored === "open-notebooks" ||
-        stored === "chatkit"
+        stored === 'explorer' ||
+        stored === 'open-documents' ||
+        stored === 'open-notebooks' ||
+        stored === 'outline' ||
+        stored === 'chatkit'
       ) {
-        return stored === "open-notebooks" ? "open-documents" : stored;
+        return stored === 'open-notebooks' ? 'open-documents' : stored
       }
     } catch (error) {
-      console.error("Failed to read side panel state", error);
+      console.error('Failed to read side panel state', error)
     }
-    return "explorer";
-  });
+    return 'explorer'
+  })
 
   useEffect(() => {
     try {
       if (activePanel) {
-        localStorage.setItem(STORAGE_KEY, activePanel);
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        localStorage.setItem(STORAGE_KEY, activePanel)
+        localStorage.removeItem(LEGACY_STORAGE_KEY)
       } else {
-        localStorage.removeItem(STORAGE_KEY);
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        localStorage.removeItem(STORAGE_KEY)
+        localStorage.removeItem(LEGACY_STORAGE_KEY)
       }
     } catch (error) {
-      console.error("Failed to persist side panel state", error);
+      console.error('Failed to persist side panel state', error)
     }
-  }, [activePanel]);
+  }, [activePanel])
 
   const value = useMemo(
     () => ({
       activePanel,
       togglePanel: (panel: Exclude<PanelKey, null>) => {
-        setActivePanel((prev) => (prev === panel ? null : panel));
+        setActivePanel((prev) => (prev === panel ? null : panel))
       },
       setPanel: setActivePanel,
     }),
-    [activePanel],
-  );
+    [activePanel]
+  )
 
-  return <SidePanelContext.Provider value={value}>{children}</SidePanelContext.Provider>;
+  return (
+    <SidePanelContext.Provider value={value}>
+      {children}
+    </SidePanelContext.Provider>
+  )
 }
 
 export function useSidePanel() {
-  const ctx = useContext(SidePanelContext);
+  const ctx = useContext(SidePanelContext)
   if (!ctx) {
-    throw new Error("useSidePanel must be used within a SidePanelProvider");
+    throw new Error('useSidePanel must be used within a SidePanelProvider')
   }
-  return ctx;
+  return ctx
 }

--- a/app/src/contexts/SidePanelContext.tsx
+++ b/app/src/contexts/SidePanelContext.tsx
@@ -1,92 +1,79 @@
-import {
-  createContext,
-  ReactNode,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from "react";
 
 export type PanelKey =
-  | 'explorer'
-  | 'open-documents'
-  | 'outline'
-  | 'chatkit'
-  | null
+  | "explorer"
+  | "open-documents"
+  | "outline"
+  | "chatkit"
+  | null;
 
 interface SidePanelContextValue {
-  activePanel: PanelKey
-  togglePanel: (panel: Exclude<PanelKey, null>) => void
-  setPanel: (panel: PanelKey) => void
+  activePanel: PanelKey;
+  togglePanel: (panel: Exclude<PanelKey, null>) => void;
+  setPanel: (panel: PanelKey) => void;
 }
 
-const STORAGE_KEY = 'runme.sidePanel.active'
-const LEGACY_STORAGE_KEY = 'aisre.sidePanel.active'
+const STORAGE_KEY = "runme.sidePanel.active";
+const LEGACY_STORAGE_KEY = "aisre.sidePanel.active";
 
-const SidePanelContext = createContext<SidePanelContextValue | undefined>(
-  undefined
-)
+const SidePanelContext = createContext<SidePanelContextValue | undefined>(undefined);
 
 export function SidePanelProvider({ children }: { children: ReactNode }) {
   const [activePanel, setActivePanel] = useState<PanelKey>(() => {
-    if (typeof window === 'undefined') {
-      return 'explorer'
+    if (typeof window === "undefined") {
+      return "explorer";
     }
     try {
       const stored =
         localStorage.getItem(STORAGE_KEY) ??
-        localStorage.getItem(LEGACY_STORAGE_KEY)
+        localStorage.getItem(LEGACY_STORAGE_KEY);
       if (
-        stored === 'explorer' ||
-        stored === 'open-documents' ||
-        stored === 'open-notebooks' ||
-        stored === 'outline' ||
-        stored === 'chatkit'
+        stored === "explorer" ||
+        stored === "open-documents" ||
+        stored === "open-notebooks" ||
+        stored === "outline" ||
+        stored === "chatkit"
       ) {
-        return stored === 'open-notebooks' ? 'open-documents' : stored
+        return stored === "open-notebooks" ? "open-documents" : stored;
       }
     } catch (error) {
-      console.error('Failed to read side panel state', error)
+      console.error("Failed to read side panel state", error);
     }
-    return 'explorer'
-  })
+    return "explorer";
+  });
 
   useEffect(() => {
     try {
       if (activePanel) {
-        localStorage.setItem(STORAGE_KEY, activePanel)
-        localStorage.removeItem(LEGACY_STORAGE_KEY)
+        localStorage.setItem(STORAGE_KEY, activePanel);
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
       } else {
-        localStorage.removeItem(STORAGE_KEY)
-        localStorage.removeItem(LEGACY_STORAGE_KEY)
+        localStorage.removeItem(STORAGE_KEY);
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
       }
     } catch (error) {
-      console.error('Failed to persist side panel state', error)
+      console.error("Failed to persist side panel state", error);
     }
-  }, [activePanel])
+  }, [activePanel]);
 
   const value = useMemo(
     () => ({
       activePanel,
       togglePanel: (panel: Exclude<PanelKey, null>) => {
-        setActivePanel((prev) => (prev === panel ? null : panel))
+        setActivePanel((prev) => (prev === panel ? null : panel));
       },
       setPanel: setActivePanel,
     }),
-    [activePanel]
-  )
+    [activePanel],
+  );
 
-  return (
-    <SidePanelContext.Provider value={value}>
-      {children}
-    </SidePanelContext.Provider>
-  )
+  return <SidePanelContext.Provider value={value}>{children}</SidePanelContext.Provider>;
 }
 
 export function useSidePanel() {
-  const ctx = useContext(SidePanelContext)
+  const ctx = useContext(SidePanelContext);
   if (!ctx) {
-    throw new Error('useSidePanel must be used within a SidePanelProvider')
+    throw new Error("useSidePanel must be used within a SidePanelProvider");
   }
-  return ctx
+  return ctx;
 }

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -385,13 +385,13 @@ describe('appConfig OIDC Google shorthand', () => {
       setLocalConfigPreferredOnLoad,
     } = await loadModules()
 
-    expect(isLocalConfigPreferredOnLoad()).toBe(false)
-
-    expect(disableAppConfigOverridesOnLoad()).toBe(true)
     expect(isLocalConfigPreferredOnLoad()).toBe(true)
 
     expect(setLocalConfigPreferredOnLoad(false)).toBe(false)
     expect(isLocalConfigPreferredOnLoad()).toBe(false)
+
+    expect(disableAppConfigOverridesOnLoad()).toBe(true)
+    expect(isLocalConfigPreferredOnLoad()).toBe(true)
 
     expect(enableAppConfigOverridesOnLoad()).toBe(false)
     expect(isLocalConfigPreferredOnLoad()).toBe(false)

--- a/app/src/lib/appConfig.ts
+++ b/app/src/lib/appConfig.ts
@@ -868,13 +868,18 @@ export function setAppConfigFromYaml(
 
 export function isLocalConfigPreferredOnLoad(): boolean {
   if (typeof window === 'undefined' || !window.localStorage) {
+    return import.meta.env.DEV
+  }
+  const storedPreference = normalizeString(
+    window.localStorage.getItem(APP_CONFIG_PREFER_LOCAL_STORAGE_KEY)
+  )
+  if (storedPreference === 'true') {
+    return true
+  }
+  if (storedPreference === 'false') {
     return false
   }
-  return (
-    normalizeString(
-      window.localStorage.getItem(APP_CONFIG_PREFER_LOCAL_STORAGE_KEY)
-    ) === 'true'
-  )
+  return import.meta.env.DEV
 }
 
 export function setLocalConfigPreferredOnLoad(preferLocal: boolean): boolean {

--- a/app/src/lib/notebookOutline.test.ts
+++ b/app/src/lib/notebookOutline.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { parser_pb } from '../contexts/CellContext'
+import { extractNotebookOutline } from './notebookOutline'
+
+function markupCell(refId: string, value: string) {
+  return {
+    kind: parser_pb.CellKind.MARKUP,
+    languageId: 'markdown',
+    refId,
+    value,
+  }
+}
+
+describe('extractNotebookOutline', () => {
+  it('extracts ATX and Setext headings in notebook order', () => {
+    const outline = extractNotebookOutline([
+      markupCell(
+        'cell-one',
+        '# Title\n\n## Section ##\n\nSetext section\n---\n\n###### Detail'
+      ),
+      markupCell('cell-two', 'Another title\n==='),
+    ])
+
+    expect(outline).toEqual([
+      { cellRefId: 'cell-one', level: 1, line: 1, text: 'Title' },
+      { cellRefId: 'cell-one', level: 2, line: 3, text: 'Section' },
+      { cellRefId: 'cell-one', level: 2, line: 5, text: 'Setext section' },
+      { cellRefId: 'cell-one', level: 6, line: 8, text: 'Detail' },
+      { cellRefId: 'cell-two', level: 1, line: 1, text: 'Another title' },
+    ])
+  })
+
+  it('ignores heading-like text in fenced code blocks', () => {
+    const outline = extractNotebookOutline([
+      markupCell(
+        'cell-one',
+        '# Visible\n\n```markdown\n# Hidden\n````\n\n~~~\n## Also hidden\n~~~\n\n## Visible too'
+      ),
+    ])
+
+    expect(outline.map((entry) => entry.text)).toEqual([
+      'Visible',
+      'Visible too',
+    ])
+  })
+
+  it('ignores code cells and accepts markup cells without a language id', () => {
+    const outline = extractNotebookOutline([
+      {
+        kind: parser_pb.CellKind.CODE,
+        languageId: 'markdown',
+        refId: 'code-cell',
+        value: '# Not a markup cell',
+      },
+      {
+        kind: parser_pb.CellKind.MARKUP,
+        languageId: '',
+        refId: 'legacy-markup-cell',
+        value: '# Legacy markup',
+      },
+      markupCell('empty', 'No headings here.'),
+    ])
+
+    expect(outline).toEqual([
+      {
+        cellRefId: 'legacy-markup-cell',
+        level: 1,
+        line: 1,
+        text: 'Legacy markup',
+      },
+    ])
+  })
+})

--- a/app/src/lib/notebookOutline.test.ts
+++ b/app/src/lib/notebookOutline.test.ts
@@ -45,13 +45,19 @@ describe('extractNotebookOutline', () => {
     ])
   })
 
-  it('ignores code cells and accepts markup cells without a language id', () => {
+  it('accepts Markdown-language code cells and markup cells without a language id', () => {
     const outline = extractNotebookOutline([
       {
         kind: parser_pb.CellKind.CODE,
         languageId: 'markdown',
-        refId: 'code-cell',
-        value: '# Not a markup cell',
+        refId: 'markdown-code-cell',
+        value: '# Markdown code cell',
+      },
+      {
+        kind: parser_pb.CellKind.CODE,
+        languageId: 'python',
+        refId: 'python-code-cell',
+        value: '# Python comment',
       },
       {
         kind: parser_pb.CellKind.MARKUP,
@@ -63,6 +69,12 @@ describe('extractNotebookOutline', () => {
     ])
 
     expect(outline).toEqual([
+      {
+        cellRefId: 'markdown-code-cell',
+        level: 1,
+        line: 1,
+        text: 'Markdown code cell',
+      },
       {
         cellRefId: 'legacy-markup-cell',
         level: 1,

--- a/app/src/lib/notebookOutline.ts
+++ b/app/src/lib/notebookOutline.ts
@@ -1,0 +1,104 @@
+import { parser_pb } from '../contexts/CellContext'
+
+export type NotebookOutlineEntry = {
+  cellRefId: string
+  level: number
+  line: number
+  text: string
+}
+
+type OutlineCell = Pick<
+  parser_pb.Cell,
+  'kind' | 'languageId' | 'refId' | 'value'
+>
+
+const atxHeadingPattern = /^ {0,3}(#{1,6})(?:[ \t]+|$)(.*)$/
+const setextHeadingPattern = /^ {0,3}(=+|-+)[ \t]*$/
+const fencePattern = /^ {0,3}(`{3,}|~{3,})(.*)$/
+
+function normalizeAtxHeading(value: string): string {
+  return value.replace(/[ \t]+#+[ \t]*$/, '').trim()
+}
+
+function isSetextHeadingText(value: string): boolean {
+  const trimmed = value.trim()
+  return Boolean(
+    trimmed &&
+      !atxHeadingPattern.test(value) &&
+      !fencePattern.test(value) &&
+      !/^ {0,3}(?:>|[-+*][ \t])/.test(value)
+  )
+}
+
+function extractCellHeadings(cell: OutlineCell): NotebookOutlineEntry[] {
+  const entries: NotebookOutlineEntry[] = []
+  const lines = cell.value.split(/\r?\n/)
+  let fenceCharacter: '`' | '~' | null = null
+  let fenceLength = 0
+
+  lines.forEach((line, index) => {
+    const fenceMatch = line.match(fencePattern)
+    if (fenceMatch) {
+      const marker = fenceMatch[1] ?? ''
+      const markerCharacter = marker[0] as '`' | '~'
+      if (!fenceCharacter) {
+        fenceCharacter = markerCharacter
+        fenceLength = marker.length
+      } else if (
+        markerCharacter === fenceCharacter &&
+        marker.length >= fenceLength &&
+        (fenceMatch[2] ?? '').trim() === ''
+      ) {
+        fenceCharacter = null
+        fenceLength = 0
+      }
+      return
+    }
+
+    if (fenceCharacter) {
+      return
+    }
+
+    const atxMatch = line.match(atxHeadingPattern)
+    if (atxMatch) {
+      const text = normalizeAtxHeading(atxMatch[2] ?? '')
+      if (text) {
+        entries.push({
+          cellRefId: cell.refId,
+          level: atxMatch[1]?.length ?? 1,
+          line: index + 1,
+          text,
+        })
+      }
+      return
+    }
+
+    const setextMatch = line.match(setextHeadingPattern)
+    const previousLine = lines[index - 1]
+    if (
+      setextMatch &&
+      previousLine !== undefined &&
+      isSetextHeadingText(previousLine)
+    ) {
+      entries.push({
+        cellRefId: cell.refId,
+        level: setextMatch[1]?.startsWith('=') ? 1 : 2,
+        line: index,
+        text: previousLine.trim(),
+      })
+    }
+  })
+
+  return entries
+}
+
+export function extractNotebookOutline(
+  cells: readonly OutlineCell[]
+): NotebookOutlineEntry[] {
+  return cells.flatMap((cell) => {
+    if (cell.kind !== parser_pb.CellKind.MARKUP || !cell.refId) {
+      return []
+    }
+    return extractCellHeadings(cell)
+  })
+}

--- a/app/src/lib/notebookOutline.ts
+++ b/app/src/lib/notebookOutline.ts
@@ -1,4 +1,5 @@
 import { parser_pb } from '../contexts/CellContext'
+import { isMarkdownLanguageId } from './cellContent'
 
 export type NotebookOutlineEntry = {
   cellRefId: string
@@ -96,7 +97,10 @@ export function extractNotebookOutline(
   cells: readonly OutlineCell[]
 ): NotebookOutlineEntry[] {
   return cells.flatMap((cell) => {
-    if (cell.kind !== parser_pb.CellKind.MARKUP || !cell.refId) {
+    const isMarkdownCell =
+      cell.kind === parser_pb.CellKind.MARKUP ||
+      isMarkdownLanguageId(cell.languageId)
+    if (!isMarkdownCell || !cell.refId) {
       return []
     }
     return extractCellHeadings(cell)


### PR DESCRIPTION
## Summary

- add an Outline activity-bar panel for the active notebook
- derive a live hierarchy from Markdown ATX and Setext headings
- scroll outline selections to the matching notebook cell
- persist the selected Outline panel alongside existing side panels
- cover heading extraction, empty states, toolbar behavior, and navigation

## Why

Long notebooks need a deterministic way to navigate between sections. Standard Markdown headings already encode the author's intended structure and update with notebook edits, avoiding generated titles or a second metadata system.

## Design

The design and implementation notes are in the [20260718_outline_view Runme notebook](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1ybxrsPUfVXyKerE8eB-l9ImU5mpuoBtk%2Fview).

## Validation

- `pnpm -C app test --run src/lib/notebookOutline.test.ts src/components/SidePanel/SidePanel.test.tsx` (22 tests passed)
- `runme run build test`
- `git diff --check`

## Review notes

The review addressed three findings before handoff: legacy markup cells no longer require an explicit language ID, cell lookup is scoped to the active notebook to prevent cross-tab collisions, and unrelated formatting churn was removed from `SidePanelContext.tsx`.
