### PR TITLE
Add Markdown links for notebook cells

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1598,7 +1598,7 @@ describe('Action component', () => {
 
       await waitFor(() => {
         expect(writeText).toHaveBeenCalledWith(
-          '[Demo notebook#Prepare [workspace\\]](http://localhost:3000/workspace?doc=local%3A%2F%2Ffile%2Fnotebook#cell=setup-cell)'
+          '[Demo notebook#Prepare \\[workspace\\]](http://localhost:3000/workspace?doc=local%3A%2F%2Ffile%2Fnotebook#cell=setup-cell)'
         )
       })
       expect(toastMocks.showToast).toHaveBeenCalledWith({

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -466,7 +466,9 @@ describe('Actions tabs', () => {
 
     render(<Actions />)
     const notebookContent = screen.getByTestId('notebook-content')
-    const dragOverEvent = createEvent.dragOver(notebookContent, { dataTransfer })
+    const dragOverEvent = createEvent.dragOver(notebookContent, {
+      dataTransfer,
+    })
     fireEvent(notebookContent, dragOverEvent)
 
     expect(dragOverEvent.defaultPrevented).toBe(true)
@@ -1551,6 +1553,50 @@ describe('Action component', () => {
     })
     expect(toastMocks.showToast).toHaveBeenCalledWith({
       message: 'Link to cell copied',
+      tone: 'success',
+    })
+  })
+
+  it('copies a markdown link with inferred notebook and cell titles', async () => {
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'setup-cell',
+      kind: parser_pb.CellKind.CODE,
+      languageId: 'javascript',
+      value: '\n// Prepare [workspace]\nconsole.log("ready")',
+      metadata: {},
+    })
+    window.history.replaceState(null, '', '/workspace')
+
+    render(
+      <Action
+        cellData={new StubCellData(cell) as unknown as CellData}
+        docUri="local://file/notebook"
+        docTitle="Demo notebook.json"
+        isFirst={false}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('code-action'))
+    const contextMenu = document.querySelector('.ctx-menu')
+    expect(contextMenu).toBeTruthy()
+    fireEvent.click(
+      within(contextMenu as HTMLElement).getByRole('button', {
+        name: 'Copy Markdown Link',
+      })
+    )
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        '[Demo notebook#Prepare [workspace\\]](http://localhost:3000/workspace?doc=local%3A%2F%2Ffile%2Fnotebook#cell=setup-cell)'
+      )
+    })
+    expect(toastMocks.showToast).toHaveBeenCalledWith({
+      message: 'Markdown link to cell copied',
       tone: 'success',
     })
   })

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1557,49 +1557,56 @@ describe('Action component', () => {
     })
   })
 
-  it('copies a markdown link with inferred notebook and cell titles', async () => {
-    const writeText = vi.fn(async () => undefined)
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-    const cell = create(parser_pb.CellSchema, {
-      refId: 'setup-cell',
-      kind: parser_pb.CellKind.CODE,
-      languageId: 'javascript',
-      value: '\n// Prepare [workspace]\nconsole.log("ready")',
-      metadata: {},
-    })
-    window.history.replaceState(null, '', '/workspace')
-
-    render(
-      <Action
-        cellData={new StubCellData(cell) as unknown as CellData}
-        docUri="local://file/notebook"
-        docTitle="Demo notebook.json"
-        isFirst={false}
-      />
-    )
-
-    fireEvent.contextMenu(screen.getByTestId('code-action'))
-    const contextMenu = document.querySelector('.ctx-menu')
-    expect(contextMenu).toBeTruthy()
-    fireEvent.click(
-      within(contextMenu as HTMLElement).getByRole('button', {
-        name: 'Copy Markdown Link',
+  it.each([
+    ['code', parser_pb.CellKind.CODE, 'javascript', 'code-action'],
+    ['Markdown', parser_pb.CellKind.MARKUP, 'markdown', 'markdown-action'],
+    ['HTML', parser_pb.CellKind.CODE, 'html', 'html-action'],
+  ])(
+    'copies a markdown link with inferred titles from a %s cell',
+    async (_, kind, languageId, testId) => {
+      const writeText = vi.fn(async () => undefined)
+      Object.defineProperty(window.navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
       })
-    )
+      const cell = create(parser_pb.CellSchema, {
+        refId: 'setup-cell',
+        kind,
+        languageId,
+        value: '\n// Prepare [workspace]\nconsole.log("ready")',
+        metadata: {},
+      })
+      window.history.replaceState(null, '', '/workspace')
 
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        '[Demo notebook#Prepare [workspace\\]](http://localhost:3000/workspace?doc=local%3A%2F%2Ffile%2Fnotebook#cell=setup-cell)'
+      render(
+        <Action
+          cellData={new StubCellData(cell) as unknown as CellData}
+          docUri="local://file/notebook"
+          docTitle="Demo notebook.json"
+          isFirst={false}
+        />
       )
-    })
-    expect(toastMocks.showToast).toHaveBeenCalledWith({
-      message: 'Markdown link to cell copied',
-      tone: 'success',
-    })
-  })
+
+      fireEvent.contextMenu(screen.getByTestId(testId))
+      const contextMenu = document.querySelector('.ctx-menu')
+      expect(contextMenu).toBeTruthy()
+      fireEvent.click(
+        within(contextMenu as HTMLElement).getByRole('button', {
+          name: 'Copy Markdown Link',
+        })
+      )
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          '[Demo notebook#Prepare [workspace\\]](http://localhost:3000/workspace?doc=local%3A%2F%2Ffile%2Fnotebook#cell=setup-cell)'
+        )
+      })
+      expect(toastMocks.showToast).toHaveBeenCalledWith({
+        message: 'Markdown link to cell copied',
+        tone: 'success',
+      })
+    }
+  )
 
   it('waits for Drive metadata before offering a cell link', async () => {
     let resolveMetadata: ((value: { remoteUri: string }) => void) | undefined

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -43,6 +43,7 @@ import {
   type NotebookActiveCellState,
 } from '../../lib/notebookActiveCellState'
 import {
+  copyNotebookCellMarkdownLink,
   copyNotebookCellShareUrl,
   copyNotebookMarkdownLink,
   copyNotebookShareUrl,
@@ -567,6 +568,7 @@ function normalizeLanguageId(
 export function Action({
   cellData,
   docUri = '',
+  docTitle = '',
   isFirst,
   isActiveCell = false,
   activeFocusRole = 'editor',
@@ -580,6 +582,7 @@ export function Action({
 }: {
   cellData: CellData
   docUri?: string
+  docTitle?: string
   isFirst: boolean
   isActiveCell?: boolean
   activeFocusRole?: CellFocusRole
@@ -731,7 +734,7 @@ export function Action({
     }
 
     const menuWidth = 200
-    const menuHeight = shareTargetUri && cell?.refId.trim() ? 128 : 88
+    const menuHeight = shareTargetUri && cell?.refId.trim() ? 164 : 88
     const left = Math.max(
       0,
       Math.min(contextMenu.x, window.innerWidth - menuWidth)
@@ -901,6 +904,45 @@ export function Action({
       setContextMenu(null)
     }
   }, [cell?.refId, shareTargetUri])
+
+  const handleCopyMarkdownLink = useCallback(async () => {
+    if (!shareTargetUri || !cell?.refId) {
+      setContextMenu(null)
+      return
+    }
+
+    const notebookTitle =
+      docTitle.trim() || getNotebookDisplayName(docUri || shareTargetUri)
+    try {
+      await copyNotebookCellMarkdownLink(
+        notebookTitle,
+        cell.value,
+        shareTargetUri,
+        cell.refId
+      )
+      showToast({ message: 'Markdown link to cell copied', tone: 'success' })
+    } catch (error) {
+      appLogger.error(
+        'Failed to copy notebook cell Markdown link from cell menu',
+        {
+          attrs: {
+            scope: 'notebook.share',
+            code: 'NOTEBOOK_CELL_MARKDOWN_LINK_COPY_FAILED',
+            notebookUri: shareTargetUri,
+            cellRefId: cell.refId,
+            error: String(error),
+          },
+        }
+      )
+      showToast({
+        message:
+          'Could not copy the cell Markdown link. Check clipboard permissions and try again.',
+        tone: 'error',
+      })
+    } finally {
+      setContextMenu(null)
+    }
+  }, [cell?.refId, cell?.value, docTitle, docUri, shareTargetUri])
 
   const handleStartComment = useCallback(() => {
     if (!cell?.refId || !onStartComment) {
@@ -1391,16 +1433,28 @@ export function Action({
             onContextMenu={(event) => event.preventDefault()}
           >
             {canCopyCellLink && (
-              <button
-                type="button"
-                className="ctx-menu-item"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  void handleCopyShareLink()
-                }}
-              >
-                {contextMenuLinkLabel}
-              </button>
+              <>
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleCopyShareLink()
+                  }}
+                >
+                  {contextMenuLinkLabel}
+                </button>
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleCopyMarkdownLink()
+                  }}
+                >
+                  Copy Markdown Link
+                </button>
+              </>
             )}
             <button
               type="button"
@@ -1506,16 +1560,28 @@ export function Action({
             onContextMenu={(event) => event.preventDefault()}
           >
             {canCopyCellLink && (
-              <button
-                type="button"
-                className="ctx-menu-item"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  void handleCopyShareLink()
-                }}
-              >
-                {contextMenuLinkLabel}
-              </button>
+              <>
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleCopyShareLink()
+                  }}
+                >
+                  {contextMenuLinkLabel}
+                </button>
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleCopyMarkdownLink()
+                  }}
+                >
+                  Copy Markdown Link
+                </button>
+              </>
             )}
             <button
               type="button"
@@ -1784,16 +1850,28 @@ export function Action({
           onContextMenu={(event) => event.preventDefault()}
         >
           {canCopyCellLink && (
-            <button
-              type="button"
-              className="ctx-menu-item"
-              onClick={(event) => {
-                event.stopPropagation()
-                void handleCopyShareLink()
-              }}
-            >
-              {contextMenuLinkLabel}
-            </button>
+            <>
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void handleCopyShareLink()
+                }}
+              >
+                {contextMenuLinkLabel}
+              </button>
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void handleCopyMarkdownLink()
+                }}
+              >
+                Copy Markdown Link
+              </button>
+            </>
           )}
           <button
             type="button"
@@ -2526,6 +2604,7 @@ function NotebookTabContent({
                     key={`action-${refId}`}
                     cellData={cellData}
                     docUri={docUri}
+                    docTitle={entry.name}
                     isFirst={index === 0}
                     isActiveCell={activeCell?.refId === refId}
                     activeFocusRole={activeCell?.focusRole ?? 'editor'}

--- a/app/src/lib/cellContent.test.ts
+++ b/app/src/lib/cellContent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCellTitle } from './cellContent'
+
+describe('getCellTitle', () => {
+  it('uses the first non-empty line', () => {
+    expect(getCellTitle('\n  First useful line  \nSecond line')).toBe(
+      'First useful line'
+    )
+  })
+
+  it.each([
+    ['# Markdown heading', 'Markdown heading'],
+    ['### Nested heading', 'Nested heading'],
+    ['// JavaScript comment', 'JavaScript comment'],
+    ['// # Commented heading', 'Commented heading'],
+    ['#// Layered markers', 'Layered markers'],
+  ])('strips heading and comment markers from %j', (value, expected) => {
+    expect(getCellTitle(value)).toBe(expected)
+  })
+
+  it('falls back for empty or marker-only cells', () => {
+    expect(getCellTitle('')).toBe('Untitled cell')
+    expect(getCellTitle('\n  ###  \n')).toBe('Untitled cell')
+  })
+})

--- a/app/src/lib/cellContent.test.ts
+++ b/app/src/lib/cellContent.test.ts
@@ -12,12 +12,20 @@ describe('getCellTitle', () => {
   it.each([
     ['# Markdown heading', 'Markdown heading'],
     ['### Nested heading', 'Nested heading'],
+    ['# shell comment', 'shell comment'],
     ['// JavaScript comment', 'JavaScript comment'],
     ['// # Commented heading', 'Commented heading'],
-    ['#// Layered markers', 'Layered markers'],
+    ['# // Layered markers', 'Layered markers'],
   ])('strips heading and comment markers from %j', (value, expected) => {
     expect(getCellTitle(value)).toBe(expected)
   })
+
+  it.each(['#!/usr/bin/env bash', '#include <stdio.h>', '#hashtag'])(
+    'preserves non-heading hash prefix in %j',
+    (value) => {
+      expect(getCellTitle(value)).toBe(value)
+    }
+  )
 
   it('falls back for empty or marker-only cells', () => {
     expect(getCellTitle('')).toBe('Untitled cell')

--- a/app/src/lib/cellContent.ts
+++ b/app/src/lib/cellContent.ts
@@ -1,6 +1,11 @@
 const MARKDOWN_LANGUAGE_IDS = new Set(['markdown', 'md'])
 const HTML_LANGUAGE_IDS = new Set(['html', 'htm'])
 
+/**
+ * Derives a user-facing title from the cell's first non-empty line.
+ * Repeated Markdown heading (`#`) and line-comment (`//`) prefixes are removed;
+ * cells without remaining text use a stable fallback.
+ */
 export function getCellTitle(value: string): string {
   const firstContentLine =
     value

--- a/app/src/lib/cellContent.ts
+++ b/app/src/lib/cellContent.ts
@@ -1,10 +1,23 @@
-const MARKDOWN_LANGUAGE_IDS = new Set(["markdown", "md"]);
-const HTML_LANGUAGE_IDS = new Set(["html", "htm"]);
+const MARKDOWN_LANGUAGE_IDS = new Set(['markdown', 'md'])
+const HTML_LANGUAGE_IDS = new Set(['html', 'htm'])
+
+export function getCellTitle(value: string): string {
+  const firstContentLine =
+    value
+      .split(/\r?\n/)
+      .find((line) => line.trim())
+      ?.trim() ?? ''
+  const withoutLeadingMarker = firstContentLine
+    .replace(/^(?:(?:#{1,6}|\/\/+)\s*)+/, '')
+    .trim()
+
+  return withoutLeadingMarker || 'Untitled cell'
+}
 
 export function isMarkdownLanguageId(languageId?: string | null): boolean {
-  return MARKDOWN_LANGUAGE_IDS.has((languageId ?? "").trim().toLowerCase());
+  return MARKDOWN_LANGUAGE_IDS.has((languageId ?? '').trim().toLowerCase())
 }
 
 export function isHtmlLanguageId(languageId?: string | null): boolean {
-  return HTML_LANGUAGE_IDS.has((languageId ?? "").trim().toLowerCase());
+  return HTML_LANGUAGE_IDS.has((languageId ?? '').trim().toLowerCase())
 }

--- a/app/src/lib/cellContent.ts
+++ b/app/src/lib/cellContent.ts
@@ -3,8 +3,9 @@ const HTML_LANGUAGE_IDS = new Set(['html', 'htm'])
 
 /**
  * Derives a user-facing title from the cell's first non-empty line.
- * Repeated Markdown heading (`#`) and line-comment (`//`) prefixes are removed;
- * cells without remaining text use a stable fallback.
+ * Repeated Markdown heading (`#` followed by whitespace) and line-comment
+ * (`//`) prefixes are removed; cells without remaining text use a stable
+ * fallback.
  */
 export function getCellTitle(value: string): string {
   const firstContentLine =
@@ -13,7 +14,7 @@ export function getCellTitle(value: string): string {
       .find((line) => line.trim())
       ?.trim() ?? ''
   const withoutLeadingMarker = firstContentLine
-    .replace(/^(?:(?:#{1,6}|\/\/+)\s*)+/, '')
+    .replace(/^(?:(?:#{1,6}(?:[ \t]+|$)|\/\/+[ \t]*))+/, '')
     .trim()
 
   return withoutLeadingMarker || 'Untitled cell'

--- a/app/src/lib/shareLinks.test.ts
+++ b/app/src/lib/shareLinks.test.ts
@@ -1,3 +1,7 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import ReactMarkdown from 'react-markdown'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -81,15 +85,20 @@ describe('notebook cell links', () => {
   it('escapes markdown characters in cell link text', () => {
     window.history.replaceState(null, '', '/')
 
+    const markdownLink = buildNotebookCellMarkdownLink(
+      String.raw`Notebook [draft].json`,
+      String.raw`// Review [inputs]`,
+      'local://file/notebook',
+      'review'
+    )
+
+    expect(markdownLink).toBe(
+      String.raw`[Notebook \[draft\]#Review \[inputs\]](http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fnotebook#cell=review)`
+    )
     expect(
-      buildNotebookCellMarkdownLink(
-        String.raw`Notebook [draft].json`,
-        String.raw`// Review [inputs]`,
-        'local://file/notebook',
-        'review'
-      )
-    ).toBe(
-      String.raw`[Notebook [draft\]#Review [inputs\]](http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fnotebook#cell=review)`
+      renderToStaticMarkup(createElement(ReactMarkdown, null, markdownLink))
+    ).toContain(
+      '<a href="http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fnotebook#cell=review">Notebook [draft]#Review [inputs]</a>'
     )
   })
 
@@ -226,7 +235,7 @@ describe('buildNotebookMarkdownLink', () => {
         'https://drive.google.com/file/d/file123/view'
       )
     ).toBe(
-      String.raw`[notebook \\[draft\]](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview)`
+      String.raw`[notebook \\\[draft\]](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2Ffile123%2Fview)`
     )
   })
 })

--- a/app/src/lib/shareLinks.test.ts
+++ b/app/src/lib/shareLinks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildNotebookCellFragment,
+  buildNotebookCellMarkdownLink,
   buildNotebookCellShareUrl,
   buildNotebookMarkdownLink,
   buildNotebookShareBaseUrl,
@@ -60,6 +61,36 @@ describe('notebook cell links', () => {
     expect(() =>
       buildNotebookCellShareUrl('local://file/notebook', '  ')
     ).toThrow('A cell reference ID is required to build a cell link')
+  })
+
+  it('builds markdown using the notebook and inferred cell titles', () => {
+    window.history.replaceState(null, '', '/workspace')
+
+    expect(
+      buildNotebookCellMarkdownLink(
+        'Demo notebook.json',
+        '\n## Install dependencies\npnpm install',
+        'local://file/notebook',
+        'cell/with spaces'
+      )
+    ).toBe(
+      '[Demo notebook#Install dependencies](http://localhost:3000/workspace?doc=local%3A%2F%2Ffile%2Fnotebook#cell=cell%2Fwith%20spaces)'
+    )
+  })
+
+  it('escapes markdown characters in cell link text', () => {
+    window.history.replaceState(null, '', '/')
+
+    expect(
+      buildNotebookCellMarkdownLink(
+        String.raw`Notebook [draft].json`,
+        String.raw`// Review [inputs]`,
+        'local://file/notebook',
+        'review'
+      )
+    ).toBe(
+      String.raw`[Notebook [draft\]#Review [inputs\]](http://localhost:3000/?doc=local%3A%2F%2Ffile%2Fnotebook#cell=review)`
+    )
   })
 
   it('decodes cell fragments and tolerates malformed encoding', () => {

--- a/app/src/lib/shareLinks.ts
+++ b/app/src/lib/shareLinks.ts
@@ -1,3 +1,5 @@
+import { getCellTitle } from './cellContent'
+
 function getShareBaseUrl(): URL {
   if (typeof window === 'undefined') {
     throw new Error('Share links are only available in a browser environment')
@@ -151,6 +153,18 @@ export function buildNotebookMarkdownLink(
   return `[${linkText}](${buildNotebookShareUrl(remoteUri)})`
 }
 
+export function buildNotebookCellMarkdownLink(
+  name: string,
+  cellValue: string,
+  remoteUri: string,
+  cellRefId: string
+): string {
+  const linkText = escapeMarkdownLinkText(
+    `${getNotebookLinkText(name)}#${getCellTitle(cellValue)}`
+  )
+  return `[${linkText}](${buildNotebookCellShareUrl(remoteUri, cellRefId)})`
+}
+
 export async function copyNotebookShareUrl(remoteUri: string): Promise<string> {
   if (
     typeof window === 'undefined' ||
@@ -178,6 +192,29 @@ export async function copyNotebookCellShareUrl(
   const shareUrl = buildNotebookCellShareUrl(remoteUri, cellRefId)
   await window.navigator.clipboard.writeText(shareUrl)
   return shareUrl
+}
+
+export async function copyNotebookCellMarkdownLink(
+  name: string,
+  cellValue: string,
+  remoteUri: string,
+  cellRefId: string
+): Promise<string> {
+  if (
+    typeof window === 'undefined' ||
+    !window.navigator?.clipboard?.writeText
+  ) {
+    throw new Error('Clipboard access is unavailable in this browser')
+  }
+
+  const markdownLink = buildNotebookCellMarkdownLink(
+    name,
+    cellValue,
+    remoteUri,
+    cellRefId
+  )
+  await window.navigator.clipboard.writeText(markdownLink)
+  return markdownLink
 }
 
 export async function copyNotebookMarkdownLink(

--- a/app/src/lib/shareLinks.ts
+++ b/app/src/lib/shareLinks.ts
@@ -30,7 +30,7 @@ function getNotebookLinkText(name: string): string {
 }
 
 function escapeMarkdownLinkText(text: string): string {
-  return text.replace(/\\/g, '\\\\').replace(/\]/g, '\\]')
+  return text.replace(/\\/g, '\\\\').replace(/\[/g, '\\[').replace(/\]/g, '\\]')
 }
 
 export function buildNotebookShareUrl(remoteUri: string): string {


### PR DESCRIPTION
## Summary

- add a Copy Markdown Link action to Markdown, HTML, and code cell context menus
- derive readable cell titles from the first non-empty line while stripping Markdown heading and line-comment prefixes
- build escaped Markdown labels in the form `notebook#cell` while reusing canonical deep-link URLs

## Impact

Users can copy a paste-ready Markdown link directly from any linkable notebook cell without manually naming the cell or formatting the URL.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run src/lib/cellContent.test.ts src/lib/shareLinks.test.ts src/components/Actions/Actions.test.tsx` (87 tests)
- `pnpm exec prettier --check app/src/lib/cellContent.ts app/src/lib/cellContent.test.ts app/src/lib/shareLinks.ts app/src/lib/shareLinks.test.ts app/src/components/Actions/Actions.tsx app/src/components/Actions/Actions.test.tsx`
- `git diff --check`