### PR TITLE
Add discoverable documentation tools for AI agents

### DIFF
--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -104,7 +104,7 @@ describe("WebMcpToolRegistrationHost", () => {
 
     const rendered = render(<WebMcpToolRegistrationHost />);
 
-    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(registerTool).toHaveBeenCalledTimes(4);
     const executeCode = registered.find(
       ({ tool }) => tool.name === "ExecuteCode",
     );
@@ -173,6 +173,46 @@ describe("WebMcpToolRegistrationHost", () => {
     expect(instructions?.tool.execute({})).toContain(window.location.origin);
     expect(instructions?.tool.execute({})).toContain(
       "await app.getSessionID()",
+    );
+
+    const listDocumentation = registered.find(
+      ({ tool }) => tool.name === "listDocumentation",
+    );
+    expect(listDocumentation?.tool.title).toBe("List Runme Documentation");
+    expect(listDocumentation?.tool.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: false,
+    });
+    expect(listDocumentation?.tool.inputSchema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    });
+    expect(JSON.parse(String(listDocumentation?.tool.execute({})))[0]).toEqual(
+      expect.objectContaining({
+        name: "getting-started",
+        description: expect.any(String),
+      }),
+    );
+
+    const getDocumentation = registered.find(
+      ({ tool }) => tool.name === "getDocumentation",
+    );
+    expect(getDocumentation?.tool.title).toBe("Get Runme Documentation");
+    expect(getDocumentation?.tool.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: false,
+    });
+    expect(getDocumentation?.tool.inputSchema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        name: { type: "string" },
+      },
+      required: ["name"],
+    });
+    await expect(getDocumentation?.tool.execute({})).rejects.toThrow(
+      "non-empty name returned by listDocumentation",
     );
 
     expect(registered.every(({ signal }) => signal?.aborted === false)).toBe(

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -10,6 +10,18 @@ import {
   READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE,
 } from "../../lib/runtime/codexInstructions";
 import {
+  buildGetDocumentationInputSchema,
+  buildListDocumentationInputSchema,
+  getDocumentationForAgents,
+  GET_DOCUMENTATION_TOOL_DESCRIPTION,
+  GET_DOCUMENTATION_TOOL_NAME,
+  GET_DOCUMENTATION_TOOL_TITLE,
+  listDocumentationForAgents,
+  LIST_DOCUMENTATION_TOOL_DESCRIPTION,
+  LIST_DOCUMENTATION_TOOL_NAME,
+  LIST_DOCUMENTATION_TOOL_TITLE,
+} from "../../lib/runtime/documentationTools";
+import {
   buildExecuteCodeInputSchema,
   EXECUTE_CODE_TOOL_DESCRIPTION,
   EXECUTE_CODE_TOOL_NAME,
@@ -141,12 +153,49 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         },
       );
+      modelContext.registerTool(
+        {
+          name: LIST_DOCUMENTATION_TOOL_NAME,
+          title: LIST_DOCUMENTATION_TOOL_TITLE,
+          description: LIST_DOCUMENTATION_TOOL_DESCRIPTION,
+          inputSchema: buildListDocumentationInputSchema(),
+          annotations: {
+            readOnlyHint: true,
+            untrustedContentHint: false,
+          },
+          execute: () => listDocumentationForAgents(),
+        },
+        {
+          signal: registrationController.signal,
+        },
+      );
+      modelContext.registerTool(
+        {
+          name: GET_DOCUMENTATION_TOOL_NAME,
+          title: GET_DOCUMENTATION_TOOL_TITLE,
+          description: GET_DOCUMENTATION_TOOL_DESCRIPTION,
+          inputSchema: buildGetDocumentationInputSchema(),
+          annotations: {
+            readOnlyHint: true,
+            untrustedContentHint: false,
+          },
+          execute: (input) =>
+            getDocumentationForAgents(
+              typeof input?.name === "string" ? input.name : "",
+            ),
+        },
+        {
+          signal: registrationController.signal,
+        },
+      );
       appLogger.info("WebMCP tools registered", {
         attrs: {
           scope: "webmcp",
           toolNames: [
             EXECUTE_CODE_TOOL_NAME,
             READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+            LIST_DOCUMENTATION_TOOL_NAME,
+            GET_DOCUMENTATION_TOOL_NAME,
           ],
         },
       });
@@ -169,6 +218,8 @@ export default function WebMcpToolRegistrationHost() {
           toolNames: [
             EXECUTE_CODE_TOOL_NAME,
             READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+            LIST_DOCUMENTATION_TOOL_NAME,
+            GET_DOCUMENTATION_TOOL_NAME,
           ],
         },
       });

--- a/app/src/lib/documentation.test.ts
+++ b/app/src/lib/documentation.test.ts
@@ -1,14 +1,16 @@
 import { readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
-
 import { describe, expect, it, vi } from 'vitest'
 
 import {
   DOCUMENTATION_MIME_TYPE,
   fetchRemoteMarkdownDocument,
+  getDocumentationEntry,
+  getDocumentationMarkdown,
   getGettingStartedDocument,
   isRemoteMarkdownUri,
   listDocumentation,
+  listDocumentationSummaries,
   resolveDocumentationHref,
   toRawMarkdownUri,
 } from './documentation'
@@ -19,9 +21,6 @@ const versionInfo: RunmeVersionInfo = {
   webRepo: 'runmedev/web',
   webBranch: 'main',
   webCommit: 'abc123def456',
-  codexRepo: null,
-  codexBranch: null,
-  codexCommit: null,
   bucket: null,
 }
 
@@ -31,6 +30,8 @@ describe('documentation catalog', () => {
 
     expect(documents.length).toBeGreaterThan(10)
     expect(documents[0]).toMatchObject({
+      name: 'getting-started',
+      description: expect.stringContaining('Open a notebook'),
       title: 'Getting Started',
       path: 'docs/00-getting-started.md',
       uri: 'https://github.com/runmedev/web/blob/abc123def456/docs/00-getting-started.md',
@@ -41,6 +42,25 @@ describe('documentation catalog', () => {
     })
     expect(documents[0]).not.toHaveProperty('content')
     expect(getGettingStartedDocument(versionInfo)).toEqual(documents[0])
+  })
+
+  it('exposes a compact, unique name and description index', () => {
+    const summaries = listDocumentationSummaries(versionInfo)
+
+    expect(summaries[0]).toEqual({
+      name: 'getting-started',
+      description:
+        'Open a notebook, configure an execution path, run a cell, and inspect its output.',
+    })
+    expect(new Set(summaries.map(({ name }) => name)).size).toBe(
+      summaries.length
+    )
+    expect(
+      summaries.every(
+        ({ name, description }) => name.length > 0 && description.length > 0
+      )
+    ).toBe(true)
+    expect(summaries[0]).not.toHaveProperty('uri')
   })
 
   it('publishes every user guide but not the repository index', () => {
@@ -102,5 +122,30 @@ describe('documentation catalog', () => {
       readOnly: true,
       version: { revisionId: 'abc123' },
     })
+  })
+
+  it('gets one commit-pinned document by its stable name', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '# WebMCP External Control',
+    })) as unknown as typeof fetch
+
+    const content = await getDocumentationMarkdown(
+      'webmcp-external-control',
+      versionInfo,
+      fetchImpl
+    )
+
+    const entry = getDocumentationEntry('webmcp-external-control', versionInfo)
+    expect(fetchImpl).toHaveBeenCalledWith(entry.rawUri, expect.any(Object))
+    expect(content).toBe('# WebMCP External Control')
+  })
+
+  it('rejects unknown documentation names with the available index', () => {
+    expect(() => getDocumentationEntry('missing', versionInfo)).toThrow(
+      'Available names: getting-started'
+    )
   })
 })

--- a/app/src/lib/documentation.ts
+++ b/app/src/lib/documentation.ts
@@ -7,6 +7,8 @@ export const GETTING_STARTED_OPENED_STORAGE_KEY =
   'runme/documentation/getting-started-opened'
 
 type DocumentationDefinition = {
+  name: string
+  description: string
   path: string
   title: string
 }
@@ -18,6 +20,11 @@ export type DocumentationEntry = DocumentationDefinition & {
   revision: string
   readOnly: true
 }
+
+export type DocumentationSummary = Pick<
+  DocumentationDefinition,
+  'name' | 'description'
+>
 
 export type RemoteMarkdownDocument = {
   uri: string
@@ -31,55 +38,117 @@ export type RemoteMarkdownDocument = {
 }
 
 const DOCUMENTATION_DEFINITIONS: readonly DocumentationDefinition[] = [
-  { path: GETTING_STARTED_DOCUMENT_PATH, title: 'Getting Started' },
   {
+    name: 'getting-started',
+    description:
+      'Open a notebook, configure an execution path, run a cell, and inspect its output.',
+    path: GETTING_STARTED_DOCUMENT_PATH,
+    title: 'Getting Started',
+  },
+  {
+    name: 'editing-and-running-cells',
+    description:
+      'Edit code and Markdown cells, choose runners, execute cells, and understand saved outputs.',
     path: 'docs/01-editing-and-running-cells.md',
     title: 'Editing And Running Cells',
   },
-  { path: 'docs/02-workspace-explorer.md', title: 'Workspace Explorer' },
   {
+    name: 'workspace-explorer',
+    description:
+      'Navigate local, filesystem, and Google Drive content in the workspace explorer.',
+    path: 'docs/02-workspace-explorer.md',
+    title: 'Workspace Explorer',
+  },
+  {
+    name: 'local-notebooks-and-browser-storage',
+    description:
+      'Understand local notebook persistence, browser storage, and recovery behavior.',
     path: 'docs/03-local-notebooks-and-browser-storage.md',
     title: 'Local Notebooks And Browser Storage',
   },
   {
+    name: 'filesystem-workspaces',
+    description:
+      'Mount and work with local directories through the browser File System Access API.',
     path: 'docs/04-filesystem-workspaces.md',
     title: 'Filesystem Workspaces',
   },
   {
+    name: 'google-drive-integration',
+    description:
+      'Configure Google Drive storage, browse Drive content, and understand synchronization.',
     path: 'docs/05-google-drive-integration.md',
     title: 'Google Drive Integration',
   },
   {
+    name: 'sharing-and-opening-drive-links',
+    description:
+      'Open, share, and troubleshoot Google Drive notebook and folder links.',
     path: 'docs/06-sharing-and-opening-drive-links.md',
     title: 'Sharing And Opening Drive Links',
   },
-  { path: 'docs/07-runners-overview.md', title: 'Runners Overview' },
   {
+    name: 'runners-overview',
+    description:
+      'Choose among Runme, AppKernel, and Jupyter execution backends.',
+    path: 'docs/07-runners-overview.md',
+    title: 'Runners Overview',
+  },
+  {
+    name: 'local-runme-runners',
+    description: 'Configure and troubleshoot a local Runme WebSocket runner.',
     path: 'docs/08-local-runme-runners.md',
     title: 'Local Runme Runners',
   },
   {
+    name: 'appkernel-browser-runners',
+    description:
+      'Run JavaScript in browser-hosted AppKernel and sandbox runtimes.',
     path: 'docs/09-appkernel-browser-runners.md',
     title: 'AppKernel Browser Runners',
   },
-  { path: 'docs/10-jupyter-runners.md', title: 'Jupyter Runners' },
   {
+    name: 'jupyter-runners',
+    description:
+      'Configure Jupyter servers and kernels for notebook execution.',
+    path: 'docs/10-jupyter-runners.md',
+    title: 'Jupyter Runners',
+  },
+  {
+    name: 'webmcp-external-control',
+    description:
+      'Safely control Runme from an external browser agent through WebMCP.',
     path: 'docs/11-webmcp-external-control.md',
     title: 'WebMCP External Control',
   },
   {
+    name: 'app-console-reference',
+    description:
+      'Use App Console namespaces for notebooks, documents, runners, Drive, and diagnostics.',
     path: 'docs/13-app-console-reference.md',
     title: 'App Console Reference',
   },
   {
+    name: 'authentication-and-app-configuration',
+    description:
+      'Configure OIDC, Google OAuth, service accounts, endpoints, and app settings.',
     path: 'docs/14-authentication-and-app-configuration.md',
     title: 'Authentication And App Configuration',
   },
   {
+    name: 'logs-diagnostics-and-troubleshooting',
+    description:
+      'Inspect logs and diagnose notebook, runner, Drive, and authentication failures.',
     path: 'docs/15-logs-diagnostics-and-troubleshooting.md',
     title: 'Logs Diagnostics And Troubleshooting',
   },
-  { path: 'docs/16-notebook-diffs.md', title: 'Notebook Diffs' },
+  {
+    name: 'notebook-diffs',
+    description:
+      'Compare local and Google Drive notebook revisions with notebook-aware diffs.',
+    path: 'docs/16-notebook-diffs.md',
+    title: 'Notebook Diffs',
+  },
 ]
 
 function encodePath(path: string): string {
@@ -119,6 +188,42 @@ export function listDocumentation(
       readOnly: true,
     }
   })
+}
+
+export function listDocumentationSummaries(
+  info: RunmeVersionInfo = runmeVersionInfo
+): DocumentationSummary[] {
+  return listDocumentation(info).map(({ name, description }) => ({
+    name,
+    description,
+  }))
+}
+
+export function getDocumentationEntry(
+  name: string,
+  info: RunmeVersionInfo = runmeVersionInfo
+): DocumentationEntry {
+  const normalizedName = typeof name === 'string' ? name.trim() : ''
+  const documents = listDocumentation(info)
+  const entry = documents.find((candidate) => candidate.name === normalizedName)
+  if (!entry) {
+    throw new Error(
+      `Unknown Runme documentation "${name}". Available names: ${documents
+        .map((candidate) => candidate.name)
+        .join(', ')}`
+    )
+  }
+  return entry
+}
+
+export async function getDocumentationMarkdown(
+  name: string,
+  info: RunmeVersionInfo = runmeVersionInfo,
+  fetchImpl: typeof fetch = fetch
+): Promise<string> {
+  const entry = getDocumentationEntry(name, info)
+  const document = await fetchRemoteMarkdownDocument(entry.uri, fetchImpl)
+  return document.content
 }
 
 export function getGettingStartedDocument(

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -358,6 +358,21 @@ describe('createAppJsGlobals notebook reference helpers', () => {
       content: '# Getting Started',
       readOnly: true,
     })
+
+    expect(globals.documentation.list()[0]).toEqual({
+      name: 'getting-started',
+      description:
+        'Open a notebook, configure an execution path, run a cell, and inspect its output.',
+    })
+    await expect(globals.documentation.get('getting-started')).resolves.toBe(
+      '# Getting Started'
+    )
+    expect(globals.documentation.help()).toContain(
+      'await documentation.get(name)'
+    )
+    expect(globals.documentation.help()).toContain(
+      'await documentation.list()'
+    )
   })
 
   it('updates raw document content in the local mirror', async () => {

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -29,8 +29,10 @@ import {
 } from '../appConfig'
 import {
   fetchRemoteMarkdownDocument,
+  getDocumentationMarkdown,
   isRemoteMarkdownUri,
   listDocumentation,
+  listDocumentationSummaries,
 } from '../documentation'
 import { driveLinkCoordinator } from '../driveLinkCoordinator'
 import {
@@ -785,6 +787,20 @@ export function createAppJsGlobals({
     },
   }
 
+  const documentationHelpers = {
+    list: () => listDocumentationSummaries(),
+    get: (name: string) => getDocumentationMarkdown(name),
+    help: () => {
+      const message = [
+        'await documentation.list()    - List Runme documentation names and descriptions',
+        'await documentation.get(name) - Get one Runme documentation page as Markdown',
+        'documentation.help()          - Show this help',
+      ].join('\n')
+      emitLine(sendOutput, message)
+      return message
+    },
+  }
+
   const resolveNotebookReference = async (
     reference?: unknown
   ): Promise<NotebookReferenceInfo> => {
@@ -1086,6 +1102,7 @@ export function createAppJsGlobals({
     notebooks: notebooksHelpers,
     embed: embedImageForRuntime,
     documents: documentsHelpers,
+    documentation: documentationHelpers,
     notebookDiff: notebookDiffApi,
     opfs: {
       exists: (path: string) => {
@@ -1564,6 +1581,7 @@ export function createAppJsGlobals({
         '  runme           - Notebook helpers (run all, clear outputs)',
         '  notebooks       - Notebook document API plus create/append helpers',
         '  documents       - List/read docs plus raw local document updates',
+        '  documentation   - Read-only Runme documentation by stable name',
         '  notebookDiff    - Compare revisions and resolve notebook sync conflicts',
         '  opfs            - Origin-private browser file storage helpers',
         '  net             - Browser network helpers',
@@ -1584,6 +1602,8 @@ export function createAppJsGlobals({
         '  await notebooks.createLocal("hello")',
         '  console.table(documents.list())',
         '  const doc = await documents.get("local://file/...")',
+        '  console.table(await documentation.list())',
+        '  const guide = await documentation.get("getting-started")',
         '  await notebooks.appendCell({ kind: "code", value: "print(1)", languageId: "python" })',
         '  await embed("/tmp/screenshot.png", { alt: "Screenshot" })',
         '  const diff = await notebookDiff.diffDriveRevision({ revisionId })',

--- a/app/src/lib/runtime/codeModeExecutor.test.ts
+++ b/app/src/lib/runtime/codeModeExecutor.test.ts
@@ -128,6 +128,50 @@ describe('codeModeExecutor', () => {
     expect(result.output).not.toContain('code-mode-session')
   })
 
+  it('bridges named documentation discovery and retrieval in sandbox mode', async () => {
+    const notebook = createNotebook()
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '# Getting Started',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    let summaries: unknown
+    let markdown: unknown
+    vi.spyOn(SandboxJSKernel.prototype, 'run').mockImplementation(
+      async function (this: SandboxJSKernel) {
+        const bridge = (
+          this as unknown as {
+            bridge: {
+              call: (method: string, args: unknown[]) => Promise<unknown>
+            }
+          }
+        ).bridge
+        summaries = await bridge.call('documentation.list', [])
+        markdown = await bridge.call('documentation.get', ['getting-started'])
+      }
+    )
+    const executor = createCodeModeExecutor({
+      mode: 'sandbox',
+      resolveNotebook: () => notebook,
+      listNotebooks: () => [notebook],
+    })
+
+    await executor.execute({
+      source: 'webmcp',
+      code: "console.log(await documentation.get('getting-started'))",
+    })
+
+    expect(summaries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'getting-started' }),
+      ])
+    )
+    expect(markdown).toBe('# Getting Started')
+    expect(fetchMock).toHaveBeenCalled()
+  })
+
   it('preserves Blob sources for top-level sandbox embed calls', async () => {
     const notebook = create(parser_pb.NotebookSchema, { cells: [] })
     const notebookData = {

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -488,6 +488,8 @@ async function handleSandboxAppKernelBridgeCall({
         String(args[1] ?? '')
       )
     }
+    case 'documents.list':
+      return globals.documents.list()
     case 'documents.get':
       return globals.documents.get(String(args[0] ?? ''))
     case 'documents.update':
@@ -500,6 +502,10 @@ async function handleSandboxAppKernelBridgeCall({
           flush?: boolean
         }) ?? undefined
       )
+    case 'documentation.list':
+      return globals.documentation.list()
+    case 'documentation.get':
+      return globals.documentation.get(String(args[0] ?? ''))
     case 'notebookDiff.listDriveRevisions':
       return notebookDiffApi.listDriveRevisions(args[0] as any)
     case 'notebookDiff.diffDriveRevision':

--- a/app/src/lib/runtime/codexInstructions.test.ts
+++ b/app/src/lib/runtime/codexInstructions.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  buildReadInstructionsForCodexInputSchema,
   READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
+  buildReadInstructionsForCodexInputSchema,
   readInstructionsForCodex,
 } from './codexInstructions'
 
@@ -32,6 +32,10 @@ describe('readInstructionsForCodex', () => {
 
     expect(instructions).toContain('WebMCP')
     expect(instructions).toContain('ExecuteCode')
+    expect(instructions).toContain('listDocumentation')
+    expect(instructions).toContain('getDocumentation')
+    expect(instructions).toContain('await documentation.list()')
+    expect(instructions).toContain('documentation.get(name)')
     expect(instructions).toContain('await app.getSessionID()')
     expect(instructions).toContain('local://')
     expect(instructions).toContain("kind: 'markup'")

--- a/app/src/lib/runtime/codexInstructions.ts
+++ b/app/src/lib/runtime/codexInstructions.ts
@@ -30,6 +30,12 @@ This Runme instance is served from ${runmeOrigin}.
 - Use the \`ExecuteCode\` WebMCP tool to run AppKernel JavaScript. Print values explicitly with \`console.log(...)\`.
 - Do not edit or execute notebook cells through DOM clicks, keyboard automation, or Computer Use. If WebMCP is unavailable, stop and tell the user what must be done manually.
 
+## Read Runme documentation on demand
+
+- Call the read-only \`listDocumentation\` WebMCP tool to discover the documentation available for this exact Runme version.
+- Choose a relevant document by its name and call \`getDocumentation\` to read that page as Markdown. Retrieve only the pages needed for the task.
+- The same progressive-disclosure API is available inside \`ExecuteCode\` as \`await documentation.list()\` and \`await documentation.get(name)\`.
+
 ## Verify the browser session
 
 The URL's \`session\` query parameter identifies a candidate tab. Before changing a notebook, call \`ExecuteCode\` with:

--- a/app/src/lib/runtime/documentationTools.test.ts
+++ b/app/src/lib/runtime/documentationTools.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RunmeVersionInfo } from '../versionInfo'
+import {
+  GET_DOCUMENTATION_TOOL_DESCRIPTION,
+  LIST_DOCUMENTATION_TOOL_DESCRIPTION,
+  buildGetDocumentationInputSchema,
+  buildListDocumentationInputSchema,
+  getDocumentationForAgents,
+  listDocumentationForAgents,
+} from './documentationTools'
+
+const versionInfo: RunmeVersionInfo = {
+  buildDate: null,
+  webRepo: 'runmedev/web',
+  webBranch: 'main',
+  webCommit: 'abc123def456',
+  bucket: null,
+}
+
+describe('documentation WebMCP tools', () => {
+  it('returns a compact JSON discovery index', () => {
+    const documents = JSON.parse(
+      listDocumentationForAgents(versionInfo)
+    ) as Array<Record<string, unknown>>
+
+    expect(documents[0]).toEqual({
+      name: 'getting-started',
+      description:
+        'Open a notebook, configure an execution path, run a cell, and inspect its output.',
+    })
+    expect(documents[0]).not.toHaveProperty('content')
+    expect(documents[0]).not.toHaveProperty('uri')
+  })
+
+  it('returns one named page as Markdown', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '# Getting Started',
+    })) as unknown as typeof fetch
+
+    await expect(
+      getDocumentationForAgents('getting-started', versionInfo, fetchImpl)
+    ).resolves.toBe('# Getting Started')
+  })
+
+  it('rejects missing names before fetching', async () => {
+    await expect(getDocumentationForAgents('')).rejects.toThrow(
+      'non-empty name returned by listDocumentation'
+    )
+  })
+
+  it('describes the progressive-disclosure workflow directly', () => {
+    expect(LIST_DOCUMENTATION_TOOL_DESCRIPTION).toContain(
+      'should invoke this read-only function'
+    )
+    expect(LIST_DOCUMENTATION_TOOL_DESCRIPTION).toContain(
+      'use getDocumentation'
+    )
+    expect(GET_DOCUMENTATION_TOOL_DESCRIPTION).toContain(
+      'name returned by listDocumentation'
+    )
+  })
+
+  it('defines strict input schemas', () => {
+    expect(buildListDocumentationInputSchema()).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    })
+    expect(buildGetDocumentationInputSchema()).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    })
+  })
+})

--- a/app/src/lib/runtime/documentationTools.ts
+++ b/app/src/lib/runtime/documentationTools.ts
@@ -1,0 +1,53 @@
+import {
+  getDocumentationMarkdown,
+  listDocumentationSummaries,
+} from '../documentation'
+import type { RunmeVersionInfo } from '../versionInfo'
+
+type JsonRecord = Record<string, unknown>
+
+export const LIST_DOCUMENTATION_TOOL_NAME = 'listDocumentation'
+export const LIST_DOCUMENTATION_TOOL_TITLE = 'List Runme Documentation'
+export const LIST_DOCUMENTATION_TOOL_DESCRIPTION =
+  'Codex, Claude, and other AI agents should invoke this read-only function to discover the Runme documentation available for this exact app version. It returns a compact JSON list of document names and descriptions; use getDocumentation to read only the pages needed for the task.'
+
+export const GET_DOCUMENTATION_TOOL_NAME = 'getDocumentation'
+export const GET_DOCUMENTATION_TOOL_TITLE = 'Get Runme Documentation'
+export const GET_DOCUMENTATION_TOOL_DESCRIPTION =
+  'Codex, Claude, and other AI agents should invoke this read-only function with a name returned by listDocumentation to get that Runme documentation page as Markdown.'
+
+export function buildListDocumentationInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {},
+  }
+}
+
+export function buildGetDocumentationInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string' },
+    },
+    required: ['name'],
+  }
+}
+
+export function listDocumentationForAgents(info?: RunmeVersionInfo): string {
+  return JSON.stringify(listDocumentationSummaries(info), null, 2)
+}
+
+export async function getDocumentationForAgents(
+  name: string,
+  info?: RunmeVersionInfo,
+  fetchImpl?: typeof fetch
+): Promise<string> {
+  if (typeof name !== 'string' || !name.trim()) {
+    throw new Error(
+      'getDocumentation requires a non-empty name returned by listDocumentation.'
+    )
+  }
+  return getDocumentationMarkdown(name, info, fetchImpl)
+}

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -20,6 +20,7 @@ type Scenario =
   | 'driveSearch'
   | 'driveSave'
   | 'documents'
+  | 'documentation'
   | 'notebooksCreate'
   | 'notebooksEmbed'
   | 'notebooksUpdateError'
@@ -138,6 +139,19 @@ class MockSandboxPort {
             { mimeType: 'application/vnd.excalidraw+json' },
           ],
         })
+      } else if (this.scenario === 'documentation') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'documentation.list',
+          args: [],
+        })
+        this.emit({
+          type: 'host-call',
+          callId: 2,
+          method: 'documentation.get',
+          args: ['getting-started'],
+        })
       } else if (this.scenario === 'notebooksCreate') {
         this.emit({
           type: 'host-call',
@@ -248,6 +262,18 @@ class MockSandboxPort {
         this.emit({
           type: 'stdout',
           data: `${JSON.stringify(this.hostResults.get(2) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'documentation' && this.hostResults.has(2)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
+        })
+        this.emit({
+          type: 'stdout',
+          data: `${String(this.hostResults.get(2) ?? '')}\n`,
         })
         this.emit({ type: 'exit', exitCode: 0 })
         return
@@ -862,6 +888,59 @@ describe('SandboxJSKernel', () => {
       { mimeType: 'application/vnd.excalidraw+json' },
     ])
     expect(stdout).toContain('test4.excalidraw')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports read-only documentation helpers through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string, args: unknown[]) => {
+      if (method === 'documentation.list') {
+        return [
+          {
+            name: 'getting-started',
+            description: 'Open a notebook and run a cell.',
+          },
+        ]
+      }
+      if (method === 'documentation.get') {
+        return `# ${args[0]}`
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('documentation'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      [
+        'console.log(await documentation.list());',
+        "console.log(await documentation.get('getting-started'));",
+      ].join('\n')
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('documentation.list', [])
+    expect(bridgeCall).toHaveBeenCalledWith('documentation.get', [
+      'getting-started',
+    ])
+    expect(stdout).toContain('getting-started')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
   })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -98,6 +98,8 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'documents.list',
   'documents.get',
   'documents.update',
+  'documentation.list',
+  'documentation.get',
   ...SANDBOX_NOTEBOOKS_API_METHODS,
   'notebooks.createLocal',
   'notebooks.appendCell',
@@ -351,6 +353,14 @@ export function buildSandboxSrcDoc(options: {
             consoleProxy.log("documents.update(uri, content, { mimeType?, expectedVersion?, flush? })");
           },
         };
+        const documentation = {
+          list: () => hostCall("documentation.list", []),
+          get: (name) => hostCall("documentation.get", [name]),
+          help: () => {
+            consoleProxy.log("await documentation.list()");
+            consoleProxy.log("await documentation.get(name)");
+          },
+        };
         const notebookDiff = {
           listDriveRevisions: (target) => hostCall("notebookDiff.listDriveRevisions", [target]),
           diffDriveRevision: (args) => hostCall("notebookDiff.diffDriveRevision", [args]),
@@ -432,6 +442,8 @@ export function buildSandboxSrcDoc(options: {
           consoleProxy.log("- documents.list()");
           consoleProxy.log("- documents.get(uri)");
           consoleProxy.log("- documents.update(uri, content, { mimeType?, expectedVersion?, flush? })");
+          consoleProxy.log("- await documentation.list()");
+          consoleProxy.log("- await documentation.get(name)");
           consoleProxy.log("- notebookDiff.listDriveRevisions([target])");
           consoleProxy.log("- notebookDiff.diffDriveRevision({ target?, revisionId, includeOutputs?, includeMetadata? })");
           consoleProxy.log("- notebookDiff.openDiffTab(diff)");
@@ -463,6 +475,7 @@ export function buildSandboxSrcDoc(options: {
               "embed",
               "notebooks",
               "documents",
+              "documentation",
               "notebookDiff",
               "app",
               "explorer",
@@ -471,7 +484,7 @@ export function buildSandboxSrcDoc(options: {
               "help",
               '"use strict"; return (async () => {\\n' + code + '\\n})();',
             );
-            await runner(consoleProxy, runme, opfs, net, embed, notebooks, documents, notebookDiff, app, explorer, credentials, drive, help);
+            await runner(consoleProxy, runme, opfs, net, embed, notebooks, documents, documentation, notebookDiff, app, explorer, credentials, drive, help);
           } catch (error) {
             exitCode = 1;
             post({ type: "stderr", data: String(error) + "\\n" });

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -16,6 +16,25 @@ controller needs Runme-specific operating instructions. Because the origin is
 resolved at runtime, its links work for hosted, proxied, and self-hosted Runme
 instances.
 
+Agents can browse the documentation for the exact running version without
+loading every page:
+
+1. Call the read-only `listDocumentation` WebMCP tool. It returns a compact JSON
+   array of `{ name, description }` entries.
+2. Choose the relevant name and call the read-only `getDocumentation` tool.
+   It returns that commit-pinned page as Markdown.
+
+The same API is available in AppKernel JavaScript:
+
+```js
+console.log(await documentation.list())
+console.log(await documentation.get('webmcp-external-control'))
+```
+
+Prefer this progressive-disclosure path over guessing documentation URLs or
+fetching every page. Unknown names fail without modifying page or notebook
+state.
+
 Browser tab control is exclusive: one controller session can control one tab
 at a time. Concurrent sessions should target different Runme tabs.
 

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -16,6 +16,7 @@ help()
 - `runme`: notebook helpers,
 - `notebooks`: notebook document API,
 - `documents`: raw URI-based document content API,
+- `documentation`: read-only, versioned Runme documentation discovery,
 - `explorer`: workspace and file-mount helpers,
 - `runmeRunners`: runner configuration,
 - `jupyter`: Jupyter server and kernel lifecycle,
@@ -35,6 +36,7 @@ explorer.help()
 runme.help()
 notebooks.help()
 documents.help()
+documentation.help()
 runmeRunners.help()
 drive.help()
 agent.help()
@@ -73,6 +75,19 @@ await notebooks.show(
   '[Notebook](https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view)'
 )
 ```
+
+Discover and read versioned Runme documentation:
+
+```js
+const available = await documentation.list()
+console.log(available)
+const guide = await documentation.get('getting-started')
+console.log(guide)
+```
+
+`await documentation.list()` returns compact `{ name, description }` entries.
+`documentation.get(name)` fetches the selected Markdown from the commit-pinned
+GitHub URL for the running app version.
 
 Read and update raw document content, including Excalidraw scenes:
 


### PR DESCRIPTION
## Summary

- add stable names and descriptions to the version-pinned documentation catalog
- expose compact `list` and named `get` APIs in JavaScript kernels and as read-only WebMCP tools
- update agent guidance and user documentation for progressive documentation discovery

## Testing

- `runme run build test`
- `pnpm -C app test --run` (657 tests)
- verified all four WebMCP tools and both documentation APIs against the local app