### PR TITLE
Add browser instructions for AI agents

### DIFF
--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -74,28 +74,26 @@ describe("WebMcpToolRegistrationHost", () => {
     );
   });
 
-  it("registers ExecuteCode and unregisters it on cleanup", async () => {
-    let registered:
-      | {
-          tool: {
-            name: string;
-            title: string;
-            description: string;
-            inputSchema: Record<string, unknown>;
-            annotations: {
-              readOnlyHint: boolean;
-              untrustedContentHint: boolean;
-            };
-            execute: (input: { code?: unknown }) => Promise<string>;
-          };
-          signal?: AbortSignal;
-        }
-      | undefined;
+  it("registers WebMCP tools and unregisters them on cleanup", async () => {
+    const registered: Array<{
+      tool: {
+        name: string;
+        title: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        annotations: {
+          readOnlyHint: boolean;
+          untrustedContentHint: boolean;
+        };
+        execute: (input: Record<string, unknown>) => Promise<string> | string;
+      };
+      signal?: AbortSignal;
+    }> = [];
     const registerTool = vi.fn((tool, options?: { signal?: AbortSignal }) => {
-      registered = {
+      registered.push({
         tool,
         signal: options?.signal,
-      };
+      });
     });
     Object.defineProperty(navigator, "modelContext", {
       configurable: true,
@@ -106,14 +104,16 @@ describe("WebMcpToolRegistrationHost", () => {
 
     const rendered = render(<WebMcpToolRegistrationHost />);
 
-    expect(registerTool).toHaveBeenCalledTimes(1);
-    expect(registered?.tool.name).toBe("ExecuteCode");
-    expect(registered?.tool.title).toBe("Runme Execute Code");
-    expect(registered?.tool.annotations).toEqual({
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    const executeCode = registered.find(
+      ({ tool }) => tool.name === "ExecuteCode",
+    );
+    expect(executeCode?.tool.title).toBe("Runme Execute Code");
+    expect(executeCode?.tool.annotations).toEqual({
       readOnlyHint: false,
       untrustedContentHint: true,
     });
-    expect(registered?.tool.inputSchema).toEqual({
+    expect(executeCode?.tool.inputSchema).toEqual({
       type: "object",
       additionalProperties: false,
       properties: {
@@ -123,7 +123,7 @@ describe("WebMcpToolRegistrationHost", () => {
     });
 
     await expect(
-      registered?.tool.execute({
+      executeCode?.tool.execute({
         code: "console.log('hello')",
       }),
     ).resolves.toBe("webmcp output");
@@ -155,9 +155,33 @@ describe("WebMcpToolRegistrationHost", () => {
     });
     expect(appConsoleDataMock.failExecution).not.toHaveBeenCalled();
 
-    expect(registered?.signal?.aborted).toBe(false);
+    const instructions = registered.find(
+      ({ tool }) => tool.name === "readInstructionsForCodex",
+    );
+    expect(instructions?.tool.title).toBe(
+      "Read Runme Instructions for Codex",
+    );
+    expect(instructions?.tool.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: false,
+    });
+    expect(instructions?.tool.inputSchema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    });
+    expect(instructions?.tool.execute({})).toContain(window.location.origin);
+    expect(instructions?.tool.execute({})).toContain(
+      "await app.getSessionID()",
+    );
+
+    expect(registered.every(({ signal }) => signal?.aborted === false)).toBe(
+      true,
+    );
     rendered.unmount();
-    expect(registered?.signal?.aborted).toBe(true);
+    expect(registered.every(({ signal }) => signal?.aborted === true)).toBe(
+      true,
+    );
   });
 
   it("marks the AppConsole cell failed when ExecuteCode rejects", async () => {

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -3,6 +3,13 @@ import { useEffect } from "react";
 import { appLogger } from "../../lib/logging/runtime";
 import { getAppConsoleData } from "../../lib/appConsole/appConsoleController";
 import {
+  buildReadInstructionsForCodexInputSchema,
+  readInstructionsForCodex,
+  READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
+  READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+  READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE,
+} from "../../lib/runtime/codexInstructions";
+import {
   buildExecuteCodeInputSchema,
   EXECUTE_CODE_TOOL_DESCRIPTION,
   EXECUTE_CODE_TOOL_NAME,
@@ -25,7 +32,10 @@ type ModelContextLike = {
         readOnlyHint: boolean;
         untrustedContentHint: boolean;
       };
-      execute: (input: { code?: unknown }, client: ModelContextClientLike) => Promise<string>;
+      execute: (
+        input: Record<string, unknown>,
+        client: ModelContextClientLike,
+      ) => Promise<string> | string;
     },
     options?: { signal?: AbortSignal },
   ) => void;
@@ -115,17 +125,36 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         },
       );
-      appLogger.info("WebMCP ExecuteCode tool registered", {
+      modelContext.registerTool(
+        {
+          name: READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+          title: READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE,
+          description: READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
+          inputSchema: buildReadInstructionsForCodexInputSchema(),
+          annotations: {
+            readOnlyHint: true,
+            untrustedContentHint: false,
+          },
+          execute: () => readInstructionsForCodex(window.location.origin),
+        },
+        {
+          signal: registrationController.signal,
+        },
+      );
+      appLogger.info("WebMCP tools registered", {
         attrs: {
           scope: "webmcp",
-          toolName: EXECUTE_CODE_TOOL_NAME,
+          toolNames: [
+            EXECUTE_CODE_TOOL_NAME,
+            READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+          ],
         },
       });
     } catch (error) {
+      registrationController.abort();
       appLogger.error("Failed to register WebMCP tool", {
         attrs: {
           scope: "webmcp",
-          toolName: EXECUTE_CODE_TOOL_NAME,
           error: String(error),
         },
       });
@@ -134,10 +163,13 @@ export default function WebMcpToolRegistrationHost() {
 
     return () => {
       registrationController.abort();
-      appLogger.info("WebMCP ExecuteCode tool unregistered", {
+      appLogger.info("WebMCP tools unregistered", {
         attrs: {
           scope: "webmcp",
-          toolName: EXECUTE_CODE_TOOL_NAME,
+          toolNames: [
+            EXECUTE_CODE_TOOL_NAME,
+            READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+          ],
         },
       });
     };

--- a/app/src/lib/runtime/codexInstructions.test.ts
+++ b/app/src/lib/runtime/codexInstructions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildReadInstructionsForCodexInputSchema,
+  READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
+  readInstructionsForCodex,
+} from './codexInstructions'
+
+describe('readInstructionsForCodex', () => {
+  it('tells Codex to read the instructions first', () => {
+    expect(READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION).toContain(
+      'Call this tool first to understand the Runme page.'
+    )
+  })
+
+  it('uses the supplied runtime origin in Runme URLs', () => {
+    const instructions = readInstructionsForCodex(
+      'https://runme.self-hosted.example:8443/path?ignored=true'
+    )
+
+    expect(instructions).toContain(
+      'https://runme.self-hosted.example:8443/?session=<session-id>'
+    )
+    expect(instructions).not.toContain('https://runme.example')
+  })
+
+  it('includes the portable Runme collaboration rules', () => {
+    const instructions = readInstructionsForCodex('https://runme.example')
+
+    expect(instructions).toContain('WebMCP')
+    expect(instructions).toContain('ExecuteCode')
+    expect(instructions).toContain('await app.getSessionID()')
+    expect(instructions).toContain('local://')
+    expect(instructions).toContain("kind: 'markup'")
+    expect(instructions).toContain('expectedRevision')
+    expect(instructions).toContain('NOTEBOOK_UPDATE_FAILED')
+    expect(instructions).toContain('verify')
+  })
+
+  it('does not include deployment-specific plugin instructions', () => {
+    const instructions = readInstructionsForCodex('https://runme.example')
+
+    expect(instructions).not.toMatch(
+      /OpenAI|monorepo|RUNME_PLUGIN_ROOT|manage_runner|go\/runme|9988/
+    )
+  })
+
+  it('defines a strict no-argument input schema', () => {
+    expect(buildReadInstructionsForCodexInputSchema()).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    })
+  })
+})

--- a/app/src/lib/runtime/codexInstructions.ts
+++ b/app/src/lib/runtime/codexInstructions.ts
@@ -1,0 +1,87 @@
+type JsonRecord = Record<string, unknown>
+
+export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME = 'readInstructionsForCodex'
+export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE =
+  'Read Runme Instructions for Codex'
+export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION =
+  'Call this tool first to understand the Runme page. It returns Markdown instructions for safely controlling this Runme instance with WebMCP.'
+
+export function buildReadInstructionsForCodexInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {},
+  }
+}
+
+export function readInstructionsForCodex(origin: string): string {
+  const runmeOrigin = new URL(origin).origin
+  const sessionUrl = `${runmeOrigin}/?session=<session-id>`
+
+  return `# Runme browser instructions for Codex
+
+This Runme instance is served from ${runmeOrigin}.
+
+## Use WebMCP
+
+- Inspect existing in-app browser tabs before opening another tab.
+- Reuse a Runme tab whose URL begins with ${runmeOrigin}. A session URL has the form \`${sessionUrl}\`.
+- Claim the selected tab and use its page-provided WebMCP tools for notebook reads, edits, and execution.
+- Use the \`ExecuteCode\` WebMCP tool to run AppKernel JavaScript. Print values explicitly with \`console.log(...)\`.
+- Do not edit or execute notebook cells through DOM clicks, keyboard automation, or Computer Use. If WebMCP is unavailable, stop and tell the user what must be done manually.
+
+## Verify the browser session
+
+The URL's \`session\` query parameter identifies a candidate tab. Before changing a notebook, call \`ExecuteCode\` with:
+
+\`\`\`js
+console.log(await app.getSessionID())
+\`\`\`
+
+Continue only when the printed value matches the selected tab's \`session\` query parameter. If they differ, do not mutate a notebook in that tab.
+
+## Bind the notebook before editing
+
+Resolve the requested notebook once, save its concrete \`local://...\` URI, and use that URI for every later operation. Do not keep targeting whichever notebook happens to be current because the user may switch tabs or notebooks while work is in progress.
+
+\`\`\`js
+const initial = await notebooks.get()
+const notebookUri = initial.summary?.uri || initial.handle?.uri
+
+if (!notebookUri?.startsWith('local://')) {
+  throw new Error(\`Unable to resolve notebook URI: \${notebookUri}\`)
+}
+
+const doc = await notebooks.get({ uri: notebookUri })
+console.log(JSON.stringify({
+  uri: notebookUri,
+  revision: doc.handle?.revision,
+  name: doc.summary?.name,
+}))
+\`\`\`
+
+If the user's notebook reference is ambiguous, ask which notebook to use before making a change.
+
+## Make safe notebook changes
+
+- Inspect \`await notebooks.help()\` when helper availability is uncertain.
+- Use \`notebooks.appendCell\` for a simple append. A Markdown cell uses \`kind: 'markup'\`, not \`kind: 'markdown'\`.
+- Use \`notebooks.update\` for multi-cell or idempotent edits. Pass \`target: { uri: notebookUri }\` and \`expectedRevision: doc.handle.revision\` when a revision is available.
+- Prefer updating a stable named cell over blindly appending duplicate status or result cells.
+- Build large cell values as data (for example with \`JSON.stringify\`) instead of hand-escaping nested JavaScript.
+- Catch and inspect \`NOTEBOOK_UPDATE_FAILED\`; a multi-operation update can partially succeed.
+
+After every mutation, read the same URI again and verify the exact \`refId\`, \`languageId\`, value, and revision that matter to the request:
+
+\`\`\`js
+const verified = await notebooks.get({ uri: notebookUri })
+console.log(JSON.stringify({
+  uri: verified.handle?.uri,
+  revision: verified.handle?.revision,
+  cells: verified.notebook?.cells,
+}))
+\`\`\`
+
+Treat the reread result—not the visible selection—as the source of truth.
+`
+}

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -9,6 +9,13 @@ the intended tab and notebook safely before using those tools.
 This is the supported integration path for Codex and other external agents.
 Runme does not include a built-in AI Chat panel.
 
+Runme also exposes the read-only `readInstructionsForCodex` WebMCP tool. It
+returns a concise Markdown version of the safe browser workflow with URLs
+generated from the current page origin. Call it before `ExecuteCode` when the
+controller needs Runme-specific operating instructions. Because the origin is
+resolved at runtime, its links work for hosted, proxied, and self-hosted Runme
+instances.
+
 Browser tab control is exclusive: one controller session can control one tab
 at a time. Concurrent sessions should target different Runme tabs.
 


### PR DESCRIPTION
## Summary

- Add a read-only WebMCP tool that gives AI agents page-specific operating instructions.
- Generate Runme URLs from the current runtime origin so hosted, proxied, and self-hosted deployments receive correct guidance.
- Document and test tool registration, safe notebook targeting, and cleanup behavior.

## Why

Browser-based AI agents need a discoverable first step for understanding the Runme page before reading, editing, or executing notebooks. The returned Markdown establishes session verification, stable notebook targeting, WebMCP usage, and post-mutation verification.

## Validation

- `runme run build test`
- Focused app tests: 9 passed
- Live WebMCP verification against the local development server