### PR TITLE
Add privacy-conscious Google Analytics events

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -41,6 +41,7 @@ jobs:
       GCP_SERVICE_ACCOUNT_EMAIL: runme-gha@runme-lewi-dev.iam.gserviceaccount.com
       RELEASER_BUCKET: gs://runme-hosted
       RELEASER_WEB_REPO: runmedev/web
+      VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ vars.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/app/assets/policies/privacypolicy.html
+++ b/app/assets/policies/privacypolicy.html
@@ -32,7 +32,7 @@
   <body>
     <main>
       <h1>Runme Web Privacy Policy</h1>
-      <p>Last updated: March 1, 2026</p>
+      <p>Last updated: July 25, 2026</p>
 
       <p>
         This Privacy Policy applies to the Runme Web application hosted at
@@ -64,12 +64,38 @@
         can continue.
       </p>
 
+      <h2>Usage Analytics</h2>
+      <p>
+        We use Google Analytics on web.runme.dev to count successful notebook
+        opens and accepted code-cell execution attempts. We send only coarse
+        categories, such as whether a notebook came from local storage, Google
+        Drive, or an HTTP address, whether it was opened read-only, and which
+        type of execution backend was used.
+      </p>
+      <p>
+        We do not send notebook or cell names, contents, identifiers, paths,
+        URLs, session values, Google Drive file identifiers, commands, outputs,
+        or errors to Google Analytics. Automatic page views and advertising
+        signals are disabled, and the page location sent with these events is
+        limited to <a href="https://web.runme.dev/">https://web.runme.dev/</a>
+        without a query string or fragment.
+      </p>
+      <p>
+        Google Analytics may process standard request information such as
+        browser and device details, IP-derived approximate geography, and its
+        own browser storage or cookies. Runme Web does not set an analytics user
+        ID. Analytics is disabled when your browser sends a Do Not Track or
+        Global Privacy Control signal. You can also block or clear analytics
+        storage using your browser settings. For more information, see
+        <a href="https://policies.google.com/privacy">Google's Privacy Policy</a>.
+      </p>
+
       <h2>How We Share Data</h2>
       <p>
-        We do not sell, transfer, or disclose Google user data to third
-        parties, except when your browser sends requests directly to Google or
-        another service you choose to use in order to provide the functionality
-        you requested.
+        We do not sell Google user data. Your browser sends the limited usage
+        analytics described above to Google Analytics and may send requests
+        directly to Google or another service you choose to use in order to
+        provide the functionality you requested.
       </p>
 
       <h2>Security</h2>
@@ -85,6 +111,10 @@
         We do not retain Google user data on application servers. Data stored in
         your browser remains there until it expires, you sign out, or you clear
         your browser's local site data.
+      </p>
+      <p>
+        Aggregate usage analytics is retained in Google Analytics according to
+        the retention settings for the Runme Web analytics property.
       </p>
 
       <h2>Changes to This Policy</h2>

--- a/app/src/lib/googleAnalytics.test.ts
+++ b/app/src/lib/googleAnalytics.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  GoogleAnalyticsClient,
+  type GoogleAnalyticsClientOptions,
+  classifyNotebookAnalyticsSource,
+} from './googleAnalytics'
+
+const validOptions = (
+  overrides: Partial<GoogleAnalyticsClientOptions> = {}
+): GoogleAnalyticsClientOptions => ({
+  measurementId: 'G-TEST123',
+  hostname: 'web.runme.dev',
+  doNotTrack: null,
+  globalPrivacyControl: false,
+  document,
+  globalObject: {},
+  ...overrides,
+})
+
+afterEach(() => {
+  document.getElementById('runme-google-analytics')?.remove()
+})
+
+describe('classifyNotebookAnalyticsSource', () => {
+  it.each([
+    ['local://file/secret-id', 'local'],
+    ['fs://workspace/private/notebook.json', 'local'],
+    ['https://drive.google.com/file/d/private-id/view', 'google_drive'],
+    ['https://example.com/private/path?token=secret', 'http'],
+    ['not a uri', 'unknown'],
+  ] as const)('collapses %s to %s', (uri, expected) => {
+    expect(classifyNotebookAnalyticsSource(uri)).toBe(expected)
+  })
+})
+
+describe('GoogleAnalyticsClient', () => {
+  it.each([
+    ['missing ID', { measurementId: undefined }],
+    ['invalid ID', { measurementId: '123456789' }],
+    ['non-production host', { hostname: 'localhost' }],
+    ['Do Not Track', { doNotTrack: '1' }],
+    ['Global Privacy Control', { globalPrivacyControl: true }],
+  ] as const)('stays disabled for %s', (_name, overrides) => {
+    const globalObject = {}
+    const client = new GoogleAnalyticsClient(
+      validOptions({ ...overrides, globalObject })
+    )
+
+    expect(client.initialize()).toBe(false)
+    expect(globalObject).toEqual({})
+    expect(document.getElementById('runme-google-analytics')).toBeNull()
+  })
+
+  it('initializes once with privacy-preserving configuration', () => {
+    const globalObject: { dataLayer?: Array<ArrayLike<unknown>> } = {}
+    const client = new GoogleAnalyticsClient(validOptions({ globalObject }))
+
+    expect(client.initialize()).toBe(true)
+    expect(client.initialize()).toBe(true)
+
+    const script = document.getElementById(
+      'runme-google-analytics'
+    ) as HTMLScriptElement
+    expect(script).toBeTruthy()
+    expect(script.async).toBe(true)
+    expect(script.referrerPolicy).toBe('no-referrer')
+    expect(script.src).toBe(
+      'https://www.googletagmanager.com/gtag/js?id=G-TEST123'
+    )
+    expect(document.querySelectorAll('#runme-google-analytics')).toHaveLength(1)
+
+    const commands = globalObject.dataLayer?.map((command) =>
+      Array.from(command)
+    )
+    expect(commands).toHaveLength(2)
+    expect(commands?.[0]?.[0]).toBe('js')
+    expect(commands?.[0]?.[1]).toBeInstanceOf(Date)
+    expect(commands?.[1]).toEqual([
+      'config',
+      'G-TEST123',
+      {
+        allow_ad_personalization_signals: false,
+        allow_google_signals: false,
+        send_page_view: false,
+        page_location: 'https://web.runme.dev/',
+        page_referrer: '',
+        page_title: 'Runme Web',
+      },
+    ])
+  })
+
+  it('emits only the allowlisted event payloads and safe page context', () => {
+    const globalObject: { dataLayer?: Array<ArrayLike<unknown>> } = {}
+    const client = new GoogleAnalyticsClient(validOptions({ globalObject }))
+    client.initialize()
+
+    client.trackNotebookOpened({
+      notebookSource: 'google_drive',
+      accessMode: 'read_only',
+    })
+    client.trackCellExecuted({ executionBackend: 'jupyter' })
+
+    const events = globalObject.dataLayer
+      ?.slice(2)
+      .map((command) => Array.from(command))
+    expect(events).toEqual([
+      [
+        'event',
+        'notebook_opened',
+        {
+          access_mode: 'read_only',
+          notebook_source: 'google_drive',
+          page_location: 'https://web.runme.dev/',
+          page_referrer: '',
+          page_title: 'Runme Web',
+        },
+      ],
+      [
+        'event',
+        'cell_executed',
+        {
+          execution_backend: 'jupyter',
+          page_location: 'https://web.runme.dev/',
+          page_referrer: '',
+          page_title: 'Runme Web',
+        },
+      ],
+    ])
+  })
+
+  it('contains analytics failures inside the client', () => {
+    const gtag = vi.fn(() => {
+      throw new Error('analytics unavailable')
+    })
+    const client = new GoogleAnalyticsClient(
+      validOptions({ globalObject: { gtag } })
+    )
+
+    expect(() => client.initialize()).not.toThrow()
+    expect(client.initialize()).toBe(false)
+    expect(() =>
+      client.trackCellExecuted({ executionBackend: 'runner' })
+    ).not.toThrow()
+  })
+})

--- a/app/src/lib/googleAnalytics.ts
+++ b/app/src/lib/googleAnalytics.ts
@@ -1,0 +1,168 @@
+export type NotebookAnalyticsSource =
+  | 'local'
+  | 'google_drive'
+  | 'http'
+  | 'unknown'
+
+export type NotebookAccessMode = 'read_write' | 'read_only'
+
+export type ExecutionBackend = 'appkernel' | 'jupyter' | 'runner'
+
+type Gtag = (...args: unknown[]) => void
+
+type AnalyticsGlobal = {
+  dataLayer?: Array<ArrayLike<unknown>>
+  gtag?: Gtag
+}
+
+export interface GoogleAnalyticsClientOptions {
+  measurementId?: string
+  hostname: string
+  doNotTrack?: string | null
+  globalPrivacyControl?: boolean
+  document: Pick<Document, 'createElement' | 'getElementById' | 'head'>
+  globalObject: AnalyticsGlobal
+}
+
+const GOOGLE_ANALYTICS_HOSTNAME = 'web.runme.dev'
+const GOOGLE_ANALYTICS_SCRIPT_ID = 'runme-google-analytics'
+const SAFE_PAGE_LOCATION = 'https://web.runme.dev/'
+const SAFE_PAGE_TITLE = 'Runme Web'
+const SAFE_PAGE_CONTEXT = {
+  page_location: SAFE_PAGE_LOCATION,
+  page_referrer: '',
+  page_title: SAFE_PAGE_TITLE,
+} as const
+
+function isValidMeasurementId(value: string | undefined): value is string {
+  return typeof value === 'string' && /^G-[A-Z0-9]+$/.test(value)
+}
+
+export function classifyNotebookAnalyticsSource(
+  requestedUri: string
+): NotebookAnalyticsSource {
+  try {
+    const url = new URL(requestedUri)
+    if (url.protocol === 'local:' || url.protocol === 'fs:') {
+      return 'local'
+    }
+    if (
+      (url.protocol === 'https:' || url.protocol === 'http:') &&
+      url.hostname === 'drive.google.com'
+    ) {
+      return 'google_drive'
+    }
+    if (url.protocol === 'https:' || url.protocol === 'http:') {
+      return 'http'
+    }
+  } catch {
+    // Unknown and malformed values intentionally collapse to one safe enum.
+  }
+  return 'unknown'
+}
+
+export class GoogleAnalyticsClient {
+  private gtag: Gtag | undefined
+
+  constructor(private readonly options: GoogleAnalyticsClientOptions) {}
+
+  initialize(): boolean {
+    if (this.gtag) {
+      return true
+    }
+
+    const {
+      document,
+      doNotTrack,
+      globalObject,
+      globalPrivacyControl,
+      hostname,
+      measurementId,
+    } = this.options
+    if (
+      !isValidMeasurementId(measurementId) ||
+      hostname !== GOOGLE_ANALYTICS_HOSTNAME ||
+      doNotTrack === '1' ||
+      globalPrivacyControl === true
+    ) {
+      return false
+    }
+
+    try {
+      const dataLayer = (globalObject.dataLayer ??= [])
+      const gtag =
+        globalObject.gtag ??
+        function (this: unknown) {
+          dataLayer.push(arguments)
+        }
+      globalObject.gtag = gtag
+
+      if (!document.getElementById(GOOGLE_ANALYTICS_SCRIPT_ID)) {
+        const script = document.createElement('script')
+        script.id = GOOGLE_ANALYTICS_SCRIPT_ID
+        script.async = true
+        script.referrerPolicy = 'no-referrer'
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
+          measurementId
+        )}`
+        document.head.append(script)
+      }
+
+      gtag('js', new Date())
+      gtag('config', measurementId, {
+        allow_ad_personalization_signals: false,
+        allow_google_signals: false,
+        send_page_view: false,
+        ...SAFE_PAGE_CONTEXT,
+      })
+      this.gtag = gtag
+      return true
+    } catch {
+      this.gtag = undefined
+      return false
+    }
+  }
+
+  trackNotebookOpened(params: {
+    notebookSource: NotebookAnalyticsSource
+    accessMode: NotebookAccessMode
+  }): void {
+    this.sendEvent('notebook_opened', {
+      access_mode: params.accessMode,
+      notebook_source: params.notebookSource,
+    })
+  }
+
+  trackCellExecuted(params: { executionBackend: ExecutionBackend }): void {
+    this.sendEvent('cell_executed', {
+      execution_backend: params.executionBackend,
+    })
+  }
+
+  private sendEvent(
+    eventName: 'notebook_opened' | 'cell_executed',
+    params: Record<string, string>
+  ): void {
+    try {
+      this.gtag?.('event', eventName, {
+        ...params,
+        ...SAFE_PAGE_CONTEXT,
+      })
+    } catch {
+      // Analytics must never affect notebook loading or execution.
+    }
+  }
+}
+
+const navigatorWithPrivacySignals = navigator as Navigator & {
+  globalPrivacyControl?: boolean
+}
+
+export const googleAnalytics = new GoogleAnalyticsClient({
+  measurementId: import.meta.env.VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID,
+  hostname: window.location.hostname,
+  doNotTrack: navigator.doNotTrack,
+  globalPrivacyControl: navigatorWithPrivacySignals.globalPrivacyControl,
+  document,
+  globalObject: window as AnalyticsGlobal,
+})

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -11,6 +11,7 @@ import {
   parser_pb,
 } from "../contexts/CellContext";
 import { LOCAL_FOLDER_URI } from "../storage/local";
+import { googleAnalytics } from "./googleAnalytics";
 import { appLogger } from "./logging/runtime";
 import { appState } from "./runtime/AppState";
 import {
@@ -241,6 +242,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
   appState.setDriveNotebookStore(null);
   appState.setLocalNotebooks(null);
@@ -575,6 +577,10 @@ describe("NotebookData.runCodeCell", () => {
   it("returns empty run id when no runner is available", () => {
     getWithFallback.mockReturnValueOnce(undefined);
     const logError = vi.spyOn(appLogger, "error");
+    const trackCellExecuted = vi.spyOn(
+      googleAnalytics,
+      "trackCellExecuted",
+    );
 
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-no-runner",
@@ -604,10 +610,15 @@ describe("NotebookData.runCodeCell", () => {
         },
       },
     );
+    expect(trackCellExecuted).not.toHaveBeenCalled();
     logError.mockRestore();
   });
 
   it("returns empty run id for html content cells", () => {
+    const trackCellExecuted = vi.spyOn(
+      googleAnalytics,
+      "trackCellExecuted",
+    );
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-html",
       kind: parser_pb.CellKind.CODE,
@@ -627,6 +638,35 @@ describe("NotebookData.runCodeCell", () => {
 
     const runID = model.runCodeCell(cell);
     expect(runID).toBe("");
+    expect(trackCellExecuted).not.toHaveBeenCalled();
+  });
+
+  it("records an accepted execution using only the backend enum", () => {
+    const trackCellExecuted = vi
+      .spyOn(googleAnalytics, "trackCellExecuted")
+      .mockImplementation(() => {});
+    const cell = create(parser_pb.CellSchema, {
+      refId: "private-cell-id",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "echo private command",
+    });
+    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
+    const model = new NotebookData({
+      notebook,
+      uri: "local://file/private-notebook-id",
+      name: "private-notebook-name",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    expect(model.runCodeCell(cell)).toBe("run-generated");
+    expect(trackCellExecuted).toHaveBeenCalledTimes(1);
+    expect(trackCellExecuted).toHaveBeenCalledWith({
+      executionBackend: "runner",
+    });
   });
 
   it("resolves CellData.run when execution monitoring becomes unknown", async () => {

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -641,6 +641,32 @@ describe("NotebookData.runCodeCell", () => {
     expect(trackCellExecuted).not.toHaveBeenCalled();
   });
 
+  it("does not record a Jupyter cell when no kernel is selected", () => {
+    const trackCellExecuted = vi.spyOn(
+      googleAnalytics,
+      "trackCellExecuted",
+    );
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-jupyter-no-kernel",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "jupyter",
+      outputs: [],
+      metadata: {},
+      value: "print('not sent')",
+    });
+    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
+    const model = new NotebookData({
+      notebook,
+      uri: "local://file/private-notebook-id",
+      name: "private-notebook-name",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    expect(model.runCodeCell(cell)).toBe("run-generated");
+    expect(trackCellExecuted).not.toHaveBeenCalled();
+  });
+
   it("records an accepted execution using only the backend enum", () => {
     const trackCellExecuted = vi
       .spyOn(googleAnalytics, "trackCellExecuted")

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -955,7 +955,6 @@ export class NotebookData {
     }
 
     if (useJupyterKernel) {
-      googleAnalytics.trackCellExecuted({ executionBackend: 'jupyter' })
       this.runCodeCellWithJupyterKernel(cell, runID, runner!, generation)
       return runID
     }
@@ -1407,6 +1406,7 @@ export class NotebookData {
       return
     }
 
+    googleAnalytics.trackCellExecuted({ executionBackend: 'jupyter' })
     const socket = new WebSocket(channelsURL)
     this.activeJupyterSockets.set(refId, {
       socket,

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -16,6 +16,7 @@ import {
   parser_pb,
 } from '../contexts/CellContext'
 import { isHtmlLanguageId } from './cellContent'
+import { googleAnalytics } from './googleAnalytics'
 import {
   IOPUB_INCOMPLETE_METADATA_KEY,
   IOPUB_MIME_TYPE,
@@ -948,11 +949,13 @@ export class NotebookData {
     this.updateCell(cell)
 
     if (useAppKernel) {
+      googleAnalytics.trackCellExecuted({ executionBackend: 'appkernel' })
       this.runCodeCellWithAppKernel(cell, runID, appKernelMode, generation)
       return runID
     }
 
     if (useJupyterKernel) {
+      googleAnalytics.trackCellExecuted({ executionBackend: 'jupyter' })
       this.runCodeCellWithJupyterKernel(cell, runID, runner!, generation)
       return runID
     }
@@ -968,6 +971,7 @@ export class NotebookData {
       return ''
     }
 
+    googleAnalytics.trackCellExecuted({ executionBackend: 'runner' })
     const commands = cell.value ? cell.value.split('\n') : []
     const execReq = buildExecuteRequest({
       languageId: cell.languageId ?? undefined,

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { parser_pb } from '../contexts/CellContext'
 import type { LocalNotebooks } from '../storage/local'
 import { NotebookStoreItemType } from '../storage/notebook'
+import { googleAnalytics } from './googleAnalytics'
 import {
   __resetNotebookDataControllerForTests,
   getNotebookDataController,
@@ -144,6 +145,7 @@ function createForceReleaseRequest(notebookUri: string): ForceReleaseRequest {
 
 describe('NotebookDataController', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     __resetNotebookDataControllerForTests()
     window.localStorage.clear()
     window.sessionStorage.clear()
@@ -184,6 +186,53 @@ describe('NotebookDataController', () => {
         loaded: true,
       })
     )
+  })
+
+  it('records only the first successful load with coarse notebook fields', async () => {
+    const requestedUri =
+      'https://drive.google.com/file/d/private-file-id/view?token=secret'
+    const localStore = createFakeLocalNotebooks()
+    const trackNotebookOpened = vi
+      .spyOn(googleAnalytics, 'trackNotebookOpened')
+      .mockImplementation(() => {})
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    await controller.openNotebook(requestedUri, { name: 'private-name.json' })
+    await controller.openNotebook(requestedUri, { name: 'private-name.json' })
+
+    expect(trackNotebookOpened).toHaveBeenCalledTimes(1)
+    expect(trackNotebookOpened).toHaveBeenCalledWith({
+      notebookSource: 'google_drive',
+      accessMode: 'read_write',
+    })
+  })
+
+  it('does not record a notebook that fails to load', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/private-id', {
+      id: 'local://file/private-id',
+      name: 'private-name.json',
+      remoteId: 'local://file/private-id',
+      notebook: createNotebook(),
+    })
+    localStore.load.mockRejectedValueOnce(new Error('load failed'))
+    const trackNotebookOpened = vi
+      .spyOn(googleAnalytics, 'trackNotebookOpened')
+      .mockImplementation(() => {})
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    const result = await controller.openNotebook('local://file/private-id')
+
+    expect(result.entry.state).toBe('error')
+    expect(trackNotebookOpened).not.toHaveBeenCalled()
   })
 
   it('resolves a remote URI to a stable local URI before loading', async () => {

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -211,6 +211,57 @@ describe('NotebookDataController', () => {
     })
   })
 
+  it('uses the upstream source for a locally addressed notebook', async () => {
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set('local://file/drive-backed', {
+      id: 'local://file/drive-backed',
+      name: 'drive-backed.json',
+      remoteId:
+        'https://drive.google.com/file/d/private-file-id/view?token=secret',
+      notebook: createNotebook(),
+    })
+    const trackNotebookOpened = vi
+      .spyOn(googleAnalytics, 'trackNotebookOpened')
+      .mockImplementation(() => {})
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    await controller.openNotebook('local://file/drive-backed')
+
+    expect(trackNotebookOpened).toHaveBeenCalledWith({
+      notebookSource: 'google_drive',
+      accessMode: 'read_write',
+    })
+  })
+
+  it('records a notebook again after it is closed and reopened', async () => {
+    const uri = 'local://file/reopened'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'reopened.json',
+      remoteId: uri,
+      notebook: createNotebook(),
+    })
+    const trackNotebookOpened = vi
+      .spyOn(googleAnalytics, 'trackNotebookOpened')
+      .mockImplementation(() => {})
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+
+    await controller.openNotebook(uri)
+    controller.closeNotebook(uri)
+    await controller.openNotebook(uri)
+
+    expect(trackNotebookOpened).toHaveBeenCalledTimes(2)
+  })
+
   it('does not record a notebook that fails to load', async () => {
     const localStore = createFakeLocalNotebooks()
     localStore.records.set('local://file/private-id', {

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -2,6 +2,10 @@ import { create } from '@bufbuild/protobuf'
 
 import { parser_pb } from '../contexts/CellContext'
 import type { LocalNotebooks } from '../storage/local'
+import {
+  classifyNotebookAnalyticsSource,
+  googleAnalytics,
+} from './googleAnalytics'
 import { appLogger } from './logging/runtime'
 import { NotebookData, type NotebookSnapshot } from './notebookData'
 import { getNotebookSessionPersistence } from './notebookSessionPersistence'
@@ -105,6 +109,7 @@ export class NotebookDataController {
   private readonly listeners = new Set<() => void>()
   private snapshot: NotebookDataControllerSnapshot = { openNotebooks: [] }
   private restored = false
+  private readonly analyticsOpenedNotebooks = new Set<string>()
   private readonly releasingNotebooks = new Set<string>()
   private readonly writeAccessRequests = new Map<
     string,
@@ -227,6 +232,7 @@ export class NotebookDataController {
             owner: acquireResult.owner,
             errorMessage: undefined,
           })
+          this.trackNotebookOpened(entry)
         } catch (error) {
           entry = this.upsertOpenEntry({
             ...entry,
@@ -266,6 +272,7 @@ export class NotebookDataController {
         errorMessage: undefined,
         owner: undefined,
       })
+      this.trackNotebookOpened(entry)
       return { localUri, entry }
     }
 
@@ -288,6 +295,7 @@ export class NotebookDataController {
           errorMessage: undefined,
           owner: undefined,
         })
+        this.trackNotebookOpened(entry)
       } catch (error) {
         this.releaseLease(localUri)
         entry = this.upsertOpenEntry({
@@ -299,6 +307,20 @@ export class NotebookDataController {
     }
 
     return { localUri, entry }
+  }
+
+  private trackNotebookOpened(entry: OpenNotebookEntry): void {
+    if (
+      entry.state !== 'loaded' ||
+      this.analyticsOpenedNotebooks.has(entry.uri)
+    ) {
+      return
+    }
+    this.analyticsOpenedNotebooks.add(entry.uri)
+    googleAnalytics.trackNotebookOpened({
+      notebookSource: classifyNotebookAnalyticsSource(entry.requestedUri),
+      accessMode: entry.readOnly ? 'read_only' : 'read_write',
+    })
   }
 
   closeNotebook(localUri: string): string | null {

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -5,6 +5,7 @@ import type { LocalNotebooks } from '../storage/local'
 import {
   classifyNotebookAnalyticsSource,
   googleAnalytics,
+  type NotebookAnalyticsSource,
 } from './googleAnalytics'
 import { appLogger } from './logging/runtime'
 import { NotebookData, type NotebookSnapshot } from './notebookData'
@@ -169,6 +170,10 @@ export class NotebookDataController {
 
     const localUri = await this.resolveLocalUri(requestedUri, options?.name)
     const name = await this.resolveNotebookName(localUri, options?.name)
+    const notebookSource = await this.resolveNotebookAnalyticsSource(
+      requestedUri,
+      localUri
+    )
     let entry = this.upsertOpenEntry({
       uri: localUri,
       requestedUri,
@@ -232,7 +237,7 @@ export class NotebookDataController {
             owner: acquireResult.owner,
             errorMessage: undefined,
           })
-          this.trackNotebookOpened(entry)
+          this.trackNotebookOpened(entry, notebookSource)
         } catch (error) {
           entry = this.upsertOpenEntry({
             ...entry,
@@ -272,7 +277,7 @@ export class NotebookDataController {
         errorMessage: undefined,
         owner: undefined,
       })
-      this.trackNotebookOpened(entry)
+      this.trackNotebookOpened(entry, notebookSource)
       return { localUri, entry }
     }
 
@@ -295,7 +300,7 @@ export class NotebookDataController {
           errorMessage: undefined,
           owner: undefined,
         })
-        this.trackNotebookOpened(entry)
+        this.trackNotebookOpened(entry, notebookSource)
       } catch (error) {
         this.releaseLease(localUri)
         entry = this.upsertOpenEntry({
@@ -309,7 +314,10 @@ export class NotebookDataController {
     return { localUri, entry }
   }
 
-  private trackNotebookOpened(entry: OpenNotebookEntry): void {
+  private trackNotebookOpened(
+    entry: OpenNotebookEntry,
+    notebookSource: NotebookAnalyticsSource
+  ): void {
     if (
       entry.state !== 'loaded' ||
       this.analyticsOpenedNotebooks.has(entry.uri)
@@ -318,7 +326,7 @@ export class NotebookDataController {
     }
     this.analyticsOpenedNotebooks.add(entry.uri)
     googleAnalytics.trackNotebookOpened({
-      notebookSource: classifyNotebookAnalyticsSource(entry.requestedUri),
+      notebookSource,
       accessMode: entry.readOnly ? 'read_only' : 'read_write',
     })
   }
@@ -574,6 +582,29 @@ export class NotebookDataController {
     return this.localNotebooks.addFile(uri, name)
   }
 
+  private async resolveNotebookAnalyticsSource(
+    requestedUri: string,
+    localUri: string
+  ): Promise<NotebookAnalyticsSource> {
+    const requestedSource = classifyNotebookAnalyticsSource(requestedUri)
+    if (
+      requestedSource !== 'local' ||
+      !this.localNotebooks ||
+      !isLocalFileUri(localUri)
+    ) {
+      return requestedSource
+    }
+    try {
+      const metadata = await this.localNotebooks.getMetadata(localUri)
+      if (metadata?.remoteUri) {
+        return classifyNotebookAnalyticsSource(metadata.remoteUri)
+      }
+    } catch {
+      // Fall back to the safe classification of the requested URI.
+    }
+    return requestedSource
+  }
+
   private async resolveNotebookName(
     uri: string,
     fallbackName?: string
@@ -730,6 +761,7 @@ export class NotebookDataController {
       handle.unsubscribe()
     }
     this.notebooks.delete(uri)
+    this.analyticsOpenedNotebooks.delete(uri)
     this.openNotebooks = this.openNotebooks.filter((item) => item.uri !== uri)
     this.emit()
     this.persist()

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -19,6 +19,7 @@ import {
   setLocalConfigPreferredOnLoad,
   setAppConfig,
 } from "./lib/appConfig";
+import { googleAnalytics } from "./lib/googleAnalytics";
 import { appLogger } from "./lib/logging/runtime";
 import { normalizeAppIndexUrl } from "./lib/appBase";
 import { ensurePersistentStorage } from "./lib/persistentStorage";
@@ -66,6 +67,7 @@ setContext(noopBridge);
 
 normalizeAppIndexUrl();
 ensureSessionQueryParam();
+googleAnalytics.initialize();
 
 void ensurePersistentStorage().then((status) => {
   switch (status) {

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID?: string
   readonly VITE_RUNME_VERSION_BUILD_DATE?: string
   readonly VITE_RUNME_VERSION_WEB_REPO?: string
   readonly VITE_RUNME_VERSION_WEB_BRANCH?: string


### PR DESCRIPTION
## Summary

- add a fail-closed GA4 client for `web.runme.dev`
- record the `notebook_opened` and `cell_executed` custom events with coarse allowlisted enum fields
- count a notebook again after it is closed and reopened
- classify locally mirrored notebooks by their actual upstream source
- count Jupyter execution only after its kernel configuration and endpoint are valid
- suppress page views, Google signals, ad-personalization signals, referrers, and live route/query/fragment data
- respect Do Not Track and Global Privacy Control
- document the limited analytics collection in the privacy policy
- wire the release build to the `GOOGLE_ANALYTICS_MEASUREMENT_ID` repository variable

## Privacy boundary

The analytics API cannot accept notebook or cell names, contents, IDs, paths, URLs, session values, Drive IDs, commands, outputs, errors, runner/kernel names, or language IDs. Every custom event uses the constant page location `https://web.runme.dev/` and an empty page referrer. Analytics is disabled unless the build receives a valid `G-...` Measurement ID and is running on the exact production hostname.

## Review findings addressed

- Drive-backed notebooks opened through their local mirror were incorrectly classified as local.
- Closing and reopening the same notebook was undercounted for the lifetime of the controller.
- A Jupyter cell without a selected kernel could be counted even though no execution request was sent.

## Validation

- `pnpm -C app exec vitest run src/lib/googleAnalytics.test.ts src/lib/notebookDataController.test.ts src/lib/notebookData.test.ts` — 69 tests passed
- `runme run build test` — build passed; 7 package tests passed
- production app build with the configured Measurement ID — ID and both custom event names present in the generated bundle
- `git diff --check` — passed
- GitHub checks — releaser, unit tests, and app tests passed
- unresolved review threads — none

## Configuration completed

- [x] Provide the GA4 **Web Data Stream Measurement ID** (`G-...`), not the numeric property ID.
- [x] Set it as the `GOOGLE_ANALYTICS_MEASUREMENT_ID` GitHub repository variable.
- [x] Disable Enhanced Measurement for the owning web data stream (confirmed by the property owner; public tag configuration propagation is pending).

## Launch follow-up

- [ ] Confirm minimal retention/access and no advertising-product links on that property.
- [ ] Complete the privacy/legal launch review, adding a consent gate first if required.
- [ ] After deployment, verify real network payloads in Tag Assistant/DebugView contain none of the forbidden fields and have exact event counts.
