### PR TITLE
Add sanitized analytics page view

### DIFF
--- a/app/assets/policies/privacypolicy.html
+++ b/app/assets/policies/privacypolicy.html
@@ -66,19 +66,21 @@
 
       <h2>Usage Analytics</h2>
       <p>
-        We use Google Analytics on web.runme.dev to count successful notebook
-        opens and accepted code-cell execution attempts. We send only coarse
-        categories, such as whether a notebook came from local storage, Google
-        Drive, or an HTTP address, whether it was opened read-only, and which
-        type of execution backend was used.
+        We use Google Analytics on web.runme.dev to count application visits,
+        successful notebook opens, and accepted code-cell execution attempts. We
+        send only coarse categories, such as whether a notebook came from local
+        storage, Google Drive, or an HTTP address, whether it was opened
+        read-only, and which type of execution backend was used.
       </p>
       <p>
         We do not send notebook or cell names, contents, identifiers, paths,
         URLs, session values, Google Drive file identifiers, commands, outputs,
         or errors to Google Analytics. Automatic page views and advertising
-        signals are disabled, and the page location sent with these events is
-        limited to <a href="https://web.runme.dev/">https://web.runme.dev/</a>
-        without a query string or fragment.
+        signals are disabled. Instead, each application load sends one manual
+        page view, and the page location sent with it and the other analytics
+        events is limited to
+        <a href="https://web.runme.dev/">https://web.runme.dev/</a> without a
+        query string or fragment.
       </p>
       <p>
         Google Analytics may process standard request information such as

--- a/app/src/lib/googleAnalytics.test.ts
+++ b/app/src/lib/googleAnalytics.test.ts
@@ -52,7 +52,7 @@ describe('GoogleAnalyticsClient', () => {
     expect(document.getElementById('runme-google-analytics')).toBeNull()
   })
 
-  it('initializes once with privacy-preserving configuration', () => {
+  it('initializes once and emits one sanitized page view', () => {
     const globalObject: { dataLayer?: Array<ArrayLike<unknown>> } = {}
     const client = new GoogleAnalyticsClient(validOptions({ globalObject }))
 
@@ -73,7 +73,7 @@ describe('GoogleAnalyticsClient', () => {
     const commands = globalObject.dataLayer?.map((command) =>
       Array.from(command)
     )
-    expect(commands).toHaveLength(2)
+    expect(commands).toHaveLength(3)
     expect(commands?.[0]?.[0]).toBe('js')
     expect(commands?.[0]?.[1]).toBeInstanceOf(Date)
     expect(commands?.[1]).toEqual([
@@ -83,6 +83,15 @@ describe('GoogleAnalyticsClient', () => {
         allow_ad_personalization_signals: false,
         allow_google_signals: false,
         send_page_view: false,
+        page_location: 'https://web.runme.dev/',
+        page_referrer: '',
+        page_title: 'Runme Web',
+      },
+    ])
+    expect(commands?.[2]).toEqual([
+      'event',
+      'page_view',
+      {
         page_location: 'https://web.runme.dev/',
         page_referrer: '',
         page_title: 'Runme Web',
@@ -102,7 +111,7 @@ describe('GoogleAnalyticsClient', () => {
     client.trackCellExecuted({ executionBackend: 'jupyter' })
 
     const events = globalObject.dataLayer
-      ?.slice(2)
+      ?.slice(3)
       .map((command) => Array.from(command))
     expect(events).toEqual([
       [

--- a/app/src/lib/googleAnalytics.ts
+++ b/app/src/lib/googleAnalytics.ts
@@ -116,6 +116,7 @@ export class GoogleAnalyticsClient {
         ...SAFE_PAGE_CONTEXT,
       })
       this.gtag = gtag
+      this.sendEvent('page_view', {})
       return true
     } catch {
       this.gtag = undefined
@@ -140,7 +141,7 @@ export class GoogleAnalyticsClient {
   }
 
   private sendEvent(
-    eventName: 'notebook_opened' | 'cell_executed',
+    eventName: 'page_view' | 'notebook_opened' | 'cell_executed',
     params: Record<string, string>
   ): void {
     try {


### PR DESCRIPTION
## Summary

- emit one manual `page_view` when the production app initializes
- keep automatic page views disabled and replace the real URL/referrer with the constant safe page context
- update the privacy policy to disclose application-visit counting
- verify repeated initialization does not double-count a visit

## Why

The initial Analytics rollout intentionally disabled page views to avoid sending notebook URLs, session values, query strings, fragments, and referrers. We still want to measure how often people open `web.runme.dev`, so this adds an explicit page-view event containing only:

- `page_location: https://web.runme.dev/`
- an empty `page_referrer`
- the constant title `Runme Web`

The existing exact-hostname, Do Not Track, and Global Privacy Control gates remain unchanged. Deployments whose browser-visible hostname is not exactly `web.runme.dev` do not emit Analytics.

## Validation

- `pnpm -C app exec vitest run src/lib/googleAnalytics.test.ts` — 13 tests passed
- `runme run build test` — build passed; 7 package tests passed
- `git diff --check` — passed
