### PR TITLE
Fix rendered Markdown link navigation

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -13,6 +13,7 @@ import {
   APPKERNEL_RUNNER_NAME,
   APPKERNEL_SANDBOX_RUNNER_NAME,
 } from '../../lib/runtime/appKernel'
+import { driveLinkCoordinator } from '../../lib/driveLinkCoordinator'
 
 import { parser_pb, RunmeMetadataKey } from '../../runme/client'
 import type { CellData } from '../../lib/notebookData'
@@ -48,6 +49,7 @@ const contextMocks = vi.hoisted(() => ({
   showDocument: vi.fn(),
   closeWorkspaceDocument: vi.fn(),
   getNotebookData: vi.fn(),
+  openNotebook: vi.fn(),
   requestWriteAccess: vi.fn(async () => undefined),
   refreshReadOnlyNotebook: vi.fn(async () => undefined),
   notebookSnapshots: new Map<
@@ -112,6 +114,7 @@ vi.mock('../../contexts/SettingsContext', () => ({
 vi.mock('../../contexts/NotebookContext', () => ({
   useNotebookContext: () => ({
     getNotebookData: contextMocks.getNotebookData,
+    openNotebook: contextMocks.openNotebook,
     requestWriteAccess: contextMocks.requestWriteAccess,
     refreshReadOnlyNotebook: contextMocks.refreshReadOnlyNotebook,
     useNotebookSnapshot: (uri: string) =>
@@ -305,6 +308,11 @@ beforeEach(() => {
   contextMocks.closeWorkspaceDocument.mockReset()
   contextMocks.getNotebookData.mockReset()
   contextMocks.getNotebookData.mockReturnValue(null)
+  contextMocks.openNotebook.mockReset()
+  contextMocks.openNotebook.mockImplementation(async (uri: string) => ({
+    localUri: uri,
+    entry: { name: 'Notes.json' },
+  }))
   contextMocks.requestWriteAccess.mockReset()
   contextMocks.requestWriteAccess.mockResolvedValue(undefined)
   contextMocks.refreshReadOnlyNotebook.mockReset()
@@ -1274,6 +1282,73 @@ describe('Actions tabs', () => {
 })
 
 describe('Action component', () => {
+  it('opens Runme notebook links in the current workspace', async () => {
+    const targetUri = 'local://file/notes'
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'markdown-notebook-link',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      value: `[Notes](/?doc=${encodeURIComponent(targetUri)}#cell=markup%2Fintro)`,
+      metadata: {},
+    })
+
+    render(
+      <Action
+        cellData={new StubCellData(cell) as unknown as CellData}
+        isFirst={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'Notes' }))
+
+    await waitFor(() => {
+      expect(contextMocks.openNotebook).toHaveBeenCalledWith(targetUri)
+    })
+    expect(contextMocks.showDocument).toHaveBeenCalledWith(targetUri, {
+      title: 'Notes.json',
+    })
+    expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(targetUri)
+    expect(window.location.hash).toBe('#cell=markup%2Fintro')
+  })
+
+  it('routes Drive-backed Runme links through shared-link coordination', async () => {
+    const targetUri = 'https://drive.google.com/file/d/file123/view'
+    const enqueue = vi
+      .spyOn(driveLinkCoordinator, 'enqueue')
+      .mockResolvedValue(undefined)
+    const getSnapshot = vi
+      .spyOn(driveLinkCoordinator, 'getSnapshot')
+      .mockReturnValue({
+        intents: [],
+        authBlocked: false,
+        lastErrorMessage: null,
+      })
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'markdown-drive-link',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      value: `[Notes](/?doc=${encodeURIComponent(targetUri)})`,
+      metadata: {},
+    })
+
+    render(
+      <Action
+        cellData={new StubCellData(cell) as unknown as CellData}
+        isFirst={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'Notes' }))
+
+    await waitFor(() => {
+      expect(enqueue).toHaveBeenCalledWith(targetUri, 'manual')
+    })
+    expect(contextMocks.openNotebook).not.toHaveBeenCalled()
+
+    enqueue.mockRestore()
+    getSnapshot.mockRestore()
+  })
+
   it('copies a deep link for the cell from its context menu', async () => {
     const writeText = vi.fn(async () => undefined)
     Object.defineProperty(window.navigator, 'clipboard', {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -45,6 +45,7 @@ import {
   copyNotebookMarkdownLink,
   copyNotebookShareUrl,
   parseNotebookCellFragment,
+  parseNotebookShareLink,
 } from '../../lib/shareLinks'
 import { isHtmlLanguageId, isMarkdownLanguageId } from '../../lib/cellContent'
 import { PlayIcon, PlusIcon, SpinnerIcon, TrashIcon } from './icons'
@@ -584,6 +585,9 @@ export function Action({
   isDeepLinkTarget?: boolean
 }) {
   const { store } = useNotebookStore()
+  const { openNotebook } = useNotebookContext()
+  const { showDocument } = useWorkspaceDocumentContext()
+  const { setCurrentDoc } = useCurrentDoc()
   const { listRunners, defaultRunnerName } = useRunners()
   const jupyterManager = useMemo(() => getJupyterManager(), [])
   const jupyterVersion = useSyncExternalStore(
@@ -788,6 +792,69 @@ export function Action({
       onFocusStateChange(nextState)
     },
     [cell?.refId, onFocusStateChange]
+  )
+
+  const handleMarkdownLinkClick = useCallback(
+    (href: string): boolean => {
+      const target = parseNotebookShareLink(href)
+      if (!target) {
+        return false
+      }
+      const isLocalNotebook =
+        target.notebookUri.startsWith('local://file/') ||
+        target.notebookUri.startsWith('fs://')
+      if (!isLocalNotebook && !isDriveItemUri(target.notebookUri)) {
+        return false
+      }
+
+      void (async () => {
+        try {
+          if (isLocalNotebook) {
+            const result = await openNotebook(target.notebookUri)
+            showDocument(result.localUri, {
+              title: result.entry.name,
+            })
+            setCurrentDoc(result.localUri)
+          } else {
+            await driveLinkCoordinator.enqueue(target.notebookUri, 'manual')
+            const isPending = driveLinkCoordinator
+              .getSnapshot()
+              .intents.some((intent) => intent.remoteUri === target.notebookUri)
+            if (isPending) {
+              return
+            }
+          }
+
+          const nextUrl = new URL(window.location.href)
+          nextUrl.hash = target.cellRefId
+            ? `cell=${encodeURIComponent(target.cellRefId)}`
+            : ''
+          window.history.pushState(
+            null,
+            '',
+            `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`
+          )
+          window.dispatchEvent(new PopStateEvent('popstate'))
+        } catch (error) {
+          appLogger.error('Failed to open rendered Markdown notebook link', {
+            attrs: {
+              scope: 'notebook.markdown-link',
+              code: 'MARKDOWN_NOTEBOOK_LINK_OPEN_FAILED',
+              href,
+              notebookUri: target.notebookUri,
+              error: String(error),
+            },
+          })
+          showToast({
+            message: 'Could not open the linked notebook.',
+            tone: 'error',
+          })
+        }
+      })()
+
+      return true
+    },
+    [openNotebook, setCurrentDoc, showDocument]
   )
 
   const handleRemoveCell = useCallback(() => {
@@ -1281,6 +1348,7 @@ export function Action({
               activeFocusRole={activeFocusRole}
               isWindowFocused={isWindowFocused}
               onFocusRoleChange={handleMarkdownFocusRoleChange}
+              onLinkClick={handleMarkdownLinkClick}
             />
             <CellCommentButton
               count={commentCount}

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -419,4 +419,85 @@ describe("MarkdownCell", () => {
       screen.getByTestId("markdown-rendered"),
     );
   });
+
+  it("opens ordinary links in a new tab", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-external-link",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "[Runme](https://runme.dev/)",
+    });
+    const onLinkClick = vi.fn(() => false);
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderMarkdownCell(new StubCellData(cell) as unknown as CellData, {
+      onLinkClick,
+    });
+
+    const link = screen.getByRole("link", { name: "Runme" });
+    expect(link.getAttribute("href")).toBe("https://runme.dev/");
+    expect(link.getAttribute("target")).toBe("_blank");
+
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    expect(link.dispatchEvent(event)).toBe(false);
+    expect(onLinkClick).toHaveBeenCalledWith("https://runme.dev/");
+    expect(openWindow).toHaveBeenCalledWith(
+      "https://runme.dev/",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    openWindow.mockRestore();
+  });
+
+  it("prevents native navigation for intercepted Runme notebook links", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-notebook-link",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "[Notes](https://runme.example/?doc=local%3A%2F%2Ffile%2Fnotes)",
+    });
+    const onLinkClick = vi.fn(() => true);
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderMarkdownCell(new StubCellData(cell) as unknown as CellData, {
+      onLinkClick,
+    });
+
+    const link = screen.getByRole("link", { name: "Notes" });
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    expect(link.dispatchEvent(event)).toBe(false);
+    expect(onLinkClick).toHaveBeenCalledOnce();
+    expect(openWindow).not.toHaveBeenCalled();
+
+    openWindow.mockRestore();
+  });
+
+  it("does not enter edit mode when a rendered link is double-clicked", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-double-click-link",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "[Runme](https://runme.dev/)",
+    });
+
+    renderMarkdownCell(new StubCellData(cell) as unknown as CellData);
+
+    fireEvent.doubleClick(screen.getByRole("link", { name: "Runme" }));
+
+    expect(screen.getByTestId("markdown-rendered")).toBeTruthy();
+    expect(screen.queryByTestId("markdown-editor")).toBeNull();
+  });
 });

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -116,17 +116,6 @@ const markdownComponents: Components = {
       {children}
     </blockquote>
   ),
-  a: ({ children, href, ...props }) => (
-    <a
-      href={href}
-      className="text-blue-600 hover:underline"
-      target="_blank"
-      rel="noopener noreferrer"
-      {...props}
-    >
-      {children}
-    </a>
-  ),
   table: ({ children, ...props }) => (
     <div className="overflow-x-auto mb-3">
       <table className="min-w-full border border-nb-border-strong" {...props}>
@@ -179,6 +168,8 @@ interface MarkdownCellProps {
   isWindowFocused?: boolean
   /** Notify parent when markdown focus target changes explicitly */
   onFocusRoleChange?: (focusRole: CellFocusRole) => void
+  /** Intercept links that should open inside the current Runme workspace. */
+  onLinkClick?: (href: string) => boolean
   /** Allow source inspection, but prevent content and metadata changes. */
   readOnly?: boolean
 }
@@ -204,6 +195,7 @@ const MarkdownCell = memo(
     activeFocusRole = 'editor',
     isWindowFocused = false,
     onFocusRoleChange,
+    onLinkClick,
     readOnly = false,
   }: MarkdownCellProps) => {
     // Subscribe to cell data changes using useSyncExternalStore for tearing-safe reads
@@ -382,6 +374,35 @@ const MarkdownCell = memo(
       }
     }, [readOnly, value])
 
+    const renderedMarkdownComponents = useMemo<Components>(
+      () => ({
+        ...markdownComponents,
+        a: ({ children, href, ...props }) => (
+          <a
+            href={href}
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            {...props}
+            onClick={(event) => {
+              event.stopPropagation()
+              event.preventDefault()
+              if (href && onLinkClick?.(href)) {
+                return
+              }
+              if (href) {
+                window.open(href, '_blank', 'noopener,noreferrer')
+              }
+            }}
+            onDoubleClick={(event) => event.stopPropagation()}
+          >
+            {children}
+          </a>
+        ),
+      }),
+      [onLinkClick]
+    )
+
     // Memoize the rendered markdown to avoid unnecessary re-renders
     const renderedMarkdown = useMemo(() => {
       if (!value.trim()) {
@@ -397,13 +418,13 @@ const MarkdownCell = memo(
         <div className="prose prose-sm max-w-none">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
-            components={markdownComponents}
+            components={renderedMarkdownComponents}
           >
             {value}
           </ReactMarkdown>
         </div>
       )
-    }, [readOnly, value])
+    }, [readOnly, renderedMarkdownComponents, value])
 
     if (!cell) {
       return null
@@ -501,6 +522,7 @@ const MarkdownCell = memo(
       prevProps.activeFocusRole === nextProps.activeFocusRole &&
       prevProps.isWindowFocused === nextProps.isWindowFocused &&
       prevProps.onFocusRoleChange === nextProps.onFocusRoleChange &&
+      prevProps.onLinkClick === nextProps.onLinkClick &&
       prevProps.readOnly === nextProps.readOnly
     )
   }

--- a/app/src/lib/shareLinks.test.ts
+++ b/app/src/lib/shareLinks.test.ts
@@ -9,6 +9,7 @@ import {
   getNotebookShareTarget,
   normalizeNotebookReferenceUri,
   parseNotebookCellFragment,
+  parseNotebookShareLink,
 } from './shareLinks'
 
 describe('buildNotebookShareUrl', () => {
@@ -74,6 +75,75 @@ describe('notebook cell links', () => {
     expect(parseNotebookCellFragment('#legacy%2Fcell')).toBeNull()
     expect(parseNotebookCellFragment('#access_token=secret')).toBeNull()
     expect(parseNotebookCellFragment('#section=overview')).toBeNull()
+  })
+})
+
+describe('parseNotebookShareLink', () => {
+  it('extracts the notebook and cell targets from a Runme share link', () => {
+    expect(
+      parseNotebookShareLink(
+        'https://runme.example/workspace?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview#cell=markup%2Fintro',
+        'https://runme.example/?session=calm-harbor'
+      )
+    ).toEqual({
+      notebookUri: 'https://drive.google.com/file/d/file123/view',
+      cellRefId: 'markup/intro',
+    })
+  })
+
+  it('resolves relative links against the current Runme app URL', () => {
+    expect(
+      parseNotebookShareLink(
+        '?doc=local%3A%2F%2Ffile%2Fnotes',
+        'https://runme.example/workspace?session=calm-harbor'
+      )
+    ).toEqual({
+      notebookUri: 'local://file/notes',
+      cellRefId: null,
+    })
+  })
+
+  it('accepts links between known Runme app origins', () => {
+    const driveUri = 'https://drive.google.com/file/d/file123/view'
+    const gatewayUrl = `https://runme.gateway.unified-0.internal.api.openai.org/?doc=${encodeURIComponent(
+      driveUri
+    )}`
+    const localhostUrl = `http://localhost:5173/?doc=${encodeURIComponent(driveUri)}`
+
+    expect(
+      parseNotebookShareLink(
+        gatewayUrl,
+        'http://localhost:5173/?session=red-valley'
+      )
+    ).toEqual({
+      notebookUri: driveUri,
+      cellRefId: null,
+    })
+    expect(
+      parseNotebookShareLink(
+        localhostUrl,
+        'https://runme.gateway.unified-0.internal.api.openai.org/?session=blue-meadow'
+      )
+    ).toEqual({
+      notebookUri: driveUri,
+      cellRefId: null,
+    })
+  })
+
+  it('ignores ordinary web links and unsupported protocols', () => {
+    expect(parseNotebookShareLink('https://example.com/docs')).toBeNull()
+    expect(
+      parseNotebookShareLink(
+        'https://other.example/?doc=local%3A%2F%2Ffile%2Fnotes',
+        'https://runme.example/'
+      )
+    ).toBeNull()
+    expect(
+      parseNotebookShareLink(
+        'mailto:someone@example.com?doc=local%3A%2F%2Ffile%2Fnotes'
+      )
+    ).toBeNull()
+    expect(parseNotebookShareLink('not a valid link')).toBeNull()
   })
 })
 

--- a/app/src/lib/shareLinks.ts
+++ b/app/src/lib/shareLinks.ts
@@ -73,6 +73,76 @@ export function parseNotebookCellFragment(hash: string): string | null {
   }
 }
 
+export type NotebookShareLinkTarget = {
+  notebookUri: string
+  cellRefId: string | null
+}
+
+const RUNME_GATEWAY_HOSTNAME =
+  /^runme\.gateway\.unified-\d+\.internal\.api\.openai\.org$/i
+
+function isKnownRunmeAppHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase()
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '[::1]' ||
+    normalized === 'web.runme.dev' ||
+    normalized.endsWith('.web.runme.dev') ||
+    RUNME_GATEWAY_HOSTNAME.test(normalized)
+  )
+}
+
+function canOpenNotebookShareLinkInCurrentApp(
+  url: URL,
+  browserUrl: URL
+): boolean {
+  return (
+    url.origin === browserUrl.origin ||
+    (isKnownRunmeAppHostname(url.hostname) &&
+      isKnownRunmeAppHostname(browserUrl.hostname))
+  )
+}
+
+export function parseNotebookShareLink(
+  href: string,
+  baseUrl?: string
+): NotebookShareLinkTarget | null {
+  const trimmed = href.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const browserBaseUrl =
+    baseUrl ??
+    (typeof window === 'undefined' ? undefined : window.location.href)
+
+  try {
+    const url = browserBaseUrl
+      ? new URL(trimmed, browserBaseUrl)
+      : new URL(trimmed)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null
+    }
+    if (
+      browserBaseUrl &&
+      !canOpenNotebookShareLinkInCurrentApp(url, new URL(browserBaseUrl))
+    ) {
+      return null
+    }
+    const notebookUri = url.searchParams.get('doc')?.trim()
+    if (!notebookUri) {
+      return null
+    }
+    return {
+      notebookUri,
+      cellRefId: parseNotebookCellFragment(url.hash),
+    }
+  } catch {
+    return null
+  }
+}
+
 export function buildNotebookMarkdownLink(
   name: string,
   remoteUri: string


### PR DESCRIPTION
## Summary

- open ordinary rendered Markdown hyperlinks explicitly in a new browser tab so the click works when default target-blank navigation is suppressed
- intercept Runme notebook links from the current origin or another recognized Runme app origin and open local, filesystem, or Drive-backed targets in the current workspace
- preserve canonical cell fragments after in-workspace navigation and avoid applying them while Drive coordination is still pending
- keep link clicks and double-clicks from switching the surrounding Markdown cell into source-editing mode

## Design

- [20260719_links](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F11BUXt58WS-JIPJEaiJzi-SkMyJXCZawK%2Fview)

The implementation adds a notebook-share-link parser that accepts the current app origin plus recognized Runme deployments (local development, `web.runme.dev`, and OpenAI Runme gateways), keeps arbitrary external navigation in the Markdown renderer, and delegates notebook opening to the existing notebook contexts and Drive link coordinator. This avoids duplicating authentication, mirroring, retry, and workspace selection behavior while preventing unrelated cross-origin `?doc=` URLs from being intercepted.

## User impact

Rendered Markdown links now respond to a normal click. External links open in a new tab. Links generated by the current Runme app or another recognized Runme deployment open the referenced notebook in the existing workspace, including an optional linked cell.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run src/lib/shareLinks.test.ts src/components/Actions/MarkdownCell.test.tsx src/components/Actions/Actions.test.tsx` (85 tests passed)

## Codex review

Codex reviewed the rebased final diff and addressed the cross-origin Runme share-link behavior reproduced during manual testing. Thread-aware GitHub review inspection found no review comments or unresolved threads. No actionable review findings remain.

Fixes #234
