### PR TITLE
Support analytics on gateway hosts

### DIFF
--- a/app/assets/policies/privacypolicy.html
+++ b/app/assets/policies/privacypolicy.html
@@ -66,11 +66,12 @@
 
       <h2>Usage Analytics</h2>
       <p>
-        We use Google Analytics on web.runme.dev to count application visits,
-        successful notebook opens, and accepted code-cell execution attempts. We
-        send only coarse categories, such as whether a notebook came from local
-        storage, Google Drive, or an HTTP address, whether it was opened
-        read-only, and which type of execution backend was used.
+        We use Google Analytics on approved Runme Web production hosts to count
+        application visits, successful notebook opens, and accepted code-cell
+        execution attempts. We send only coarse categories, such as whether a
+        notebook came from local storage, Google Drive, or an HTTP address,
+        whether it was opened read-only, and which type of execution backend
+        was used.
       </p>
       <p>
         We do not send notebook or cell names, contents, identifiers, paths,
@@ -78,9 +79,8 @@
         or errors to Google Analytics. Automatic page views and advertising
         signals are disabled. Instead, each application load sends one manual
         page view, and the page location sent with it and the other analytics
-        events is limited to
-        <a href="https://web.runme.dev/">https://web.runme.dev/</a> without a
-        query string or fragment.
+        events is limited to the current page origin (the scheme, hostname, and
+        optional port) without a path, query string, or fragment.
       </p>
       <p>
         Google Analytics may process standard request information such as

--- a/app/src/lib/googleAnalytics.test.ts
+++ b/app/src/lib/googleAnalytics.test.ts
@@ -11,6 +11,7 @@ const validOptions = (
 ): GoogleAnalyticsClientOptions => ({
   measurementId: 'G-TEST123',
   hostname: 'web.runme.dev',
+  origin: 'https://web.runme.dev',
   doNotTrack: null,
   globalPrivacyControl: false,
   document,
@@ -39,6 +40,9 @@ describe('GoogleAnalyticsClient', () => {
     ['missing ID', { measurementId: undefined }],
     ['invalid ID', { measurementId: '123456789' }],
     ['non-production host', { hostname: 'localhost' }],
+    ['gateway lookalike', { hostname: 'example.runme.gateway.test' }],
+    ['gateway without a suffix', { hostname: 'runme.gateway.' }],
+    ['origin mismatch', { origin: 'https://runme.gateway.example.test' }],
     ['Do Not Track', { doNotTrack: '1' }],
     ['Global Privacy Control', { globalPrivacyControl: true }],
   ] as const)('stays disabled for %s', (_name, overrides) => {
@@ -50,6 +54,41 @@ describe('GoogleAnalyticsClient', () => {
     expect(client.initialize()).toBe(false)
     expect(globalObject).toEqual({})
     expect(document.getElementById('runme-google-analytics')).toBeNull()
+  })
+
+  it('initializes on a generic Runme gateway hostname', () => {
+    const globalObject: { dataLayer?: Array<ArrayLike<unknown>> } = {}
+    const client = new GoogleAnalyticsClient(
+      validOptions({
+        hostname: 'runme.gateway.example.test',
+        origin:
+          'https://runme.gateway.example.test:8443/private/notebook?token=secret#cell',
+        globalObject,
+      })
+    )
+
+    expect(client.initialize()).toBe(true)
+    expect(
+      globalObject.dataLayer?.map((command) => Array.from(command))
+    ).toEqual([
+      ['js', expect.any(Date)],
+      [
+        'config',
+        'G-TEST123',
+        expect.objectContaining({
+          page_location: 'https://runme.gateway.example.test:8443/',
+          page_referrer: '',
+        }),
+      ],
+      [
+        'event',
+        'page_view',
+        expect.objectContaining({
+          page_location: 'https://runme.gateway.example.test:8443/',
+          page_referrer: '',
+        }),
+      ],
+    ])
   })
 
   it('initializes once and emits one sanitized page view', () => {

--- a/app/src/lib/googleAnalytics.ts
+++ b/app/src/lib/googleAnalytics.ts
@@ -15,27 +15,47 @@ type AnalyticsGlobal = {
   gtag?: Gtag
 }
 
+type AnalyticsPageContext = {
+  page_location: string
+  page_referrer: ''
+  page_title: 'Runme Web'
+}
+
 export interface GoogleAnalyticsClientOptions {
   measurementId?: string
   hostname: string
+  origin: string
   doNotTrack?: string | null
   globalPrivacyControl?: boolean
   document: Pick<Document, 'createElement' | 'getElementById' | 'head'>
   globalObject: AnalyticsGlobal
 }
 
-const GOOGLE_ANALYTICS_HOSTNAME = 'web.runme.dev'
+const GOOGLE_ANALYTICS_HOSTNAME_PATTERN =
+  /^(?:web\.runme\.dev|runme\.gateway\.[a-z0-9-]+(?:\.[a-z0-9-]+)*)$/i
 const GOOGLE_ANALYTICS_SCRIPT_ID = 'runme-google-analytics'
-const SAFE_PAGE_LOCATION = 'https://web.runme.dev/'
-const SAFE_PAGE_TITLE = 'Runme Web'
-const SAFE_PAGE_CONTEXT = {
-  page_location: SAFE_PAGE_LOCATION,
-  page_referrer: '',
-  page_title: SAFE_PAGE_TITLE,
-} as const
 
 function isValidMeasurementId(value: string | undefined): value is string {
   return typeof value === 'string' && /^G-[A-Z0-9]+$/.test(value)
+}
+
+function createAnalyticsPageContext(
+  origin: string,
+  hostname: string
+): AnalyticsPageContext | undefined {
+  try {
+    const url = new URL(origin)
+    if (url.protocol !== 'https:' || url.hostname !== hostname.toLowerCase()) {
+      return undefined
+    }
+    return {
+      page_location: new URL('/', url.origin).toString(),
+      page_referrer: '',
+      page_title: 'Runme Web',
+    }
+  } catch {
+    return undefined
+  }
 }
 
 export function classifyNotebookAnalyticsSource(
@@ -63,6 +83,7 @@ export function classifyNotebookAnalyticsSource(
 
 export class GoogleAnalyticsClient {
   private gtag: Gtag | undefined
+  private pageContext: AnalyticsPageContext | undefined
 
   constructor(private readonly options: GoogleAnalyticsClientOptions) {}
 
@@ -78,10 +99,13 @@ export class GoogleAnalyticsClient {
       globalPrivacyControl,
       hostname,
       measurementId,
+      origin,
     } = this.options
+    const pageContext = createAnalyticsPageContext(origin, hostname)
     if (
       !isValidMeasurementId(measurementId) ||
-      hostname !== GOOGLE_ANALYTICS_HOSTNAME ||
+      !GOOGLE_ANALYTICS_HOSTNAME_PATTERN.test(hostname) ||
+      !pageContext ||
       doNotTrack === '1' ||
       globalPrivacyControl === true
     ) {
@@ -113,13 +137,15 @@ export class GoogleAnalyticsClient {
         allow_ad_personalization_signals: false,
         allow_google_signals: false,
         send_page_view: false,
-        ...SAFE_PAGE_CONTEXT,
+        ...pageContext,
       })
+      this.pageContext = pageContext
       this.gtag = gtag
       this.sendEvent('page_view', {})
       return true
     } catch {
       this.gtag = undefined
+      this.pageContext = undefined
       return false
     }
   }
@@ -145,9 +171,12 @@ export class GoogleAnalyticsClient {
     params: Record<string, string>
   ): void {
     try {
+      if (!this.gtag || !this.pageContext) {
+        return
+      }
       this.gtag?.('event', eventName, {
         ...params,
-        ...SAFE_PAGE_CONTEXT,
+        ...this.pageContext,
       })
     } catch {
       // Analytics must never affect notebook loading or execution.
@@ -162,6 +191,7 @@ const navigatorWithPrivacySignals = navigator as Navigator & {
 export const googleAnalytics = new GoogleAnalyticsClient({
   measurementId: import.meta.env.VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID,
   hostname: window.location.hostname,
+  origin: window.location.origin,
   doNotTrack: navigator.doNotTrack,
   globalPrivacyControl: navigatorWithPrivacySignals.globalPrivacyControl,
   document,


### PR DESCRIPTION
## Summary

- allow Google Analytics on `web.runme.dev` and generic `runme.gateway.*` hosts without embedding any private deployment suffix
- report the browser’s actual origin on page-view, notebook-open, and cell-execution events while stripping paths, query strings, fragments, and referrers
- fail closed for non-HTTPS or mismatched origins and retain the existing DNT, GPC, and measurement-ID gates
- update the privacy policy to describe origin-only reporting on approved production hosts

## Validation

- `runme run build test`
- focused Google Analytics tests (17 passed)
- `git diff --check`