### PR TITLE
Add per-hunk conflict resolution shortcuts

### DIFF
--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -1,5 +1,5 @@
 import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { parser_pb } from '../../runme/client'
@@ -560,5 +560,101 @@ describe('NotebookDiffContent', () => {
       "print('shared')\nprint('upstream only')\nprint('tail')"
     )
     expect(screen.getByText('0 modified')).toBeTruthy()
+  })
+
+  it('prevents concurrent conflict mutations across diff rows', async () => {
+    const createNotebook = (values: Array<[string, string]>) =>
+      create(parser_pb.NotebookSchema, {
+        cells: values.map(([refId, value]) =>
+          create(parser_pb.CellSchema, {
+            refId,
+            kind: parser_pb.CellKind.CODE,
+            languageId: 'python',
+            value,
+          })
+        ),
+        metadata: {},
+      })
+    const upstreamNotebook = createNotebook([
+      ['cell-a', 'shared a\nupstream a'],
+      ['cell-b', 'shared b\nupstream b'],
+    ])
+    const localNotebook = createNotebook([
+      ['cell-a', 'shared a\nlocal a'],
+      ['cell-b', 'shared b\nlocal b'],
+    ])
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    let allowSave: (() => void) | undefined
+    const saveAllowed = new Promise<void>((resolve) => {
+      allowSave = resolve
+    })
+    const localStore = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        await saveAllowed
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(upstreamNotebook, localNotebook),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={localStore}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    const insertButtons = screen.getAllByRole('button', {
+      name: 'Insert this upstream block into the local cell',
+    })
+    expect(insertButtons).toHaveLength(2)
+
+    fireEvent.click(insertButtons[0])
+    fireEvent.click(insertButtons[1])
+
+    await waitFor(() => {
+      expect(localStore.save).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      allowSave?.()
+      await saveAllowed
+    })
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', {
+          name: 'Insert this upstream block into the local cell',
+        })
+      ).toHaveLength(1)
+    })
+
+    const savedNotebook = fromJsonString(parser_pb.NotebookSchema, record.doc, {
+      ignoreUnknownFields: true,
+    })
+    expect(savedNotebook.cells[0]?.value).toBe('shared a\nupstream a\nlocal a')
+    expect(savedNotebook.cells[1]?.value).toBe('shared b\nlocal b')
   })
 })

--- a/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.test.tsx
@@ -153,6 +153,43 @@ describe('NotebookDiffContent', () => {
     ).toBeTruthy()
   })
 
+  it('shows one action for each upstream-only and local-only source block', () => {
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(
+        notebook(
+          "print('shared')\nprint('upstream one')\nprint('anchor')\nprint('upstream two')"
+        ),
+        notebook(
+          "print('shared')\nprint('local one')\nprint('anchor')\nprint('local two')"
+        )
+      ),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={{} as unknown as LocalNotebooks}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    expect(
+      screen.getAllByRole('button', {
+        name: 'Insert this upstream block into the local cell',
+      })
+    ).toHaveLength(2)
+    expect(
+      screen.getAllByRole('button', {
+        name: 'Remove this local-only block from the local cell',
+      })
+    ).toHaveLength(2)
+  })
+
   it('loads an older Drive revision from the Base revision selector', async () => {
     const upstreamNotebook = notebook("print('upstream')")
     const olderNotebook = notebook("print('older')")
@@ -263,6 +300,16 @@ describe('NotebookDiffContent', () => {
     expect(
       screen.queryByRole('button', {
         name: 'Remove cell from local notebook',
+      })
+    ).toBeNull()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Insert this upstream block into the local cell',
+      })
+    ).toBeNull()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Remove this local-only block from the local cell',
       })
     ).toBeNull()
     expect(screen.getByLabelText('Compare against')).toBeTruthy()
@@ -423,5 +470,95 @@ describe('NotebookDiffContent', () => {
     })
     expect(savedNotebook.cells).toHaveLength(0)
     expect(screen.getByText('0 inserted')).toBeTruthy()
+  })
+
+  it('applies source blocks independently and refreshes the diff', async () => {
+    const upstreamNotebook = notebook(
+      "print('shared')\nprint('upstream only')\nprint('tail')"
+    )
+    const localNotebook = notebook(
+      "print('shared')\nprint('local only')\nprint('tail')"
+    )
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const localStore = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+    const doc = {
+      id: 'conflict-diff',
+      base: { label: 'Upstream version', revisionId: 'upstream' },
+      compare: { label: 'Local version' },
+      diff: computeNotebookDiff(upstreamNotebook, localNotebook),
+      resolution: {
+        kind: 'notebook-sync-conflict' as const,
+        localUri: 'local://file/conflict',
+      },
+    }
+
+    render(
+      <NotebookStoreProvider initialStore={localStore}>
+        <NotebookDiffContent document={doc} />
+      </NotebookStoreProvider>
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert this upstream block into the local cell',
+      })
+    )
+
+    await waitFor(() => {
+      expect(localStore.save).toHaveBeenCalledTimes(1)
+      expect(
+        screen.queryByRole('button', {
+          name: 'Insert this upstream block into the local cell',
+        })
+      ).toBeNull()
+    })
+    let savedNotebook = fromJsonString(parser_pb.NotebookSchema, record.doc, {
+      ignoreUnknownFields: true,
+    })
+    expect(savedNotebook.cells[0]?.value).toBe(
+      "print('shared')\nprint('upstream only')\nprint('local only')\nprint('tail')"
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Remove this local-only block from the local cell',
+      })
+    )
+
+    await waitFor(() => {
+      expect(localStore.save).toHaveBeenCalledTimes(2)
+      expect(
+        screen.queryByRole('button', {
+          name: 'Remove this local-only block from the local cell',
+        })
+      ).toBeNull()
+    })
+    savedNotebook = fromJsonString(parser_pb.NotebookSchema, record.doc, {
+      ignoreUnknownFields: true,
+    })
+    expect(savedNotebook.cells[0]?.value).toBe(
+      "print('shared')\nprint('upstream only')\nprint('tail')"
+    )
+    expect(screen.getByText('0 modified')).toBeTruthy()
   })
 })

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -12,6 +12,8 @@ import type {
   TextDiffLine,
 } from '../../lib/notebookDiff/model'
 import {
+  applyConflictSourceHunk,
+  type ConflictSourceHunk,
   openNotebookDriveRevisionDiff,
   refreshNotebookConflictDiff,
   removeInsertedConflictCell,
@@ -85,40 +87,169 @@ function lineText(line: TextDiffLine, side: 'base' | 'compare'): string {
   return line.compareLine ?? ''
 }
 
+interface SourceDiffBlock {
+  kind: TextDiffLine['kind']
+  startLine: number
+  lines: TextDiffLine[]
+}
+
+function groupSourceDiffLines(lines: TextDiffLine[]): SourceDiffBlock[] {
+  return lines.reduce<SourceDiffBlock[]>((blocks, line, index) => {
+    const previous = blocks.at(-1)
+    if (previous?.kind === line.kind) {
+      previous.lines.push(line)
+    } else {
+      blocks.push({
+        kind: line.kind,
+        startLine: index,
+        lines: [line],
+      })
+    }
+    return blocks
+  }, [])
+}
+
+interface SourceHunkActionContext {
+  localUri: string
+  row: CellDiff
+  onApplied: (document: NotebookDiffDocument) => void
+  pendingHunk?: string
+  setPendingHunk: (hunk?: string) => void
+}
+
+function SourceHunkActionButton({
+  action,
+  hunk,
+}: {
+  action: SourceHunkActionContext
+  hunk: ConflictSourceHunk
+}) {
+  const { store } = useNotebookStore()
+  const isUpstream = hunk.kind === 'upstream'
+  const hunkKey = `${hunk.kind}:${hunk.startLine}`
+  const isApplying = action.pendingHunk === hunkKey
+  const label = isUpstream
+    ? 'Insert this upstream block into the local cell'
+    : 'Remove this local-only block from the local cell'
+
+  const applyHunk = async () => {
+    if (!store) {
+      return
+    }
+    action.setPendingHunk(hunkKey)
+    try {
+      const notebookData = getNotebookDataController().getNotebookData(
+        action.localUri
+      )
+      await notebookData?.flushPendingPersist()
+      const result = await applyConflictSourceHunk(
+        store,
+        action.localUri,
+        action.row,
+        hunk,
+        {
+          localNotebook: notebookData?.getSnapshot().notebook,
+        }
+      )
+      notebookData?.loadNotebook(result.localNotebook, { persist: false })
+      action.onApplied(result.document)
+      showToast({
+        message: isUpstream
+          ? 'Inserted upstream text into the local cell.'
+          : 'Removed local-only text from the local cell.',
+        tone: 'success',
+      })
+    } catch {
+      showToast({
+        message: isUpstream
+          ? 'Unable to insert upstream text. Refresh the diff and try again.'
+          : 'Unable to remove local-only text. Refresh the diff and try again.',
+        tone: 'error',
+      })
+    } finally {
+      action.setPendingHunk(undefined)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={!store || action.pendingHunk !== undefined}
+      aria-label={label}
+      title={label}
+      className={`absolute top-0 z-10 flex h-5 w-5 items-center justify-center rounded border bg-white font-sans text-xs font-semibold shadow-sm transition-colors disabled:cursor-wait disabled:opacity-60 ${
+        isUpstream
+          ? 'right-1 border-emerald-300 text-emerald-700 hover:bg-emerald-100'
+          : 'left-1 border-red-300 text-red-700 hover:bg-red-100'
+      }`}
+      onClick={() => {
+        void applyHunk()
+      }}
+    >
+      {isApplying ? '…' : isUpstream ? '→' : '×'}
+    </button>
+  )
+}
+
 function SourceDiff({
   diff,
   side,
   fallback,
+  action,
 }: {
   diff?: TextDiff
   side: 'base' | 'compare'
   fallback: string
+  action?: SourceHunkActionContext
 }) {
-  const lines = diff?.lines.length
+  const lines: TextDiffLine[] = diff?.lines.length
     ? diff.lines
     : fallback
-      ? fallback.split(/\r?\n/)
+      ? fallback.split(/\r?\n/).map((line) => ({
+          kind: 'equal',
+          baseLine: line,
+          compareLine: line,
+        }))
       : []
+  const blocks = groupSourceDiffLines(lines)
   return (
     <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words p-3 font-mono text-xs leading-5">
-      {lines.length === 0 ? (
+      {blocks.length === 0 ? (
         <span className="text-nb-text-faint">No source</span>
       ) : (
-        lines.map((line, index) => {
-          const normalizedLine =
-            typeof line === 'string'
-              ? ({
-                  kind: 'equal',
-                  baseLine: line,
-                  compareLine: line,
-                } as TextDiffLine)
-              : line
+        blocks.map((block) => {
+          const actionableKind =
+            side === 'base' && block.kind === 'removed'
+              ? 'upstream'
+              : side === 'compare' && block.kind === 'added'
+                ? 'local'
+                : undefined
           return (
             <div
-              key={`${side}-line-${index}`}
-              className={`min-h-5 rounded px-1 ${lineClass(normalizedLine, side)}`}
+              key={`${side}-block-${block.startLine}`}
+              className={`relative rounded ${lineClass(block.lines[0], side)}`}
             >
-              {lineText(normalizedLine, side) || ' '}
+              {block.lines.map((line, offset) => (
+                <div
+                  key={`${side}-line-${block.startLine + offset}`}
+                  className={`min-h-5 px-1 ${
+                    actionableKind === 'upstream' && offset === 0 ? 'pr-7' : ''
+                  } ${
+                    actionableKind === 'local' && offset === 0 ? 'pl-7' : ''
+                  }`}
+                >
+                  {lineText(line, side) || ' '}
+                </div>
+              ))}
+              {action && actionableKind && (
+                <SourceHunkActionButton
+                  action={action}
+                  hunk={{
+                    kind: actionableKind,
+                    startLine: block.startLine,
+                  }}
+                />
+              )}
             </div>
           )
         })
@@ -163,7 +294,15 @@ function OutputSummary({
   )
 }
 
-function CellPanel({ row, side }: { row: CellDiff; side: 'base' | 'compare' }) {
+function CellPanel({
+  row,
+  side,
+  sourceAction,
+}: {
+  row: CellDiff
+  side: 'base' | 'compare'
+  sourceAction?: SourceHunkActionContext
+}) {
   const cell = side === 'base' ? row.baseCell : row.compareCell
   const empty =
     (side === 'base' && row.kind === 'inserted') ||
@@ -195,6 +334,7 @@ function CellPanel({ row, side }: { row: CellDiff; side: 'base' | 'compare' }) {
         diff={row.sourceDiff}
         side={side}
         fallback={cell?.value ?? ''}
+        action={sourceAction}
       />
       {row.outputDiff?.changed && (
         <div className="border-t border-nb-border p-3">
@@ -459,6 +599,8 @@ function DiffRow({
   conflictLocalUri?: string
   onConflictDocumentChanged: (document: NotebookDiffDocument) => void
 }) {
+  const [pendingSourceHunk, setPendingSourceHunk] = useState<string>()
+
   if (row.kind === 'unchanged') {
     return (
       <details className="rounded border border-nb-border bg-nb-surface-2 text-sm text-nb-text-muted">
@@ -474,6 +616,17 @@ function DiffRow({
       </details>
     )
   }
+
+  const sourceAction =
+    conflictLocalUri && row.kind === 'modified' && row.sourceDiff?.changed
+      ? {
+          localUri: conflictLocalUri,
+          row,
+          onApplied: onConflictDocumentChanged,
+          pendingHunk: pendingSourceHunk,
+          setPendingHunk: setPendingSourceHunk,
+        }
+      : undefined
 
   return (
     <section className="rounded-lg border border-nb-border bg-nb-bg p-3 shadow-sm">
@@ -503,8 +656,8 @@ function DiffRow({
         )}
       </div>
       <div className="grid min-w-[920px] grid-cols-2 gap-3">
-        <CellPanel row={row} side="base" />
-        <CellPanel row={row} side="compare" />
+        <CellPanel row={row} side="base" sourceAction={sourceAction} />
+        <CellPanel row={row} side="compare" sourceAction={sourceAction} />
       </div>
     </section>
   )

--- a/app/src/components/NotebookDiff/NotebookDiffView.tsx
+++ b/app/src/components/NotebookDiff/NotebookDiffView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Badge, Button, ScrollArea, Text } from '@radix-ui/themes'
 
@@ -113,8 +113,13 @@ interface SourceHunkActionContext {
   localUri: string
   row: CellDiff
   onApplied: (document: NotebookDiffDocument) => void
-  pendingHunk?: string
-  setPendingHunk: (hunk?: string) => void
+  mutationLock: ConflictMutationLock
+}
+
+interface ConflictMutationLock {
+  pending?: string
+  acquire: (key: string) => boolean
+  release: () => void
 }
 
 function SourceHunkActionButton({
@@ -126,8 +131,8 @@ function SourceHunkActionButton({
 }) {
   const { store } = useNotebookStore()
   const isUpstream = hunk.kind === 'upstream'
-  const hunkKey = `${hunk.kind}:${hunk.startLine}`
-  const isApplying = action.pendingHunk === hunkKey
+  const hunkKey = `source:${action.row.id}:${hunk.kind}:${hunk.startLine}`
+  const isApplying = action.mutationLock.pending === hunkKey
   const label = isUpstream
     ? 'Insert this upstream block into the local cell'
     : 'Remove this local-only block from the local cell'
@@ -136,7 +141,9 @@ function SourceHunkActionButton({
     if (!store) {
       return
     }
-    action.setPendingHunk(hunkKey)
+    if (!action.mutationLock.acquire(hunkKey)) {
+      return
+    }
     try {
       const notebookData = getNotebookDataController().getNotebookData(
         action.localUri
@@ -167,14 +174,14 @@ function SourceHunkActionButton({
         tone: 'error',
       })
     } finally {
-      action.setPendingHunk(undefined)
+      action.mutationLock.release()
     }
   }
 
   return (
     <button
       type="button"
-      disabled={!store || action.pendingHunk !== undefined}
+      disabled={!store || action.mutationLock.pending !== undefined}
       aria-label={label}
       title={label}
       className={`absolute top-0 z-10 flex h-5 w-5 items-center justify-center rounded border bg-white font-sans text-xs font-semibold shadow-sm transition-colors disabled:cursor-wait disabled:opacity-60 ${
@@ -349,19 +356,24 @@ function RestoreDeletedCellButton({
   localUri,
   row,
   onRestored,
+  mutationLock,
 }: {
   localUri: string
   row: CellDiff
   onRestored: (document: NotebookDiffDocument) => void
+  mutationLock: ConflictMutationLock
 }) {
   const { store } = useNotebookStore()
-  const [isRestoring, setIsRestoring] = useState(false)
+  const mutationKey = `restore:${row.id}`
+  const isRestoring = mutationLock.pending === mutationKey
 
   const restoreCell = async () => {
     if (!store) {
       return
     }
-    setIsRestoring(true)
+    if (!mutationLock.acquire(mutationKey)) {
+      return
+    }
     try {
       const notebookData = getNotebookDataController().getNotebookData(localUri)
       await notebookData?.flushPendingPersist()
@@ -380,7 +392,7 @@ function RestoreDeletedCellButton({
         tone: 'error',
       })
     } finally {
-      setIsRestoring(false)
+      mutationLock.release()
     }
   }
 
@@ -390,7 +402,7 @@ function RestoreDeletedCellButton({
       size="1"
       color="red"
       variant="soft"
-      disabled={!store || isRestoring}
+      disabled={!store || mutationLock.pending !== undefined}
       aria-label="Insert upstream cell into local notebook"
       title="Insert upstream cell into local notebook"
       onClick={() => {
@@ -406,19 +418,24 @@ function RemoveInsertedCellButton({
   localUri,
   row,
   onRemoved,
+  mutationLock,
 }: {
   localUri: string
   row: CellDiff
   onRemoved: (document: NotebookDiffDocument) => void
+  mutationLock: ConflictMutationLock
 }) {
   const { store } = useNotebookStore()
-  const [isRemoving, setIsRemoving] = useState(false)
+  const mutationKey = `remove:${row.id}`
+  const isRemoving = mutationLock.pending === mutationKey
 
   const removeCell = async () => {
     if (!store) {
       return
     }
-    setIsRemoving(true)
+    if (!mutationLock.acquire(mutationKey)) {
+      return
+    }
     try {
       const notebookData = getNotebookDataController().getNotebookData(localUri)
       await notebookData?.flushPendingPersist()
@@ -437,7 +454,7 @@ function RemoveInsertedCellButton({
         tone: 'error',
       })
     } finally {
-      setIsRemoving(false)
+      mutationLock.release()
     }
   }
 
@@ -447,7 +464,7 @@ function RemoveInsertedCellButton({
       size="1"
       color="red"
       variant="soft"
-      disabled={!store || isRemoving}
+      disabled={!store || mutationLock.pending !== undefined}
       aria-label="Remove cell from local notebook"
       title="Remove cell from local notebook"
       onClick={() => {
@@ -594,13 +611,13 @@ function DiffRow({
   row,
   conflictLocalUri,
   onConflictDocumentChanged,
+  mutationLock,
 }: {
   row: CellDiff
   conflictLocalUri?: string
   onConflictDocumentChanged: (document: NotebookDiffDocument) => void
+  mutationLock: ConflictMutationLock
 }) {
-  const [pendingSourceHunk, setPendingSourceHunk] = useState<string>()
-
   if (row.kind === 'unchanged') {
     return (
       <details className="rounded border border-nb-border bg-nb-surface-2 text-sm text-nb-text-muted">
@@ -623,8 +640,7 @@ function DiffRow({
           localUri: conflictLocalUri,
           row,
           onApplied: onConflictDocumentChanged,
-          pendingHunk: pendingSourceHunk,
-          setPendingHunk: setPendingSourceHunk,
+          mutationLock,
         }
       : undefined
 
@@ -645,6 +661,7 @@ function DiffRow({
             localUri={conflictLocalUri}
             row={row}
             onRestored={onConflictDocumentChanged}
+            mutationLock={mutationLock}
           />
         )}
         {conflictLocalUri && row.kind === 'inserted' && (
@@ -652,6 +669,7 @@ function DiffRow({
             localUri={conflictLocalUri}
             row={row}
             onRemoved={onConflictDocumentChanged}
+            mutationLock={mutationLock}
           />
         )}
       </div>
@@ -663,43 +681,59 @@ function DiffRow({
   )
 }
 
-function ConflictResolutionActions({ localUri }: { localUri: string }) {
+function ConflictResolutionActions({
+  localUri,
+  mutationLock,
+}: {
+  localUri: string
+  mutationLock: ConflictMutationLock
+}) {
   const { store } = useNotebookStore()
-  const [isResolving, setIsResolving] = useState(false)
-  const [isRefreshing, setIsRefreshing] = useState(false)
+  const saveMutationKey = `save:${localUri}`
+  const refreshMutationKey = `refresh:${localUri}`
+  const isResolving = mutationLock.pending === saveMutationKey
+  const isRefreshing = mutationLock.pending === refreshMutationKey
 
-  const saveLocalVersion = async (force = false) => {
+  const saveLocalVersion = async () => {
     if (!store) {
       return
     }
-    setIsResolving(true)
+    if (!mutationLock.acquire(saveMutationKey)) {
+      return
+    }
     try {
-      await store.resolveConflictWithLocal(localUri, {
-        force,
-      })
-      showToast({
-        message: 'Saved local notebook version to upstream.',
-        tone: 'success',
-      })
-    } catch (error) {
-      if (error instanceof NotebookConflictChangedError && !force) {
+      try {
+        await store.resolveConflictWithLocal(localUri, {
+          force: false,
+        })
+      } catch (error) {
+        if (!(error instanceof NotebookConflictChangedError)) {
+          throw error
+        }
         const shouldOverwrite =
           typeof window !== 'undefined' &&
           window.confirm(
             'The upstream file changed again since this conflict was detected. ' +
               'Saving local version will replace the latest upstream version.'
           )
-        if (shouldOverwrite) {
-          await saveLocalVersion(true)
+        if (!shouldOverwrite) {
+          return
         }
-        return
+        await store.resolveConflictWithLocal(localUri, {
+          force: true,
+        })
       }
+      showToast({
+        message: 'Saved local notebook version to upstream.',
+        tone: 'success',
+      })
+    } catch {
       showToast({
         message: 'Unable to save local version. Please try again.',
         tone: 'error',
       })
     } finally {
-      setIsResolving(false)
+      mutationLock.release()
     }
   }
 
@@ -707,7 +741,9 @@ function ConflictResolutionActions({ localUri }: { localUri: string }) {
     if (!store) {
       return
     }
-    setIsRefreshing(true)
+    if (!mutationLock.acquire(refreshMutationKey)) {
+      return
+    }
     try {
       await refreshNotebookConflictDiff(store, localUri)
       showToast({
@@ -720,7 +756,7 @@ function ConflictResolutionActions({ localUri }: { localUri: string }) {
         tone: 'error',
       })
     } finally {
-      setIsRefreshing(false)
+      mutationLock.release()
     }
   }
 
@@ -730,7 +766,7 @@ function ConflictResolutionActions({ localUri }: { localUri: string }) {
         type="button"
         color="gray"
         variant="soft"
-        disabled={!store || isRefreshing || isResolving}
+        disabled={!store || mutationLock.pending !== undefined}
         onClick={() => {
           void refreshDiff()
         }}
@@ -740,7 +776,7 @@ function ConflictResolutionActions({ localUri }: { localUri: string }) {
       <Button
         type="button"
         color="amber"
-        disabled={!store || isResolving || isRefreshing}
+        disabled={!store || mutationLock.pending !== undefined}
         onClick={() => {
           void saveLocalVersion()
         }}
@@ -757,6 +793,24 @@ export function NotebookDiffContent({
   document: NotebookDiffDocument
 }) {
   const [currentDocument, setCurrentDocument] = useState(document)
+  const conflictMutationInFlight = useRef(false)
+  const [pendingConflictMutation, setPendingConflictMutation] =
+    useState<string>()
+  const mutationLock: ConflictMutationLock = {
+    pending: pendingConflictMutation,
+    acquire: (key) => {
+      if (conflictMutationInFlight.current) {
+        return false
+      }
+      conflictMutationInFlight.current = true
+      setPendingConflictMutation(key)
+      return true
+    },
+    release: () => {
+      conflictMutationInFlight.current = false
+      setPendingConflictMutation(undefined)
+    },
+  }
 
   useEffect(() => {
     setCurrentDocument(document)
@@ -804,6 +858,7 @@ export function NotebookDiffContent({
           {activeConflictResolution && (
             <ConflictResolutionActions
               localUri={activeConflictResolution.localUri}
+              mutationLock={mutationLock}
             />
           )}
         </div>
@@ -848,6 +903,7 @@ export function NotebookDiffContent({
               row={row}
               conflictLocalUri={activeConflictResolution?.localUri}
               onConflictDocumentChanged={setCurrentDocument}
+              mutationLock={mutationLock}
             />
           ))}
         </div>

--- a/app/src/lib/notebookDiff/conflict.test.ts
+++ b/app/src/lib/notebookDiff/conflict.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { RunmeMetadataKey, parser_pb } from '../../runme/client'
 import type LocalNotebooks from '../../storage/local'
 import {
+  applyConflictSourceHunk,
   openNotebookDriveRevisionDiff,
   openNotebookUpstreamDiff,
   removeInsertedConflictCell,
@@ -274,6 +275,172 @@ describe('removeInsertedConflictCell', () => {
     expect(result.localNotebook.cells).toHaveLength(1)
     expect(result.localNotebook.cells[0]?.value).toBe('keep me')
     expect(result.document.diff.summary.insertedCells).toBe(0)
+  })
+})
+
+describe('applyConflictSourceHunk', () => {
+  it('inserts one upstream block without replacing local-only text', async () => {
+    const upstreamNotebook = notebook([
+      cell({
+        refId: 'a',
+        value: 'shared\nupstream one\nupstream two\ntail',
+      }),
+      cell({ refId: 'b', value: 'upstream b' }),
+    ])
+    const staleLocalNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nlocal only\ntail' }),
+      cell({ refId: 'b', value: 'local b' }),
+    ])
+    const liveLocalNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nlocal only\ntail' }),
+      cell({ refId: 'b', value: 'unsaved local b' }),
+    ])
+    liveLocalNotebook.cells[0].outputs = [
+      create(parser_pb.CellOutputSchema, {
+        items: [],
+      }),
+    ]
+    const diff = computeNotebookDiff(upstreamNotebook, staleLocalNotebook)
+    const modifiedRow = diff.cells.find((row) => row.compareCell?.refId === 'a')
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(staleLocalNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+
+    const startLine = modifiedRow!.sourceDiff!.lines.findIndex(
+      (line) => line.kind === 'removed'
+    )
+    const result = await applyConflictSourceHunk(
+      store,
+      'local://file/conflict',
+      modifiedRow!,
+      { kind: 'upstream', startLine },
+      { localNotebook: liveLocalNotebook }
+    )
+
+    expect(result.localNotebook.cells[0]?.value).toBe(
+      'shared\nupstream one\nupstream two\nlocal only\ntail'
+    )
+    expect(result.localNotebook.cells[0]?.outputs).toEqual([])
+    expect(result.localNotebook.cells[1]?.value).toBe('unsaved local b')
+    expect(
+      result.localNotebook.cells[0]?.metadata?.[RunmeMetadataKey.UpdatedAt]
+    ).toBeTruthy()
+  })
+
+  it('removes one local-only block without inserting upstream text', async () => {
+    const upstreamNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nupstream only\ntail' }),
+    ])
+    const localNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nlocal one\nlocal two\ntail' }),
+    ])
+    localNotebook.cells[0].outputs = [
+      create(parser_pb.CellOutputSchema, {
+        items: [],
+      }),
+    ]
+    const diff = computeNotebookDiff(upstreamNotebook, localNotebook)
+    const modifiedRow = diff.cells[0]
+    let record = {
+      id: 'local://file/conflict',
+      name: 'conflict.json',
+      doc: serialize(localNotebook),
+      conflict: {
+        detectedAt: '2026-06-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream',
+        localChecksumAtDetection: 'local',
+      },
+    }
+    const store = {
+      files: {
+        get: vi.fn(async () => record),
+      },
+      getConflictUpstreamDoc: vi.fn(async () => serialize(upstreamNotebook)),
+      save: vi.fn(async (_localUri: string, saved: parser_pb.Notebook) => {
+        record = {
+          ...record,
+          doc: serialize(saved),
+        }
+      }),
+    } as unknown as LocalNotebooks
+
+    const startLine = modifiedRow.sourceDiff!.lines.findIndex(
+      (line) => line.kind === 'added'
+    )
+    const result = await applyConflictSourceHunk(
+      store,
+      'local://file/conflict',
+      modifiedRow,
+      { kind: 'local', startLine }
+    )
+
+    expect(result.localNotebook.cells[0]?.value).toBe('shared\ntail')
+    expect(result.localNotebook.cells[0]?.outputs).toEqual([])
+    expect(result.document.diff.summary.modifiedCells).toBe(1)
+  })
+
+  it('rejects a stale hunk instead of editing newly changed local source', async () => {
+    const upstreamNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nupstream only' }),
+    ])
+    const localNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nlocal only' }),
+    ])
+    const liveLocalNotebook = notebook([
+      cell({ refId: 'a', value: 'shared\nnew local edit' }),
+    ])
+    const modifiedRow = computeNotebookDiff(upstreamNotebook, localNotebook)
+      .cells[0]
+    const store = {
+      files: {
+        get: vi.fn(async () => ({
+          id: 'local://file/conflict',
+          name: 'conflict.json',
+          doc: serialize(localNotebook),
+          conflict: {
+            detectedAt: '2026-06-01T00:00:00.000Z',
+            upstreamChecksum: 'upstream',
+            localChecksumAtDetection: 'local',
+          },
+        })),
+      },
+      save: vi.fn(),
+    } as unknown as LocalNotebooks
+
+    await expect(
+      applyConflictSourceHunk(
+        store,
+        'local://file/conflict',
+        modifiedRow,
+        {
+          kind: 'upstream',
+          startLine: modifiedRow.sourceDiff!.lines.findIndex(
+            (line) => line.kind === 'removed'
+          ),
+        },
+        { localNotebook: liveLocalNotebook }
+      )
+    ).rejects.toThrow('The local cell changed after this diff was created')
+    expect(store.save).not.toHaveBeenCalled()
   })
 })
 

--- a/app/src/lib/notebookDiff/conflict.ts
+++ b/app/src/lib/notebookDiff/conflict.ts
@@ -27,6 +27,12 @@ export interface ConflictCellMutationOptions {
 
 export type RestoreDeletedConflictCellOptions = ConflictCellMutationOptions
 export type RemoveInsertedConflictCellOptions = ConflictCellMutationOptions
+export type ApplyConflictSourceHunkOptions = ConflictCellMutationOptions
+
+export interface ConflictSourceHunk {
+  kind: 'upstream' | 'local'
+  startLine: number
+}
 
 type DriveDiffResolutionKind = NonNullable<
   NotebookDiffDocument['resolution']
@@ -381,6 +387,168 @@ function findInsertedCellIndex(
   }
 
   throw new Error('Local cell is no longer present at the expected position.')
+}
+
+function findModifiedCellIndex(
+  localNotebook: parser_pb.Notebook,
+  row: CellDiff
+): number {
+  const localCells = localNotebook.cells ?? []
+  const compareCell = row.compareCell
+  const compareIndex = row.compareIndex
+  const refId = compareCell?.refId
+
+  if (refId) {
+    const matchingIndexes = localCells.flatMap((cell, index) =>
+      cell.refId === refId ? [index] : []
+    )
+    if (matchingIndexes.length === 1) {
+      return matchingIndexes[0]
+    }
+    if (matchingIndexes.length > 1) {
+      const indexedCandidate =
+        compareIndex === undefined ? undefined : localCells[compareIndex]
+      if (
+        compareIndex !== undefined &&
+        indexedCandidate?.refId === refId &&
+        compareCell &&
+        indexedCandidate.kind === compareCell.kind &&
+        indexedCandidate.languageId === compareCell.languageId
+      ) {
+        return compareIndex
+      }
+      throw new Error(`Local notebook has duplicate cell refId ${refId}.`)
+    }
+    throw new Error(`Local cell ${refId} is no longer present.`)
+  }
+
+  if (compareCell && compareIndex !== undefined) {
+    const candidate = localCells[compareIndex]
+    if (
+      candidate &&
+      !candidate.refId &&
+      candidate.kind === compareCell.kind &&
+      candidate.languageId === compareCell.languageId
+    ) {
+      return compareIndex
+    }
+  }
+
+  throw new Error('Local cell is no longer present at the expected position.')
+}
+
+function splitSourceLines(source: string): string[] {
+  if (!source) {
+    return []
+  }
+  return source.replace(/\r\n/g, '\n').split('\n')
+}
+
+export async function applyConflictSourceHunk(
+  store: LocalNotebooks,
+  localUri: string,
+  row: CellDiff,
+  hunk: ConflictSourceHunk,
+  options: ApplyConflictSourceHunkOptions = {}
+): Promise<ConflictCellMutationResult> {
+  if (
+    row.kind !== 'modified' ||
+    !row.baseCell ||
+    !row.compareCell ||
+    !row.sourceDiff?.changed
+  ) {
+    throw new Error('Only source hunks from modified cells can be applied.')
+  }
+
+  const expectedLineKind = hunk.kind === 'upstream' ? 'removed' : 'added'
+  const diffLines = row.sourceDiff.lines
+  const firstLine = diffLines[hunk.startLine]
+  if (
+    !firstLine ||
+    firstLine.kind !== expectedLineKind ||
+    diffLines[hunk.startLine - 1]?.kind === expectedLineKind
+  ) {
+    throw new Error('The selected source hunk is no longer available.')
+  }
+  let endLine = hunk.startLine + 1
+  while (diffLines[endLine]?.kind === expectedLineKind) {
+    endLine += 1
+  }
+  const hunkLines = diffLines.slice(hunk.startLine, endLine)
+
+  const record = await store.files.get(localUri)
+  if (!record) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+  if (!record.conflict) {
+    throw new Error(`Local notebook ${localUri} does not have a conflict`)
+  }
+
+  const localNotebook = options.localNotebook
+    ? clone(parser_pb.NotebookSchema, options.localNotebook)
+    : parseNotebookJson(record.doc ?? '', 'local')
+  const localIndex = findModifiedCellIndex(localNotebook, row)
+  const localCell = localNotebook.cells[localIndex]
+  if (!localCell) {
+    throw new Error('Local cell is no longer present at the expected position.')
+  }
+
+  if (localCell.value !== row.compareCell.value) {
+    throw new Error(
+      'The local cell changed after this diff was created. Refresh the diff and try again.'
+    )
+  }
+
+  const localLines = splitSourceLines(localCell.value)
+  const localStart = diffLines
+    .slice(0, hunk.startLine)
+    .filter((line) => line.kind !== 'removed').length
+
+  if (hunk.kind === 'upstream') {
+    localLines.splice(
+      localStart,
+      0,
+      ...hunkLines.map((line) => line.baseLine ?? '')
+    )
+  } else {
+    const expectedLocalLines = hunkLines.map((line) => line.compareLine ?? '')
+    const currentLocalLines = localLines.slice(
+      localStart,
+      localStart + expectedLocalLines.length
+    )
+    if (
+      currentLocalLines.length !== expectedLocalLines.length ||
+      currentLocalLines.some(
+        (line, index) => line !== expectedLocalLines[index]
+      )
+    ) {
+      throw new Error(
+        'The local source no longer matches this diff. Refresh the diff and try again.'
+      )
+    }
+    localLines.splice(localStart, expectedLocalLines.length)
+  }
+
+  localCell.value = localLines.join('\n')
+  localCell.outputs = []
+  localCell.metadata ??= {}
+  localCell.metadata[RunmeMetadataKey.UpdatedAt] = new Date().toISOString()
+
+  await store.save(localUri, localNotebook)
+
+  const updatedRecord = await store.files.get(localUri)
+  if (!updatedRecord) {
+    throw new Error(`Local notebook record not found for ${localUri}`)
+  }
+  return {
+    document: await registerConflictDiffDocument(
+      store,
+      localUri,
+      updatedRecord,
+      record.conflict
+    ),
+    localNotebook,
+  }
 }
 
 export async function removeInsertedConflictCell(


### PR DESCRIPTION
## Summary

- add an `→` action to every contiguous upstream-only source block
- add an `×` action to every contiguous local-only source block
- apply only the selected block and immediately recompute the conflict diff
- preserve unrelated live notebook edits, clear stale outputs, reject stale hunks, and serialize hunk actions within a cell
- retain the whole-cell restore/remove shortcuts from PR #278

## Why

PR #278 added whole-cell restore/remove actions, but modified cells still had no block-level affordances. The first draft of this PR replaced the entire local cell source, which was too coarse: users need VS Code-style controls that apply or remove one source delta at a time.

## User impact

Each upstream-only source block now has an arrow at the right edge of the upstream pane. Each local-only source block has a remove control at the left edge of the local pane. Both remain visible together in the center gutter, including when the diff is horizontally scrollable.

## Validation

- `runme run build test`
- `pnpm --dir app exec vitest run` — 68 files, 618 tests passed
- focused conflict tests — 22 tests passed
- ESLint on all four changed source/test files
- real Drive-backed conflict with two upstream-only and two local-only blocks:
  - verified two arrows and two remove controls
  - applied each block independently
  - verified the diff changed from `1 modified` to `0 modified`
