### PR TITLE
Add versioned documentation explorer

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -171,6 +171,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.gcp_auth.outputs.access_token }}
           CUJ_MANAGE_SERVERS: "true"
+          CUJ_OIDC_TOKEN_TTL_SECONDS: "1800"
           CUJ_FRONTEND_CMD: "pnpm run dev:app"
           CUJ_UPLOAD: "true"
           CUJ_COMMENT: "false"

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -45,6 +45,12 @@ const contextMocks = vi.hoisted(() => ({
     refreshErrorMessage?: string
     owner?: NotebookOwnershipRecord | null
   }>,
+  openNotebooks: [] as Array<{
+    uri: string
+    requestedUri: string
+    name: string
+    state: 'loading' | 'loaded' | 'blocked' | 'error'
+  }>,
   currentDoc: null as string | null,
   setCurrentDoc: vi.fn(),
   showDocument: vi.fn(),
@@ -141,6 +147,7 @@ vi.mock('../../contexts/NotebookContext', () => ({
     openNotebook: contextMocks.openNotebook,
     requestWriteAccess: contextMocks.requestWriteAccess,
     refreshReadOnlyNotebook: contextMocks.refreshReadOnlyNotebook,
+    useNotebookList: () => contextMocks.openNotebooks,
     useNotebookSnapshot: (uri: string) =>
       contextMocks.notebookSnapshots.get(uri) ?? null,
   }),
@@ -325,6 +332,7 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn()
   window.history.replaceState(null, '', '/')
   contextMocks.workspaceDocuments = []
+  contextMocks.openNotebooks = []
   contextMocks.currentDoc = null
   contextMocks.setCurrentDoc.mockReset()
   contextMocks.setCurrentDoc.mockImplementation((uri: string | null) => {
@@ -938,6 +946,35 @@ describe('Actions tabs', () => {
         'local://file/restored'
       )
     })
+  })
+
+  it('preserves a current notebook while its workspace tab is restoring', async () => {
+    const restoredUri = 'local://file/restored.runme.md'
+    contextMocks.currentDoc = restoredUri
+    contextMocks.openNotebooks = [
+      {
+        uri: restoredUri,
+        requestedUri: restoredUri,
+        name: 'restored.runme.md',
+        state: 'loading',
+      },
+    ]
+    contextMocks.workspaceDocuments = [
+      {
+        uri: 'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md',
+        title: 'Getting Started',
+        readOnly: true,
+      },
+    ]
+
+    render(<Actions />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('tab', { name: /Getting Started/ })
+      ).toBeTruthy()
+    })
+    expect(contextMocks.setCurrentDoc).not.toHaveBeenCalled()
   })
 
   it('renames the notebook from the tab context menu', async () => {

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -147,7 +147,7 @@ vi.mock('../../contexts/NotebookContext', () => ({
     openNotebook: contextMocks.openNotebook,
     requestWriteAccess: contextMocks.requestWriteAccess,
     refreshReadOnlyNotebook: contextMocks.refreshReadOnlyNotebook,
-    useNotebookList: () => contextMocks.openNotebooks,
+    getOpenNotebooks: () => contextMocks.openNotebooks,
     useNotebookSnapshot: (uri: string) =>
       contextMocks.notebookSnapshots.get(uri) ?? null,
   }),

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -70,6 +70,7 @@ import {
 import {
   isDriveLinkStatusUri,
   isDriveSyncStatusUri,
+  isDocumentationDocumentUri,
   isAppConsoleUri,
   isExcalidrawWorkspaceDocument,
   isLogsUri,
@@ -117,6 +118,7 @@ import LogsPane from '../Logs/LogsPane'
 import { ActionOutputItems } from './ActionOutputItems'
 import React from 'react'
 import ExcalidrawDocument from '../Excalidraw/ExcalidrawDocument'
+import RemoteMarkdownDocument from '../Documentation/RemoteMarkdownDocument'
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
   'data-state'?: 'active' | 'inactive'
@@ -2793,6 +2795,10 @@ function renderWorkspaceDocument({
 
   if (isNotebookDiffUri(document.uri)) {
     return <NotebookDiffTabContent diffUri={document.uri} />
+  }
+
+  if (isDocumentationDocumentUri(document.uri)) {
+    return <RemoteMarkdownDocument document={document} />
   }
 
   if (isDriveLinkStatusUri(document.uri)) {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2831,9 +2831,9 @@ function renderWorkspaceDocument({
 export default function Actions() {
   const { useWorkspaceDocuments, showDocument, closeWorkspaceDocument } =
     useWorkspaceDocumentContext()
-  const { getNotebookData, useNotebookList } = useNotebookContext()
+  const { getNotebookData, getOpenNotebooks } = useNotebookContext()
   const { store } = useNotebookStore()
-  const openNotebooks = useNotebookList()
+  const openNotebooks = getOpenNotebooks()
   const workspaceDocuments = useWorkspaceDocuments()
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
   const currentDocUri = getCurrentDoc()

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2831,8 +2831,9 @@ function renderWorkspaceDocument({
 export default function Actions() {
   const { useWorkspaceDocuments, showDocument, closeWorkspaceDocument } =
     useWorkspaceDocumentContext()
-  const { getNotebookData } = useNotebookContext()
+  const { getNotebookData, useNotebookList } = useNotebookContext()
   const { store } = useNotebookStore()
+  const openNotebooks = useNotebookList()
   const workspaceDocuments = useWorkspaceDocuments()
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
   const currentDocUri = getCurrentDoc()
@@ -2911,6 +2912,12 @@ export default function Actions() {
   const currentDocIsOpen = currentDocUri
     ? workspaceDocumentUris.has(currentDocUri)
     : false
+  const currentDocIsRestoring =
+    Boolean(currentDocUri && isNotebookDocumentUri(currentDocUri)) &&
+    openNotebooks.some(
+      (notebook) =>
+        notebook.uri === currentDocUri || notebook.requestedUri === currentDocUri
+    )
   const resolvedSelectedTabUri =
     (selectedTabIsOpen ? selectedTabUri : null) ??
     (currentDocIsOpen ? currentDocUri : null) ??
@@ -3007,11 +3014,12 @@ export default function Actions() {
     if (selectedTabUri && !selectedTabIsOpen) {
       setSelectedTabUri(null)
     }
-    if (currentDocUri && !currentDocIsOpen) {
+    if (currentDocUri && !currentDocIsOpen && !currentDocIsRestoring) {
       setCurrentDoc(workspaceDocuments[0]?.uri ?? null)
     }
   }, [
     currentDocIsOpen,
+    currentDocIsRestoring,
     currentDocUri,
     selectedTabIsOpen,
     selectedTabUri,

--- a/app/src/components/CurrentDocInitializer.test.tsx
+++ b/app/src/components/CurrentDocInitializer.test.tsx
@@ -175,4 +175,23 @@ describe('CurrentDocInitializer', () => {
     expect(window.location.search).toBe('?existing=1')
     expect(window.location.hash).toBe('#section')
   })
+
+  it('opens a Markdown HTML link as a read-only document', async () => {
+    const uri =
+      'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md'
+    setDocUrl(uri)
+
+    render(<CurrentDocInitializer />)
+
+    await waitFor(() => {
+      expect(mocks.setCurrentDoc).toHaveBeenCalledWith(uri)
+    })
+    expect(mocks.openNotebook).not.toHaveBeenCalled()
+    expect(mocks.showDocument).toHaveBeenCalledWith(uri, {
+      title: '00-getting-started',
+      mimeType: 'text/markdown',
+      readOnly: true,
+    })
+    expect(window.location.search).toBe('?existing=1')
+  })
 })

--- a/app/src/components/CurrentDocInitializer.tsx
+++ b/app/src/components/CurrentDocInitializer.tsx
@@ -6,10 +6,15 @@ import { useWorkspaceDocumentContext } from '../contexts/WorkspaceDocumentContex
 import {
   deriveWorkspaceDocumentTitle,
   isAppConsoleUri,
+  isDocumentationDocumentUri,
   isDriveSyncStatusUri,
   isLogsUri,
   isRunnerStatusUri,
 } from '../lib/workspaceDocuments/workspaceDocumentTypes'
+import {
+  DOCUMENTATION_MIME_TYPE,
+  markDocumentationOpened,
+} from '../lib/documentation'
 
 function isNotebookDocParam(uri: string): boolean {
   return uri.startsWith('local://file/') || uri.startsWith('fs://')
@@ -49,6 +54,17 @@ export function CurrentDocInitializer() {
     ) {
       showDocument(docParam, {
         title: deriveWorkspaceDocumentTitle(docParam),
+      })
+      setCurrentDoc(docParam)
+      clearDocParam()
+      return
+    }
+    if (isDocumentationDocumentUri(docParam)) {
+      markDocumentationOpened(docParam)
+      showDocument(docParam, {
+        title: deriveWorkspaceDocumentTitle(docParam).replace(/\.md$/i, ''),
+        mimeType: DOCUMENTATION_MIME_TYPE,
+        readOnly: true,
       })
       setCurrentDoc(docParam)
       clearDocParam()

--- a/app/src/components/Documentation/DocumentationExplorer.test.tsx
+++ b/app/src/components/Documentation/DocumentationExplorer.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getGettingStartedDocument } from '../../lib/documentation'
+import { DocumentationExplorer } from './DocumentationExplorer'
+
+const mocks = vi.hoisted(() => ({
+  setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
+}))
+
+vi.mock('../../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({
+    getCurrentDoc: () => null,
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}))
+
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
+  }),
+}))
+
+describe('DocumentationExplorer', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mocks.setCurrentDoc.mockReset()
+    mocks.showDocument.mockReset()
+  })
+
+  it('renders a documentation tree and opens a selected page read-only', () => {
+    const gettingStarted = getGettingStartedDocument()
+    render(<DocumentationExplorer />)
+
+    expect(
+      screen.getByRole('tree', { name: 'Runme documentation' })
+    ).toBeTruthy()
+    fireEvent.click(screen.getByRole('treeitem', { name: 'Getting Started' }))
+
+    expect(mocks.showDocument).toHaveBeenCalledWith(gettingStarted.uri, {
+      title: 'Getting Started',
+      mimeType: 'text/markdown',
+      readOnly: true,
+    })
+    expect(mocks.setCurrentDoc).toHaveBeenCalledWith(gettingStarted.uri)
+  })
+})

--- a/app/src/components/Documentation/DocumentationExplorer.tsx
+++ b/app/src/components/Documentation/DocumentationExplorer.tsx
@@ -1,0 +1,108 @@
+import {
+  BookOpenIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  DocumentTextIcon,
+} from '@heroicons/react/24/outline'
+import { useMemo, useState } from 'react'
+
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
+import {
+  DOCUMENTATION_MIME_TYPE,
+  listDocumentation,
+  markDocumentationOpened,
+} from '../../lib/documentation'
+
+export function DocumentationExplorer() {
+  const [expanded, setExpanded] = useState(true)
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
+  const { showDocument } = useWorkspaceDocumentContext()
+  const currentDoc = getCurrentDoc()
+  const result = useMemo(() => {
+    try {
+      return { documents: listDocumentation(), error: null }
+    } catch (error) {
+      return {
+        documents: [],
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }, [])
+
+  return (
+    <div
+      id="documentation-explorer"
+      className="flex h-full min-h-0 w-full flex-col bg-nb-surface"
+    >
+      <div className="border-b border-nb-border px-4 py-3">
+        <p className="text-xs font-semibold tracking-[0.18em] text-nb-text-faint uppercase">
+          Documentation
+        </p>
+        <p className="mt-1 text-sm text-nb-text-muted">
+          Versioned with this Runme build
+        </p>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        {result.error ? (
+          <div className="rounded-nb-sm border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+            {result.error}
+          </div>
+        ) : (
+          <div role="tree" aria-label="Runme documentation">
+            <button
+              type="button"
+              role="treeitem"
+              aria-expanded={expanded}
+              className="flex w-full items-center gap-1.5 rounded-nb-sm px-2 py-1.5 text-left text-sm font-semibold text-nb-text hover:bg-white/80"
+              onClick={() => setExpanded((value) => !value)}
+            >
+              {expanded ? (
+                <ChevronDownIcon className="h-4 w-4 shrink-0" />
+              ) : (
+                <ChevronRightIcon className="h-4 w-4 shrink-0" />
+              )}
+              <BookOpenIcon className="h-4 w-4 shrink-0" />
+              <span>Runme Web</span>
+            </button>
+            {expanded ? (
+              <div role="group" className="ml-4 border-l border-nb-border pl-1">
+                {result.documents.map((document) => {
+                  const selected = currentDoc === document.uri
+                  return (
+                    <button
+                      key={document.path}
+                      type="button"
+                      role="treeitem"
+                      aria-selected={selected}
+                      title={document.uri}
+                      className={`flex w-full items-center gap-2 rounded-nb-sm px-2 py-1.5 text-left text-sm transition-colors ${
+                        selected
+                          ? 'bg-nb-accent-soft text-nb-text'
+                          : 'text-nb-text-muted hover:bg-white/80 hover:text-nb-text'
+                      }`}
+                      onClick={() => {
+                        markDocumentationOpened(document.uri)
+                        showDocument(document.uri, {
+                          title: document.title,
+                          mimeType: DOCUMENTATION_MIME_TYPE,
+                          readOnly: true,
+                        })
+                        setCurrentDoc(document.uri)
+                      }}
+                    >
+                      <DocumentTextIcon className="h-4 w-4 shrink-0" />
+                      <span className="truncate">{document.title}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DocumentationExplorer

--- a/app/src/components/Documentation/DocumentationInitializer.test.tsx
+++ b/app/src/components/Documentation/DocumentationInitializer.test.tsx
@@ -9,12 +9,14 @@ import {
 import { DocumentationInitializer } from './DocumentationInitializer'
 
 const mocks = vi.hoisted(() => ({
+  currentDoc: null as string | null,
   setCurrentDoc: vi.fn(),
   showDocument: vi.fn(),
 }))
 
 vi.mock('../../contexts/CurrentDocContext', () => ({
   useCurrentDoc: () => ({
+    getCurrentDoc: () => mocks.currentDoc,
     setCurrentDoc: mocks.setCurrentDoc,
   }),
 }))
@@ -29,6 +31,7 @@ describe('DocumentationInitializer', () => {
   beforeEach(() => {
     window.localStorage.clear()
     window.history.replaceState(null, '', '/')
+    mocks.currentDoc = null
     mocks.setCurrentDoc.mockReset()
     mocks.showDocument.mockReset()
   })
@@ -52,6 +55,23 @@ describe('DocumentationInitializer', () => {
     mocks.showDocument.mockClear()
     render(<DocumentationInitializer />)
     expect(mocks.showDocument).not.toHaveBeenCalled()
+  })
+
+  it('opens Getting Started in the background when a document is restored', () => {
+    const document = getGettingStartedDocument()
+    mocks.currentDoc = 'local://file/restored.runme.md'
+
+    render(<DocumentationInitializer />)
+
+    expect(mocks.showDocument).toHaveBeenCalledWith(document.uri, {
+      title: 'Getting Started',
+      mimeType: 'text/markdown',
+      readOnly: true,
+    })
+    expect(mocks.setCurrentDoc).not.toHaveBeenCalled()
+    expect(
+      window.localStorage.getItem(GETTING_STARTED_OPENED_STORAGE_KEY)
+    ).toBe('true')
   })
 
   it('does not replace an explicit doc URL', () => {

--- a/app/src/components/Documentation/DocumentationInitializer.test.tsx
+++ b/app/src/components/Documentation/DocumentationInitializer.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  GETTING_STARTED_OPENED_STORAGE_KEY,
+  getGettingStartedDocument,
+} from '../../lib/documentation'
+import { DocumentationInitializer } from './DocumentationInitializer'
+
+const mocks = vi.hoisted(() => ({
+  setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
+}))
+
+vi.mock('../../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}))
+
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
+  }),
+}))
+
+describe('DocumentationInitializer', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.history.replaceState(null, '', '/')
+    mocks.setCurrentDoc.mockReset()
+    mocks.showDocument.mockReset()
+  })
+
+  it('opens Getting Started once for a first-time user', () => {
+    const document = getGettingStartedDocument()
+
+    const { unmount } = render(<DocumentationInitializer />)
+
+    expect(mocks.showDocument).toHaveBeenCalledWith(document.uri, {
+      title: 'Getting Started',
+      mimeType: 'text/markdown',
+      readOnly: true,
+    })
+    expect(mocks.setCurrentDoc).toHaveBeenCalledWith(document.uri)
+    expect(
+      window.localStorage.getItem(GETTING_STARTED_OPENED_STORAGE_KEY)
+    ).toBe('true')
+
+    unmount()
+    mocks.showDocument.mockClear()
+    render(<DocumentationInitializer />)
+    expect(mocks.showDocument).not.toHaveBeenCalled()
+  })
+
+  it('does not replace an explicit doc URL', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/?doc=local%3A%2F%2Ffile%2Frequested'
+    )
+
+    const view = render(<DocumentationInitializer />)
+    window.history.replaceState(null, '', '/')
+    view.rerender(<DocumentationInitializer />)
+
+    expect(mocks.showDocument).not.toHaveBeenCalled()
+    expect(
+      window.localStorage.getItem(GETTING_STARTED_OPENED_STORAGE_KEY)
+    ).toBeNull()
+  })
+})

--- a/app/src/components/Documentation/DocumentationInitializer.tsx
+++ b/app/src/components/Documentation/DocumentationInitializer.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../lib/documentation'
 
 export function DocumentationInitializer() {
-  const { setCurrentDoc } = useCurrentDoc()
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
   const { showDocument } = useWorkspaceDocumentContext()
   const explicitDocumentRequested = useRef(
     typeof window !== 'undefined' &&
@@ -29,11 +29,13 @@ export function DocumentationInitializer() {
         mimeType: DOCUMENTATION_MIME_TYPE,
         readOnly: true,
       })
-      setCurrentDoc(document.uri)
+      if (!getCurrentDoc()) {
+        setCurrentDoc(document.uri)
+      }
     } catch (error) {
       console.error('Failed to open Getting Started documentation', error)
     }
-  }, [setCurrentDoc, showDocument])
+  }, [getCurrentDoc, setCurrentDoc, showDocument])
 
   return null
 }

--- a/app/src/components/Documentation/DocumentationInitializer.tsx
+++ b/app/src/components/Documentation/DocumentationInitializer.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react'
+
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
+import {
+  DOCUMENTATION_MIME_TYPE,
+  getGettingStartedDocument,
+  hasOpenedGettingStarted,
+  markGettingStartedOpened,
+} from '../../lib/documentation'
+
+export function DocumentationInitializer() {
+  const { setCurrentDoc } = useCurrentDoc()
+  const { showDocument } = useWorkspaceDocumentContext()
+  const explicitDocumentRequested = useRef(
+    typeof window !== 'undefined' &&
+      new URLSearchParams(window.location.search).has('doc')
+  )
+
+  useEffect(() => {
+    if (explicitDocumentRequested.current || hasOpenedGettingStarted()) {
+      return
+    }
+    try {
+      const document = getGettingStartedDocument()
+      markGettingStartedOpened()
+      showDocument(document.uri, {
+        title: document.title,
+        mimeType: DOCUMENTATION_MIME_TYPE,
+        readOnly: true,
+      })
+      setCurrentDoc(document.uri)
+    } catch (error) {
+      console.error('Failed to open Getting Started documentation', error)
+    }
+  }, [setCurrentDoc, showDocument])
+
+  return null
+}
+
+export default DocumentationInitializer

--- a/app/src/components/Documentation/RemoteMarkdownDocument.test.tsx
+++ b/app/src/components/Documentation/RemoteMarkdownDocument.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RemoteMarkdownDocument } from './RemoteMarkdownDocument'
+
+const mocks = vi.hoisted(() => ({
+  setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
+}))
+
+vi.mock('../../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}))
+
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
+  }),
+}))
+
+describe('RemoteMarkdownDocument', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    mocks.setCurrentDoc.mockReset()
+    mocks.showDocument.mockReset()
+  })
+
+  it('fetches raw Markdown and opens relative Markdown links in-app', async () => {
+    const uri =
+      'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md'
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () =>
+        '# Getting Started\n\n[Editing cells](01-editing-and-running-cells.md)',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <RemoteMarkdownDocument
+        document={{
+          uri,
+          title: 'Getting Started',
+          mimeType: 'text/markdown',
+          readOnly: true,
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Getting Started' })
+      ).toBeTruthy()
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/runmedev/web/abc123/docs/00-getting-started.md',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'Editing cells' }))
+
+    const linkedUri =
+      'https://github.com/runmedev/web/blob/abc123/docs/01-editing-and-running-cells.md'
+    expect(mocks.showDocument).toHaveBeenCalledWith(linkedUri, {
+      title: '01-editing-and-running-cells',
+      mimeType: 'text/markdown',
+      readOnly: true,
+    })
+    expect(mocks.setCurrentDoc).toHaveBeenCalledWith(linkedUri)
+  })
+})

--- a/app/src/components/Documentation/RemoteMarkdownDocument.tsx
+++ b/app/src/components/Documentation/RemoteMarkdownDocument.tsx
@@ -1,0 +1,247 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid'
+import { Button, ScrollArea } from '@radix-ui/themes'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
+import {
+  DOCUMENTATION_MIME_TYPE,
+  fetchRemoteMarkdownDocument,
+  isRemoteMarkdownUri,
+  markDocumentationOpened,
+  resolveDocumentationHref,
+  toRawMarkdownUri,
+} from '../../lib/documentation'
+import type { WorkspaceDocument } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
+
+export function RemoteMarkdownDocument({
+  document,
+}: {
+  document: WorkspaceDocument
+}) {
+  const { setCurrentDoc } = useCurrentDoc()
+  const { showDocument } = useWorkspaceDocumentContext()
+  const [content, setContent] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [attempt, setAttempt] = useState(0)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+    void fetchRemoteMarkdownDocument(document.uri, (input, init) =>
+      fetch(input, { ...init, signal: controller.signal })
+    )
+      .then((result) => {
+        if (!controller.signal.aborted) {
+          setContent(result.content)
+          setLoading(false)
+        }
+      })
+      .catch((cause) => {
+        if (!controller.signal.aborted) {
+          setError(cause instanceof Error ? cause.message : String(cause))
+          setLoading(false)
+        }
+      })
+    return () => controller.abort()
+  }, [attempt, document.uri])
+
+  const openMarkdownLink = useCallback(
+    (uri: string) => {
+      markDocumentationOpened(uri)
+      showDocument(uri, {
+        title:
+          decodeURIComponent(
+            new URL(uri).pathname.split('/').filter(Boolean).pop() ||
+              'Documentation'
+          ).replace(/\.md$/i, '') || 'Documentation',
+        mimeType: DOCUMENTATION_MIME_TYPE,
+        readOnly: true,
+      })
+      setCurrentDoc(uri)
+    },
+    [setCurrentDoc, showDocument]
+  )
+
+  const components = useMemo<Components>(
+    () => ({
+      h1: ({ children, ...props }) => (
+        <h1 className="mb-4 mt-6 text-3xl font-bold text-nb-text" {...props}>
+          {children}
+        </h1>
+      ),
+      h2: ({ children, ...props }) => (
+        <h2 className="mb-3 mt-7 text-2xl font-bold text-nb-text" {...props}>
+          {children}
+        </h2>
+      ),
+      h3: ({ children, ...props }) => (
+        <h3 className="mb-2 mt-6 text-xl font-semibold text-nb-text" {...props}>
+          {children}
+        </h3>
+      ),
+      p: ({ children, ...props }) => (
+        <p className="mb-4 leading-7 text-nb-text" {...props}>
+          {children}
+        </p>
+      ),
+      ul: ({ children, ...props }) => (
+        <ul className="mb-4 ml-6 list-disc space-y-1 text-nb-text" {...props}>
+          {children}
+        </ul>
+      ),
+      ol: ({ children, ...props }) => (
+        <ol
+          className="mb-4 ml-6 list-decimal space-y-1 text-nb-text"
+          {...props}
+        >
+          {children}
+        </ol>
+      ),
+      code: ({ children, className, ...props }) =>
+        className ? (
+          <code
+            className={`${className} block overflow-x-auto rounded-md bg-nb-surface-2 p-3 font-mono text-sm`}
+            {...props}
+          >
+            {children}
+          </code>
+        ) : (
+          <code
+            className="rounded bg-nb-surface-2 px-1.5 py-0.5 font-mono text-sm"
+            {...props}
+          >
+            {children}
+          </code>
+        ),
+      pre: ({ children, ...props }) => (
+        <pre className="mb-4 overflow-x-auto" {...props}>
+          {children}
+        </pre>
+      ),
+      blockquote: ({ children, ...props }) => (
+        <blockquote
+          className="my-4 border-l-4 border-nb-border-strong pl-4 text-nb-text-muted"
+          {...props}
+        >
+          {children}
+        </blockquote>
+      ),
+      a: ({ children, href, ...props }) => {
+        if (!href) {
+          return <a {...props}>{children}</a>
+        }
+        const resolved = href.startsWith('#')
+          ? href
+          : resolveDocumentationHref(href, document.uri)
+        const opensDocumentation =
+          !resolved.startsWith('#') && isRemoteMarkdownUri(resolved)
+        return (
+          <a
+            href={resolved}
+            className="text-blue-600 hover:underline"
+            target={opensDocumentation ? undefined : '_blank'}
+            rel={opensDocumentation ? undefined : 'noopener noreferrer'}
+            onClick={
+              opensDocumentation
+                ? (event) => {
+                    event.preventDefault()
+                    openMarkdownLink(resolved)
+                  }
+                : undefined
+            }
+            {...props}
+          >
+            {children}
+          </a>
+        )
+      },
+      img: ({ src, alt, ...props }) => {
+        const resolved = src
+          ? toRawMarkdownUri(resolveDocumentationHref(src, document.uri))
+          : undefined
+        return (
+          <img
+            src={resolved}
+            alt={alt || ''}
+            className="my-4 h-auto max-w-full rounded-md"
+            {...props}
+          />
+        )
+      },
+      table: ({ children, ...props }) => (
+        <div className="mb-4 overflow-x-auto">
+          <table
+            className="min-w-full border border-nb-border-strong"
+            {...props}
+          >
+            {children}
+          </table>
+        </div>
+      ),
+      th: ({ children, ...props }) => (
+        <th
+          className="border border-nb-border-strong bg-nb-surface-2 px-3 py-2 text-left font-semibold"
+          {...props}
+        >
+          {children}
+        </th>
+      ),
+      td: ({ children, ...props }) => (
+        <td className="border border-nb-border-strong px-3 py-2" {...props}>
+          {children}
+        </td>
+      ),
+    }),
+    [document.uri, openMarkdownLink]
+  )
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-white">
+      <div className="flex items-center justify-between gap-3 border-b border-nb-border bg-nb-surface px-4 py-2">
+        <span className="truncate text-xs text-nb-text-muted">
+          Read-only · {document.uri}
+        </span>
+        <a
+          href={document.uri}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex shrink-0 items-center gap-1 text-xs text-blue-600 hover:underline"
+        >
+          View on GitHub
+          <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+        </a>
+      </div>
+      <ScrollArea type="auto" scrollbars="vertical" className="min-h-0 flex-1">
+        <article className="mx-auto max-w-4xl px-8 py-6">
+          {loading ? (
+            <p className="text-sm text-nb-text-muted">Loading documentation…</p>
+          ) : error ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+              <p>{error}</p>
+              <Button
+                type="button"
+                variant="soft"
+                color="red"
+                className="mt-3"
+                onClick={() => setAttempt((value) => value + 1)}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+              {content}
+            </ReactMarkdown>
+          )}
+        </article>
+      </ScrollArea>
+    </div>
+  )
+}
+
+export default RemoteMarkdownDocument

--- a/app/src/components/MainPage/MainPage.tsx
+++ b/app/src/components/MainPage/MainPage.tsx
@@ -3,6 +3,7 @@ import { SidePanelContent, SidePanelToolbar } from "../SidePanel/SidePanel";
 import { useSidePanel } from "../../contexts/SidePanelContext";
 import { CommentsPanelProvider } from "../../contexts/CommentsPanelContext";
 import { CurrentDocInitializer } from "../CurrentDocInitializer";
+import { DocumentationInitializer } from "../Documentation/DocumentationInitializer";
 
 const SIDE_PANEL_WIDTH = 360;
 const TOOLBAR_WIDTH = 48; // ~12 tailwind units (12 * 4px)
@@ -15,6 +16,7 @@ export default function MainPage() {
     <CommentsPanelProvider>
       <div id="main-page" className="flex h-screen w-screen bg-nb-bg">
         <CurrentDocInitializer />
+        <DocumentationInitializer />
         <div className="flex h-full min-h-0 w-full">
           <div
             id="toolbar-column"

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -240,13 +240,19 @@ describe('SidePanelToolbar drive status button', () => {
     expect(togglePanelMock).toHaveBeenCalledWith('outline')
   })
 
-  it('exposes a Documentation Explorer button in the toolbar', () => {
+  it('places the Documentation Explorer button directly above About', () => {
     render(<SidePanelToolbar />)
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Toggle Documentation panel' })
-    )
+    const documentationButton = screen.getByRole('button', {
+      name: 'Toggle Documentation panel',
+    })
+    const aboutButton = screen.getByRole('button', {
+      name: 'Open Version Information',
+    })
 
+    expect(documentationButton.nextElementSibling).toBe(aboutButton)
+
+    fireEvent.click(documentationButton)
     expect(togglePanelMock).toHaveBeenCalledWith('documentation')
   })
 

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -2,7 +2,12 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-type PanelKey = 'explorer' | 'open-documents' | 'outline' | null
+type PanelKey =
+  | 'explorer'
+  | 'documentation'
+  | 'open-documents'
+  | 'outline'
+  | null
 
 let authData: {} | null = null
 let isDriveSyncing = false
@@ -107,6 +112,10 @@ vi.mock('../../contexts/RunnersContext', () => ({
 
 vi.mock('../Workspace/WorkspaceExplorer', () => ({
   default: () => <div data-testid="workspace-explorer-mock" />,
+}))
+
+vi.mock('../Documentation/DocumentationExplorer', () => ({
+  default: () => <div data-testid="documentation-explorer-mock" />,
 }))
 
 import { SidePanelContent, SidePanelToolbar } from './SidePanel'
@@ -231,6 +240,16 @@ describe('SidePanelToolbar drive status button', () => {
     expect(togglePanelMock).toHaveBeenCalledWith('outline')
   })
 
+  it('exposes a Documentation Explorer button in the toolbar', () => {
+    render(<SidePanelToolbar />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle Documentation panel' })
+    )
+
+    expect(togglePanelMock).toHaveBeenCalledWith('documentation')
+  })
+
   it('exposes an App Console button in the toolbar', () => {
     render(<SidePanelToolbar />)
 
@@ -344,6 +363,14 @@ describe('SidePanelContent', () => {
     expect(screen.getByTestId('workspace-explorer-mock')).toBeTruthy()
   })
 
+  it('renders the Documentation Explorer panel', () => {
+    activePanelState = 'documentation'
+
+    render(<SidePanelContent />)
+
+    expect(screen.getByTestId('documentation-explorer-mock')).toBeTruthy()
+  })
+
   it('renders the Open Documents panel and routes document actions through shared context state', () => {
     activePanelState = 'open-documents'
     currentDocUri = 'local://file/alpha.json'
@@ -355,6 +382,11 @@ describe('SidePanelContent', () => {
       { uri: 'status://drive-sync', title: 'Google Drive Sync Status' },
       { uri: 'app://console', title: 'App Console' },
       { uri: 'app://logs', title: 'Logs' },
+      {
+        uri: 'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md',
+        title: 'Getting Started',
+        readOnly: true,
+      },
     ]
     closeWorkspaceDocumentMock.mockReturnValue('diff://notebook/beta')
 
@@ -369,6 +401,11 @@ describe('SidePanelContent', () => {
     expect(screen.getByText('Drive Sync · status://drive-sync')).toBeTruthy()
     expect(screen.getByText('App Console · app://console')).toBeTruthy()
     expect(screen.getByText('Logs · app://logs')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Documentation · https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md'
+      )
+    ).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Close alpha.json' }))
     expect(closeWorkspaceDocumentMock).toHaveBeenCalledWith(

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -1,5 +1,6 @@
 import {
   ChatBubbleLeftIcon,
+  BookOpenIcon,
   CommandLineIcon,
   FolderIcon,
   DocumentTextIcon,
@@ -22,6 +23,7 @@ import {
 
 import NotebookOutlinePanel from './NotebookOutlinePanel'
 import WorkspaceExplorer from '../Workspace/WorkspaceExplorer'
+import DocumentationExplorer from '../Documentation/DocumentationExplorer'
 import {
   getBrowserAdapter,
   useBrowserAuthData,
@@ -35,6 +37,7 @@ import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentCon
 import {
   isDriveLinkStatusUri,
   isDriveSyncStatusUri,
+  isDocumentationDocumentUri,
   DRIVE_SYNC_STATUS_DOCUMENT_URI,
   isExcalidrawWorkspaceDocument,
   isNotebookDiffUri,
@@ -142,21 +145,23 @@ function OpenDocumentsPanel() {
                 ? 'Excalidraw'
                 : isNotebookDocumentUri(doc.uri)
                   ? 'Notebook'
-                  : isNotebookDiffUri(doc.uri)
-                    ? 'Diff'
-                    : isDriveLinkStatusUri(doc.uri)
-                      ? 'Status'
-                      : isDriveSyncStatusUri(doc.uri)
-                        ? 'Drive Sync'
-                        : isVersionInfoUri(doc.uri)
-                          ? 'Version'
-                          : isRunnerStatusUri(doc.uri)
-                            ? 'Runner Status'
-                            : isAppConsoleUri(doc.uri)
-                              ? 'App Console'
-                              : isLogsUri(doc.uri)
-                                ? 'Logs'
-                                : 'Document'
+                  : isDocumentationDocumentUri(doc.uri)
+                    ? 'Documentation'
+                    : isNotebookDiffUri(doc.uri)
+                      ? 'Diff'
+                      : isDriveLinkStatusUri(doc.uri)
+                        ? 'Status'
+                        : isDriveSyncStatusUri(doc.uri)
+                          ? 'Drive Sync'
+                          : isVersionInfoUri(doc.uri)
+                            ? 'Version'
+                            : isRunnerStatusUri(doc.uri)
+                              ? 'Runner Status'
+                              : isAppConsoleUri(doc.uri)
+                                ? 'App Console'
+                                : isLogsUri(doc.uri)
+                                  ? 'Logs'
+                                  : 'Document'
               return (
                 <li key={doc.uri}>
                   <div
@@ -349,6 +354,20 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
+            activePanel === 'documentation'
+              ? sideButtonActive
+              : sideButtonInactive
+          }`}
+          aria-pressed={activePanel === 'documentation'}
+          aria-label="Toggle Documentation panel"
+          onClick={() => togglePanel('documentation')}
+        >
+          <BookOpenIcon className="h-5 w-5" />
+          <span className={tooltipBase}>Documentation</span>
+        </button>
+        <button
+          type="button"
+          className={`${sideButtonBase} ${
             activePanel === 'explorer' ? sideButtonActive : sideButtonInactive
           }`}
           aria-pressed={activePanel === 'explorer'}
@@ -536,6 +555,12 @@ export function SidePanelContent() {
         aria-hidden={activePanel !== 'explorer'}
       >
         <WorkspaceExplorer />
+      </div>
+      <div
+        className={`h-full min-h-0 w-full ${activePanel === 'documentation' ? 'flex' : 'hidden'}`}
+        aria-hidden={activePanel !== 'documentation'}
+      >
+        <DocumentationExplorer />
       </div>
       <div
         className={`h-full min-h-0 w-full ${activePanel === 'open-documents' ? 'flex' : 'hidden'}`}

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -354,20 +354,6 @@ export function SidePanelToolbar() {
         <button
           type="button"
           className={`${sideButtonBase} ${
-            activePanel === 'documentation'
-              ? sideButtonActive
-              : sideButtonInactive
-          }`}
-          aria-pressed={activePanel === 'documentation'}
-          aria-label="Toggle Documentation panel"
-          onClick={() => togglePanel('documentation')}
-        >
-          <BookOpenIcon className="h-5 w-5" />
-          <span className={tooltipBase}>Documentation</span>
-        </button>
-        <button
-          type="button"
-          className={`${sideButtonBase} ${
             activePanel === 'explorer' ? sideButtonActive : sideButtonInactive
           }`}
           aria-pressed={activePanel === 'explorer'}
@@ -527,6 +513,20 @@ export function SidePanelToolbar() {
         >
           <UserCircleIcon className="h-5 w-5" />
           <span className={tooltipBase}>{authData ? 'Logout' : 'Login'}</span>
+        </button>
+        <button
+          type="button"
+          className={`${sideButtonBase} ${
+            activePanel === 'documentation'
+              ? sideButtonActive
+              : sideButtonInactive
+          }`}
+          aria-pressed={activePanel === 'documentation'}
+          aria-label="Toggle Documentation panel"
+          onClick={() => togglePanel('documentation')}
+        >
+          <BookOpenIcon className="h-5 w-5" />
+          <span className={tooltipBase}>Documentation</span>
         </button>
         <button
           type="button"

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -28,6 +28,7 @@ type NotebookContextValue = {
     uri: string,
     options?: OpenNotebookOptions,
   ) => Promise<OpenNotebookResult>;
+  getOpenNotebooks: () => OpenNotebookEntry[];
   useNotebookSnapshot: (uri: string) => NotebookSnapshot | null;
   useNotebookList: () => OpenNotebookEntry[];
   requestWriteAccess: (uri: string) => Promise<OpenNotebookResult>;
@@ -63,6 +64,11 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
   const openNotebook = useCallback(
     (uri: string, options?: OpenNotebookOptions) =>
       controller.openNotebook(uri, options),
+    [controller],
+  );
+
+  const getOpenNotebooks = useCallback(
+    () => controller.getOpenNotebooks(),
     [controller],
   );
 
@@ -152,6 +158,7 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
     () => ({
       getNotebookData,
       openNotebook,
+      getOpenNotebooks,
       useNotebookSnapshot,
       useNotebookList,
       requestWriteAccess,
@@ -160,6 +167,7 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
     }),
     [
       getNotebookData,
+      getOpenNotebooks,
       openNotebook,
       refreshReadOnlyNotebook,
       removeNotebook,

--- a/app/src/contexts/SidePanelContext.tsx
+++ b/app/src/contexts/SidePanelContext.tsx
@@ -1,6 +1,11 @@
 import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from "react";
 
-export type PanelKey = "explorer" | "open-documents" | "outline" | null;
+export type PanelKey =
+  | "explorer"
+  | "documentation"
+  | "open-documents"
+  | "outline"
+  | null;
 
 interface SidePanelContextValue {
   activePanel: PanelKey;
@@ -24,6 +29,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
         localStorage.getItem(LEGACY_STORAGE_KEY);
       if (
         stored === "explorer" ||
+        stored === "documentation" ||
         stored === "open-documents" ||
         stored === "open-notebooks" ||
         stored === "outline"

--- a/app/src/lib/documentation.test.ts
+++ b/app/src/lib/documentation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DOCUMENTATION_MIME_TYPE,
+  fetchRemoteMarkdownDocument,
+  getGettingStartedDocument,
+  isRemoteMarkdownUri,
+  listDocumentation,
+  resolveDocumentationHref,
+  toRawMarkdownUri,
+} from './documentation'
+import type { RunmeVersionInfo } from './versionInfo'
+
+const versionInfo: RunmeVersionInfo = {
+  buildDate: null,
+  webRepo: 'runmedev/web',
+  webBranch: 'main',
+  webCommit: 'abc123def456',
+  codexRepo: null,
+  codexBranch: null,
+  codexCommit: null,
+  bucket: null,
+}
+
+describe('documentation catalog', () => {
+  it('uses commit-pinned GitHub permalinks without bundling document content', () => {
+    const documents = listDocumentation(versionInfo)
+
+    expect(documents.length).toBeGreaterThan(10)
+    expect(documents[0]).toMatchObject({
+      title: 'Getting Started',
+      path: 'docs/00-getting-started.md',
+      uri: 'https://github.com/runmedev/web/blob/abc123def456/docs/00-getting-started.md',
+      rawUri:
+        'https://raw.githubusercontent.com/runmedev/web/abc123def456/docs/00-getting-started.md',
+      revision: 'abc123def456',
+      readOnly: true,
+    })
+    expect(documents[0]).not.toHaveProperty('content')
+    expect(getGettingStartedDocument(versionInfo)).toEqual(documents[0])
+  })
+
+  it('requires an exact web commit', () => {
+    expect(() =>
+      listDocumentation({ ...versionInfo, webCommit: null })
+    ).toThrow('does not identify its web commit')
+  })
+
+  it('recognizes and resolves Markdown links', () => {
+    const base =
+      'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md'
+
+    expect(isRemoteMarkdownUri(base)).toBe(true)
+    expect(isRemoteMarkdownUri('https://example.com/index.html')).toBe(false)
+    expect(resolveDocumentationHref('01-next.md', base)).toBe(
+      'https://github.com/runmedev/web/blob/abc123/docs/01-next.md'
+    )
+    expect(toRawMarkdownUri(base)).toBe(
+      'https://raw.githubusercontent.com/runmedev/web/abc123/docs/00-getting-started.md'
+    )
+  })
+
+  it('fetches GitHub Markdown through its raw permalink', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '# Getting Started',
+    })) as unknown as typeof fetch
+    const uri =
+      'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md'
+
+    const document = await fetchRemoteMarkdownDocument(uri, fetchImpl)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/runmedev/web/abc123/docs/00-getting-started.md',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: expect.any(String) }),
+      })
+    )
+    expect(document).toEqual({
+      uri,
+      name: '00-getting-started.md',
+      mimeType: DOCUMENTATION_MIME_TYPE,
+      content: '# Getting Started',
+      readOnly: true,
+      version: { revisionId: 'abc123' },
+    })
+  })
+})

--- a/app/src/lib/documentation.ts
+++ b/app/src/lib/documentation.ts
@@ -1,0 +1,276 @@
+import { type RunmeVersionInfo, runmeVersionInfo } from './versionInfo'
+
+export const DOCUMENTATION_MIME_TYPE = 'text/markdown'
+export const GETTING_STARTED_DOCUMENT_PATH = 'docs/00-getting-started.md'
+export const GETTING_STARTED_OPENED_STORAGE_KEY =
+  'runme/documentation/getting-started-opened'
+
+type DocumentationDefinition = {
+  path: string
+  title: string
+}
+
+export type DocumentationEntry = DocumentationDefinition & {
+  uri: string
+  rawUri: string
+  repository: string
+  revision: string
+  readOnly: true
+}
+
+export type RemoteMarkdownDocument = {
+  uri: string
+  name: string
+  mimeType: typeof DOCUMENTATION_MIME_TYPE
+  content: string
+  readOnly: true
+  version?: {
+    revisionId?: string
+  }
+}
+
+const DOCUMENTATION_DEFINITIONS: readonly DocumentationDefinition[] = [
+  { path: GETTING_STARTED_DOCUMENT_PATH, title: 'Getting Started' },
+  {
+    path: 'docs/01-editing-and-running-cells.md',
+    title: 'Editing And Running Cells',
+  },
+  { path: 'docs/02-workspace-explorer.md', title: 'Workspace Explorer' },
+  {
+    path: 'docs/03-local-notebooks-and-browser-storage.md',
+    title: 'Local Notebooks And Browser Storage',
+  },
+  {
+    path: 'docs/04-filesystem-workspaces.md',
+    title: 'Filesystem Workspaces',
+  },
+  {
+    path: 'docs/05-google-drive-integration.md',
+    title: 'Google Drive Integration',
+  },
+  {
+    path: 'docs/06-sharing-and-opening-drive-links.md',
+    title: 'Sharing And Opening Drive Links',
+  },
+  { path: 'docs/07-runners-overview.md', title: 'Runners Overview' },
+  {
+    path: 'docs/08-local-runme-runners.md',
+    title: 'Local Runme Runners',
+  },
+  {
+    path: 'docs/09-appkernel-browser-runners.md',
+    title: 'AppKernel Browser Runners',
+  },
+  { path: 'docs/10-jupyter-runners.md', title: 'Jupyter Runners' },
+  {
+    path: 'docs/11-ai-chat-and-chatkit.md',
+    title: 'AI Chat And ChatKit',
+  },
+  {
+    path: 'docs/12-agentic-search-and-codex.md',
+    title: 'Agentic Search And Codex',
+  },
+  {
+    path: 'docs/13-app-console-reference.md',
+    title: 'App Console Reference',
+  },
+  {
+    path: 'docs/14-authentication-and-app-configuration.md',
+    title: 'Authentication And App Configuration',
+  },
+  {
+    path: 'docs/15-logs-diagnostics-and-troubleshooting.md',
+    title: 'Logs Diagnostics And Troubleshooting',
+  },
+  { path: 'docs/16-notebook-diffs.md', title: 'Notebook Diffs' },
+  { path: 'docs/README.md', title: 'Documentation Index' },
+  { path: 'docs/codex-chat-panel.md', title: 'Codex Chat Panel' },
+  {
+    path: 'docs/codex-chrome-webmcp.md',
+    title: 'Codex Chrome And WebMCP',
+  },
+  { path: 'docs/using-codex.md', title: 'Using Codex' },
+]
+
+function encodePath(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+}
+
+function normalizeRepository(value: string | null): string {
+  return value?.trim() || 'runmedev/web'
+}
+
+function requireRevision(info: RunmeVersionInfo): string {
+  const revision = info.webCommit?.trim()
+  if (!revision) {
+    throw new Error(
+      'Runme documentation is unavailable because this build does not identify its web commit.'
+    )
+  }
+  return revision
+}
+
+export function listDocumentation(
+  info: RunmeVersionInfo = runmeVersionInfo
+): DocumentationEntry[] {
+  const repository = normalizeRepository(info.webRepo)
+  const revision = requireRevision(info)
+  return DOCUMENTATION_DEFINITIONS.map((definition) => {
+    const path = encodePath(definition.path)
+    return {
+      ...definition,
+      repository,
+      revision,
+      uri: `https://github.com/${repository}/blob/${revision}/${path}`,
+      rawUri: `https://raw.githubusercontent.com/${repository}/${revision}/${path}`,
+      readOnly: true,
+    }
+  })
+}
+
+export function getGettingStartedDocument(
+  info: RunmeVersionInfo = runmeVersionInfo
+): DocumentationEntry {
+  const entry = listDocumentation(info).find(
+    (candidate) => candidate.path === GETTING_STARTED_DOCUMENT_PATH
+  )
+  if (!entry) {
+    throw new Error('Getting Started documentation is not configured.')
+  }
+  return entry
+}
+
+export function isRemoteMarkdownUri(value: string | null | undefined): boolean {
+  if (!value) {
+    return false
+  }
+  try {
+    const url = new URL(value)
+    return (
+      (url.protocol === 'https:' || url.protocol === 'http:') &&
+      url.pathname.toLowerCase().endsWith('.md')
+    )
+  } catch {
+    return false
+  }
+}
+
+export function resolveDocumentationHref(
+  href: string,
+  baseUri: string
+): string {
+  return new URL(href, baseUri).toString()
+}
+
+export function toRawMarkdownUri(uri: string): string {
+  const url = new URL(uri)
+  if (url.hostname === 'github.com' && url.pathname.includes('/blob/')) {
+    const segments = url.pathname.split('/').filter(Boolean)
+    const blobIndex = segments.indexOf('blob')
+    if (blobIndex >= 2 && blobIndex + 2 < segments.length) {
+      const [owner, repository] = segments
+      const revision = segments[blobIndex + 1]
+      const path = segments.slice(blobIndex + 2).join('/')
+      return `https://raw.githubusercontent.com/${owner}/${repository}/${revision}/${path}`
+    }
+  }
+  return url.toString()
+}
+
+function deriveRemoteDocumentName(uri: string): string {
+  try {
+    const url = new URL(uri)
+    return decodeURIComponent(
+      url.pathname.split('/').filter(Boolean).pop() || 'documentation.md'
+    )
+  } catch {
+    return 'documentation.md'
+  }
+}
+
+function getRevisionFromGitHubUri(uri: string): string | undefined {
+  try {
+    const url = new URL(uri)
+    const segments = url.pathname.split('/').filter(Boolean)
+    if (url.hostname === 'github.com') {
+      const blobIndex = segments.indexOf('blob')
+      return blobIndex >= 0 ? segments[blobIndex + 1] : undefined
+    }
+    if (url.hostname === 'raw.githubusercontent.com') {
+      return segments[2]
+    }
+  } catch {
+    // The caller reports the invalid URL.
+  }
+  return undefined
+}
+
+export async function fetchRemoteMarkdownDocument(
+  uri: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<RemoteMarkdownDocument> {
+  if (!isRemoteMarkdownUri(uri)) {
+    throw new Error(
+      `Unsupported documentation URI ${uri}. Expected an HTTP(S) Markdown link.`
+    )
+  }
+  const rawUri = toRawMarkdownUri(uri)
+  const response = await fetchImpl(rawUri, {
+    headers: {
+      Accept: 'text/markdown, text/plain;q=0.9, */*;q=0.1',
+    },
+  })
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load documentation (${response.status} ${response.statusText}) from ${uri}`
+    )
+  }
+  const revisionId = getRevisionFromGitHubUri(uri)
+  return {
+    uri,
+    name: deriveRemoteDocumentName(uri),
+    mimeType: DOCUMENTATION_MIME_TYPE,
+    content: await response.text(),
+    readOnly: true,
+    ...(revisionId ? { version: { revisionId } } : {}),
+  }
+}
+
+export function hasOpenedGettingStarted(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    return (
+      window.localStorage.getItem(GETTING_STARTED_OPENED_STORAGE_KEY) === 'true'
+    )
+  } catch {
+    return false
+  }
+}
+
+export function markGettingStartedOpened(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(GETTING_STARTED_OPENED_STORAGE_KEY, 'true')
+  } catch {
+    // Opening documentation should not depend on localStorage availability.
+  }
+}
+
+export function markDocumentationOpened(uri: string): void {
+  let gettingStarted: DocumentationEntry
+  try {
+    gettingStarted = getGettingStartedDocument()
+  } catch {
+    return
+  }
+  if (uri === gettingStarted.uri || uri === gettingStarted.rawUri) {
+    markGettingStartedOpened()
+  }
+}

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -325,6 +325,41 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     })
   })
 
+  it('lists commit-pinned documentation and fetches remote Markdown', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '# Getting Started',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+    })
+
+    const [gettingStarted] = globals.documents.list()
+    expect(gettingStarted).toMatchObject({
+      title: 'Getting Started',
+      readOnly: true,
+    })
+    expect(gettingStarted.uri).toContain(
+      'https://github.com/runmedev/web/blob/'
+    )
+
+    const document = await globals.documents.get(gettingStarted.uri)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      gettingStarted.rawUri,
+      expect.any(Object)
+    )
+    expect(document).toMatchObject({
+      uri: gettingStarted.uri,
+      mimeType: 'text/markdown',
+      content: '# Getting Started',
+      readOnly: true,
+    })
+  })
+
   it('updates raw document content in the local mirror', async () => {
     const localStore = {
       getMetadata: vi.fn(async () => ({

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -27,6 +27,11 @@ import {
   setAppConfigFromYaml,
   setLocalConfigPreferredOnLoad,
 } from '../appConfig'
+import {
+  fetchRemoteMarkdownDocument,
+  isRemoteMarkdownUri,
+  listDocumentation,
+} from '../documentation'
 import { driveLinkCoordinator } from '../driveLinkCoordinator'
 import {
   copyDriveNotebookFile,
@@ -109,6 +114,7 @@ type DocumentContent = {
   name: string
   mimeType?: string
   content: string
+  readOnly?: boolean
   syncStatus?: string
   version?: {
     checksum?: string
@@ -716,7 +722,11 @@ export function createAppJsGlobals({
   }
 
   const documentsHelpers = {
+    list: () => listDocumentation(),
     get: async (uri: string): Promise<DocumentContent> => {
+      if (isRemoteMarkdownUri(uri)) {
+        return fetchRemoteMarkdownDocument(uri)
+      }
       const resolved = await resolveDocumentLocalUri(uri)
       return buildDocumentContent(resolved.localUri, resolved.requestedUri)
     },
@@ -764,7 +774,9 @@ export function createAppJsGlobals({
     },
     help: () => {
       return [
+        'documents.list()                           - List commit-pinned Runme documentation',
         'documents.get(uri)                         - Read raw document content from the local mirror',
+        '                                             or fetch a read-only remote Markdown document',
         'documents.update(uri, content, options?)   - Write raw document content to the local mirror',
         '  options.mimeType                         - Preserve or set the content MIME type',
         '  options.expectedVersion                  - Optional optimistic checksum/revision guard',
@@ -1551,7 +1563,7 @@ export function createAppJsGlobals({
         'Available namespaces:',
         '  runme           - Notebook helpers (run all, clear outputs)',
         '  notebooks       - Notebook document API plus create/append helpers',
-        '  documents       - Raw URI-based document content get/update helpers',
+        '  documents       - List/read docs plus raw local document updates',
         '  notebookDiff    - Compare revisions and resolve notebook sync conflicts',
         '  opfs            - Origin-private browser file storage helpers',
         '  net             - Browser network helpers',
@@ -1570,6 +1582,7 @@ export function createAppJsGlobals({
         '  await app.getSessionId()',
         '  await app.getSessionID()',
         '  await notebooks.createLocal("hello")',
+        '  console.table(documents.list())',
         '  const doc = await documents.get("local://file/...")',
         '  await notebooks.appendCell({ kind: "code", value: "print(1)", languageId: "python" })',
         '  await embed("/tmp/screenshot.png", { alt: "Screenshot" })',

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -119,12 +119,18 @@ class MockSandboxPort {
         this.emit({
           type: 'host-call',
           callId: 1,
+          method: 'documents.list',
+          args: [],
+        })
+        this.emit({
+          type: 'host-call',
+          callId: 2,
           method: 'documents.get',
           args: ['local://file/test4'],
         })
         this.emit({
           type: 'host-call',
-          callId: 2,
+          callId: 3,
           method: 'documents.update',
           args: [
             'local://file/test4',
@@ -791,6 +797,14 @@ describe('SandboxJSKernel', () => {
     let stderr = ''
     let exitCode = -1
     const bridgeCall = vi.fn(async (method: string, args: unknown[]) => {
+      if (method === 'documents.list') {
+        return [
+          {
+            title: 'Getting Started',
+            uri: 'https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md',
+          },
+        ]
+      }
       if (method === 'documents.get') {
         return {
           uri: args[0],
@@ -830,6 +844,7 @@ describe('SandboxJSKernel', () => {
 
     await kernel.run(
       [
+        'console.log(await documents.list());',
         "const doc = await documents.get('local://file/test4');",
         'const scene = JSON.parse(doc.content);',
         "scene.elements.push({ id: 'label', type: 'text', text: 'Box A' });",
@@ -837,6 +852,7 @@ describe('SandboxJSKernel', () => {
       ].join('\n')
     )
 
+    expect(bridgeCall).toHaveBeenCalledWith('documents.list', [])
     expect(bridgeCall).toHaveBeenCalledWith('documents.get', [
       'local://file/test4',
     ])

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -95,6 +95,7 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'drive.create',
   'drive.update',
   'drive.saveAsCurrentNotebook',
+  'documents.list',
   'documents.get',
   'documents.update',
   ...SANDBOX_NOTEBOOKS_API_METHODS,
@@ -341,9 +342,11 @@ export function buildSandboxSrcDoc(options: {
 
         const notebooks = createSandboxNotebooksApiClient(hostCall);
         const documents = {
+          list: () => hostCall("documents.list", []),
           get: (uri) => hostCall("documents.get", [uri]),
           update: (uri, content, options) => hostCall("documents.update", [uri, content, options]),
           help: () => {
+            consoleProxy.log("documents.list()");
             consoleProxy.log("documents.get(uri)");
             consoleProxy.log("documents.update(uri, content, { mimeType?, expectedVersion?, flush? })");
           },
@@ -426,6 +429,7 @@ export function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.show([reference])");
           consoleProxy.log("- notebooks.shareUrl([reference])");
           consoleProxy.log("- notebooks.markdownLink([reference])");
+          consoleProxy.log("- documents.list()");
           consoleProxy.log("- documents.get(uri)");
           consoleProxy.log("- documents.update(uri, content, { mimeType?, expectedVersion?, flush? })");
           consoleProxy.log("- notebookDiff.listDriveRevisions([target])");

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
@@ -60,6 +60,10 @@ describe("WorkspaceDocumentController", () => {
     });
     controller.showDocument("diff://notebook/1", { title: "Diff" });
     controller.showDocument("status://drive-link", { title: "Drive Link Status" });
+    controller.showDocument(
+      "https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md",
+      { title: "Getting Started", mimeType: "text/markdown", readOnly: true },
+    );
 
     expect(
       JSON.parse(window.sessionStorage.getItem("runme/workspaceDocuments") ?? "[]"),
@@ -70,6 +74,12 @@ describe("WorkspaceDocumentController", () => {
         title: "diagram.excalidraw",
         requestedUri: "https://drive.google.com/file/d/diagram123/view",
         mimeType: EXCALIDRAW_MIME_TYPE,
+      },
+      {
+        uri: "https://github.com/runmedev/web/blob/abc123/docs/00-getting-started.md",
+        title: "Getting Started",
+        mimeType: "text/markdown",
+        readOnly: true,
       },
     ]);
   });

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -89,6 +89,7 @@ class SessionStorageWorkspaceDocumentPersistence
         title: item.title,
         requestedUri: item.requestedUri,
         mimeType: item.mimeType,
+        readOnly: item.readOnly,
       }))
       window.sessionStorage.setItem(
         WORKSPACE_DOCUMENTS_STORAGE_KEY,
@@ -114,6 +115,7 @@ function normalizeWorkspaceDocument(item: unknown): WorkspaceDocument | null {
     title: candidate.title?.trim() || deriveWorkspaceDocumentTitle(uri),
     requestedUri: candidate.requestedUri?.trim() || undefined,
     mimeType: candidate.mimeType?.trim() || undefined,
+    ...(candidate.readOnly === true ? { readOnly: true } : {}),
   }
 }
 

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -1,6 +1,7 @@
+import { isExcalidrawDocumentMetadata } from '../../storage/excalidraw'
+import { isRemoteMarkdownUri } from '../documentation'
 import type { NotebookTabState } from '../notebookDataController'
 import type { NotebookOwnershipRecord } from '../tabCoordination/notebookOwnership'
-import { isExcalidrawDocumentMetadata } from '../../storage/excalidraw'
 
 export const DRIVE_LINK_STATUS_DOCUMENT_URI = 'status://drive-link'
 export const DRIVE_SYNC_STATUS_DOCUMENT_URI = 'status://drive-sync'
@@ -72,8 +73,14 @@ export function isLogsUri(uri: string | null | undefined): boolean {
   return uri === LOGS_DOCUMENT_URI
 }
 
+export function isDocumentationDocumentUri(
+  uri: string | null | undefined
+): uri is string {
+  return isRemoteMarkdownUri(uri)
+}
+
 export function isRestorableWorkspaceDocument(uri: string): boolean {
-  return isNotebookDocumentUri(uri)
+  return isNotebookDocumentUri(uri) || isDocumentationDocumentUri(uri)
 }
 
 export function deriveWorkspaceDocumentTitle(uri: string): string {

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -1,5 +1,6 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
+import { execFileSync } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { defineConfig } from "vite";
@@ -25,6 +26,25 @@ const IMAGE_MIME_BY_EXTENSION = new Map([
   [".svg", "image/svg+xml"],
   [".webp", "image/webp"],
 ]);
+
+function resolveWebCommit(): string | undefined {
+  const configured = process.env.VITE_RUNME_VERSION_WEB_COMMIT?.trim();
+  if (configured) {
+    return configured;
+  }
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+const webCommit = resolveWebCommit();
+const webRepository =
+  process.env.VITE_RUNME_VERSION_WEB_REPO?.trim() || "runmedev/web";
 
 function localServiceAccountKeyPlugin() {
   return {
@@ -123,6 +143,12 @@ export default defineConfig({
   // Use root-relative assets so LB rewrites to /index.html still load bundles from /.
   base: "/",
   cacheDir: ".vite",
+  define: {
+    "import.meta.env.VITE_RUNME_VERSION_WEB_REPO":
+      JSON.stringify(webRepository),
+    "import.meta.env.VITE_RUNME_VERSION_WEB_COMMIT":
+      JSON.stringify(webCommit ?? ""),
+  },
   publicDir: "assets",
   optimizeDeps: {
     exclude: ["@runmedev/renderers"],

--- a/app/vitest.config.mts
+++ b/app/vitest.config.mts
@@ -4,6 +4,14 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   cacheDir: '.vite',
+  define: {
+    'import.meta.env.VITE_RUNME_VERSION_WEB_REPO': JSON.stringify(
+      process.env.VITE_RUNME_VERSION_WEB_REPO || 'runmedev/web'
+    ),
+    'import.meta.env.VITE_RUNME_VERSION_WEB_COMMIT': JSON.stringify(
+      process.env.VITE_RUNME_VERSION_WEB_COMMIT || 'test-web-commit'
+    ),
+  },
   plugins: [react()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

- add a left-side Documentation Explorer backed by commit-pinned GitHub Markdown permalinks
- open remote Markdown links as read-only workspace documents, including direct `?doc=` links and relative links between documentation pages
- expose `documents.list()` and remote Markdown support in `documents.get()` to App Console and WebMCP code mode
- open Getting Started once for first-time users without overriding an explicit document link
- derive local build documentation links from the exact Git commit while preserving release-provided version metadata

## Verification

- `runme run build test`
- 68 focused app tests covering the documentation catalog, explorer, renderer, first-run behavior, URL opening, workspace persistence, and AppKernel/WebMCP bridge
- GitHub raw Getting Started permalink returns `200 text/plain`

## Additional test note

A full app Vitest run completed 539 tests successfully; seven unrelated legacy suites failed during module loading because the current Node runtime requires a JSON import attribute for `open-color.json`.
