### PR TITLE
Add a guided onboarding experience

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
+import type { ReactElement, ReactNode } from 'react'
+
+import { Theme } from '@radix-ui/themes'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  render,
+  render as renderWithoutTheme,
   screen,
   act,
   createEvent,
@@ -31,6 +34,14 @@ import {
 } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 import { ActionOutputItems } from './ActionOutputItems'
 import Actions, { Action } from './Actions'
+
+function ThemeWrapper({ children }: { children: ReactNode }) {
+  return <Theme>{children}</Theme>
+}
+
+function render(ui: ReactElement) {
+  return renderWithoutTheme(ui, { wrapper: ThemeWrapper })
+}
 
 const contextMocks = vi.hoisted(() => ({
   workspaceDocuments: [] as Array<{
@@ -684,7 +695,7 @@ describe('Actions tabs', () => {
     )
   })
 
-  it('marks read-only notebook tabs and content clearly', () => {
+  it('marks read-only notebook tabs and content clearly', async () => {
     const uri = 'local://file/reference.runme.md'
     const owner: NotebookOwnershipRecord = {
       notebookUri: uri,
@@ -717,9 +728,17 @@ describe('Actions tabs', () => {
 
     render(<Actions />)
 
+    const readOnlyIndicators = screen.getAllByLabelText('Read-only notebook')
+    expect(readOnlyIndicators.length).toBeGreaterThan(0)
+    expect(screen.getByTitle('reference.runme.md').dataset.state).toBe('active')
+    fireEvent.pointerMove(readOnlyIndicators[0], { pointerType: 'mouse' })
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip.textContent).toContain(
+      'Read-only. This notebook is open for editing in another browser tab.'
+    )
     expect(
-      screen.getAllByLabelText('Read-only notebook').length
-    ).toBeGreaterThan(0)
+      document.querySelector('#notebook-tabs-scroll')?.contains(tooltip)
+    ).toBe(false)
     expect(
       screen.getByTestId('notebook-readonly-banner').textContent
     ).toContain('session calm-harbor')
@@ -970,9 +989,7 @@ describe('Actions tabs', () => {
     render(<Actions />)
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('tab', { name: /Getting Started/ })
-      ).toBeTruthy()
+      expect(screen.getByRole('tab', { name: /Getting Started/ })).toBeTruthy()
     })
     expect(contextMocks.setCurrentDoc).not.toHaveBeenCalled()
   })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react'
 
 import { create } from '@bufbuild/protobuf'
-import { Button, ScrollArea, Tabs, Text } from '@radix-ui/themes'
+import { Button, ScrollArea, Tabs, Text, Tooltip } from '@radix-ui/themes'
 
 import {
   ChatBubbleLeftIcon,
@@ -380,19 +380,18 @@ function isDriveBackedNotebook(
 
 function ReadOnlyTabIndicator() {
   return (
-    <span
-      className="relative inline-flex h-4 w-4 items-center justify-center text-nb-text-muted"
-      role="img"
-      aria-label="Read-only notebook"
+    <Tooltip
+      content="Read-only. This notebook is open for editing in another browser tab."
+      side="bottom"
     >
-      <LockClosedIcon className="h-3.5 w-3.5" aria-hidden="true" />
       <span
-        role="tooltip"
-        className="pointer-events-none absolute left-1/2 top-6 z-20 hidden w-max max-w-[220px] -translate-x-1/2 rounded-nb-sm border border-nb-border bg-white px-2 py-1 text-xs font-normal text-nb-text shadow-nb-sm group-hover:inline-block group-focus:inline-block"
+        className="inline-flex h-4 w-4 items-center justify-center text-nb-text-muted"
+        role="img"
+        aria-label="Read-only notebook"
       >
-        Read-only. This notebook is open for editing in another browser tab.
+        <LockClosedIcon className="h-3.5 w-3.5" aria-hidden="true" />
       </span>
-    </span>
+    </Tooltip>
   )
 }
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -74,6 +74,7 @@ import {
   isAppConsoleUri,
   isExcalidrawWorkspaceDocument,
   isLogsUri,
+  isOnboardingDocumentUri,
   isNotebookDiffUri,
   isNotebookDocumentUri,
   isVersionInfoUri,
@@ -119,6 +120,7 @@ import { ActionOutputItems } from './ActionOutputItems'
 import React from 'react'
 import ExcalidrawDocument from '../Excalidraw/ExcalidrawDocument'
 import RemoteMarkdownDocument from '../Documentation/RemoteMarkdownDocument'
+import OnboardingDocument from '../Onboarding/OnboardingDocument'
 
 type TabPanelProps = React.HTMLAttributes<HTMLDivElement> & {
   'data-state'?: 'active' | 'inactive'
@@ -2801,6 +2803,10 @@ function renderWorkspaceDocument({
     return <RemoteMarkdownDocument document={document} />
   }
 
+  if (isOnboardingDocumentUri(document.uri)) {
+    return <OnboardingDocument />
+  }
+
   if (isDriveLinkStatusUri(document.uri)) {
     return <DriveLinkStatusTab onLogin={onDriveLogin} onRetry={onDriveRetry} />
   }
@@ -2916,7 +2922,8 @@ export default function Actions() {
     Boolean(currentDocUri && isNotebookDocumentUri(currentDocUri)) &&
     openNotebooks.some(
       (notebook) =>
-        notebook.uri === currentDocUri || notebook.requestedUri === currentDocUri
+        notebook.uri === currentDocUri ||
+        notebook.requestedUri === currentDocUri
     )
   const resolvedSelectedTabUri =
     (selectedTabIsOpen ? selectedTabUri : null) ??

--- a/app/src/components/Documentation/DocumentationExplorer.tsx
+++ b/app/src/components/Documentation/DocumentationExplorer.tsx
@@ -13,6 +13,11 @@ import {
   listDocumentation,
   markDocumentationOpened,
 } from '../../lib/documentation'
+import {
+  markOnboardingOpened,
+  ONBOARDING_DOCUMENT_URI,
+  ONBOARDING_MIME_TYPE,
+} from '../../lib/onboarding'
 
 export function DocumentationExplorer() {
   const [expanded, setExpanded] = useState(true)
@@ -44,6 +49,26 @@ export function DocumentationExplorer() {
         </p>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        <button
+          type="button"
+          className={`mb-2 flex w-full items-center gap-2 rounded-nb-sm border px-2 py-2 text-left text-sm font-medium transition-colors ${
+            currentDoc === ONBOARDING_DOCUMENT_URI
+              ? 'border-nb-accent bg-nb-accent-soft text-nb-text'
+              : 'border-nb-border bg-white/70 text-nb-text-muted hover:bg-white hover:text-nb-text'
+          }`}
+          onClick={() => {
+            markOnboardingOpened()
+            showDocument(ONBOARDING_DOCUMENT_URI, {
+              title: 'Welcome to Runme',
+              mimeType: ONBOARDING_MIME_TYPE,
+              readOnly: true,
+            })
+            setCurrentDoc(ONBOARDING_DOCUMENT_URI)
+          }}
+        >
+          <DocumentTextIcon className="h-4 w-4 shrink-0" />
+          <span className="truncate">Welcome to Runme</span>
+        </button>
         {result.error ? (
           <div className="rounded-nb-sm border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
             {result.error}

--- a/app/src/components/MainPage/MainPage.tsx
+++ b/app/src/components/MainPage/MainPage.tsx
@@ -4,6 +4,7 @@ import { useSidePanel } from "../../contexts/SidePanelContext";
 import { CommentsPanelProvider } from "../../contexts/CommentsPanelContext";
 import { CurrentDocInitializer } from "../CurrentDocInitializer";
 import { DocumentationInitializer } from "../Documentation/DocumentationInitializer";
+import { OnboardingInitializer } from "../Onboarding/OnboardingInitializer";
 
 const SIDE_PANEL_WIDTH = 360;
 const TOOLBAR_WIDTH = 48; // ~12 tailwind units (12 * 4px)
@@ -17,6 +18,7 @@ export default function MainPage() {
       <div id="main-page" className="flex h-screen w-screen bg-nb-bg">
         <CurrentDocInitializer />
         <DocumentationInitializer />
+        <OnboardingInitializer />
         <div className="flex h-full min-h-0 w-full">
           <div
             id="toolbar-column"

--- a/app/src/components/Onboarding/OnboardingDocument.test.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  markOnboardingNotebookCreated,
+  ONBOARDING_STORAGE_KEY,
+} from '../../lib/onboarding'
+import { OnboardingDocument } from './OnboardingDocument'
+
+const mocks = vi.hoisted(() => ({
+  copyNotebookMarkdownLink: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('../../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({ setCurrentDoc: vi.fn() }),
+}))
+
+vi.mock('../../contexts/GoogleAuthContext', () => ({
+  useGoogleAuth: () => ({ startGoogleDriveOAuth: vi.fn() }),
+}))
+
+vi.mock('../../contexts/SidePanelContext', () => ({
+  useSidePanel: () => ({ setPanel: vi.fn() }),
+}))
+
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: vi.fn(),
+    closeWorkspaceDocument: vi.fn(),
+  }),
+}))
+
+vi.mock('../Workspace/GoogleDrivePickerButton', () => ({
+  GoogleDrivePickerButton: ({ label }: { label: string }) => (
+    <button type="button">{label}</button>
+  ),
+}))
+
+vi.mock('../../lib/shareLinks', () => ({
+  copyNotebookMarkdownLink: mocks.copyNotebookMarkdownLink,
+}))
+
+vi.mock('../../lib/toast', () => ({
+  showToast: mocks.showToast,
+}))
+
+describe('OnboardingDocument sharing step', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mocks.copyNotebookMarkdownLink.mockReset()
+    mocks.copyNotebookMarkdownLink.mockResolvedValue(
+      '[latest](http://localhost/?doc=drive)'
+    )
+    mocks.showToast.mockReset()
+  })
+
+  it('enables Copy Link for the most recently created Drive notebook', async () => {
+    render(<OnboardingDocument />)
+
+    expect(
+      (screen.getByRole('button', { name: 'Copy Link' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+
+    act(() => {
+      markOnboardingNotebookCreated({
+        uri: 'local://file/latest',
+        name: 'latest.json',
+        remoteUri: 'https://drive.google.com/file/d/latest/view',
+      })
+    })
+
+    const button = screen.getByRole('button', { name: 'Copy Link' })
+    expect((button as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(mocks.copyNotebookMarkdownLink).toHaveBeenCalledWith(
+        'latest.json',
+        'https://drive.google.com/file/d/latest/view'
+      )
+    })
+    expect(mocks.showToast).toHaveBeenCalledWith({
+      message: 'Markdown link copied',
+      tone: 'success',
+    })
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toContain(
+      'latest.json'
+    )
+  })
+})

--- a/app/src/components/Onboarding/OnboardingDocument.test.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.test.tsx
@@ -56,6 +56,19 @@ describe('OnboardingDocument sharing step', () => {
     mocks.showToast.mockReset()
   })
 
+  it('offers Codex a machine-independent sample task', () => {
+    render(<OnboardingDocument />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Document What Codex Does' })
+    ).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Open https://web.runme.dev in @Browser. Create a notebook that documents how to convert Celsius to Fahrenheit. Add and run a JavaScript cell that converts 20°C, then explain the result.'
+      )
+    ).toBeTruthy()
+  })
+
   it('enables Copy Link for the most recently created Drive notebook', async () => {
     render(<OnboardingDocument />)
 

--- a/app/src/components/Onboarding/OnboardingDocument.test.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.test.tsx
@@ -56,7 +56,7 @@ describe('OnboardingDocument sharing step', () => {
     mocks.showToast.mockReset()
   })
 
-  it('offers Codex a machine-independent sample task', () => {
+  it('offers Codex a concrete sample task', () => {
     render(<OnboardingDocument />)
 
     expect(
@@ -64,7 +64,7 @@ describe('OnboardingDocument sharing step', () => {
     ).toBeTruthy()
     expect(
       screen.getByText(
-        'Open https://web.runme.dev in @Browser. Create a notebook that documents how to convert Celsius to Fahrenheit. Add and run a JavaScript cell that converts 20°C, then explain the result.'
+        "Open https://web.runme.dev in @Browser. Create a notebook with today's forecast for where I live. Document how you obtained today's forecast."
       )
     ).toBeTruthy()
   })

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -202,12 +202,11 @@ export function OnboardingDocument() {
               Welcome to Runme
             </div>
             <h1 className="mt-5 max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-              Share the work, not just the answer.
+              Document and Share How Work Gets Done
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-600">
-              Runme turns Markdown into collaborative, executable documents.
-              Build design docs and runbooks with your AI agent, then share the
-              exact context with your team.
+              Use Runme to document and share what your AI did as notebooks
+              stored in Google Drive.
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <button

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -205,8 +205,10 @@ export function OnboardingDocument() {
               Document, Share, Learn
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-600">
-              Use Runme to document and share what your AI did as notebooks
-              stored in Google Drive.
+              Use Runme to collaborate with your AI on notebooks stored in
+              Google Drive. Ask your AI to document how it accomplishes tasks.
+              Share those documents with your colleagues (and their AIs) so
+              they can learn.
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <button

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -29,6 +29,8 @@ import {
   getGettingStartedDocument,
   markDocumentationOpened,
 } from '../../lib/documentation'
+import { copyNotebookMarkdownLink } from '../../lib/shareLinks'
+import { showToast } from '../../lib/toast'
 import {
   dismissOnboarding,
   getOnboardingStateSnapshot,
@@ -93,8 +95,8 @@ const TASKS: TaskDefinition[] = [
     id: 'share-notebook',
     title: 'Share the notebook',
     description:
-      'Copy a link so a teammate or AI agent can work from the same context.',
-    actionLabel: 'Open Explorer',
+      'Copy a Markdown link so a teammate or AI agent can work from the same context.',
+    actionLabel: 'Copy Link',
     icon: ShareIcon,
   },
 ]
@@ -116,6 +118,8 @@ export function OnboardingDocument() {
   const { showDocument, closeWorkspaceDocument } = useWorkspaceDocumentContext()
   const [copiedPrompt, setCopiedPrompt] = useState(false)
   const [authBusy, setAuthBusy] = useState(false)
+  const [shareBusy, setShareBusy] = useState(false)
+  const [copiedNotebookLink, setCopiedNotebookLink] = useState(false)
 
   const completedTaskIds = useMemo(
     () => new Set(onboardingState.completedTaskIds),
@@ -156,6 +160,28 @@ export function OnboardingDocument() {
     await navigator.clipboard.writeText(CODEX_PROMPT)
     setCopiedPrompt(true)
     window.setTimeout(() => setCopiedPrompt(false), 2_000)
+  }
+
+  const copyRecentNotebookLink = async () => {
+    const notebook = onboardingState.recentNotebook
+    if (!notebook?.remoteUri) {
+      return
+    }
+    setShareBusy(true)
+    try {
+      await copyNotebookMarkdownLink(notebook.name, notebook.remoteUri)
+      setCopiedNotebookLink(true)
+      showToast({ message: 'Markdown link copied', tone: 'success' })
+      window.setTimeout(() => setCopiedNotebookLink(false), 2_000)
+    } catch (error) {
+      console.error('Failed to copy onboarding notebook link', error)
+      showToast({
+        message: 'Could not copy the notebook link',
+        tone: 'error',
+      })
+    } finally {
+      setShareBusy(false)
+    }
   }
 
   const dismiss = () => {
@@ -323,12 +349,33 @@ export function OnboardingDocument() {
                     <p className="mt-1 text-sm leading-5 text-slate-600">
                       {task.description}
                     </p>
-                    {!complete &&
+                    {(task.id === 'share-notebook' || !complete) &&
                       (task.id === 'add-drive-folder' ? (
                         <GoogleDrivePickerButton
                           label={task.actionLabel}
                           className="mt-3 inline-flex rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
                         />
+                      ) : task.id === 'share-notebook' ? (
+                        <button
+                          type="button"
+                          disabled={
+                            !onboardingState.recentNotebook?.remoteUri ||
+                            shareBusy
+                          }
+                          title={
+                            onboardingState.recentNotebook?.remoteUri
+                              ? `Copy a Markdown link to ${onboardingState.recentNotebook.name}`
+                              : 'Create a notebook in Google Drive to enable sharing'
+                          }
+                          onClick={() => void copyRecentNotebookLink()}
+                          className="mt-3 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                        >
+                          {shareBusy
+                            ? 'Copying…'
+                            : copiedNotebookLink
+                              ? 'Copied!'
+                              : task.actionLabel}
+                        </button>
                       ) : (
                         <button
                           type="button"

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -44,7 +44,7 @@ import { GoogleDrivePickerButton } from '../Workspace/GoogleDrivePickerButton'
 
 const CODEX_URL = 'https://chatgpt.com/codex'
 const CODEX_PROMPT =
-  'Open https://web.runme.dev in @Browser. Create a notebook that documents how to convert Celsius to Fahrenheit. Add and run a JavaScript cell that converts 20°C, then explain the result.'
+  "Open https://web.runme.dev in @Browser. Create a notebook with today's forecast for where I live. Document how you obtained today's forecast."
 
 type TaskDefinition = {
   id: OnboardingTaskId

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -202,7 +202,7 @@ export function OnboardingDocument() {
               Welcome to Runme
             </div>
             <h1 className="mt-5 max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-              Document and Share How Work Gets Done
+              Document, Share, Learn
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-600">
               Use Runme to document and share what your AI did as notebooks

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -1,0 +1,383 @@
+import {
+  ArrowTopRightOnSquareIcon,
+  BookOpenIcon,
+  CheckCircleIcon,
+  ClipboardDocumentIcon,
+  CloudArrowUpIcon,
+  CodeBracketSquareIcon,
+  DocumentPlusIcon,
+  DocumentTextIcon,
+  FolderPlusIcon,
+  PlayCircleIcon,
+  ShareIcon,
+  SparklesIcon,
+} from '@heroicons/react/24/outline'
+import {
+  type ComponentType,
+  type SVGProps,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useGoogleAuth } from '../../contexts/GoogleAuthContext'
+import { useSidePanel } from '../../contexts/SidePanelContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
+import {
+  DOCUMENTATION_MIME_TYPE,
+  getGettingStartedDocument,
+  markDocumentationOpened,
+} from '../../lib/documentation'
+import {
+  dismissOnboarding,
+  getOnboardingStateSnapshot,
+  markOnboardingOpened,
+  ONBOARDING_DOCUMENT_URI,
+  parseOnboardingState,
+  subscribeToOnboardingState,
+  type OnboardingTaskId,
+} from '../../lib/onboarding'
+import { GoogleDrivePickerButton } from '../Workspace/GoogleDrivePickerButton'
+
+const CODEX_URL = 'https://chatgpt.com/codex'
+const CODEX_PROMPT =
+  'Open https://web.runme.dev in @Browser and help me create a shareable design document or runbook.'
+
+type TaskDefinition = {
+  id: OnboardingTaskId
+  title: string
+  description: string
+  actionLabel: string
+  icon: ComponentType<SVGProps<SVGSVGElement>>
+}
+
+const TASKS: TaskDefinition[] = [
+  {
+    id: 'read-getting-started',
+    title: 'Read the Getting Started guide',
+    description:
+      'Learn the editor, runners, and sharing model in a few minutes.',
+    actionLabel: 'Open guide',
+    icon: BookOpenIcon,
+  },
+  {
+    id: 'sign-in-google-drive',
+    title: 'Sign in to Google Drive',
+    description: 'Keep notebooks available across browsers and devices.',
+    actionLabel: 'Sign in',
+    icon: CloudArrowUpIcon,
+  },
+  {
+    id: 'add-drive-folder',
+    title: 'Add a Drive folder',
+    description: 'Choose where Runme should organize your shared documents.',
+    actionLabel: 'Choose folder',
+    icon: FolderPlusIcon,
+  },
+  {
+    id: 'create-first-notebook',
+    title: 'Create your first notebook',
+    description: 'Start a design doc, runbook, or lightweight workflow.',
+    actionLabel: 'Open Explorer',
+    icon: DocumentPlusIcon,
+  },
+  {
+    id: 'run-first-cell',
+    title: 'Run your first cell',
+    description: 'Mix narrative and executable steps in the same document.',
+    actionLabel: 'Open Explorer',
+    icon: PlayCircleIcon,
+  },
+  {
+    id: 'share-notebook',
+    title: 'Share the notebook',
+    description:
+      'Copy a link so a teammate or AI agent can work from the same context.',
+    actionLabel: 'Open Explorer',
+    icon: ShareIcon,
+  },
+]
+
+function useOnboardingState() {
+  const snapshot = useSyncExternalStore(
+    subscribeToOnboardingState,
+    getOnboardingStateSnapshot,
+    () => ''
+  )
+  return useMemo(() => parseOnboardingState(snapshot), [snapshot])
+}
+
+export function OnboardingDocument() {
+  const onboardingState = useOnboardingState()
+  const { setCurrentDoc } = useCurrentDoc()
+  const { setPanel } = useSidePanel()
+  const { startGoogleDriveOAuth } = useGoogleAuth()
+  const { showDocument, closeWorkspaceDocument } = useWorkspaceDocumentContext()
+  const [copiedPrompt, setCopiedPrompt] = useState(false)
+  const [authBusy, setAuthBusy] = useState(false)
+
+  const completedTaskIds = useMemo(
+    () => new Set(onboardingState.completedTaskIds),
+    [onboardingState.completedTaskIds]
+  )
+  const completedCount = completedTaskIds.size
+  const progress = Math.round((completedCount / TASKS.length) * 100)
+
+  const openGettingStarted = () => {
+    const document = getGettingStartedDocument()
+    markDocumentationOpened(document.uri)
+    showDocument(document.uri, {
+      title: document.title,
+      mimeType: DOCUMENTATION_MIME_TYPE,
+      readOnly: true,
+    })
+    setCurrentDoc(document.uri)
+  }
+
+  const handleTaskAction = (taskId: OnboardingTaskId) => {
+    if (taskId === 'read-getting-started') {
+      openGettingStarted()
+      return
+    }
+    if (taskId === 'sign-in-google-drive') {
+      setAuthBusy(true)
+      void startGoogleDriveOAuth()
+        .catch((error) => {
+          console.error('Failed to start Google Drive sign-in', error)
+        })
+        .finally(() => setAuthBusy(false))
+      return
+    }
+    setPanel('explorer')
+  }
+
+  const copyCodexPrompt = async () => {
+    await navigator.clipboard.writeText(CODEX_PROMPT)
+    setCopiedPrompt(true)
+    window.setTimeout(() => setCopiedPrompt(false), 2_000)
+  }
+
+  const dismiss = () => {
+    dismissOnboarding()
+    closeWorkspaceDocument(ONBOARDING_DOCUMENT_URI)
+  }
+
+  return (
+    <div
+      className="h-full overflow-y-auto bg-[radial-gradient(circle_at_top_left,_rgba(99,102,241,0.12),_transparent_34%),linear-gradient(180deg,#ffffff_0%,#f8fafc_100%)]"
+      data-testid="onboarding-document"
+    >
+      <main className="mx-auto w-full max-w-6xl px-6 py-10 lg:px-10 lg:py-14">
+        <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold tracking-wide text-indigo-700 uppercase">
+              <SparklesIcon className="h-4 w-4" />
+              Welcome to Runme
+            </div>
+            <h1 className="mt-5 max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+              Share the work, not just the answer.
+            </h1>
+            <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-600">
+              Runme turns Markdown into collaborative, executable documents.
+              Build design docs and runbooks with your AI agent, then share the
+              exact context with your team.
+            </p>
+            <div className="mt-7 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={openGettingStarted}
+                className="inline-flex items-center gap-2 rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+              >
+                <BookOpenIcon className="h-5 w-5" />
+                Read Getting Started
+              </button>
+              <button
+                type="button"
+                onClick={() => setPanel('explorer')}
+                className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50"
+              >
+                <DocumentPlusIcon className="h-5 w-5" />
+                Create a notebook
+              </button>
+            </div>
+          </div>
+
+          <aside className="overflow-hidden rounded-2xl border border-indigo-200 bg-slate-950 p-6 text-white shadow-xl shadow-indigo-100/80">
+            <div className="flex items-center gap-2 text-sm font-semibold text-indigo-200">
+              <CodeBracketSquareIcon className="h-5 w-5" />
+              Try Runme with Codex
+            </div>
+            <h2 className="mt-3 text-2xl font-semibold">
+              Bring an AI collaborator into your document.
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              Open Codex, launch Runme in its in-app Browser, and ask it to help
+              create a shareable design doc or runbook.
+            </p>
+            <div className="mt-5 rounded-lg border border-white/10 bg-white/5 p-3 font-mono text-xs leading-5 text-slate-200">
+              {CODEX_PROMPT}
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <a
+                href={CODEX_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-500 px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+              >
+                Open Codex
+                <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+              </a>
+              <button
+                type="button"
+                onClick={() => void copyCodexPrompt()}
+                className="inline-flex items-center gap-2 rounded-lg border border-white/20 bg-white/10 px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-white/15"
+              >
+                <ClipboardDocumentIcon className="h-4 w-4" />
+                {copiedPrompt ? 'Prompt copied' : 'Copy Codex prompt'}
+              </button>
+            </div>
+          </aside>
+        </section>
+
+        <section className="mt-12 grid gap-5 md:grid-cols-2">
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <DocumentTextIcon className="h-7 w-7 text-indigo-600" />
+            <h2 className="mt-4 text-lg font-semibold text-slate-950">
+              Design docs that stay actionable
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Develop decisions with an agent, keep evidence beside the
+              proposal, and hand teammates one durable document.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <PlayCircleIcon className="h-7 w-7 text-emerald-600" />
+            <h2 className="mt-4 text-lg font-semibold text-slate-950">
+              Runbooks people can actually run
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Explain the workflow in Markdown, execute its steps in cells, and
+              share a repeatable operational playbook.
+            </p>
+          </div>
+        </section>
+
+        <section className="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold tracking-[0.16em] text-indigo-600 uppercase">
+                Your first Runme
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-slate-950">
+                Six steps to a shared notebook
+              </h2>
+            </div>
+            <p className="text-sm font-medium text-slate-600">
+              {completedCount} of {TASKS.length} complete
+            </p>
+          </div>
+          <div
+            className="mt-5 h-2 overflow-hidden rounded-full bg-slate-100"
+            aria-label={`${progress}% complete`}
+          >
+            <div
+              className="h-full rounded-full bg-indigo-500 transition-[width]"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+
+          <ol className="mt-7 grid gap-3 lg:grid-cols-2">
+            {TASKS.map((task, index) => {
+              const complete = completedTaskIds.has(task.id)
+              const Icon = task.icon
+              return (
+                <li
+                  key={task.id}
+                  className={`flex gap-4 rounded-xl border p-4 ${
+                    complete
+                      ? 'border-emerald-200 bg-emerald-50/60'
+                      : 'border-slate-200 bg-white'
+                  }`}
+                >
+                  <div
+                    className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${
+                      complete
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    {complete ? (
+                      <CheckCircleIcon className="h-6 w-6" />
+                    ) : (
+                      <span className="text-sm font-semibold">{index + 1}</span>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <Icon className="h-5 w-5 shrink-0 text-slate-500" />
+                      <h3 className="font-semibold text-slate-900">
+                        {task.title}
+                      </h3>
+                    </div>
+                    <p className="mt-1 text-sm leading-5 text-slate-600">
+                      {task.description}
+                    </p>
+                    {!complete &&
+                      (task.id === 'add-drive-folder' ? (
+                        <GoogleDrivePickerButton
+                          label={task.actionLabel}
+                          className="mt-3 inline-flex rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={
+                            task.id === 'sign-in-google-drive' && authBusy
+                          }
+                          onClick={() => handleTaskAction(task.id)}
+                          className="mt-3 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+                        >
+                          {task.id === 'sign-in-google-drive' && authBusy
+                            ? 'Starting sign in…'
+                            : task.actionLabel}
+                        </button>
+                      ))}
+                  </div>
+                </li>
+              )
+            })}
+          </ol>
+        </section>
+
+        <div className="mt-8 flex items-center justify-between gap-4 border-t border-slate-200 pt-6">
+          <p className="text-sm text-slate-500">
+            You can reopen this page anytime from Documentation.
+          </p>
+          <button
+            type="button"
+            onClick={dismiss}
+            className="text-sm font-semibold text-slate-600 hover:text-slate-950"
+          >
+            Not now
+          </button>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export function showOnboardingDocument(
+  showDocument: ReturnType<typeof useWorkspaceDocumentContext>['showDocument'],
+  setCurrentDoc: ReturnType<typeof useCurrentDoc>['setCurrentDoc']
+) {
+  markOnboardingOpened()
+  showDocument(ONBOARDING_DOCUMENT_URI, {
+    title: 'Welcome to Runme',
+    mimeType: 'application/vnd.runme.onboarding',
+    readOnly: true,
+  })
+  setCurrentDoc(ONBOARDING_DOCUMENT_URI)
+}
+
+export default OnboardingDocument

--- a/app/src/components/Onboarding/OnboardingDocument.tsx
+++ b/app/src/components/Onboarding/OnboardingDocument.tsx
@@ -44,7 +44,7 @@ import { GoogleDrivePickerButton } from '../Workspace/GoogleDrivePickerButton'
 
 const CODEX_URL = 'https://chatgpt.com/codex'
 const CODEX_PROMPT =
-  'Open https://web.runme.dev in @Browser and help me create a shareable design document or runbook.'
+  'Open https://web.runme.dev in @Browser. Create a notebook that documents how to convert Celsius to Fahrenheit. Add and run a JavaScript cell that converts 20°C, then explain the result.'
 
 type TaskDefinition = {
   id: OnboardingTaskId
@@ -207,8 +207,8 @@ export function OnboardingDocument() {
             <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-600">
               Use Runme to collaborate with your AI on notebooks stored in
               Google Drive. Ask your AI to document how it accomplishes tasks.
-              Share those documents with your colleagues (and their AIs) so
-              they can learn.
+              Share those documents with your colleagues (and their AIs) so they
+              can learn.
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <button
@@ -236,11 +236,11 @@ export function OnboardingDocument() {
               Try Runme with Codex
             </div>
             <h2 className="mt-3 text-2xl font-semibold">
-              Bring an AI collaborator into your document.
+              Document What Codex Does
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-300">
-              Open Codex, launch Runme in its in-app Browser, and ask it to help
-              create a shareable design doc or runbook.
+              Open Codex, launch Runme in its in-app Browser, and ask it to
+              document a simple task as a runnable notebook.
             </p>
             <div className="mt-5 rounded-lg border border-white/10 bg-white/5 p-3 font-mono text-xs leading-5 text-slate-200">
               {CODEX_PROMPT}

--- a/app/src/components/Onboarding/OnboardingInitializer.test.tsx
+++ b/app/src/components/Onboarding/OnboardingInitializer.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ONBOARDING_DOCUMENT_URI,
+  ONBOARDING_MIME_TYPE,
+  ONBOARDING_STORAGE_KEY,
+} from '../../lib/onboarding'
+import { OnboardingInitializer } from './OnboardingInitializer'
+
+const mocks = vi.hoisted(() => ({
+  currentDoc: null as string | null,
+  setCurrentDoc: vi.fn(),
+  showDocument: vi.fn(),
+}))
+
+vi.mock('../../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({
+    getCurrentDoc: () => mocks.currentDoc,
+    setCurrentDoc: mocks.setCurrentDoc,
+  }),
+}))
+
+vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({
+    showDocument: mocks.showDocument,
+  }),
+}))
+
+describe('OnboardingInitializer', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.history.replaceState(null, '', '/')
+    mocks.currentDoc = null
+    mocks.setCurrentDoc.mockReset()
+    mocks.showDocument.mockReset()
+  })
+
+  it('opens onboarding as a document on the first visit', () => {
+    render(<OnboardingInitializer />)
+
+    expect(mocks.showDocument).toHaveBeenCalledWith(ONBOARDING_DOCUMENT_URI, {
+      title: 'Welcome to Runme',
+      mimeType: ONBOARDING_MIME_TYPE,
+      readOnly: true,
+    })
+    expect(mocks.setCurrentDoc).toHaveBeenCalledWith(ONBOARDING_DOCUMENT_URI)
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toContain(
+      '"opened":true'
+    )
+  })
+
+  it('opens in the background without replacing restored work', () => {
+    mocks.currentDoc = 'local://file/restored.json'
+
+    render(<OnboardingInitializer />)
+
+    expect(mocks.showDocument).toHaveBeenCalledOnce()
+    expect(mocks.setCurrentDoc).not.toHaveBeenCalled()
+  })
+
+  it('does not open again or replace an explicit doc URL', () => {
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        opened: true,
+        dismissed: true,
+        completedTaskIds: [],
+      })
+    )
+    render(<OnboardingInitializer />)
+    expect(mocks.showDocument).not.toHaveBeenCalled()
+
+    window.localStorage.clear()
+    window.history.replaceState(
+      null,
+      '',
+      '/?doc=local%3A%2F%2Ffile%2Frequested'
+    )
+    render(<OnboardingInitializer />)
+    expect(mocks.showDocument).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/Onboarding/OnboardingInitializer.tsx
+++ b/app/src/components/Onboarding/OnboardingInitializer.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react'
+
+import { useCurrentDoc } from '../../contexts/CurrentDocContext'
+import { useWorkspaceDocumentContext } from '../../contexts/WorkspaceDocumentContext'
+import {
+  hasOpenedOnboarding,
+  markOnboardingOpened,
+  ONBOARDING_DOCUMENT_URI,
+  ONBOARDING_MIME_TYPE,
+} from '../../lib/onboarding'
+
+export function OnboardingInitializer() {
+  const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
+  const { showDocument } = useWorkspaceDocumentContext()
+  const explicitDocumentRequested = useRef(
+    typeof window !== 'undefined' &&
+      new URLSearchParams(window.location.search).has('doc')
+  )
+
+  useEffect(() => {
+    if (explicitDocumentRequested.current || hasOpenedOnboarding()) {
+      return
+    }
+    markOnboardingOpened()
+    showDocument(ONBOARDING_DOCUMENT_URI, {
+      title: 'Welcome to Runme',
+      mimeType: ONBOARDING_MIME_TYPE,
+      readOnly: true,
+    })
+    if (!getCurrentDoc()) {
+      setCurrentDoc(ONBOARDING_DOCUMENT_URI)
+    }
+  }, [getCurrentDoc, setCurrentDoc, showDocument])
+
+  return null
+}
+
+export default OnboardingInitializer

--- a/app/src/components/Workspace/GoogleDrivePickerButton.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.tsx
@@ -5,6 +5,7 @@ import { useWorkspace } from "../../contexts/WorkspaceContext";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { driveFolderUrl } from "../../storage/drive";
 import { googleClientManager } from "../../lib/googleClientManager";
+import { markOnboardingTaskComplete } from "../../lib/onboarding";
 
 type PickerAction = "picked" | "cancel";
 
@@ -126,6 +127,7 @@ export function GoogleDrivePickerButton({
               if (!workspaceUris.includes(localUri)) {
                 addItem(localUri);
               }
+              markOnboardingTaskComplete("add-drive-folder");
             } catch (error) {
               console.error("Failed to mirror Drive folder", error);
             }

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -50,7 +50,11 @@ import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentCon
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
 import { openNotebookUpstreamDiff } from "../../lib/notebookDiff/conflict";
 import { appState } from "../../lib/runtime/AppState";
-import { markOnboardingTaskComplete } from "../../lib/onboarding";
+import {
+  getOnboardingState,
+  markOnboardingNotebookCreated,
+  updateOnboardingNotebookMetadata,
+} from "../../lib/onboarding";
 import {
   EXCALIDRAW_MIME_TYPE,
   createInitialExcalidrawDocumentJson,
@@ -623,6 +627,13 @@ export function WorkspaceExplorer() {
               remoteUri: metadata.remoteUri,
             }),
           );
+          if (getOnboardingState().recentNotebook?.uri === metadata.uri) {
+            updateOnboardingNotebookMetadata({
+              uri: metadata.uri,
+              name: metadata.name,
+              remoteUri: metadata.remoteUri,
+            });
+          }
         } catch (error) {
           console.error("Failed to refresh notebook metadata", error);
         }
@@ -819,7 +830,21 @@ export function WorkspaceExplorer() {
         const timestamp = formatShortTimestamp(new Date());
         const name = `untitled-${timestamp}.json`;
         const newItem = await targetStore.create(folderUri, name);
-        markOnboardingTaskComplete("create-first-notebook");
+        markOnboardingNotebookCreated({
+          uri: newItem.uri,
+          name: newItem.name,
+          remoteUri: newItem.remoteUri,
+        });
+        if (store && newItem.uri.startsWith("local://file/")) {
+          const metadata = await store.getMetadata(newItem.uri);
+          if (metadata) {
+            updateOnboardingNotebookMetadata({
+              uri: metadata.uri,
+              name: metadata.name,
+              remoteUri: metadata.remoteUri,
+            });
+          }
+        }
         await fetchChildren(folderUri);
         setPendingEditId(newItem.uri);
         setErrorMessage(null);

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -50,6 +50,7 @@ import { useWorkspaceDocumentContext } from "../../contexts/WorkspaceDocumentCon
 import { driveLinkCoordinator } from "../../lib/driveLinkCoordinator";
 import { openNotebookUpstreamDiff } from "../../lib/notebookDiff/conflict";
 import { appState } from "../../lib/runtime/AppState";
+import { markOnboardingTaskComplete } from "../../lib/onboarding";
 import {
   EXCALIDRAW_MIME_TYPE,
   createInitialExcalidrawDocumentJson,
@@ -818,6 +819,7 @@ export function WorkspaceExplorer() {
         const timestamp = formatShortTimestamp(new Date());
         const name = `untitled-${timestamp}.json`;
         const newItem = await targetStore.create(folderUri, name);
+        markOnboardingTaskComplete("create-first-notebook");
         await fetchChildren(folderUri);
         setPendingEditId(newItem.uri);
         setErrorMessage(null);

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -21,6 +21,7 @@ import type {
   GoogleDriveAuthUxMode,
 } from '../lib/googleClientManager'
 import { appLogger } from '../lib/logging/runtime'
+import { markOnboardingTaskComplete } from '../lib/onboarding'
 import { appState } from '../lib/runtime/AppState'
 
 // N.B. I couldn't make sharing work with the more restrictive "https://www.googleapis.com/auth/drive.file"
@@ -247,6 +248,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       } catch (error) {
         console.error('Failed to persist Google auth token', error)
       }
+      markOnboardingTaskComplete('sign-in-google-drive')
     },
     []
   )

--- a/app/src/lib/documentation.test.ts
+++ b/app/src/lib/documentation.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -38,6 +41,19 @@ describe('documentation catalog', () => {
     })
     expect(documents[0]).not.toHaveProperty('content')
     expect(getGettingStartedDocument(versionInfo)).toEqual(documents[0])
+  })
+
+  it('publishes exactly the Markdown files that exist in docs', () => {
+    const docsDirectory = resolve(process.cwd(), '../docs')
+    const markdownFiles = readdirSync(docsDirectory)
+      .filter((name) => name.endsWith('.md'))
+      .map((name) => `docs/${name}`)
+      .sort()
+    const publishedPaths = listDocumentation(versionInfo)
+      .map(({ path }) => path)
+      .sort()
+
+    expect(publishedPaths).toEqual(markdownFiles)
   })
 
   it('requires an exact web commit', () => {

--- a/app/src/lib/documentation.test.ts
+++ b/app/src/lib/documentation.test.ts
@@ -43,10 +43,10 @@ describe('documentation catalog', () => {
     expect(getGettingStartedDocument(versionInfo)).toEqual(documents[0])
   })
 
-  it('publishes exactly the Markdown files that exist in docs', () => {
+  it('publishes every user guide but not the repository index', () => {
     const docsDirectory = resolve(process.cwd(), '../docs')
     const markdownFiles = readdirSync(docsDirectory)
-      .filter((name) => name.endsWith('.md'))
+      .filter((name) => name.endsWith('.md') && name !== 'README.md')
       .map((name) => `docs/${name}`)
       .sort()
     const publishedPaths = listDocumentation(versionInfo)

--- a/app/src/lib/documentation.ts
+++ b/app/src/lib/documentation.ts
@@ -80,7 +80,6 @@ const DOCUMENTATION_DEFINITIONS: readonly DocumentationDefinition[] = [
     title: 'Logs Diagnostics And Troubleshooting',
   },
   { path: 'docs/16-notebook-diffs.md', title: 'Notebook Diffs' },
-  { path: 'docs/README.md', title: 'Documentation Index' },
 ]
 
 function encodePath(path: string): string {

--- a/app/src/lib/documentation.ts
+++ b/app/src/lib/documentation.ts
@@ -64,12 +64,8 @@ const DOCUMENTATION_DEFINITIONS: readonly DocumentationDefinition[] = [
   },
   { path: 'docs/10-jupyter-runners.md', title: 'Jupyter Runners' },
   {
-    path: 'docs/11-ai-chat-and-chatkit.md',
-    title: 'AI Chat And ChatKit',
-  },
-  {
-    path: 'docs/12-agentic-search-and-codex.md',
-    title: 'Agentic Search And Codex',
+    path: 'docs/11-webmcp-external-control.md',
+    title: 'WebMCP External Control',
   },
   {
     path: 'docs/13-app-console-reference.md',
@@ -85,12 +81,6 @@ const DOCUMENTATION_DEFINITIONS: readonly DocumentationDefinition[] = [
   },
   { path: 'docs/16-notebook-diffs.md', title: 'Notebook Diffs' },
   { path: 'docs/README.md', title: 'Documentation Index' },
-  { path: 'docs/codex-chat-panel.md', title: 'Codex Chat Panel' },
-  {
-    path: 'docs/codex-chrome-webmcp.md',
-    title: 'Codex Chrome And WebMCP',
-  },
-  { path: 'docs/using-codex.md', title: 'Using Codex' },
 ]
 
 function encodePath(path: string): string {

--- a/app/src/lib/documentation.ts
+++ b/app/src/lib/documentation.ts
@@ -1,3 +1,4 @@
+import { markOnboardingTaskComplete } from './onboarding'
 import { type RunmeVersionInfo, runmeVersionInfo } from './versionInfo'
 
 export const DOCUMENTATION_MIME_TYPE = 'text/markdown'
@@ -272,5 +273,6 @@ export function markDocumentationOpened(uri: string): void {
   }
   if (uri === gettingStarted.uri || uri === gettingStarted.rawUri) {
     markGettingStartedOpened()
+    markOnboardingTaskComplete('read-getting-started')
   }
 }

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -22,6 +22,7 @@ import {
   maybeParseIPykernelMessage,
 } from './ipykernel'
 import { appLogger } from './logging/runtime'
+import { markOnboardingTaskComplete } from './onboarding'
 import { buildExecuteRequest } from './runme'
 import type { Runner } from './runner'
 import { createAppJsGlobals } from './runtime/appJsGlobals'
@@ -660,6 +661,13 @@ export class NotebookData {
     }
 
     if (!transient) {
+      if (
+        cloned.metadata[RunmeMetadataKey.ExecutionState] ===
+          RunmeExecutionState.Completed &&
+        typeof cloned.metadata[RunmeMetadataKey.ExitCode] === 'string'
+      ) {
+        markOnboardingTaskComplete('run-first-cell')
+      }
       this.snapshotCache = this.buildSnapshot()
       this.emit()
       this.schedulePersist()

--- a/app/src/lib/onboarding.test.ts
+++ b/app/src/lib/onboarding.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ONBOARDING_STATE_CHANGED_EVENT,
+  ONBOARDING_STORAGE_KEY,
+  dismissOnboarding,
+  getOnboardingState,
+  markOnboardingOpened,
+  markOnboardingTaskComplete,
+  parseOnboardingState,
+} from './onboarding'
+
+describe('onboarding state', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('persists open, dismiss, and task completion state', () => {
+    markOnboardingOpened()
+    markOnboardingTaskComplete('read-getting-started')
+    markOnboardingTaskComplete('read-getting-started')
+    dismissOnboarding()
+
+    expect(getOnboardingState()).toEqual({
+      version: 1,
+      opened: true,
+      dismissed: true,
+      completedTaskIds: ['read-getting-started'],
+    })
+  })
+
+  it('reopening clears dismissal without losing progress', () => {
+    markOnboardingTaskComplete('create-first-notebook')
+    dismissOnboarding()
+    markOnboardingOpened()
+
+    expect(getOnboardingState()).toMatchObject({
+      opened: true,
+      dismissed: false,
+      completedTaskIds: ['create-first-notebook'],
+    })
+  })
+
+  it('ignores malformed and unknown persisted values', () => {
+    expect(parseOnboardingState('not-json')).toMatchObject({
+      opened: false,
+      completedTaskIds: [],
+    })
+    expect(
+      parseOnboardingState(
+        JSON.stringify({
+          opened: true,
+          completedTaskIds: ['run-first-cell', 'unknown-task'],
+        })
+      )
+    ).toMatchObject({
+      opened: true,
+      completedTaskIds: ['run-first-cell'],
+    })
+  })
+
+  it('notifies the current tab when state changes', () => {
+    const listener = vi.fn()
+    window.addEventListener(ONBOARDING_STATE_CHANGED_EVENT, listener)
+
+    markOnboardingTaskComplete('share-notebook')
+
+    expect(listener).toHaveBeenCalledOnce()
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toContain(
+      'share-notebook'
+    )
+  })
+})

--- a/app/src/lib/onboarding.test.ts
+++ b/app/src/lib/onboarding.test.ts
@@ -6,9 +6,11 @@ import {
   ONBOARDING_STORAGE_KEY,
   dismissOnboarding,
   getOnboardingState,
+  markOnboardingNotebookCreated,
   markOnboardingOpened,
   markOnboardingTaskComplete,
   parseOnboardingState,
+  updateOnboardingNotebookMetadata,
 } from './onboarding'
 
 describe('onboarding state', () => {
@@ -39,6 +41,49 @@ describe('onboarding state', () => {
       opened: true,
       dismissed: false,
       completedTaskIds: ['create-first-notebook'],
+    })
+  })
+
+  it('tracks the most recently created notebook and its Drive URI', () => {
+    markOnboardingNotebookCreated({
+      uri: 'local://file/first',
+      name: 'first.json',
+    })
+    markOnboardingNotebookCreated({
+      uri: 'local://file/latest',
+      name: 'latest.json',
+    })
+    updateOnboardingNotebookMetadata({
+      uri: 'local://file/latest',
+      name: 'latest.json',
+      remoteUri: 'https://drive.google.com/file/d/latest/view',
+    })
+
+    expect(getOnboardingState()).toMatchObject({
+      completedTaskIds: ['create-first-notebook'],
+      recentNotebook: {
+        uri: 'local://file/latest',
+        name: 'latest.json',
+        remoteUri: 'https://drive.google.com/file/d/latest/view',
+      },
+    })
+  })
+
+  it('ignores metadata updates for older notebooks', () => {
+    markOnboardingNotebookCreated({
+      uri: 'local://file/latest',
+      name: 'latest.json',
+    })
+
+    updateOnboardingNotebookMetadata({
+      uri: 'local://file/older',
+      name: 'older.json',
+      remoteUri: 'https://drive.google.com/file/d/older/view',
+    })
+
+    expect(getOnboardingState().recentNotebook).toEqual({
+      uri: 'local://file/latest',
+      name: 'latest.json',
     })
   })
 

--- a/app/src/lib/onboarding.ts
+++ b/app/src/lib/onboarding.ts
@@ -14,11 +14,18 @@ export const ONBOARDING_TASK_IDS = [
 
 export type OnboardingTaskId = (typeof ONBOARDING_TASK_IDS)[number]
 
+export type OnboardingNotebook = {
+  uri: string
+  name: string
+  remoteUri?: string
+}
+
 export type OnboardingState = {
   version: 1
   opened: boolean
   dismissed: boolean
   completedTaskIds: OnboardingTaskId[]
+  recentNotebook?: OnboardingNotebook
 }
 
 const DEFAULT_STATE: OnboardingState = {
@@ -35,6 +42,29 @@ function isOnboardingTaskId(value: unknown): value is OnboardingTaskId {
   )
 }
 
+function parseOnboardingNotebook(
+  value: unknown
+): OnboardingNotebook | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const candidate = value as {
+    uri?: unknown
+    name?: unknown
+    remoteUri?: unknown
+  }
+  if (typeof candidate.uri !== 'string' || typeof candidate.name !== 'string') {
+    return undefined
+  }
+  return {
+    uri: candidate.uri,
+    name: candidate.name,
+    ...(typeof candidate.remoteUri === 'string' && candidate.remoteUri
+      ? { remoteUri: candidate.remoteUri }
+      : {}),
+  }
+}
+
 export function parseOnboardingState(raw: string | null): OnboardingState {
   if (!raw) {
     return DEFAULT_STATE
@@ -45,7 +75,9 @@ export function parseOnboardingState(raw: string | null): OnboardingState {
       opened?: unknown
       dismissed?: unknown
       completedTaskIds?: unknown
+      recentNotebook?: unknown
     }
+    const recentNotebook = parseOnboardingNotebook(value.recentNotebook)
     return {
       version: 1,
       opened: value.opened === true,
@@ -53,6 +85,7 @@ export function parseOnboardingState(raw: string | null): OnboardingState {
       completedTaskIds: Array.isArray(value.completedTaskIds)
         ? [...new Set(value.completedTaskIds.filter(isOnboardingTaskId))]
         : [],
+      ...(recentNotebook ? { recentNotebook } : {}),
     }
   } catch {
     return DEFAULT_STATE
@@ -134,5 +167,31 @@ export function markOnboardingTaskComplete(taskId: OnboardingTaskId): void {
   persistOnboardingState({
     ...state,
     completedTaskIds: [...state.completedTaskIds, taskId],
+  })
+}
+
+export function markOnboardingNotebookCreated(
+  notebook: OnboardingNotebook
+): void {
+  const state = getOnboardingState()
+  persistOnboardingState({
+    ...state,
+    completedTaskIds: state.completedTaskIds.includes('create-first-notebook')
+      ? state.completedTaskIds
+      : [...state.completedTaskIds, 'create-first-notebook'],
+    recentNotebook: notebook,
+  })
+}
+
+export function updateOnboardingNotebookMetadata(
+  notebook: OnboardingNotebook
+): void {
+  const state = getOnboardingState()
+  if (state.recentNotebook?.uri !== notebook.uri) {
+    return
+  }
+  persistOnboardingState({
+    ...state,
+    recentNotebook: notebook,
   })
 }

--- a/app/src/lib/onboarding.ts
+++ b/app/src/lib/onboarding.ts
@@ -1,0 +1,138 @@
+export const ONBOARDING_DOCUMENT_URI = 'app://onboarding'
+export const ONBOARDING_MIME_TYPE = 'application/vnd.runme.onboarding'
+export const ONBOARDING_STORAGE_KEY = 'runme/onboarding/v1'
+export const ONBOARDING_STATE_CHANGED_EVENT = 'runme:onboarding-state-changed'
+
+export const ONBOARDING_TASK_IDS = [
+  'read-getting-started',
+  'sign-in-google-drive',
+  'add-drive-folder',
+  'create-first-notebook',
+  'run-first-cell',
+  'share-notebook',
+] as const
+
+export type OnboardingTaskId = (typeof ONBOARDING_TASK_IDS)[number]
+
+export type OnboardingState = {
+  version: 1
+  opened: boolean
+  dismissed: boolean
+  completedTaskIds: OnboardingTaskId[]
+}
+
+const DEFAULT_STATE: OnboardingState = {
+  version: 1,
+  opened: false,
+  dismissed: false,
+  completedTaskIds: [],
+}
+
+function isOnboardingTaskId(value: unknown): value is OnboardingTaskId {
+  return (
+    typeof value === 'string' &&
+    ONBOARDING_TASK_IDS.includes(value as OnboardingTaskId)
+  )
+}
+
+export function parseOnboardingState(raw: string | null): OnboardingState {
+  if (!raw) {
+    return DEFAULT_STATE
+  }
+  try {
+    const value = JSON.parse(raw) as {
+      version?: unknown
+      opened?: unknown
+      dismissed?: unknown
+      completedTaskIds?: unknown
+    }
+    return {
+      version: 1,
+      opened: value.opened === true,
+      dismissed: value.dismissed === true,
+      completedTaskIds: Array.isArray(value.completedTaskIds)
+        ? [...new Set(value.completedTaskIds.filter(isOnboardingTaskId))]
+        : [],
+    }
+  } catch {
+    return DEFAULT_STATE
+  }
+}
+
+export function getOnboardingState(): OnboardingState {
+  if (typeof window === 'undefined') {
+    return DEFAULT_STATE
+  }
+  try {
+    return parseOnboardingState(
+      window.localStorage.getItem(ONBOARDING_STORAGE_KEY)
+    )
+  } catch {
+    return DEFAULT_STATE
+  }
+}
+
+export function getOnboardingStateSnapshot(): string {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+  try {
+    return window.localStorage.getItem(ONBOARDING_STORAGE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function subscribeToOnboardingState(listener: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined
+  }
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === ONBOARDING_STORAGE_KEY) {
+      listener()
+    }
+  }
+  window.addEventListener('storage', handleStorage)
+  window.addEventListener(ONBOARDING_STATE_CHANGED_EVENT, listener)
+  return () => {
+    window.removeEventListener('storage', handleStorage)
+    window.removeEventListener(ONBOARDING_STATE_CHANGED_EVENT, listener)
+  }
+}
+
+function persistOnboardingState(state: OnboardingState): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state))
+    window.dispatchEvent(new Event(ONBOARDING_STATE_CHANGED_EVENT))
+  } catch {
+    // Onboarding should remain usable when browser storage is unavailable.
+  }
+}
+
+export function hasOpenedOnboarding(): boolean {
+  return getOnboardingState().opened
+}
+
+export function markOnboardingOpened(): void {
+  const state = getOnboardingState()
+  persistOnboardingState({ ...state, opened: true, dismissed: false })
+}
+
+export function dismissOnboarding(): void {
+  const state = getOnboardingState()
+  persistOnboardingState({ ...state, opened: true, dismissed: true })
+}
+
+export function markOnboardingTaskComplete(taskId: OnboardingTaskId): void {
+  const state = getOnboardingState()
+  if (state.completedTaskIds.includes(taskId)) {
+    return
+  }
+  persistOnboardingState({
+    ...state,
+    completedTaskIds: [...state.completedTaskIds, taskId],
+  })
+}

--- a/app/src/lib/shareLinks.ts
+++ b/app/src/lib/shareLinks.ts
@@ -1,4 +1,5 @@
 import { getCellTitle } from './cellContent'
+import { markOnboardingTaskComplete } from './onboarding'
 
 function getShareBaseUrl(): URL {
   if (typeof window === 'undefined') {
@@ -175,6 +176,7 @@ export async function copyNotebookShareUrl(remoteUri: string): Promise<string> {
 
   const shareUrl = buildNotebookShareUrl(remoteUri)
   await window.navigator.clipboard.writeText(shareUrl)
+  markOnboardingTaskComplete('share-notebook')
   return shareUrl
 }
 
@@ -191,6 +193,7 @@ export async function copyNotebookCellShareUrl(
 
   const shareUrl = buildNotebookCellShareUrl(remoteUri, cellRefId)
   await window.navigator.clipboard.writeText(shareUrl)
+  markOnboardingTaskComplete('share-notebook')
   return shareUrl
 }
 
@@ -214,6 +217,7 @@ export async function copyNotebookCellMarkdownLink(
     cellRefId
   )
   await window.navigator.clipboard.writeText(markdownLink)
+  markOnboardingTaskComplete('share-notebook')
   return markdownLink
 }
 
@@ -230,6 +234,7 @@ export async function copyNotebookMarkdownLink(
 
   const markdownLink = buildNotebookMarkdownLink(name, remoteUri)
   await window.navigator.clipboard.writeText(markdownLink)
+  markOnboardingTaskComplete('share-notebook')
   return markdownLink
 }
 

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -1,6 +1,7 @@
 import { isExcalidrawDocumentMetadata } from '../../storage/excalidraw'
 import { isRemoteMarkdownUri } from '../documentation'
 import type { NotebookTabState } from '../notebookDataController'
+import { ONBOARDING_DOCUMENT_URI } from '../onboarding'
 import type { NotebookOwnershipRecord } from '../tabCoordination/notebookOwnership'
 
 export const DRIVE_LINK_STATUS_DOCUMENT_URI = 'status://drive-link'
@@ -73,6 +74,12 @@ export function isLogsUri(uri: string | null | undefined): boolean {
   return uri === LOGS_DOCUMENT_URI
 }
 
+export function isOnboardingDocumentUri(
+  uri: string | null | undefined
+): boolean {
+  return uri === ONBOARDING_DOCUMENT_URI
+}
+
 export function isDocumentationDocumentUri(
   uri: string | null | undefined
 ): uri is string {
@@ -80,7 +87,11 @@ export function isDocumentationDocumentUri(
 }
 
 export function isRestorableWorkspaceDocument(uri: string): boolean {
-  return isNotebookDocumentUri(uri) || isDocumentationDocumentUri(uri)
+  return (
+    isNotebookDocumentUri(uri) ||
+    isDocumentationDocumentUri(uri) ||
+    isOnboardingDocumentUri(uri)
+  )
 }
 
 export function deriveWorkspaceDocumentTitle(uri: string): string {
@@ -102,6 +113,9 @@ export function deriveWorkspaceDocumentTitle(uri: string): string {
   }
   if (isLogsUri(documentUri)) {
     return 'Logs'
+  }
+  if (isOnboardingDocumentUri(documentUri)) {
+    return 'Welcome to Runme'
   }
   if (isNotebookDiffUri(documentUri)) {
     return 'Notebook diff'

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -6,6 +6,9 @@ Runme Web exposes WebMCP tools that let an external browser controller inspect,
 edit, and execute work in an open Runme tab. This page describes how to select
 the intended tab and notebook safely before using those tools.
 
+This is the supported integration path for Codex and other external agents.
+Runme does not include a built-in AI Chat panel.
+
 Browser tab control is exclusive: one controller session can control one tab
 at a time. Concurrent sessions should target different Runme tabs.
 


### PR DESCRIPTION
## What

- add a restorable Welcome to Runme document that opens for first-time users alongside Getting Started
- explain what Runme is and why it is useful for shareable design docs and runbooks
- add a prominent Codex flow with an @Browser prompt users can copy
- track six conversion steps from reading Getting Started through sharing a notebook
- persist progress and dismissal state, and let users reopen onboarding from Documentation

## Why

New visitors to web.runme.dev need a clear path from understanding Runme to creating and sharing their first agent-assisted notebook.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run` (67 files, 608 tests)
- focused onboarding tests (10 tests)
- `pnpm -C app run typecheck` still reports the existing repository-wide baseline errors; no onboarding-specific diagnostics were emitted
