### PR TITLE
Fix duplicate Drive notebook creation

### DIFF
--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -173,6 +173,54 @@ describe("DriveNotebookStore", () => {
     });
   });
 
+  it("finds a Drive file by its create operation id", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files");
+        expect(url.searchParams.get("q")).toBe(
+          "'folder123' in parents and trashed = false and appProperties has { key='runmeCreateOperationId' and value='operation-123' }",
+        );
+        expect(url.searchParams.get("orderBy")).toBe("createdTime asc");
+        expect(url.searchParams.get("pageSize")).toBe("2");
+        return new Response(
+          JSON.stringify({
+            files: [
+              {
+                id: "file123",
+                name: "draft.json",
+                mimeType: "application/json",
+                parents: ["folder123"],
+                appProperties: {
+                  runmeCreateOperationId: "operation-123",
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    await expect(
+      store.findByCreateOperation(
+        "https://drive.google.com/drive/folders/folder123",
+        "operation-123",
+      ),
+    ).resolves.toMatchObject({
+      uri: "https://drive.google.com/file/d/file123/view",
+      name: "draft.json",
+      type: NotebookStoreItemType.File,
+      parents: ["https://drive.google.com/drive/folders/folder123"],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("paginates Drive folder listings beyond the first page", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const firstPageFiles = Array.from({ length: 100 }, (_, index) => ({
@@ -246,6 +294,9 @@ describe("DriveNotebookStore", () => {
             name: "diagram.excalidraw",
             mimeType: "application/vnd.excalidraw+json",
             parents: ["folder123"],
+            appProperties: {
+              runmeCreateOperationId: "operation-123",
+            },
           });
           return new Response(
             JSON.stringify({
@@ -277,6 +328,7 @@ describe("DriveNotebookStore", () => {
       "diagram.excalidraw",
       '{"type":"excalidraw"}',
       "application/vnd.excalidraw+json",
+      { createOperationId: "operation-123" },
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -17,6 +17,7 @@ const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
 const DRIVE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
+const DRIVE_CREATE_OPERATION_PROPERTY = 'runmeCreateOperationId'
 
 let gapiScriptPromise: Promise<void> | null = null
 let clientPromise: Promise<DriveFilesClient> | null = null
@@ -37,6 +38,7 @@ export type DriveDoc = {
   driveId?: string
   content?: string
   trashed?: boolean
+  appProperties?: Record<string, string>
 }
 
 export type DriveSearchFile = DriveDoc &
@@ -314,6 +316,9 @@ class GapiDriveFilesClient implements DriveFilesClient {
     if (typeof doc.trashed === 'boolean') {
       resource.trashed = doc.trashed
     }
+    if (doc.appProperties) {
+      resource.appProperties = doc.appProperties
+    }
     return resource
   }
 
@@ -574,6 +579,9 @@ class FetchDriveFilesClient implements DriveFilesClient {
     }
     if (typeof doc.trashed === 'boolean') {
       resource.trashed = doc.trashed
+    }
+    if (doc.appProperties) {
+      resource.appProperties = doc.appProperties
     }
     return resource
   }
@@ -1126,6 +1134,14 @@ function extractBody(response: { body?: string; result?: unknown }): string {
   throw new Error('Google Drive response did not include any content')
 }
 
+export interface DriveCreateOptions {
+  createOperationId?: string
+}
+
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
 export class DriveNotebookStore {
   // ensureAccessToken is injected because it comes from the GoogleAuthContext
   constructor(private readonly ensureAccessToken: () => Promise<string>) {}
@@ -1137,7 +1153,11 @@ export class DriveNotebookStore {
     return ensureDriveFilesClient(token)
   }
 
-  async create(parentUri: string, name: string): Promise<NotebookStoreItem> {
+  async create(
+    parentUri: string,
+    name: string,
+    options: DriveCreateOptions = {}
+  ): Promise<NotebookStoreItem> {
     const { id, type } = parseDriveItem(parentUri)
     if (type !== NotebookStoreItemType.Folder) {
       throw new Error('DriveNotebookStore.create expects a folder URI')
@@ -1148,6 +1168,13 @@ export class DriveNotebookStore {
       mimeType: 'application/json',
       parents: [id],
       content: createInitialNotebookJson(),
+      ...(options.createOperationId
+        ? {
+            appProperties: {
+              [DRIVE_CREATE_OPERATION_PROPERTY]: options.createOperationId,
+            },
+          }
+        : {}),
     })
 
     if (!file.id) {
@@ -1173,7 +1200,8 @@ export class DriveNotebookStore {
     parentUri: string,
     name: string,
     content: string,
-    mimeType: string = 'application/octet-stream'
+    mimeType: string = 'application/octet-stream',
+    options: DriveCreateOptions = {}
   ): Promise<NotebookStoreItem> {
     const { id, type } = parseDriveItem(parentUri)
     if (type !== NotebookStoreItemType.Folder) {
@@ -1185,6 +1213,13 @@ export class DriveNotebookStore {
       mimeType,
       parents: [id],
       content,
+      ...(options.createOperationId
+        ? {
+            appProperties: {
+              [DRIVE_CREATE_OPERATION_PROPERTY]: options.createOperationId,
+            },
+          }
+        : {}),
     })
 
     if (!file.id) {
@@ -1202,6 +1237,60 @@ export class DriveNotebookStore {
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
       mimeType: file.mimeType ?? mimeType,
+      parents: [parentUri],
+    }
+  }
+
+  async findByCreateOperation(
+    parentUri: string,
+    createOperationId: string
+  ): Promise<NotebookStoreItem | null> {
+    const { id, type } = parseDriveItem(parentUri)
+    if (type !== NotebookStoreItemType.Folder) {
+      throw new Error(
+        'DriveNotebookStore.findByCreateOperation expects a folder URI'
+      )
+    }
+    if (!createOperationId) {
+      throw new Error(
+        'DriveNotebookStore.findByCreateOperation requires an operation id'
+      )
+    }
+
+    const escapedParentId = escapeDriveQueryValue(id)
+    const escapedOperationId = escapeDriveQueryValue(createOperationId)
+    const result = await this.search({
+      q:
+        `'${escapedParentId}' in parents and trashed = false and ` +
+        `appProperties has { key='${DRIVE_CREATE_OPERATION_PROPERTY}' and ` +
+        `value='${escapedOperationId}' }`,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+      orderBy: 'createdTime asc',
+      pageSize: 2,
+      fields: 'files(id,name,mimeType,parents,createdTime,appProperties)',
+    })
+
+    if (result.files.length > 1) {
+      throw new Error(
+        `Multiple Drive files found for create operation ${createOperationId}`
+      )
+    }
+    const file = result.files[0]
+    if (!file?.id) {
+      return null
+    }
+
+    const isFolder = file.mimeType === DRIVE_FOLDER_MIME_TYPE
+    return {
+      uri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
+      name: file.name ?? 'Untitled item',
+      type: isFolder
+        ? NotebookStoreItemType.Folder
+        : NotebookStoreItemType.File,
+      children: [],
+      remoteUri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
+      mimeType: file.mimeType,
       parents: [parentUri],
     }
   }
@@ -1639,7 +1728,9 @@ export class DriveNotebookStore {
       throw new Error('DriveNotebookStore.move expects folder parent URIs')
     }
     if (sourceParent.id === destinationParent.id) {
-      throw new Error('DriveNotebookStore.move expects a new destination folder')
+      throw new Error(
+        'DriveNotebookStore.move expects a new destination folder'
+      )
     }
 
     const client = await this.getFilesClient()

--- a/app/src/storage/driveSyncCoordinator.test.ts
+++ b/app/src/storage/driveSyncCoordinator.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="vitest" />
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { browserDriveSyncCoordinator } from './driveSyncCoordinator'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('browserDriveSyncCoordinator', () => {
+  it('uses one named Web Lock per local notebook', async () => {
+    const request = vi.fn(
+      async (_name: string, operation: () => Promise<string>) => operation()
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+
+    await expect(
+      browserDriveSyncCoordinator.runExclusive(
+        'local://file/notebook',
+        async () => 'synced'
+      )
+    ).resolves.toBe('synced')
+
+    expect(request).toHaveBeenCalledWith(
+      'runme:drive-sync:local://file/notebook',
+      expect.any(Function)
+    )
+  })
+})

--- a/app/src/storage/driveSyncCoordinator.ts
+++ b/app/src/storage/driveSyncCoordinator.ts
@@ -1,0 +1,55 @@
+export interface DriveSyncCoordinator {
+  runExclusive<T>(localUri: string, operation: () => Promise<T>): Promise<T>
+}
+
+const DRIVE_SYNC_LOCK_PREFIX = 'runme:drive-sync:'
+const fallbackTails = new Map<string, Promise<void>>()
+
+function hasWebLocks(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.locks?.request === 'function'
+  )
+}
+
+async function runInProcessExclusive<T>(
+  lockName: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = fallbackTails.get(lockName) ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const tail = previous.then(() => current)
+  fallbackTails.set(lockName, tail)
+
+  await previous
+  try {
+    return await operation()
+  } finally {
+    release()
+    if (fallbackTails.get(lockName) === tail) {
+      fallbackTails.delete(lockName)
+    }
+  }
+}
+
+/**
+ * Coordinates Drive work for one local notebook across same-origin tabs and
+ * workers. Web Locks are authoritative in browsers. The in-process fallback
+ * keeps tests and non-browser callers serialized without pretending to provide
+ * cross-tab safety where the Web Locks API is unavailable.
+ */
+export const browserDriveSyncCoordinator: DriveSyncCoordinator = {
+  async runExclusive<T>(
+    localUri: string,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const lockName = `${DRIVE_SYNC_LOCK_PREFIX}${localUri}`
+    if (!hasWebLocks()) {
+      return runInProcessExclusive(lockName, operation)
+    }
+    return navigator.locks.request(lockName, operation)
+  },
+}

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { MimeType, parser_pb } from '../runme/client'
 import { MemoryConflictDocStorage } from './conflictDocs'
+import type { DriveSyncCoordinator } from './driveSyncCoordinator'
 import {
   EXCALIDRAW_MIME_TYPE,
   createInitialExcalidrawDocumentJson,
@@ -57,11 +58,59 @@ function createMockTable<T extends { id: string }>() {
   }
 }
 
-function createTestStore(driveStore: unknown) {
+function createTestDriveSyncCoordinator(): DriveSyncCoordinator {
+  const tails = new Map<string, Promise<void>>()
+  return {
+    async runExclusive<T>(
+      localUri: string,
+      operation: () => Promise<T>
+    ): Promise<T> {
+      const previous = tails.get(localUri) ?? Promise.resolve()
+      let release!: () => void
+      const current = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const tail = previous.then(() => current)
+      tails.set(localUri, tail)
+
+      await previous
+      try {
+        return await operation()
+      } finally {
+        release()
+        if (tails.get(localUri) === tail) {
+          tails.delete(localUri)
+        }
+      }
+    },
+  }
+}
+
+type MockTable<T extends { id: string }> = ReturnType<typeof createMockTable<T>>
+
+function createTestStore(
+  driveStore: unknown,
+  options: {
+    files?: MockTable<LocalFileRecord>
+    folders?: MockTable<LocalFolderRecord>
+    driveSyncCoordinator?: DriveSyncCoordinator
+  } = {}
+) {
   const localStore = Object.create(LocalNotebooks.prototype) as any
-  localStore.files = createMockTable<LocalFileRecord>()
-  localStore.folders = createMockTable<LocalFolderRecord>()
+  localStore.files = options.files ?? createMockTable<LocalFileRecord>()
+  localStore.folders = options.folders ?? createMockTable<LocalFolderRecord>()
+  if (
+    driveStore &&
+    typeof driveStore === 'object' &&
+    !('findByCreateOperation' in driveStore)
+  ) {
+    Object.assign(driveStore, {
+      findByCreateOperation: vi.fn(async () => null),
+    })
+  }
   localStore.driveStore = driveStore
+  localStore.driveSyncCoordinator =
+    options.driveSyncCoordinator ?? createTestDriveSyncCoordinator()
   localStore.filesystemStore = null
   localStore.inFlightSyncs = new Map()
   localStore.syncListeners = new Map()
@@ -330,7 +379,8 @@ describe('LocalNotebooks pending Drive create', () => {
     })
     expect(driveStore.create).toHaveBeenCalledWith(
       destinationRemoteUri,
-      'notebook.index.md'
+      'notebook.index.md',
+      { createOperationId: expect.any(String) }
     )
     expect(driveStore.saveContent).toHaveBeenCalledWith(
       replacementMarkdownUri,
@@ -520,7 +570,8 @@ describe('LocalNotebooks pending Drive create', () => {
     })
     expect(driveStore.create).toHaveBeenCalledWith(
       parentRemoteUri,
-      'draft.json'
+      'draft.json',
+      { createOperationId: expect.any(String) }
     )
   })
 
@@ -626,7 +677,8 @@ describe('LocalNotebooks pending Drive create', () => {
       parentRemoteUri,
       'diagram.excalidraw',
       content,
-      EXCALIDRAW_MIME_TYPE
+      EXCALIDRAW_MIME_TYPE,
+      { createOperationId: expect.any(String) }
     )
     await expect(store.files.get(item.uri)).resolves.toMatchObject({
       remoteId: remoteUri,
@@ -788,6 +840,157 @@ describe('LocalNotebooks pending Drive create', () => {
     expect(record?.remoteId).toBe(remoteUri)
     expect(record?.parentRemoteIdWhenCreated).toBeUndefined()
     expect(driveStore.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('serializes pending creates across independent storage instances', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const files = createMockTable<LocalFileRecord>()
+    const driveSyncCoordinator = createTestDriveSyncCoordinator()
+    let releaseCreate!: () => void
+    let createStarted!: () => void
+    const createStartedPromise = new Promise<void>((resolve) => {
+      createStarted = resolve
+    })
+    const releaseCreatePromise = new Promise<void>((resolve) => {
+      releaseCreate = resolve
+    })
+    const driveStore = {
+      findByCreateOperation: vi.fn(async () => null),
+      create: vi.fn(async () => {
+        createStarted()
+        await releaseCreatePromise
+        return {
+          uri: remoteUri,
+          name: 'draft.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [parentRemoteUri],
+        }
+      }),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'checksum-1',
+        headRevisionId: 'revision-1',
+      })),
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'draft.json',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      save: vi.fn(async () => ({ conflicted: false })),
+    }
+    const firstStore = createTestStore(driveStore, {
+      files,
+      driveSyncCoordinator,
+    })
+    const secondStore = createTestStore(driveStore, {
+      files,
+      driveSyncCoordinator,
+    })
+    await files.put({
+      id: 'local://file/pending',
+      name: 'draft.json',
+      remoteId: '',
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      driveCreateOperationId: 'create-operation-1',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    const firstSync = firstStore.sync('local://file/pending')
+    await createStartedPromise
+    const secondSync = secondStore.sync('local://file/pending')
+    releaseCreate()
+    await Promise.all([firstSync, secondSync])
+
+    expect(driveStore.create).toHaveBeenCalledTimes(1)
+    expect(driveStore.findByCreateOperation).toHaveBeenCalledTimes(1)
+    await expect(files.get('local://file/pending')).resolves.toMatchObject({
+      remoteId: remoteUri,
+      parentRemoteIdWhenCreated: undefined,
+      driveCreateOperationId: 'create-operation-1',
+    })
+  })
+
+  it('adopts a Drive file after a crash before recording its remote id', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const operationId = 'create-operation-1'
+    const files = createMockTable<LocalFileRecord>()
+    const driveSyncCoordinator = createTestDriveSyncCoordinator()
+    const createdFile = {
+      uri: remoteUri,
+      name: 'draft.json',
+      type: NotebookStoreItemType.File,
+      children: [],
+      parents: [parentRemoteUri],
+    }
+    let wasCreated = false
+    const driveStore = {
+      findByCreateOperation: vi.fn(async () =>
+        wasCreated ? createdFile : null
+      ),
+      create: vi.fn(async () => {
+        wasCreated = true
+        return createdFile
+      }),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'checksum-1',
+        headRevisionId: 'revision-1',
+      })),
+      getMetadata: vi.fn(async () => ({
+        ...createdFile,
+        uri: remoteUri,
+      })),
+      save: vi.fn(async () => ({ conflicted: false })),
+    }
+    const firstStore = createTestStore(driveStore, {
+      files,
+      driveSyncCoordinator,
+    })
+    await files.put({
+      id: 'local://file/pending',
+      name: 'draft.json',
+      remoteId: '',
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      driveCreateOperationId: operationId,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    const update = files.update
+    let failRemoteIdWrite = true
+    files.update = vi.fn(async (id, changes) => {
+      if (failRemoteIdWrite && changes.remoteId === remoteUri) {
+        failRemoteIdWrite = false
+        throw new Error('simulated tab crash')
+      }
+      return update(id, changes)
+    })
+
+    await expect(firstStore.sync('local://file/pending')).rejects.toThrow(
+      'simulated tab crash'
+    )
+
+    const restartedStore = createTestStore(driveStore, {
+      files,
+      driveSyncCoordinator,
+    })
+    await restartedStore.sync('local://file/pending')
+
+    expect(driveStore.create).toHaveBeenCalledTimes(1)
+    expect(driveStore.findByCreateOperation).toHaveBeenCalledTimes(2)
+    await expect(files.get('local://file/pending')).resolves.toMatchObject({
+      remoteId: remoteUri,
+      parentRemoteIdWhenCreated: undefined,
+      driveCreateOperationId: operationId,
+    })
   })
 })
 
@@ -1461,5 +1664,75 @@ describe('LocalNotebooks markdown sidecar sync', () => {
       ].join('\n'),
       'text/markdown'
     )
+  })
+
+  it('creates one sidecar across independent storage instances', async () => {
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const remoteUri = 'https://drive.google.com/file/d/notebook123/view'
+    const markdownUri = 'https://drive.google.com/file/d/sidecar123/view'
+    const files = createMockTable<LocalFileRecord>()
+    const driveSyncCoordinator = createTestDriveSyncCoordinator()
+    let releaseCreate!: () => void
+    let createStarted!: () => void
+    const createStartedPromise = new Promise<void>((resolve) => {
+      createStarted = resolve
+    })
+    const releaseCreatePromise = new Promise<void>((resolve) => {
+      releaseCreate = resolve
+    })
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'notebook.json',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
+      findByCreateOperation: vi.fn(async () => null),
+      create: vi.fn(async () => {
+        createStarted()
+        await releaseCreatePromise
+        return {
+          uri: markdownUri,
+          name: 'notebook.index.md',
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [parentRemoteUri],
+        }
+      }),
+      saveContent: vi.fn(async () => undefined),
+    }
+    const firstStore = createTestStore(driveStore, {
+      files,
+      driveSyncCoordinator,
+    })
+    const secondStore = createTestStore(driveStore, {
+      files,
+      driveSyncCoordinator,
+    })
+    await files.put({
+      id: 'local://file/notebook',
+      name: 'notebook.json',
+      remoteId: remoteUri,
+      markdownCreateOperationId: 'markdown-operation-1',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: notebookJson('print("hello")'),
+      md5Checksum: '',
+    })
+
+    const firstSync = firstStore.syncMarkdownFile('local://file/notebook')
+    await createStartedPromise
+    const secondSync = secondStore.syncMarkdownFile('local://file/notebook')
+    releaseCreate()
+    await Promise.all([firstSync, secondSync])
+
+    expect(driveStore.create).toHaveBeenCalledTimes(1)
+    expect(driveStore.findByCreateOperation).toHaveBeenCalledTimes(1)
+    expect(driveStore.saveContent).toHaveBeenCalledTimes(2)
+    await expect(files.get('local://file/notebook')).resolves.toMatchObject({
+      markdownUri,
+      markdownCreateOperationId: 'markdown-operation-1',
+    })
   })
 })

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -19,6 +19,10 @@ import {
   type DriveVersionMetadata,
   isDriveItemUri,
 } from './drive'
+import {
+  type DriveSyncCoordinator,
+  browserDriveSyncCoordinator,
+} from './driveSyncCoordinator'
 import type { FilesystemNotebookStore } from './fs'
 import { NotebookStoreItem, NotebookStoreItemType } from './notebook'
 import {
@@ -57,8 +61,12 @@ export interface LocalFileRecord {
   remoteId: string
   /** Creation-time upstream parent URI used to finish a pending remote create. */
   parentRemoteIdWhenCreated?: string
+  /** Stable idempotency key for creating the primary Drive file. */
+  driveCreateOperationId?: string
   /** Remote Drive URI of the Markdown sidecar (e.g. *.index.md) if present. */
   markdownUri?: string
+  /** Stable idempotency key for creating the Markdown sidecar. */
+  markdownCreateOperationId?: string
   /**
    * Checksum returned by the most recent Drive sync. Empty string means the
    * notebook has never been uploaded or the checksum was unavailable.
@@ -198,6 +206,7 @@ export class LocalNotebooks extends Dexie {
   folders!: Table<LocalFolderRecord, string>
 
   private readonly driveStore: DriveNotebookStore
+  private readonly driveSyncCoordinator: DriveSyncCoordinator
   private filesystemStore: FilesystemNotebookStore | null = null
   private readonly conflictDocStorage: ConflictDocStorage
   private readonly revisionDocStorage: RevisionDocStorage
@@ -211,7 +220,8 @@ export class LocalNotebooks extends Dexie {
     driveStore: DriveNotebookStore,
     databaseName: string = 'runme-local-notebooks',
     conflictDocStorage: ConflictDocStorage = createDefaultConflictDocStorage(),
-    revisionDocStorage: RevisionDocStorage = createDefaultRevisionDocStorage()
+    revisionDocStorage: RevisionDocStorage = createDefaultRevisionDocStorage(),
+    driveSyncCoordinator: DriveSyncCoordinator = browserDriveSyncCoordinator
   ) {
     super(databaseName)
 
@@ -304,6 +314,7 @@ export class LocalNotebooks extends Dexie {
     this.folders = this.table('folders')
 
     this.driveStore = driveStore
+    this.driveSyncCoordinator = driveSyncCoordinator
     this.conflictDocStorage = conflictDocStorage
     this.revisionDocStorage = revisionDocStorage
 
@@ -1149,6 +1160,7 @@ export class LocalNotebooks extends Dexie {
       parentRemoteIdWhenCreated: isDriveBackedParent
         ? parent.remoteId
         : undefined,
+      driveCreateOperationId: isDriveBackedParent ? uuidv4() : undefined,
       lastRemoteChecksum: '',
       lastSynced: isDriveBackedParent ? '' : nowIsoString(),
       doc: options.content,
@@ -1528,6 +1540,12 @@ export class LocalNotebooks extends Dexie {
       throw new Error('syncMarkdownFile expects a local://file/ URI')
     }
 
+    await this.driveSyncCoordinator.runExclusive(localUri, () =>
+      this.syncMarkdownFileInner(localUri)
+    )
+  }
+
+  private async syncMarkdownFileInner(localUri: string): Promise<void> {
     const record = await this.files.get(localUri)
     if (!record) {
       throw new Error(`Local notebook record not found for ${localUri}`)
@@ -1560,8 +1578,21 @@ export class LocalNotebooks extends Dexie {
 
       const baseName = name.replace(/\.[^.]+$/, '')
       const markdownName = `${baseName}.index.md`
-
-      const markdownFile = await driveStore.create(parentUri, markdownName)
+      const createOperationId = record.markdownCreateOperationId ?? uuidv4()
+      if (!record.markdownCreateOperationId) {
+        await this.files.update(localUri, {
+          markdownCreateOperationId: createOperationId,
+        })
+      }
+      const existingFile = await driveStore.findByCreateOperation(
+        parentUri,
+        createOperationId
+      )
+      const markdownFile =
+        existingFile ??
+        (await driveStore.create(parentUri, markdownName, {
+          createOperationId,
+        }))
       markdownUri = markdownFile.uri
       await this.files.update(localUri, { markdownUri })
     }
@@ -1779,15 +1810,19 @@ export class LocalNotebooks extends Dexie {
       return existingSync
     }
 
-    const operation = Promise.resolve().then(async () => {
-      try {
-        await this.syncFileInner(localUri)
-        await this.files.update(localUri, { lastSyncError: undefined })
-      } catch (error) {
-        await this.files.update(localUri, { lastSyncError: String(error) })
-        throw error
-      }
-    })
+    const operation = Promise.resolve().then(() =>
+      this.driveSyncCoordinator.runExclusive(localUri, async () => {
+        try {
+          // Re-read and reconcile only after acquiring the cross-context lock.
+          // Another tab may have completed the pending create while we waited.
+          await this.syncFileInner(localUri)
+          await this.files.update(localUri, { lastSyncError: undefined })
+        } catch (error) {
+          await this.files.update(localUri, { lastSyncError: String(error) })
+          throw error
+        }
+      })
+    )
     this.inFlightSyncs.set(localUri, operation)
     this.notifySync(localUri)
 
@@ -2155,15 +2190,29 @@ export class LocalNotebooks extends Dexie {
       )
     }
 
+    const createOperationId = record.driveCreateOperationId ?? uuidv4()
+    if (!record.driveCreateOperationId) {
+      await this.files.update(localUri, {
+        driveCreateOperationId: createOperationId,
+      })
+    }
+    const existingFile = await this.driveStore.findByCreateOperation(
+      parentRemoteUri,
+      createOperationId
+    )
     const newFile =
-      record.mimeType && record.mimeType !== NOTEBOOK_MIME_TYPE
+      existingFile ??
+      (record.mimeType && record.mimeType !== NOTEBOOK_MIME_TYPE
         ? await this.driveStore.createContent(
             parentRemoteUri,
             record.name,
             record.doc ?? '',
-            record.mimeType
+            record.mimeType,
+            { createOperationId }
           )
-        : await this.driveStore.create(parentRemoteUri, record.name)
+        : await this.driveStore.create(parentRemoteUri, record.name, {
+            createOperationId,
+          }))
     let version: UpstreamVersion = {}
     try {
       version = driveMetadataToUpstreamVersion(
@@ -2203,6 +2252,8 @@ export class LocalNotebooks extends Dexie {
         localUri,
         parentRemoteUri,
         remoteUri: newFile.uri,
+        createOperationId,
+        outcome: existingFile ? 'adopted' : 'created',
         upstreamChecksum: version.checksum,
         upstreamRevisionId: version.revisionId,
       },


### PR DESCRIPTION
## Summary

- serialize Drive synchronization for a local notebook across same-origin browser contexts with the Web Locks API
- persist a stable create-operation ID in IndexedDB and Drive `appProperties` so retries adopt an existing remote file after a crash
- apply the same coordination and recovery mechanism to Markdown sidecars
- add cross-instance concurrency, crash-window, Drive metadata, and sidecar regression tests

## Root cause

`LocalNotebooks.inFlightSyncs` only serialized work within one JavaScript object. Multiple Runme sessions could read the same pending IndexedDB record and each call the non-idempotent Drive create API before any session persisted the winning remote URI. A lock alone would still leave a crash window after Drive creation, so the fix combines cross-context serialization with a durable Drive-side operation identity.

## Design notebook

[20260722_runme_duplicate_drive_notebook_bug](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1cLQiQBueVAOfxINh8KEHlN89HM6ozweU%2Fview)

## Validation

- `runme run build test`
- `pnpm -C app test --run src/storage/local.test.ts src/storage/drive.test.ts src/storage/driveSyncCoordinator.test.ts` — 56 tests passed
- `git diff --check`