### PR TITLE
Remove obsolete backend static asset configuration

### DIFF
--- a/app/config.dev.yaml
+++ b/app/config.dev.yaml
@@ -23,8 +23,6 @@ iamPolicy:
           kind: "user"
 
 assistantServer:
-    # TODO(jlewi): How should this be set 
-    staticAssets: /Users/jlewi/git_runmeweb/app/dist
     # Older Runme releases default this removed service to enabled.
     agentService: false
     runnerService: true

--- a/app/test/browser/run-cuj-scenarios.ts
+++ b/app/test/browser/run-cuj-scenarios.ts
@@ -213,18 +213,11 @@ function resolveFakeDriveConfig(): FakeDriveConfig {
   };
 }
 
-function ensureBackendAssetsAndConfig(
+function ensureBackendConfig(
   frontendUrl: string,
   backendUrl: string,
   oidc: OidcAuthConfig,
 ): string {
-  const assetsDir = join(OUTPUT_DIR, "cuj-agent-assets");
-  mkdirSync(assetsDir, { recursive: true });
-  writeFileSync(
-    join(assetsDir, "index.html"),
-    "<!doctype html><html><body>CUJ backend assets</body></html>\n",
-    "utf-8",
-  );
   const configPath = join(OUTPUT_DIR, "cuj-agent-config.yaml");
   const origins = buildBackendOrigins(frontendUrl);
   const originsYaml = origins.map((origin) => `    - "${origin}"`).join("\n");
@@ -242,7 +235,6 @@ function ensureBackendAssetsAndConfig(
     "  agentService: false",
     "  parserService: true",
     "  runnerService: true",
-    `  staticAssets: "${assetsDir}"`,
     "  corsOrigins:",
     originsYaml,
     ...(oidc.enabled
@@ -285,7 +277,7 @@ function detectBackendCommand(
   backendUrl: string,
   oidc: OidcAuthConfig,
 ): BackendCommandConfig {
-  const configPath = ensureBackendAssetsAndConfig(frontendUrl, backendUrl, oidc);
+  const configPath = ensureBackendConfig(frontendUrl, backendUrl, oidc);
   const candidateBinaries = [
     process.env.CUJ_RUNME_AGENT_BIN?.trim(),
     "runme",


### PR DESCRIPTION
## Summary

- remove the obsolete assistantServer.staticAssets development setting
- stop creating a synthetic backend SPA in browser CUJ setup
- keep the web frontend independently served while the Runme backend provides cell execution

## Verification

- runme run build test
- pnpm -C app run cuj:build
- CUJ_SCENARIOS=hello-world CUJ_UPLOAD=false CUJ_RUNME_AGENT_BIN=/private/tmp/runme-pr1255-no-assets pnpm -C app run cuj:run (11/11 checks passed)

## Related work

- runmedev/runme#1255

## Design and status

[Remove AI Chat notebook](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1nyZTM6GvotoCuW8YRD-3AAT-9fT7RVsR%2Fview#cell=markup_cdc7b6fc3c62409b822fd4ffb74ccadd)