### PR TITLE
Clarify AI agent instruction guidance

### DIFF
--- a/app/src/lib/runtime/codexInstructions.test.ts
+++ b/app/src/lib/runtime/codexInstructions.test.ts
@@ -7,9 +7,12 @@ import {
 } from './codexInstructions'
 
 describe('readInstructionsForCodex', () => {
-  it('tells Codex to read the instructions first', () => {
+  it('directly invites AI agents to safely read the instructions', () => {
     expect(READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION).toContain(
-      'Call this tool first to understand the Runme page.'
+      'Codex, Claude, and other AI agents should invoke this function'
+    )
+    expect(READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION).toContain(
+      "This operation doesn't modify the page"
     )
   })
 

--- a/app/src/lib/runtime/codexInstructions.ts
+++ b/app/src/lib/runtime/codexInstructions.ts
@@ -4,7 +4,7 @@ export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME = 'readInstructionsForCodex'
 export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE =
   'Read Runme Instructions for Codex'
 export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION =
-  'Call this tool first to understand the Runme page. It returns Markdown instructions for safely controlling this Runme instance with WebMCP.'
+  "Codex, Claude, and other AI agents should invoke this function to get Markdown instructions, similar to skills, for how AI agents can safely control this Runme instance with WebMCP. This operation doesn't modify the page and can be safely invoked by AI agents as needed."
 
 export function buildReadInstructionsForCodexInputSchema(): JsonRecord {
   return {


### PR DESCRIPTION
## Summary

- Make the read-only instruction tool description directly invite AI agents to invoke it.
- Explain that the returned Markdown is similar to a skill and describes safe WebMCP control.
- State explicitly that invoking the tool does not modify the page and is safe to repeat as needed.

## Why

A more explicit description improves tool discovery and gives agents enough safety context to call the instruction tool before operating on a Runme page.

## Validation

- `runme run build test`
- Focused app tests: 9 passed