### PR TITLE
feat: add ipynb notebook support

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   removeItem: vi.fn(),
   store: {
     getMetadata: vi.fn(),
+    create: vi.fn(),
     createContent: vi.fn(),
     createFolder: vi.fn(),
     move: vi.fn(),
@@ -176,6 +177,16 @@ describe('WorkspaceExplorer current document handling', () => {
       remoteUri: 'https://drive.google.com/drive/folders/new',
       parents: ['local://folder/drive'],
     })
+    mocks.store.create.mockReset()
+    mocks.store.create.mockResolvedValue({
+      uri: 'local://file/ipynb',
+      name: 'untitled.ipynb',
+      type: NotebookStoreItemType.File,
+      children: [],
+      remoteUri: undefined,
+      mimeType: 'application/x-ipynb+json',
+      parents: ['local://folder/drive'],
+    })
     mocks.store.createContent.mockReset()
     mocks.store.createContent.mockResolvedValue({
       uri: 'local://file/excalidraw',
@@ -261,6 +272,42 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(window.prompt).not.toHaveBeenCalled()
     await waitFor(() => {
       expect(mocks.treeEdit).toHaveBeenCalledWith('local://folder/new')
+    })
+  })
+
+  it('creates a Jupyter notebook from a folder context menu', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    fireEvent.contextMenu(await screen.findByText('Drive Root'))
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'New Jupyter Notebook (.ipynb)',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.store.create).toHaveBeenCalledWith(
+        'local://folder/drive',
+        expect.stringMatching(/^untitled-\d{8}-\d{4}\.ipynb$/)
+      )
+    })
+    await waitFor(() => {
+      expect(mocks.treeEdit).toHaveBeenCalledWith('local://file/ipynb')
     })
   })
 

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -27,6 +27,10 @@ import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
 import { appLogger } from "../../lib/logging/runtime";
 import {
+  type NotebookFileFormat,
+  isNotebookFileName,
+} from '../../lib/notebookFormat'
+import {
   copyNotebookMarkdownLink,
   copyNotebookShareUrl,
 } from "../../lib/shareLinks";
@@ -126,12 +130,8 @@ function createFileNode(
   };
 }
 
-function isJsonNotebookFile(name: string): boolean {
-  return /\.json$/i.test(name.trim());
-}
-
 function isVisibleDocumentFile(name: string): boolean {
-  return isJsonNotebookFile(name) || isExcalidrawFileName(name)
+  return isNotebookFileName(name) || isExcalidrawFileName(name)
 }
 
 function isMovableDriveNode(data: TreeNode): boolean {
@@ -208,17 +208,13 @@ const DEFAULT_DRIVE_FOLDER_NAME = "New Folder";
 
 function getContextMenuItemCount(menu: ContextMenuState): number {
   if (menu.type === NotebookStoreItemType.File) {
-    return (
-      (menu.uri.startsWith("fs://") ? 0 : 1) +
-      2 +
-      (menu.remoteUri ? 5 : 0)
-    );
+    return (menu.uri.startsWith('fs://') ? 0 : 1) + 3 + (menu.remoteUri ? 5 : 0)
   }
 
   if (menu.type === NotebookStoreItemType.Folder) {
     return (
-      (menu.uri.startsWith("fs://") ? 0 : 1) +
-      1 +
+      (menu.uri.startsWith('fs://') ? 0 : 1) +
+      2 +
       (menu.remoteUri ? 1 : 0) +
       (menu.remoteUri ? 2 : 0) +
       (menu.uri === LOCAL_FOLDER_URI ? 0 : 1)
@@ -701,8 +697,8 @@ export function WorkspaceExplorer() {
                 continue;
               }
               childNodes.push(
-                createFileNode(childMetadata, { parentUri: folderMetadata.uri }),
-              );
+                createFileNode(childMetadata, { parentUri: folderMetadata.uri })
+              )
             } else {
               childNodes.push(createPlaceholderNode(childUri, "Unknown item"));
             }
@@ -820,16 +816,16 @@ export function WorkspaceExplorer() {
   );
 
   const handleCreateDocument = useCallback(
-    async (folderUri: string) => {
-      const targetStore = storeForUri(folderUri, store, fsStore);
+    async (folderUri: string, format: NotebookFileFormat = 'runme-json') => {
+      const targetStore = storeForUri(folderUri, store, fsStore)
       if (!targetStore) {
         return;
       }
       try {
-        treeRef.current?.open(folderUri);
-        const timestamp = formatShortTimestamp(new Date());
-        const name = `untitled-${timestamp}.json`;
-        const newItem = await targetStore.create(folderUri, name);
+        treeRef.current?.open(folderUri)
+        const timestamp = formatShortTimestamp(new Date())
+        const name = `untitled-${timestamp}.${format === 'ipynb' ? 'ipynb' : 'json'}`
+        const newItem = await targetStore.create(folderUri, name)
         markOnboardingNotebookCreated({
           uri: newItem.uri,
           name: newItem.name,
@@ -849,8 +845,8 @@ export function WorkspaceExplorer() {
         setPendingEditId(newItem.uri);
         setErrorMessage(null);
       } catch (error) {
-        console.error("Failed to create notebook", error);
-        setErrorMessage("Unable to create a new document. Please try again.");
+        console.error('Failed to create notebook', error)
+        setErrorMessage('Unable to create a new notebook. Please try again.')
       }
     },
     [fetchChildren, fsStore, store],
@@ -1449,7 +1445,10 @@ function formatShortTimestamp(date: Date): string {
                   event.stopPropagation();
                   setContextMenu(null);
                   if (adjustedContextMenu.parentUri) {
-                    void handleCreateDocument(adjustedContextMenu.parentUri);
+                    void handleCreateDocument(
+                      adjustedContextMenu.parentUri,
+                      'runme-json'
+                    )
                   } else {
                     console.warn(
                       "Cannot create document: no parent folder for",
@@ -1458,7 +1457,24 @@ function formatShortTimestamp(date: Date): string {
                   }
                 }}
               >
-                New Document
+                New Runme Notebook (.json)
+              </button>
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setContextMenu(null)
+                  if (adjustedContextMenu.parentUri) {
+                    void handleCreateDocument(
+                      adjustedContextMenu.parentUri,
+                      'ipynb'
+                    )
+                  }
+                }}
+              >
+                New Jupyter Notebook (.ipynb)
               </button>
               <button
                 type="button"
@@ -1601,12 +1617,27 @@ function formatShortTimestamp(date: Date): string {
                 className="ctx-menu-item"
                 onMouseDown={(event) => event.stopPropagation()}
                 onClick={(event) => {
-                  event.stopPropagation();
-                  setContextMenu(null);
-                  void handleCreateDocument(adjustedContextMenu.uri);
+                  event.stopPropagation()
+                  setContextMenu(null)
+                  void handleCreateDocument(
+                    adjustedContextMenu.uri,
+                    'runme-json'
+                  )
                 }}
               >
-                New Document
+                New Runme Notebook (.json)
+              </button>
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setContextMenu(null)
+                  void handleCreateDocument(adjustedContextMenu.uri, 'ipynb')
+                }}
+              >
+                New Jupyter Notebook (.ipynb)
               </button>
               {adjustedContextMenu.remoteUri && (
                 <button

--- a/app/src/lib/driveTransfer.test.ts
+++ b/app/src/lib/driveTransfer.test.ts
@@ -146,12 +146,46 @@ describe("driveTransfer", () => {
     });
   });
 
-  it("saves a notebook as a drive copy, mirrors locally, and switches current doc", async () => {
+  it('copies ipynb bytes without dropping Jupyter-only fields', async () => {
+    const sourceUri = 'https://drive.google.com/file/d/src123/view'
+    const destinationUri = 'https://drive.google.com/file/d/copied123/view'
+    const sourceText = JSON.stringify({
+      cells: [],
+      metadata: { colab: { provenance: ['keep-me'] } },
+      nbformat: 4,
+      nbformat_minor: 5,
+    })
+    const getMetadata = vi.fn().mockResolvedValue({
+      uri: sourceUri,
+      name: 'source.ipynb',
+      type: NotebookStoreItemType.File,
+      children: [],
+      parents: [],
+    })
+    const loadContent = vi.fn().mockResolvedValue(sourceText)
+    const createContent = vi.fn().mockResolvedValue({ uri: destinationUri })
+    appState.setDriveNotebookStore({
+      getMetadata,
+      loadContent,
+      createContent,
+    } as any)
+
+    await copyDriveNotebookFile('src123', 'folder999')
+
+    expect(createContent).toHaveBeenCalledWith(
+      'https://drive.google.com/drive/folders/folder999',
+      'source.ipynb',
+      sourceText,
+      'application/x-ipynb+json'
+    )
+  })
+
+  it('saves a notebook as a drive copy, mirrors locally, and switches current doc', async () => {
     const createRemote = vi.fn().mockResolvedValue({
-      uri: "https://drive.google.com/file/d/drive123/view",
-    });
-    const saveContent = vi.fn().mockResolvedValue(undefined);
-    appState.setDriveNotebookStore({ create: createRemote, saveContent } as any);
+      uri: 'https://drive.google.com/file/d/drive123/view',
+    })
+    const saveContent = vi.fn().mockResolvedValue(undefined)
+    appState.setDriveNotebookStore({ create: createRemote, saveContent } as any)
 
     const addFile = vi.fn().mockResolvedValue("local://file/new-copy");
     const saveLocal = vi.fn().mockResolvedValue(undefined);
@@ -177,7 +211,34 @@ describe("driveTransfer", () => {
     expect(saveContent).toHaveBeenCalledWith(
       "https://drive.google.com/file/d/drive123/view",
       expect.any(String),
-      "application/json",
-    );
-  });
-});
+      'application/json'
+    )
+  })
+
+  it('uses the ipynb extension to save a Jupyter notebook', async () => {
+    const createRemote = vi.fn().mockResolvedValue({
+      uri: 'https://drive.google.com/file/d/drive123/view',
+    })
+    const saveContent = vi.fn().mockResolvedValue(undefined)
+    appState.setDriveNotebookStore({ create: createRemote, saveContent } as any)
+    appState.setLocalNotebooks({
+      addFile: vi.fn().mockResolvedValue('local://file/new-copy'),
+      save: vi.fn().mockResolvedValue(undefined),
+    } as any)
+    appState.setOpenNotebookHandler(vi.fn().mockResolvedValue(undefined))
+
+    await saveNotebookAsDriveCopy(
+      create(parser_pb.NotebookSchema, { cells: [] }),
+      'folder123',
+      'copy.ipynb'
+    )
+
+    const [, content, mimeType] = saveContent.mock.calls[0]
+    expect(mimeType).toBe('application/x-ipynb+json')
+    expect(JSON.parse(content)).toMatchObject({
+      cells: [],
+      nbformat: 4,
+      nbformat_minor: 5,
+    })
+  })
+})

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -1,14 +1,20 @@
-import { appState } from "./runtime/AppState";
+import { parser_pb } from '../runme/client'
 import {
   type DriveSearchResult,
   driveFileUrl,
   driveFolderUrl,
   parseDriveItem,
-} from "../storage/drive";
-import { NotebookStoreItemType } from "../storage/notebook";
-import { appLogger } from "./logging/runtime";
-import { parser_pb } from "../runme/client";
-import { toJsonString } from "@bufbuild/protobuf";
+} from '../storage/drive'
+import { NotebookStoreItemType } from '../storage/notebook'
+import { IPYNB_MIME_TYPE } from './ipynb'
+import { appLogger } from './logging/runtime'
+import {
+  decodeNotebookFile,
+  detectNotebookFileFormat,
+  encodeIpynbNotebook,
+  encodeRunmeNotebook,
+} from './notebookFormat'
+import { appState } from './runtime/AppState'
 
 function ensureDriveStore() {
   const store = appState.driveNotebookStore;
@@ -262,16 +268,18 @@ export async function saveNotebookAsDriveCopy(
     throw new Error("drive.saveAsCurrentNotebook requires a non-empty file name");
   }
 
-  const fileId = await createDriveFile(folder, name);
-  const remoteUri = driveFileUrl(fileId);
-  const notebookJson = toJsonString(parser_pb.NotebookSchema, notebook, {
-    emitDefaultValues: true,
-  });
+  const fileId = await createDriveFile(folder, name)
+  const remoteUri = driveFileUrl(fileId)
+  const format = detectNotebookFileFormat(name)
+  const notebookJson =
+    format === 'ipynb'
+      ? encodeIpynbNotebook(notebook).text
+      : encodeRunmeNotebook(notebook)
   await updateDriveFileBytes(
     remoteUri,
     new TextEncoder().encode(notebookJson),
-    "application/json",
-  );
+    format === 'ipynb' ? IPYNB_MIME_TYPE : 'application/json'
+  )
 
   const localStore = ensureLocalStore();
   const localUri = await localStore.addFile(remoteUri, name);
@@ -360,11 +368,32 @@ export async function copyDriveNotebookFile(
       throw new Error("drive.copyNotebook requires a non-empty file name");
     }
 
-    const sourceNotebook = await store.load(sourceUri);
-    const created = await store.create(targetFolderRef, fileName);
-    const saveResult = await store.save(created.uri, sourceNotebook);
-    if (saveResult?.conflicted) {
-      throw new Error("drive.copyNotebook failed due to save conflict");
+    const sourceFormat = detectNotebookFileFormat(metadata.name)
+    const targetFormat = detectNotebookFileFormat(fileName)
+    let sourceNotebook: parser_pb.Notebook
+    let sourceIpynb: string | undefined
+    if (sourceFormat === 'ipynb') {
+      sourceIpynb = await store.loadContent(sourceUri)
+      sourceNotebook = decodeNotebookFile(sourceIpynb, metadata.name).notebook
+    } else {
+      sourceNotebook = await store.load(sourceUri)
+    }
+
+    let created
+    if (targetFormat === 'ipynb') {
+      const content = sourceIpynb ?? encodeIpynbNotebook(sourceNotebook).text
+      created = await store.createContent(
+        targetFolderRef,
+        fileName,
+        content,
+        IPYNB_MIME_TYPE
+      )
+    } else {
+      created = await store.create(targetFolderRef, fileName)
+      const saveResult = await store.save(created.uri, sourceNotebook)
+      if (saveResult?.conflicted) {
+        throw new Error('drive.copyNotebook failed due to save conflict')
+      }
     }
 
     const { id: fileId } = parseDriveItem(created.uri);

--- a/app/src/lib/ipynb.test.ts
+++ b/app/src/lib/ipynb.test.ts
@@ -1,0 +1,167 @@
+/// <reference types="vitest" />
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+
+import {
+  IPYNB_CELL_ID_METADATA_KEY,
+  IPYNB_RAW_CELL_METADATA_KEY,
+  decodeIpynb,
+  encodeIpynb,
+} from './ipynb'
+
+const sourceNotebook = {
+  cells: [
+    {
+      cell_type: 'markdown',
+      id: 'intro',
+      metadata: { tags: ['docs'], vendor: { folded: true } },
+      source: ['# Hello\n', 'world'],
+      attachments: {
+        'pixel.png': { 'image/png': 'AA==' },
+      },
+    },
+    {
+      cell_type: 'raw',
+      id: 'raw-cell',
+      metadata: { format: 'text/plain' },
+      source: 'raw payload',
+    },
+    {
+      cell_type: 'code',
+      id: 'code-cell',
+      metadata: { trusted: true, custom: 42 },
+      execution_count: 7,
+      source: ['print("hello")\n'],
+      outputs: [
+        {
+          output_type: 'stream',
+          name: 'stdout',
+          text: ['hello\n'],
+        },
+        {
+          output_type: 'display_data',
+          data: {
+            'text/plain': ['a value'],
+            'application/json': { answer: 42 },
+          },
+          metadata: { isolated: true },
+        },
+      ],
+    },
+  ],
+  metadata: {
+    kernelspec: {
+      display_name: 'Python 3',
+      language: 'python',
+      name: 'python3',
+    },
+    custom_notebook_metadata: { keep: 'me' },
+  },
+  nbformat: 4,
+  nbformat_minor: 5,
+}
+
+describe('ipynb codec', () => {
+  it('uses a Runme notebook internally and preserves Jupyter-only fields', () => {
+    const text = `${JSON.stringify(sourceNotebook, null, 2)}\n`
+    const decoded = decodeIpynb(text)
+
+    expect(decoded.notebook.cells).toHaveLength(3)
+    expect(decoded.notebook.cells[0]?.value).toBe('# Hello\nworld')
+    expect(
+      decoded.notebook.cells[1]?.metadata?.[IPYNB_RAW_CELL_METADATA_KEY]
+    ).toBe('true')
+    expect(
+      decoded.notebook.cells[2]?.metadata?.[IPYNB_CELL_ID_METADATA_KEY]
+    ).toBe('code-cell')
+    expect(decoded.notebook.cells[2]?.outputs).toHaveLength(2)
+
+    decoded.notebook.cells[2]!.value = 'print("edited")\n'
+    const encoded = encodeIpynb(decoded.notebook, text, decoded)
+    const roundTripped = JSON.parse(encoded.text)
+
+    expect(roundTripped.cells[0].attachments).toEqual(
+      sourceNotebook.cells[0].attachments
+    )
+    expect(roundTripped.cells[0].metadata).toMatchObject(
+      sourceNotebook.cells[0].metadata
+    )
+    expect(roundTripped.cells[1].cell_type).toBe('raw')
+    expect(roundTripped.cells[2].metadata).toMatchObject(
+      sourceNotebook.cells[2].metadata
+    )
+    expect(roundTripped.cells[2].source).toBe('print("edited")\n')
+    expect(roundTripped.cells[2].outputs).toEqual(
+      sourceNotebook.cells[2].outputs
+    )
+    expect(roundTripped.metadata).toMatchObject(sourceNotebook.metadata)
+  })
+
+  it('repairs duplicate and invalid cell ids without losing cell metadata', () => {
+    const input = structuredClone(sourceNotebook)
+    input.cells[0]!.id = 'invalid id'
+    input.cells[1]!.id = 'invalid id'
+
+    const decoded = decodeIpynb(JSON.stringify(input))
+    const encoded = encodeIpynb(
+      decoded.notebook,
+      JSON.stringify(decoded.source),
+      decoded
+    )
+    const ids = JSON.parse(encoded.text).cells.map(
+      (cell: { id: string }) => cell.id
+    )
+
+    expect(ids).toEqual(['invalid-id', 'invalid-id-2', 'code-cell'])
+    expect(JSON.parse(encoded.text).cells[0].metadata).toMatchObject(
+      sourceNotebook.cells[0].metadata
+    )
+  })
+
+  it('round-trips Runme-specific metadata through the ipynb namespace', () => {
+    const decoded = decodeIpynb(JSON.stringify(sourceNotebook))
+    decoded.notebook.metadata['runme.dev/notebookSetting'] = 'keep'
+    decoded.notebook.cells[2]!.languageId = 'bash'
+    decoded.notebook.cells[2]!.metadata['runme.dev/runnerName'] = 'shell'
+
+    const encoded = encodeIpynb(
+      decoded.notebook,
+      JSON.stringify(sourceNotebook),
+      decoded
+    )
+    const portable = JSON.parse(encoded.text)
+    expect(portable.metadata.runme).toMatchObject({
+      version: 1,
+      notebook: {
+        metadata: {
+          'runme.dev/notebookSetting': 'keep',
+        },
+      },
+    })
+    expect(portable.cells[2].metadata.runme).toMatchObject({
+      version: 1,
+      cell: {
+        languageId: 'bash',
+        metadata: {
+          'runme.dev/runnerName': 'shell',
+        },
+      },
+    })
+
+    const reopened = decodeIpynb(encoded.text).notebook
+    expect(reopened.metadata['runme.dev/notebookSetting']).toBe('keep')
+    expect(reopened.cells[2]?.languageId).toBe('bash')
+    expect(reopened.cells[2]?.metadata['runme.dev/runnerName']).toBe('shell')
+  })
+
+  it('rejects unsupported nbformat major versions', () => {
+    expect(() =>
+      decodeIpynb(
+        JSON.stringify({
+          ...sourceNotebook,
+          nbformat: 3,
+        })
+      )
+    ).toThrow('Unsupported Jupyter nbformat major version: 3')
+  })
+})

--- a/app/src/lib/ipynb.test.ts
+++ b/app/src/lib/ipynb.test.ts
@@ -164,4 +164,21 @@ describe('ipynb codec', () => {
       )
     ).toThrow('Unsupported Jupyter nbformat major version: 3')
   })
+
+  it('rejects array-valued notebook and cell metadata', () => {
+    expect(() =>
+      decodeIpynb(
+        JSON.stringify({
+          ...sourceNotebook,
+          metadata: [],
+        })
+      )
+    ).toThrow('Jupyter notebook metadata must be a JSON object')
+
+    const notebook = structuredClone(sourceNotebook)
+    notebook.cells[0]!.metadata = [] as never
+    expect(() => decodeIpynb(JSON.stringify(notebook))).toThrow(
+      'Jupyter cell 0 metadata must be a JSON object'
+    )
+  })
 })

--- a/app/src/lib/ipynb.ts
+++ b/app/src/lib/ipynb.ts
@@ -376,9 +376,10 @@ function validateNotebook(value: unknown): IpynbNotebook {
   if (!Array.isArray(document.cells)) {
     throw new Error('Jupyter notebook cells must be an array')
   }
-  if (!document.metadata || typeof document.metadata !== 'object') {
-    throw new Error('Jupyter notebook metadata must be an object')
-  }
+  document.metadata = asObject(
+    document.metadata,
+    'Jupyter notebook metadata'
+  )
   return document as unknown as IpynbNotebook
 }
 
@@ -417,6 +418,10 @@ export function decodeIpynb(text: string): DecodedIpynb {
         `Unsupported Jupyter cell type: ${String(sourceCell.cell_type)}`
       )
     }
+    sourceCell.metadata = asObject(
+      sourceCell.metadata,
+      `Jupyter cell ${index} metadata`
+    )
     const id = uniqueCellId(sourceCell.id, index, usedIds)
     // Treat nbformat cell IDs as repairable input. Keeping the repaired value
     // in the shadow makes the next save both valid and lossless for the rest

--- a/app/src/lib/ipynb.ts
+++ b/app/src/lib/ipynb.ts
@@ -1,0 +1,593 @@
+import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
+import md5 from 'md5'
+
+import { MimeType, parser_pb } from '../runme/client'
+
+export const IPYNB_MIME_TYPE = 'application/x-ipynb+json'
+export const IPYNB_RAW_CELL_METADATA_KEY = 'runme.dev/ipynbRawCell'
+export const IPYNB_CELL_ID_METADATA_KEY = 'runme.dev/ipynbCellId'
+
+const IPYNB_OUTPUT_TYPE = 'runme.dev/ipynbOutputType'
+const IPYNB_OUTPUT_METADATA = 'runme.dev/ipynbOutputMetadata'
+const IPYNB_EXECUTION_COUNT = 'runme.dev/ipynbExecutionCount'
+const IPYNB_ERROR = 'runme.dev/ipynbError'
+const RUNME_IPYNB_METADATA_KEY = 'runme'
+const RUNME_IPYNB_METADATA_VERSION = 1
+
+const PROTO_JSON_WRITE_OPTIONS = {
+  emitDefaultValues: true,
+} as unknown as Parameters<typeof toJsonString>[2]
+
+type JsonObject = Record<string, unknown>
+
+export interface IpynbNotebook extends JsonObject {
+  cells: IpynbCell[]
+  metadata: JsonObject
+  nbformat: number
+  nbformat_minor: number
+}
+
+export interface IpynbCell extends JsonObject {
+  cell_type: 'code' | 'markdown' | 'raw'
+  id?: string
+  metadata: JsonObject
+  source: string | string[]
+  outputs?: IpynbOutput[]
+  execution_count?: number | null
+  attachments?: JsonObject
+}
+
+export type IpynbOutput = JsonObject & {
+  output_type: string
+}
+
+export interface DecodedIpynb {
+  notebook: parser_pb.Notebook
+  source: IpynbNotebook
+  jupyterIdByRunmeRefId: Record<string, string>
+  baselineCellHashes: Record<string, string>
+  baselineOutputHashes: Record<string, string>
+}
+
+export interface IpynbMergeState {
+  jupyterIdByRunmeRefId: Record<string, string>
+  baselineCellHashes: Record<string, string>
+  baselineOutputHashes: Record<string, string>
+}
+
+export interface EncodedIpynb {
+  text: string
+  state: IpynbMergeState
+}
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function asObject(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object`)
+  }
+  return value as JsonObject
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function optionalObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonObject)
+    : undefined
+}
+
+function embeddedRunmeCell(metadata: JsonObject): parser_pb.Cell | undefined {
+  const runme = optionalObject(metadata[RUNME_IPYNB_METADATA_KEY])
+  const cell = optionalObject(runme?.cell)
+  if (!cell) {
+    return undefined
+  }
+  try {
+    return fromJsonString(parser_pb.CellSchema, JSON.stringify(cell), {
+      ignoreUnknownFields: true,
+    })
+  } catch {
+    return undefined
+  }
+}
+
+function embeddedRunmeNotebook(
+  metadata: JsonObject
+): parser_pb.Notebook | undefined {
+  const runme = optionalObject(metadata[RUNME_IPYNB_METADATA_KEY])
+  const notebook = optionalObject(runme?.notebook)
+  if (!notebook) {
+    return undefined
+  }
+  try {
+    return fromJsonString(parser_pb.NotebookSchema, JSON.stringify(notebook), {
+      ignoreUnknownFields: true,
+    })
+  } catch {
+    return undefined
+  }
+}
+
+function runmeCellEnvelope(cell: parser_pb.Cell): JsonObject {
+  const json = JSON.parse(
+    toJsonString(parser_pb.CellSchema, cell, PROTO_JSON_WRITE_OPTIONS)
+  ) as JsonObject
+  delete json.kind
+  delete json.value
+  delete json.outputs
+  delete json.executionSummary
+  delete json.refId
+  const metadata = optionalObject(json.metadata)
+  if (metadata) {
+    delete metadata[IPYNB_CELL_ID_METADATA_KEY]
+    delete metadata[IPYNB_RAW_CELL_METADATA_KEY]
+    if (Object.keys(metadata).length === 0) {
+      delete json.metadata
+    }
+  }
+  return json
+}
+
+function runmeNotebookEnvelope(notebook: parser_pb.Notebook): JsonObject {
+  const json = JSON.parse(
+    toJsonString(parser_pb.NotebookSchema, notebook, PROTO_JSON_WRITE_OPTIONS)
+  ) as JsonObject
+  delete json.cells
+  const metadata = optionalObject(json.metadata)
+  if (metadata) {
+    delete metadata['runme.dev/ipynb']
+    if (Object.keys(metadata).length === 0) {
+      delete json.metadata
+    }
+  }
+  return json
+}
+
+function sourceText(source: unknown): string {
+  if (typeof source === 'string') {
+    return source
+  }
+  if (
+    Array.isArray(source) &&
+    source.every((part) => typeof part === 'string')
+  ) {
+    return source.join('')
+  }
+  throw new Error('Jupyter cell source must be a string or string array')
+}
+
+function legalCellId(value: unknown, fallback: string): string {
+  const candidate =
+    typeof value === 'string'
+      ? value.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 64)
+      : ''
+  return candidate || fallback.slice(0, 64)
+}
+
+function uniqueCellId(
+  value: unknown,
+  index: number,
+  used: Set<string>
+): string {
+  const base = legalCellId(value, `cell-${index + 1}`)
+  let candidate = base
+  let suffix = 2
+  while (used.has(candidate)) {
+    const tail = `-${suffix++}`
+    candidate = `${base.slice(0, 64 - tail.length)}${tail}`
+  }
+  used.add(candidate)
+  return candidate
+}
+
+function languageIdForNotebook(metadata: JsonObject): string {
+  const kernelspec =
+    metadata.kernelspec && typeof metadata.kernelspec === 'object'
+      ? (metadata.kernelspec as JsonObject)
+      : undefined
+  const languageInfo =
+    metadata.language_info && typeof metadata.language_info === 'object'
+      ? (metadata.language_info as JsonObject)
+      : undefined
+  return (
+    (typeof kernelspec?.language === 'string'
+      ? kernelspec.language
+      : undefined) ??
+    (typeof languageInfo?.name === 'string' ? languageInfo.name : undefined) ??
+    'python'
+  )
+}
+
+function textValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (Array.isArray(value) && value.every((part) => typeof part === 'string')) {
+    return value.join('')
+  }
+  return JSON.stringify(value)
+}
+
+function outputItem(mime: string, value: unknown): parser_pb.CellOutputItem {
+  return create(parser_pb.CellOutputItemSchema, {
+    mime,
+    type: 'Buffer',
+    data: encoder.encode(textValue(value)),
+  })
+}
+
+function ipynbOutputToRunme(output: IpynbOutput): parser_pb.CellOutput {
+  const metadata: Record<string, string> = {
+    [IPYNB_OUTPUT_TYPE]: output.output_type,
+  }
+  if (output.metadata && typeof output.metadata === 'object') {
+    metadata[IPYNB_OUTPUT_METADATA] = JSON.stringify(output.metadata)
+  }
+  if (
+    output.execution_count === null ||
+    typeof output.execution_count === 'number'
+  ) {
+    metadata[IPYNB_EXECUTION_COUNT] = JSON.stringify(output.execution_count)
+  }
+
+  if (output.output_type === 'stream') {
+    const streamName = output.name === 'stderr' ? 'stderr' : 'stdout'
+    return create(parser_pb.CellOutputSchema, {
+      metadata,
+      items: [
+        outputItem(
+          streamName === 'stderr'
+            ? MimeType.VSCodeNotebookStdErr
+            : MimeType.VSCodeNotebookStdOut,
+          output.text
+        ),
+      ],
+    })
+  }
+
+  if (output.output_type === 'error') {
+    metadata[IPYNB_ERROR] = JSON.stringify({
+      ename: output.ename,
+      evalue: output.evalue,
+      traceback: output.traceback,
+    })
+    return create(parser_pb.CellOutputSchema, {
+      metadata,
+      items: [
+        outputItem('application/vnd.code.notebook.error', {
+          ename: output.ename,
+          evalue: output.evalue,
+          traceback: output.traceback,
+        }),
+      ],
+    })
+  }
+
+  const data =
+    output.data && typeof output.data === 'object'
+      ? (output.data as JsonObject)
+      : {}
+  return create(parser_pb.CellOutputSchema, {
+    metadata,
+    items: Object.entries(data).map(([mime, value]) => outputItem(mime, value)),
+  })
+}
+
+function runmeOutputToIpynb(output: parser_pb.CellOutput): IpynbOutput {
+  const outputType = output.metadata?.[IPYNB_OUTPUT_TYPE]
+  if (
+    output.items.length === 1 &&
+    (output.items[0]?.mime === MimeType.VSCodeNotebookStdOut ||
+      output.items[0]?.mime === MimeType.VSCodeNotebookStdErr)
+  ) {
+    const item = output.items[0]
+    return {
+      output_type: 'stream',
+      name: item.mime === MimeType.VSCodeNotebookStdErr ? 'stderr' : 'stdout',
+      text: decoder.decode(item.data),
+    }
+  }
+
+  if (outputType === 'error' || output.metadata?.[IPYNB_ERROR]) {
+    const error = JSON.parse(
+      output.metadata?.[IPYNB_ERROR] ??
+        decoder.decode(output.items[0]?.data ?? new Uint8Array())
+    ) as JsonObject
+    return {
+      output_type: 'error',
+      ename: typeof error.ename === 'string' ? error.ename : 'Error',
+      evalue: typeof error.evalue === 'string' ? error.evalue : '',
+      traceback: Array.isArray(error.traceback) ? error.traceback : [],
+    }
+  }
+
+  const data: JsonObject = {}
+  for (const item of output.items) {
+    const text = decoder.decode(item.data)
+    if (
+      item.mime === 'application/json' ||
+      item.mime.endsWith('+json') ||
+      item.mime === 'application/vnd.plotly.v1+json'
+    ) {
+      try {
+        data[item.mime] = JSON.parse(text)
+        continue
+      } catch {
+        // Preserve malformed JSON-valued output as text instead of dropping it.
+      }
+    }
+    data[item.mime || 'text/plain'] = text
+  }
+
+  const executionCount = output.metadata?.[IPYNB_EXECUTION_COUNT]
+  const metadata = output.metadata?.[IPYNB_OUTPUT_METADATA]
+  return {
+    output_type:
+      outputType === 'execute_result' ? 'execute_result' : 'display_data',
+    data,
+    metadata: metadata ? JSON.parse(metadata) : {},
+    ...(outputType === 'execute_result'
+      ? {
+          execution_count: executionCount
+            ? (JSON.parse(executionCount) as number | null)
+            : null,
+        }
+      : {}),
+  }
+}
+
+function outputHash(cell: parser_pb.Cell): string {
+  return md5(
+    JSON.stringify(
+      cell.outputs.map((output) => ({
+        metadata: output.metadata,
+        items: output.items.map((item) => ({
+          mime: item.mime,
+          type: item.type,
+          data: Array.from(item.data),
+        })),
+      }))
+    )
+  )
+}
+
+function cellHash(cell: parser_pb.Cell): string {
+  return md5(
+    JSON.stringify({
+      kind: cell.kind,
+      value: cell.value,
+      languageId: cell.languageId,
+      raw: cell.metadata?.[IPYNB_RAW_CELL_METADATA_KEY] ?? '',
+    })
+  )
+}
+
+function validateNotebook(value: unknown): IpynbNotebook {
+  const document = asObject(value, 'Jupyter notebook')
+  if (document.nbformat !== 4) {
+    throw new Error(
+      `Unsupported Jupyter nbformat major version: ${String(document.nbformat)}`
+    )
+  }
+  if (!Array.isArray(document.cells)) {
+    throw new Error('Jupyter notebook cells must be an array')
+  }
+  if (!document.metadata || typeof document.metadata !== 'object') {
+    throw new Error('Jupyter notebook metadata must be an object')
+  }
+  return document as unknown as IpynbNotebook
+}
+
+export function createEmptyIpynb(): IpynbNotebook {
+  return {
+    cells: [],
+    metadata: {},
+    nbformat: 4,
+    nbformat_minor: 5,
+  }
+}
+
+export function decodeIpynb(text: string): DecodedIpynb {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    throw new Error(`Invalid Jupyter notebook JSON: ${String(error)}`)
+  }
+  const source = validateNotebook(parsed)
+  const languageId = languageIdForNotebook(source.metadata)
+  const preservedNotebook = embeddedRunmeNotebook(source.metadata)
+  const usedIds = new Set<string>()
+  const jupyterIdByRunmeRefId: Record<string, string> = {}
+  const baselineCellHashes: Record<string, string> = {}
+  const baselineOutputHashes: Record<string, string> = {}
+
+  const cells = source.cells.map((input, index) => {
+    const sourceCell = asObject(input, `Jupyter cell ${index}`) as IpynbCell
+    if (
+      sourceCell.cell_type !== 'code' &&
+      sourceCell.cell_type !== 'markdown' &&
+      sourceCell.cell_type !== 'raw'
+    ) {
+      throw new Error(
+        `Unsupported Jupyter cell type: ${String(sourceCell.cell_type)}`
+      )
+    }
+    const id = uniqueCellId(sourceCell.id, index, usedIds)
+    // Treat nbformat cell IDs as repairable input. Keeping the repaired value
+    // in the shadow makes the next save both valid and lossless for the rest
+    // of the cell object.
+    sourceCell.id = id
+    const preservedCell = embeddedRunmeCell(sourceCell.metadata)
+    const kind =
+      sourceCell.cell_type === 'code'
+        ? parser_pb.CellKind.CODE
+        : parser_pb.CellKind.MARKUP
+    const refId = `${kind === parser_pb.CellKind.CODE ? 'code' : 'markup'}_${id}`
+    const metadata: Record<string, string> = {
+      ...(preservedCell?.metadata ?? {}),
+      [IPYNB_CELL_ID_METADATA_KEY]: id,
+    }
+    if (sourceCell.cell_type === 'raw') {
+      metadata[IPYNB_RAW_CELL_METADATA_KEY] = 'true'
+    }
+    const cell = create(parser_pb.CellSchema, {
+      kind,
+      refId,
+      value: sourceText(sourceCell.source),
+      languageId:
+        preservedCell?.languageId ||
+        (sourceCell.cell_type === 'code'
+          ? languageId
+          : sourceCell.cell_type === 'raw'
+            ? 'text'
+            : 'markdown'),
+      metadata,
+      textRange: preservedCell?.textRange,
+      outputs:
+        sourceCell.cell_type === 'code' && Array.isArray(sourceCell.outputs)
+          ? sourceCell.outputs.map((output) =>
+              ipynbOutputToRunme(
+                asObject(output, `Jupyter output in cell ${id}`) as IpynbOutput
+              )
+            )
+          : [],
+      executionSummary:
+        sourceCell.cell_type === 'code' &&
+        typeof sourceCell.execution_count === 'number'
+          ? create(parser_pb.CellExecutionSummarySchema, {
+              executionOrder: sourceCell.execution_count,
+            })
+          : undefined,
+      role: preservedCell?.role,
+      callId: preservedCell?.callId,
+      docResults: preservedCell?.docResults,
+    })
+    jupyterIdByRunmeRefId[refId] = id
+    baselineCellHashes[refId] = cellHash(cell)
+    baselineOutputHashes[refId] = outputHash(cell)
+    return cell
+  })
+
+  return {
+    notebook: create(parser_pb.NotebookSchema, {
+      cells,
+      metadata: {
+        ...(preservedNotebook?.metadata ?? {}),
+        'runme.dev/ipynb': 'true',
+      },
+      frontmatter: preservedNotebook?.frontmatter,
+    }),
+    source,
+    jupyterIdByRunmeRefId,
+    baselineCellHashes,
+    baselineOutputHashes,
+  }
+}
+
+function newJupyterId(cell: parser_pb.Cell, index: number): string {
+  return legalCellId(
+    cell.metadata?.[IPYNB_CELL_ID_METADATA_KEY] || cell.refId,
+    `cell-${index + 1}`
+  )
+}
+
+export function encodeIpynb(
+  notebook: parser_pb.Notebook,
+  shadowText?: string,
+  previousState?: Partial<IpynbMergeState>
+): EncodedIpynb {
+  const shadow = shadowText
+    ? validateNotebook(JSON.parse(shadowText))
+    : createEmptyIpynb()
+  const sourceById = new Map(
+    shadow.cells
+      .filter((cell) => typeof cell.id === 'string')
+      .map((cell) => [cell.id as string, cell])
+  )
+  const usedIds = new Set<string>()
+  const jupyterIdByRunmeRefId: Record<string, string> = {}
+  const baselineCellHashes: Record<string, string> = {}
+  const baselineOutputHashes: Record<string, string> = {}
+
+  const cells = notebook.cells.map((cell, index): IpynbCell => {
+    const mappedId = previousState?.jupyterIdByRunmeRefId?.[cell.refId]
+    const id = uniqueCellId(
+      mappedId ?? newJupyterId(cell, index),
+      index,
+      usedIds
+    )
+    const matched = mappedId ? sourceById.get(mappedId) : undefined
+    const outputUnchanged =
+      previousState?.baselineOutputHashes?.[cell.refId] === outputHash(cell)
+    const raw = cell.metadata?.[IPYNB_RAW_CELL_METADATA_KEY] === 'true'
+    const cellType: IpynbCell['cell_type'] =
+      cell.kind === parser_pb.CellKind.CODE ? 'code' : raw ? 'raw' : 'markdown'
+    const result: IpynbCell = matched
+      ? cloneJson(matched)
+      : {
+          cell_type: cellType,
+          id,
+          metadata: {},
+          source: '',
+        }
+    result.cell_type = cellType
+    result.id = id
+    result.source = cell.value
+    result.metadata =
+      result.metadata && typeof result.metadata === 'object'
+        ? result.metadata
+        : {}
+    const existingRunme = optionalObject(
+      result.metadata[RUNME_IPYNB_METADATA_KEY]
+    )
+    result.metadata[RUNME_IPYNB_METADATA_KEY] = {
+      ...(existingRunme ? cloneJson(existingRunme) : {}),
+      version: RUNME_IPYNB_METADATA_VERSION,
+      cell: runmeCellEnvelope(cell),
+    }
+
+    if (cellType === 'code') {
+      result.execution_count = cell.executionSummary?.executionOrder ?? null
+      result.outputs =
+        matched && outputUnchanged && Array.isArray(matched.outputs)
+          ? cloneJson(matched.outputs)
+          : cell.outputs.map(runmeOutputToIpynb)
+    } else {
+      delete result.outputs
+      delete result.execution_count
+    }
+
+    jupyterIdByRunmeRefId[cell.refId] = id
+    baselineCellHashes[cell.refId] = cellHash(cell)
+    baselineOutputHashes[cell.refId] = outputHash(cell)
+    return result
+  })
+
+  const next: IpynbNotebook = {
+    ...cloneJson(shadow),
+    cells,
+    metadata: cloneJson(shadow.metadata ?? {}),
+    nbformat: 4,
+    nbformat_minor:
+      typeof shadow.nbformat_minor === 'number' ? shadow.nbformat_minor : 5,
+  }
+  const existingRunme = optionalObject(next.metadata[RUNME_IPYNB_METADATA_KEY])
+  next.metadata[RUNME_IPYNB_METADATA_KEY] = {
+    ...(existingRunme ? cloneJson(existingRunme) : {}),
+    version: RUNME_IPYNB_METADATA_VERSION,
+    notebook: runmeNotebookEnvelope(notebook),
+  }
+  return {
+    text: `${JSON.stringify(next, null, 2)}\n`,
+    state: {
+      jupyterIdByRunmeRefId,
+      baselineCellHashes,
+      baselineOutputHashes,
+    },
+  }
+}

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -1,0 +1,88 @@
+import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
+
+import { parser_pb } from '../runme/client'
+import {
+  type DecodedIpynb,
+  type EncodedIpynb,
+  createEmptyIpynb,
+  decodeIpynb,
+  encodeIpynb,
+} from './ipynb'
+
+const NOTEBOOK_JSON_WRITE_OPTIONS = {
+  emitDefaultValues: true,
+} as unknown as Parameters<typeof toJsonString>[2]
+
+export type NotebookFileFormat = 'runme-json' | 'ipynb'
+
+export interface DecodedNotebookFile {
+  format: NotebookFileFormat
+  notebook: parser_pb.Notebook
+  ipynb?: DecodedIpynb
+}
+
+export function detectNotebookFileFormat(
+  fileName: string
+): NotebookFileFormat | null {
+  const normalized = fileName.trim().toLowerCase()
+  if (normalized.endsWith('.ipynb')) {
+    return 'ipynb'
+  }
+  if (normalized.endsWith('.json')) {
+    return 'runme-json'
+  }
+  return null
+}
+
+export function isNotebookFileName(fileName: string): boolean {
+  return detectNotebookFileFormat(fileName) !== null
+}
+
+export function decodeNotebookFile(
+  text: string,
+  fileName: string
+): DecodedNotebookFile {
+  const format = detectNotebookFileFormat(fileName)
+  if (!format) {
+    throw new Error(`Unsupported notebook file extension: ${fileName}`)
+  }
+  if (format === 'ipynb') {
+    const ipynb = decodeIpynb(text)
+    return { format, notebook: ipynb.notebook, ipynb }
+  }
+  return {
+    format,
+    notebook: text
+      ? fromJsonString(parser_pb.NotebookSchema, text, {
+          ignoreUnknownFields: true,
+        })
+      : create(parser_pb.NotebookSchema, { cells: [] }),
+  }
+}
+
+export function encodeRunmeNotebook(notebook: parser_pb.Notebook): string {
+  return toJsonString(
+    parser_pb.NotebookSchema,
+    notebook,
+    NOTEBOOK_JSON_WRITE_OPTIONS
+  )
+}
+
+export function encodeIpynbNotebook(
+  notebook: parser_pb.Notebook,
+  shadowText?: string,
+  state?: Parameters<typeof encodeIpynb>[2]
+): EncodedIpynb {
+  return encodeIpynb(notebook, shadowText, state)
+}
+
+export function createInitialNotebookFile(fileName: string): string {
+  const format = detectNotebookFileFormat(fileName)
+  if (format === 'ipynb') {
+    return `${JSON.stringify(createEmptyIpynb(), null, 2)}\n`
+  }
+  if (format === 'runme-json') {
+    return encodeRunmeNotebook(create(parser_pb.NotebookSchema, { cells: [] }))
+  }
+  throw new Error(`Unsupported notebook file extension: ${fileName}`)
+}

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1,6 +1,11 @@
 import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 
 import { getGoogleDriveBaseUrl } from '../lib/googleDriveRuntime'
+import { IPYNB_MIME_TYPE } from '../lib/ipynb'
+import {
+  createInitialNotebookFile,
+  detectNotebookFileFormat,
+} from '../lib/notebookFormat'
 import { parser_pb } from '../runme/client'
 import {
   type ConflictResult,
@@ -1163,11 +1168,16 @@ export class DriveNotebookStore {
       throw new Error('DriveNotebookStore.create expects a folder URI')
     }
     const client = await this.getFilesClient()
+    const format = detectNotebookFileFormat(name)
+    const mimeType = format === 'ipynb' ? IPYNB_MIME_TYPE : 'application/json'
     let file = await client.create({
       name,
-      mimeType: 'application/json',
+      mimeType,
       parents: [id],
-      content: createInitialNotebookJson(),
+      content:
+        format === 'ipynb'
+          ? createInitialNotebookFile(name)
+          : createInitialNotebookJson(),
       ...(options.createOperationId
         ? {
             appProperties: {
@@ -1191,7 +1201,7 @@ export class DriveNotebookStore {
         : NotebookStoreItemType.File,
       children: [],
       remoteUri: isFolder ? driveFolderUrl(fileId) : driveFileUrl(fileId),
-      mimeType: file.mimeType ?? 'application/json',
+      mimeType: file.mimeType ?? mimeType,
       parents: [parentUri],
     }
   }
@@ -1675,6 +1685,28 @@ export class DriveNotebookStore {
     return fromJsonString(parser_pb.NotebookSchema, body, {
       ignoreUnknownFields: true,
     })
+  }
+
+  async loadRevisionContent(uri: string, revisionId: string): Promise<string> {
+    const { id, type } = parseDriveItem(uri)
+    if (type !== NotebookStoreItemType.File) {
+      throw new Error(
+        'DriveNotebookStore.loadRevisionContent expects a file URI'
+      )
+    }
+    if (!revisionId?.trim()) {
+      throw new Error(
+        'DriveNotebookStore.loadRevisionContent requires a revision id'
+      )
+    }
+    const client = await this.getFilesClient()
+    const response = await client.getRevision({
+      fileId: id,
+      revisionId: revisionId.trim(),
+      supportsAllDrives: true,
+      alt: 'media',
+    })
+    return extractBody(response)
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -1,13 +1,13 @@
 /// <reference types="vitest" />
 // @vitest-environment node
+import { create } from '@bufbuild/protobuf'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { create, toJsonString } from "@bufbuild/protobuf";
-
-import { parser_pb } from "../runme/client";
-import { NotebookStoreItemType } from "./notebook";
-import { FilesystemNotebookStore, isFileSystemAccessSupported } from "./fs";
-import type { FsDatabase, WorkspaceRecord, FsEntryRecord } from "./fsdb";
+import { encodeRunmeNotebook } from '../lib/notebookFormat'
+import { parser_pb } from '../runme/client'
+import { FilesystemNotebookStore, isFileSystemAccessSupported } from './fs'
+import type { FsDatabase, FsEntryRecord, WorkspaceRecord } from './fsdb'
+import { NotebookStoreItemType } from './notebook'
 
 // Provide minimal browser globals for Node environment.
 const g = globalThis as any;
@@ -152,10 +152,8 @@ function createMockDb(): FsDatabase {
 // ---------------------------------------------------------------------------
 
 function makeEmptyNotebookJson(): string {
-  const nb = create(parser_pb.NotebookSchema, { cells: [] });
-  return toJsonString(parser_pb.NotebookSchema, nb, {
-    emitDefaultValues: true,
-  });
+  const nb = create(parser_pb.NotebookSchema, { cells: [] })
+  return encodeRunmeNotebook(nb)
 }
 
 // ---------------------------------------------------------------------------
@@ -336,28 +334,59 @@ describe("FilesystemNotebookStore", () => {
       const items = await store.list(ROOT_URI);
 
       // Should have the directory first, then the .json file. readme.md is filtered out.
-      expect(items).toHaveLength(2);
-      expect(items[0].type).toBe(NotebookStoreItemType.Folder);
-      expect(items[0].name).toBe("sub");
-      expect(items[1].type).toBe(NotebookStoreItemType.File);
-      expect(items[1].name).toBe("notebook.json");
-    });
+      expect(items).toHaveLength(2)
+      expect(items[0].type).toBe(NotebookStoreItemType.Folder)
+      expect(items[0].name).toBe('sub')
+      expect(items[1].type).toBe(NotebookStoreItemType.File)
+      expect(items[1].name).toBe('notebook.json')
+    })
 
-    it("filters out non-.json files", async () => {
-      rootEntries.set("readme.md", createMockFileHandle("readme.md", "# Hi"));
-      rootEntries.set("image.png", createMockFileHandle("image.png", "binary"));
+    it('returns .ipynb files with the Jupyter MIME type', async () => {
+      rootEntries.set(
+        'notebook.ipynb',
+        createMockFileHandle(
+          'notebook.ipynb',
+          JSON.stringify({
+            cells: [],
+            metadata: {},
+            nbformat: 4,
+            nbformat_minor: 5,
+          })
+        )
+      )
 
-      const items = await store.list(ROOT_URI);
-      expect(items).toHaveLength(0);
-    });
+      const items = await store.list(ROOT_URI)
 
-    it("sorts folders before files, then alphabetically", async () => {
-      rootEntries.set("b.json", createMockFileHandle("b.json", makeEmptyNotebookJson()));
-      rootEntries.set("a.json", createMockFileHandle("a.json", makeEmptyNotebookJson()));
-      rootEntries.set("z-dir", createMockDirectoryHandle("z-dir", new Map()));
-      rootEntries.set("a-dir", createMockDirectoryHandle("a-dir", new Map()));
+      expect(items).toEqual([
+        expect.objectContaining({
+          name: 'notebook.ipynb',
+          mimeType: 'application/x-ipynb+json',
+          type: NotebookStoreItemType.File,
+        }),
+      ])
+    })
 
-      const items = await store.list(ROOT_URI);
+    it('filters out non-.json files', async () => {
+      rootEntries.set('readme.md', createMockFileHandle('readme.md', '# Hi'))
+      rootEntries.set('image.png', createMockFileHandle('image.png', 'binary'))
+
+      const items = await store.list(ROOT_URI)
+      expect(items).toHaveLength(0)
+    })
+
+    it('sorts folders before files, then alphabetically', async () => {
+      rootEntries.set(
+        'b.json',
+        createMockFileHandle('b.json', makeEmptyNotebookJson())
+      )
+      rootEntries.set(
+        'a.json',
+        createMockFileHandle('a.json', makeEmptyNotebookJson())
+      )
+      rootEntries.set('z-dir', createMockDirectoryHandle('z-dir', new Map()))
+      rootEntries.set('a-dir', createMockDirectoryHandle('a-dir', new Map()))
+
+      const items = await store.list(ROOT_URI)
       expect(items.map((i) => i.name)).toEqual([
         "a-dir",
         "z-dir",
@@ -431,10 +460,51 @@ describe("FilesystemNotebookStore", () => {
       expect(notebook.cells).toEqual([]);
     });
 
-    it("records base revision after load", async () => {
-      const nbJson = makeEmptyNotebookJson();
-      const fileHandle = createMockFileHandle("notebook.json", nbJson);
-      const fileUri = `fs://workspace/${WORKSPACE_ID}/file/${encodeURIComponent("notebook.json")}`;
+    it('loads and saves ipynb without dropping Jupyter-only fields', async () => {
+      const source = {
+        cells: [
+          {
+            cell_type: 'code',
+            id: 'code-cell',
+            metadata: { trusted: true },
+            execution_count: null,
+            source: "print('before')\n",
+            outputs: [],
+          },
+        ],
+        metadata: { colab: { name: 'keep-me' } },
+        nbformat: 4,
+        nbformat_minor: 5,
+      }
+      const fileHandle = createMockFileHandle(
+        'notebook.ipynb',
+        JSON.stringify(source)
+      )
+      const fileUri = `fs://workspace/${WORKSPACE_ID}/file/${encodeURIComponent('notebook.ipynb')}`
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:notebook.ipynb`, {
+        id: `${WORKSPACE_ID}:notebook.ipynb`,
+        workspaceId: WORKSPACE_ID,
+        relativePath: 'notebook.ipynb',
+        kind: 'file',
+        handle: fileHandle,
+        lastKnownMtime: 0,
+        lastKnownSize: 0,
+      })
+
+      const notebook = await store.load(fileUri)
+      notebook.cells[0]!.value = "print('after')\n"
+      await store.save(fileUri, notebook)
+
+      const saved = JSON.parse(await (await fileHandle.getFile()).text())
+      expect(saved.cells[0].source).toBe("print('after')\n")
+      expect(saved.cells[0].metadata).toMatchObject(source.cells[0].metadata)
+      expect(saved.metadata).toMatchObject(source.metadata)
+    })
+
+    it('records base revision after load', async () => {
+      const nbJson = makeEmptyNotebookJson()
+      const fileHandle = createMockFileHandle('notebook.json', nbJson)
+      const fileUri = `fs://workspace/${WORKSPACE_ID}/file/${encodeURIComponent('notebook.json')}`;
 
       (db.entries as any)._store.set(`${WORKSPACE_ID}:notebook.json`, {
         id: `${WORKSPACE_ID}:notebook.json`,
@@ -527,17 +597,17 @@ describe("FilesystemNotebookStore", () => {
       // The mock returns fresh lastModified on each getFile call (Date.now()),
       // so a second getFile call during save will have a different timestamp.
       // We need to manipulate the mock to return different values.
-      const originalGetFile = fileHandle.getFile;
-      let callCount = 0;
-      fileHandle.getFile = vi.fn(async () => {
-        callCount++;
+      const originalGetFile = fileHandle.getFile
+      let callCount = 0
+      fileHandle.getFile = vi.fn(async (): Promise<File> => {
+        callCount++
         if (callCount === 1) {
           // During save's conflict check — return different stats.
           return {
-            text: async () => "externally modified",
+            text: async (): Promise<string> => 'externally modified',
             lastModified: 999999999,
             size: 999,
-          };
+          } as unknown as File
         }
         return originalGetFile();
       });
@@ -601,8 +671,25 @@ describe("FilesystemNotebookStore", () => {
       expect(item.parents).toEqual([ROOT_URI]);
     });
 
-    it("calls getFileHandle with create: true", async () => {
-      await store.create(ROOT_URI, "new-notebook.json");
+    it('creates a valid empty ipynb document', async () => {
+      const item = await store.create(ROOT_URI, 'new-notebook.ipynb')
+      const file = await rootEntries.get('new-notebook.ipynb').getFile()
+      const document = JSON.parse(await file.text())
+
+      expect(item).toMatchObject({
+        name: 'new-notebook.ipynb',
+        mimeType: 'application/x-ipynb+json',
+      })
+      expect(document).toMatchObject({
+        cells: [],
+        metadata: {},
+        nbformat: 4,
+        nbformat_minor: 5,
+      })
+    })
+
+    it('calls getFileHandle with create: true', async () => {
+      await store.create(ROOT_URI, 'new-notebook.json')
       expect(rootHandle.getFileHandle).toHaveBeenCalledWith(
         "new-notebook.json",
         { create: true },
@@ -666,13 +753,39 @@ describe("FilesystemNotebookStore", () => {
   // rename
   // -------------------------------------------------------------------------
 
-  describe("rename", () => {
-    it("copies content to new file and removes old", async () => {
-      const nbJson = makeEmptyNotebookJson();
-      const oldHandle = createMockFileHandle("old.json", nbJson);
-      rootEntries.set("old.json", oldHandle);
+  describe('rename', () => {
+    it('rejects changing formats by rename', async () => {
+      const oldHandle = createMockFileHandle(
+        'old.ipynb',
+        JSON.stringify({
+          cells: [],
+          metadata: {},
+          nbformat: 4,
+          nbformat_minor: 5,
+        })
+      )
+      rootEntries.set('old.ipynb', oldHandle)
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:old.ipynb`, {
+        id: `${WORKSPACE_ID}:old.ipynb`,
+        workspaceId: WORKSPACE_ID,
+        relativePath: 'old.ipynb',
+        kind: 'file',
+        handle: oldHandle,
+        lastKnownMtime: 0,
+        lastKnownSize: 0,
+      })
+      const oldUri = `fs://workspace/${WORKSPACE_ID}/file/${encodeURIComponent('old.ipynb')}`
 
-      (db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
+      await expect(store.rename(oldUri, 'new.json')).rejects.toThrow(
+        'Changing notebook formats by rename'
+      )
+    })
+
+    it('copies content to new file and removes old', async () => {
+      const nbJson = makeEmptyNotebookJson()
+      const oldHandle = createMockFileHandle('old.json', nbJson)
+      rootEntries.set('old.json', oldHandle)
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
         id: `${WORKSPACE_ID}:old.json`,
         workspaceId: WORKSPACE_ID,
         relativePath: "old.json",
@@ -692,12 +805,11 @@ describe("FilesystemNotebookStore", () => {
       );
     });
 
-    it("removes old entry from DB", async () => {
-      const nbJson = makeEmptyNotebookJson();
-      const oldHandle = createMockFileHandle("old.json", nbJson);
-      rootEntries.set("old.json", oldHandle);
-
-      (db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
+    it('removes old entry from DB', async () => {
+      const nbJson = makeEmptyNotebookJson()
+      const oldHandle = createMockFileHandle('old.json', nbJson)
+      rootEntries.set('old.json', oldHandle)
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
         id: `${WORKSPACE_ID}:old.json`,
         workspaceId: WORKSPACE_ID,
         relativePath: "old.json",
@@ -713,12 +825,11 @@ describe("FilesystemNotebookStore", () => {
       expect(db.entries.delete).toHaveBeenCalledWith(`${WORKSPACE_ID}:old.json`);
     });
 
-    it("removes old file from directory", async () => {
-      const nbJson = makeEmptyNotebookJson();
-      const oldHandle = createMockFileHandle("old.json", nbJson);
-      rootEntries.set("old.json", oldHandle);
-
-      (db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
+    it('removes old file from directory', async () => {
+      const nbJson = makeEmptyNotebookJson()
+      const oldHandle = createMockFileHandle('old.json', nbJson)
+      rootEntries.set('old.json', oldHandle)
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
         id: `${WORKSPACE_ID}:old.json`,
         workspaceId: WORKSPACE_ID,
         relativePath: "old.json",
@@ -734,12 +845,11 @@ describe("FilesystemNotebookStore", () => {
       expect(rootHandle.removeEntry).toHaveBeenCalledWith("old.json");
     });
 
-    it("creates new entry in DB", async () => {
-      const nbJson = makeEmptyNotebookJson();
-      const oldHandle = createMockFileHandle("old.json", nbJson);
-      rootEntries.set("old.json", oldHandle);
-
-      (db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
+    it('creates new entry in DB', async () => {
+      const nbJson = makeEmptyNotebookJson()
+      const oldHandle = createMockFileHandle('old.json', nbJson)
+      rootEntries.set('old.json', oldHandle)
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
         id: `${WORKSPACE_ID}:old.json`,
         workspaceId: WORKSPACE_ID,
         relativePath: "old.json",
@@ -756,18 +866,17 @@ describe("FilesystemNotebookStore", () => {
         expect.objectContaining({
           id: `${WORKSPACE_ID}:new.json`,
           workspaceId: WORKSPACE_ID,
-          relativePath: "new.json",
-          kind: "file",
-        }),
-      );
-    });
+          relativePath: 'new.json',
+          kind: 'file',
+        })
+      )
+    })
 
-    it("sets parent URI in the returned item", async () => {
-      const nbJson = makeEmptyNotebookJson();
-      const oldHandle = createMockFileHandle("old.json", nbJson);
-      rootEntries.set("old.json", oldHandle);
-
-      (db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
+    it('sets parent URI in the returned item', async () => {
+      const nbJson = makeEmptyNotebookJson()
+      const oldHandle = createMockFileHandle('old.json', nbJson)
+      rootEntries.set('old.json', oldHandle)
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:old.json`, {
         id: `${WORKSPACE_ID}:old.json`,
         workspaceId: WORKSPACE_ID,
         relativePath: "old.json",

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -501,6 +501,52 @@ describe("FilesystemNotebookStore", () => {
       expect(saved.metadata).toMatchObject(source.metadata)
     })
 
+    it('uses raw ipynb updates as the preservation source for later saves', async () => {
+      const source = {
+        cells: [
+          {
+            cell_type: 'code',
+            id: 'code-cell',
+            metadata: { vendor: { folded: false } },
+            execution_count: null,
+            source: "print('before')\n",
+            outputs: [],
+          },
+        ],
+        metadata: { colab: { provenance: ['original'] } },
+        nbformat: 4,
+        nbformat_minor: 5,
+      }
+      const fileHandle = createMockFileHandle(
+        'notebook.ipynb',
+        JSON.stringify(source)
+      )
+      const fileUri = `fs://workspace/${WORKSPACE_ID}/file/${encodeURIComponent('notebook.ipynb')}`
+      ;(db.entries as any)._store.set(`${WORKSPACE_ID}:notebook.ipynb`, {
+        id: `${WORKSPACE_ID}:notebook.ipynb`,
+        workspaceId: WORKSPACE_ID,
+        relativePath: 'notebook.ipynb',
+        kind: 'file',
+        handle: fileHandle,
+        lastKnownMtime: 0,
+        lastKnownSize: 0,
+      })
+
+      const notebook = await store.load(fileUri)
+      const rawUpdate = structuredClone(source)
+      rawUpdate.cells[0]!.metadata.vendor.folded = true
+      rawUpdate.metadata.colab.provenance = ['raw-update']
+      await store.saveContent(fileUri, JSON.stringify(rawUpdate))
+
+      notebook.cells[0]!.value = "print('from Runme')\n"
+      await store.save(fileUri, notebook)
+
+      const saved = JSON.parse(await (await fileHandle.getFile()).text())
+      expect(saved.cells[0].source).toBe("print('from Runme')\n")
+      expect(saved.cells[0].metadata.vendor.folded).toBe(true)
+      expect(saved.metadata.colab.provenance).toEqual(['raw-update'])
+    })
+
     it('records base revision after load', async () => {
       const nbJson = makeEmptyNotebookJson()
       const fileHandle = createMockFileHandle('notebook.json', nbJson)

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -705,6 +705,10 @@ export class FilesystemNotebookStore {
       parsed.relativePath
     )
     const recId = entryRecordId(parsed.workspaceId, parsed.relativePath)
+    const decoded =
+      detectNotebookFileFormat(parsed.relativePath) === 'ipynb'
+        ? decodeNotebookFile(content, parsed.relativePath)
+        : undefined
     const baseRevision = this.baseRevisions.get(recId)
     if (baseRevision) {
       const current = await handle.getFile()
@@ -730,6 +734,12 @@ export class FilesystemNotebookStore {
       lastKnownSize: updated.size,
       cachedDoc: content,
     })
+    if (decoded?.ipynb) {
+      this.ipynbState.set(recId, {
+        shadowText: content,
+        state: decoded.ipynb,
+      })
+    }
   }
 
   async getType(uri: string): Promise<NotebookStoreItemType> {

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -1,12 +1,17 @@
-import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid'
 
-import { parser_pb } from "../runme/client";
+import { IPYNB_MIME_TYPE, type IpynbMergeState } from '../lib/ipynb'
 import {
-  NotebookStoreItem,
-  NotebookStoreItemType,
-} from "./notebook";
-import { FsDatabase, WorkspaceRecord } from "./fsdb";
+  createInitialNotebookFile,
+  decodeNotebookFile,
+  detectNotebookFileFormat,
+  encodeIpynbNotebook,
+  encodeRunmeNotebook,
+  isNotebookFileName,
+} from '../lib/notebookFormat'
+import { parser_pb } from '../runme/client'
+import { FsDatabase, WorkspaceRecord } from './fsdb'
+import { NotebookStoreItem, NotebookStoreItemType } from './notebook'
 
 // ---------------------------------------------------------------------------
 // File System Access API type augmentations
@@ -123,11 +128,36 @@ function entryRecordId(workspaceId: string, relativePath: string): string {
 // Notebook helpers
 // ---------------------------------------------------------------------------
 
-function createEmptyNotebookJson(): string {
-  const notebook = create(parser_pb.NotebookSchema, { cells: [] });
-  return toJsonString(parser_pb.NotebookSchema, notebook, {
-    emitDefaultValues: true,
-  });
+function notebookNameForCreate(name: string): string {
+  const trimmed = name.trim()
+  if (detectNotebookFileFormat(trimmed)) {
+    return trimmed
+  }
+  if (/\.[^/]+$/.test(trimmed)) {
+    throw new Error(`Unsupported notebook file extension: ${name}`)
+  }
+  return `${trimmed}.json`
+}
+
+function notebookNameForRename(oldName: string, name: string): string {
+  const oldFormat = detectNotebookFileFormat(oldName)
+  if (!oldFormat) {
+    throw new Error(`Unsupported notebook file extension: ${oldName}`)
+  }
+  const trimmed = name.trim()
+  const nextFormat = detectNotebookFileFormat(trimmed)
+  if (nextFormat && nextFormat !== oldFormat) {
+    throw new Error(
+      'Changing notebook formats by rename is not supported. Use Save as instead.'
+    )
+  }
+  if (nextFormat) {
+    return trimmed
+  }
+  if (/\.[^/]+$/.test(trimmed)) {
+    throw new Error(`Unsupported notebook file extension: ${name}`)
+  }
+  return `${trimmed}${oldFormat === 'ipynb' ? '.ipynb' : '.json'}`
 }
 
 /**
@@ -192,7 +222,11 @@ export class FilesystemNotebookStore {
   private readonly db: FsDatabase;
 
   /** In-memory base revision map keyed by entry record id. */
-  private readonly baseRevisions = new Map<string, BaseRevision>();
+  private readonly baseRevisions = new Map<string, BaseRevision>()
+  private readonly ipynbState = new Map<
+    string,
+    { shadowText: string; state: IpynbMergeState }
+  >()
 
   constructor(db?: FsDatabase) {
     this.db = db ?? new FsDatabase();
@@ -283,9 +317,9 @@ export class FilesystemNotebookStore {
 
     const items: NotebookStoreItem[] = [];
     for await (const [name, handle] of dirHandle.entries()) {
-      if (handle.kind === "file") {
-        if (!name.endsWith(".json")) {
-          continue;
+      if (handle.kind === 'file') {
+        if (!isNotebookFileName(name)) {
+          continue
         }
         const relPath = parsed.relativePath
           ? `${parsed.relativePath}/${name}`
@@ -309,6 +343,9 @@ export class FilesystemNotebookStore {
           name,
           type: NotebookStoreItemType.File,
           children: [],
+          mimeType: name.toLowerCase().endsWith('.ipynb')
+            ? IPYNB_MIME_TYPE
+            : 'application/json',
           parents: [uri],
         });
       } else if (handle.kind === "directory") {
@@ -376,11 +413,16 @@ export class FilesystemNotebookStore {
       cachedDoc: text,
     });
 
-    const notebook = fromJsonString(parser_pb.NotebookSchema, text, {
-      ignoreUnknownFields: true,
-    });
-    ensureCellRefIds(notebook);
-    return notebook;
+    const decoded = decodeNotebookFile(text, parsed.relativePath)
+    const notebook = decoded.notebook
+    if (decoded.ipynb) {
+      this.ipynbState.set(recId, {
+        shadowText: text,
+        state: decoded.ipynb,
+      })
+    }
+    ensureCellRefIds(notebook)
+    return notebook
   }
 
   async save(uri: string, notebook: parser_pb.Notebook): Promise<void> {
@@ -409,9 +451,29 @@ export class FilesystemNotebookStore {
       }
     }
 
-    const json = toJsonString(parser_pb.NotebookSchema, notebook, {
-      emitDefaultValues: true,
-    });
+    let json: string
+    if (detectNotebookFileFormat(parsed.relativePath) === 'ipynb') {
+      let preservation = this.ipynbState.get(recId)
+      if (!preservation) {
+        const currentText = await (await fileHandle.getFile()).text()
+        const decoded = decodeNotebookFile(currentText, parsed.relativePath)
+        preservation = decoded.ipynb
+          ? { shadowText: currentText, state: decoded.ipynb }
+          : undefined
+      }
+      const encoded = encodeIpynbNotebook(
+        notebook,
+        preservation?.shadowText,
+        preservation?.state
+      )
+      json = encoded.text
+      this.ipynbState.set(recId, {
+        shadowText: json,
+        state: encoded.state,
+      })
+    } else {
+      json = encodeRunmeNotebook(notebook)
+    }
 
     const writable = await fileHandle.createWritable();
     await writable.write(json);
@@ -439,21 +501,19 @@ export class FilesystemNotebookStore {
       );
     }
 
-    // Ensure .json extension so the file will be visible via list().
-    const safeName = name.endsWith(".json") ? name : `${name}.json`;
+    const safeName = notebookNameForCreate(name)
 
     const dirHandle = await this.resolveDirectoryHandle(
       parsed.workspaceId,
       parsed.relativePath,
     );
 
-    const fileHandle = await dirHandle.getFileHandle(safeName, { create: true });
+    const fileHandle = await dirHandle.getFileHandle(safeName, { create: true })
 
-    // Write an empty notebook.
-    const json = createEmptyNotebookJson();
-    const writable = await fileHandle.createWritable();
-    await writable.write(json);
-    await writable.close();
+    const json = createInitialNotebookFile(safeName)
+    const writable = await fileHandle.createWritable()
+    await writable.write(json)
+    await writable.close()
 
     const relPath = parsed.relativePath
       ? `${parsed.relativePath}/${safeName}`
@@ -484,6 +544,9 @@ export class FilesystemNotebookStore {
       name: safeName,
       type: NotebookStoreItemType.File,
       children: [],
+      mimeType: safeName.toLowerCase().endsWith('.ipynb')
+        ? IPYNB_MIME_TYPE
+        : 'application/json',
       parents: [parentUri],
     };
   }
@@ -494,8 +557,8 @@ export class FilesystemNotebookStore {
       throw new Error("FilesystemNotebookStore.rename expects a file URI");
     }
 
-    // Ensure .json extension so the file remains visible via list().
-    const safeName = name.endsWith(".json") ? name : `${name}.json`;
+    const oldName = parsed.relativePath.split('/').at(-1) ?? parsed.relativePath
+    const safeName = notebookNameForRename(oldName, name)
 
     // Read the old file contents.
     const fileHandle = await this.resolveFileHandle(
@@ -521,13 +584,15 @@ export class FilesystemNotebookStore {
     await writable.close();
 
     // Remove the old file.
-    const oldName = segments[segments.length - 1];
-    await dirHandle.removeEntry(oldName);
+    const oldEntryName = segments[segments.length - 1]
+    await dirHandle.removeEntry(oldEntryName)
 
     // Clean up old entry record.
-    const oldRecId = entryRecordId(parsed.workspaceId, parsed.relativePath);
-    await this.db.entries.delete(oldRecId);
-    this.baseRevisions.delete(oldRecId);
+    const oldRecId = entryRecordId(parsed.workspaceId, parsed.relativePath)
+    await this.db.entries.delete(oldRecId)
+    this.baseRevisions.delete(oldRecId)
+    const preservation = this.ipynbState.get(oldRecId)
+    this.ipynbState.delete(oldRecId)
 
     // Register the new entry.
     const newRelPath = parentRelPath ? `${parentRelPath}/${safeName}` : safeName;
@@ -549,7 +614,10 @@ export class FilesystemNotebookStore {
     this.baseRevisions.set(newRecId, {
       lastModified: newFile.lastModified,
       size: newFile.size,
-    });
+    })
+    if (preservation) {
+      this.ipynbState.set(newRecId, preservation)
+    }
 
     const parentUri = buildFsUri(
       parsed.workspaceId,
@@ -562,6 +630,9 @@ export class FilesystemNotebookStore {
       name: safeName,
       type: NotebookStoreItemType.File,
       children: [],
+      mimeType: safeName.toLowerCase().endsWith('.ipynb')
+        ? IPYNB_MIME_TYPE
+        : 'application/json',
       parents: [parentUri],
     };
   }
@@ -602,8 +673,63 @@ export class FilesystemNotebookStore {
       name: displayName,
       type,
       children: [],
+      mimeType:
+        type === NotebookStoreItemType.File
+          ? displayName.toLowerCase().endsWith('.ipynb')
+            ? IPYNB_MIME_TYPE
+            : 'application/json'
+          : undefined,
       parents: [parentUri],
     };
+  }
+
+  async loadContent(uri: string): Promise<string> {
+    const parsed = parseFsUri(uri)
+    if (parsed.kind !== 'file') {
+      throw new Error('FilesystemNotebookStore.loadContent expects a file URI')
+    }
+    const handle = await this.resolveFileHandle(
+      parsed.workspaceId,
+      parsed.relativePath
+    )
+    return (await handle.getFile()).text()
+  }
+
+  async saveContent(uri: string, content: string): Promise<void> {
+    const parsed = parseFsUri(uri)
+    if (parsed.kind !== 'file') {
+      throw new Error('FilesystemNotebookStore.saveContent expects a file URI')
+    }
+    const handle = await this.resolveFileHandle(
+      parsed.workspaceId,
+      parsed.relativePath
+    )
+    const recId = entryRecordId(parsed.workspaceId, parsed.relativePath)
+    const baseRevision = this.baseRevisions.get(recId)
+    if (baseRevision) {
+      const current = await handle.getFile()
+      if (
+        current.lastModified !== baseRevision.lastModified ||
+        current.size !== baseRevision.size
+      ) {
+        throw new Error(
+          `Conflict detected for ${parsed.relativePath}: the file was modified externally since last load.`
+        )
+      }
+    }
+    const writable = await handle.createWritable()
+    await writable.write(content)
+    await writable.close()
+    const updated = await handle.getFile()
+    this.baseRevisions.set(recId, {
+      lastModified: updated.lastModified,
+      size: updated.size,
+    })
+    await this.db.entries.update(recId, {
+      lastKnownMtime: updated.lastModified,
+      lastKnownSize: updated.size,
+      cachedDoc: content,
+    })
   }
 
   async getType(uri: string): Promise<NotebookStoreItemType> {

--- a/app/src/storage/ipynbShadows.test.ts
+++ b/app/src/storage/ipynbShadows.test.ts
@@ -1,0 +1,24 @@
+/// <reference types="vitest" />
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+
+import { MemoryIpynbShadowStorage } from './ipynbShadows'
+
+describe('MemoryIpynbShadowStorage', () => {
+  it('stores content-addressed shadows and verifies their integrity', async () => {
+    const storage = new MemoryIpynbShadowStorage()
+    const first = await storage.write('local://file/a', '{"nbformat":4}')
+    const duplicate = await storage.write('local://file/a', '{"nbformat":4}')
+    const changed = await storage.write(
+      'local://file/a',
+      '{"nbformat":4,"cells":[]}'
+    )
+
+    expect(duplicate.path).toBe(first.path)
+    expect(changed.path).not.toBe(first.path)
+    await expect(storage.read(first)).resolves.toBe('{"nbformat":4}')
+
+    await storage.delete(first)
+    await expect(storage.read(first)).rejects.toThrow('shadow not found')
+  })
+})

--- a/app/src/storage/ipynbShadows.ts
+++ b/app/src/storage/ipynbShadows.ts
@@ -9,6 +9,11 @@ export interface IpynbShadowRef {
 
 export interface IpynbPreservationState {
   upstreamFingerprint: string
+  /**
+   * Checksum of the Runme representation at the last successful upstream
+   * read or write. This differs from the checksum of the raw .ipynb bytes.
+   */
+  baselineNotebookChecksum?: string
   shadowRef: IpynbShadowRef
   jupyterIdByRunmeRefId: Record<string, string>
   baselineCellHashes: Record<string, string>

--- a/app/src/storage/ipynbShadows.ts
+++ b/app/src/storage/ipynbShadows.ts
@@ -1,0 +1,147 @@
+import md5 from 'md5'
+
+export interface IpynbShadowRef {
+  storage: 'opfs'
+  path: string
+  sizeBytes: number
+  checksum: string
+}
+
+export interface IpynbPreservationState {
+  upstreamFingerprint: string
+  shadowRef: IpynbShadowRef
+  jupyterIdByRunmeRefId: Record<string, string>
+  baselineCellHashes: Record<string, string>
+  baselineOutputHashes: Record<string, string>
+}
+
+export interface IpynbShadowStorage {
+  write(canonicalUri: string, document: string): Promise<IpynbShadowRef>
+  read(ref: IpynbShadowRef): Promise<string>
+  delete(ref: IpynbShadowRef): Promise<void>
+}
+
+const ROOT_DIR = 'runme'
+const SHADOW_DIR = 'ipynb-shadows'
+const textEncoder = new TextEncoder()
+
+function pathFor(canonicalUri: string, document: string): string {
+  return [
+    ROOT_DIR,
+    SHADOW_DIR,
+    encodeURIComponent(canonicalUri),
+    `${md5(document)}.ipynb`,
+  ].join('/')
+}
+
+async function getDirectory(
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+  options: FileSystemGetDirectoryOptions = {}
+): Promise<FileSystemDirectoryHandle> {
+  let directory = root
+  for (const segment of segments) {
+    directory = await directory.getDirectoryHandle(segment, options)
+  }
+  return directory
+}
+
+async function getOpfsRoot(): Promise<FileSystemDirectoryHandle> {
+  const storage = globalThis.navigator?.storage
+  if (!storage?.getDirectory) {
+    throw new Error('Origin private file system is not available')
+  }
+  return storage.getDirectory()
+}
+
+function verify(ref: IpynbShadowRef, document: string): void {
+  const sizeBytes = textEncoder.encode(document).byteLength
+  const checksum = md5(document)
+  if (sizeBytes !== ref.sizeBytes || checksum !== ref.checksum) {
+    throw new Error(`IPYNB shadow checksum mismatch: ${ref.path}`)
+  }
+}
+
+export class OpfsIpynbShadowStorage implements IpynbShadowStorage {
+  async write(canonicalUri: string, document: string): Promise<IpynbShadowRef> {
+    const path = pathFor(canonicalUri, document)
+    const segments = path.split('/')
+    const root = await getOpfsRoot()
+    const directory = await getDirectory(root, segments.slice(0, -1), {
+      create: true,
+    })
+    const handle = await directory.getFileHandle(segments.at(-1)!, {
+      create: true,
+    })
+    const writable = await handle.createWritable()
+    await writable.write(document)
+    await writable.close()
+    const ref = {
+      storage: 'opfs' as const,
+      path,
+      sizeBytes: textEncoder.encode(document).byteLength,
+      checksum: md5(document),
+    }
+    verify(ref, await this.readUnchecked(ref))
+    return ref
+  }
+
+  private async readUnchecked(ref: IpynbShadowRef): Promise<string> {
+    const segments = ref.path.split('/').filter(Boolean)
+    const root = await getOpfsRoot()
+    const directory = await getDirectory(root, segments.slice(0, -1))
+    const handle = await directory.getFileHandle(segments.at(-1)!)
+    return (await handle.getFile()).text()
+  }
+
+  async read(ref: IpynbShadowRef): Promise<string> {
+    if (ref.storage !== 'opfs') {
+      throw new Error(`Unsupported IPYNB shadow storage: ${ref.storage}`)
+    }
+    const document = await this.readUnchecked(ref)
+    verify(ref, document)
+    return document
+  }
+
+  async delete(ref: IpynbShadowRef): Promise<void> {
+    const segments = ref.path.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return
+    }
+    const root = await getOpfsRoot()
+    const directory = await getDirectory(root, segments.slice(0, -1))
+    await directory.removeEntry(segments.at(-1)!).catch(() => {})
+  }
+}
+
+export class MemoryIpynbShadowStorage implements IpynbShadowStorage {
+  private readonly documents = new Map<string, string>()
+
+  async write(canonicalUri: string, document: string): Promise<IpynbShadowRef> {
+    const path = pathFor(canonicalUri, document)
+    this.documents.set(path, document)
+    return {
+      storage: 'opfs',
+      path,
+      sizeBytes: textEncoder.encode(document).byteLength,
+      checksum: md5(document),
+    }
+  }
+
+  async read(ref: IpynbShadowRef): Promise<string> {
+    const document = this.documents.get(ref.path)
+    if (document === undefined) {
+      throw new Error(`IPYNB shadow not found: ${ref.path}`)
+    }
+    verify(ref, document)
+    return document
+  }
+
+  async delete(ref: IpynbShadowRef): Promise<void> {
+    this.documents.delete(ref.path)
+  }
+}
+
+export function createDefaultIpynbShadowStorage(): IpynbShadowStorage {
+  return new OpfsIpynbShadowStorage()
+}

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1142,6 +1142,82 @@ describe('LocalNotebooks ipynb conversion', () => {
     })
   })
 
+  it('accepts remote-only Drive ipynb edits without a false conflict', async () => {
+    const localUri = 'local://file/ipynb'
+    const remoteUri = 'https://drive.google.com/file/d/ipynb123/view'
+    const makeSource = (value: string) =>
+      `${JSON.stringify({
+        cells: [
+          {
+            cell_type: 'code',
+            id: 'code-cell',
+            metadata: { vendor: { folded: false } },
+            execution_count: null,
+            source: value,
+            outputs: [],
+          },
+        ],
+        metadata: { kernelspec: { name: 'python3', language: 'python' } },
+        nbformat: 4,
+        nbformat_minor: 5,
+      })}\n`
+    let remoteText = makeSource('print("before")\n')
+    let remoteChecksum = 'remote-1'
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'shared.ipynb',
+        type: NotebookStoreItemType.File,
+        children: [],
+        mimeType: IPYNB_MIME_TYPE,
+        parents: [],
+      })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: remoteChecksum,
+        headRevisionId: `${remoteChecksum}-revision`,
+      })),
+      loadContent: vi.fn(async () => remoteText),
+    }
+    const shadowStorage = new MemoryIpynbShadowStorage()
+    const store = createTestStore(driveStore, {
+      ipynbShadowStorage: shadowStorage,
+    })
+    await store.files.put({
+      id: localUri,
+      name: 'shared.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.sync(localUri)
+    const firstShadow = (await store.files.get(localUri))!.ipynbPreservation!
+      .shadowRef
+
+    remoteText = makeSource('print("after")\n')
+    remoteChecksum = 'remote-2'
+    await store.sync(localUri)
+
+    await expect(store.load(localUri)).resolves.toMatchObject({
+      cells: [expect.objectContaining({ value: 'print("after")\n' })],
+    })
+    const record = await store.files.get(localUri)
+    expect(record?.conflict).toBeUndefined()
+    expect(record).toMatchObject({
+      lastRemoteChecksum: 'remote-2',
+      ipynbPreservation: {
+        upstreamFingerprint: 'remote-2',
+        baselineNotebookChecksum: expect.any(String),
+      },
+    })
+    await expect(shadowStorage.read(firstShadow)).rejects.toThrow(
+      'IPYNB shadow not found'
+    )
+  })
+
   it('rejects renaming a notebook across formats', async () => {
     const store = createTestStore({})
     await store.files.put({
@@ -1291,15 +1367,35 @@ describe('LocalNotebooks moveToTrash', () => {
         parents: [],
       })),
     }
-    const store = createTestStore(driveStore)
+    const shadowStorage = new MemoryIpynbShadowStorage()
+    const shadowRef = await shadowStorage.write(
+      'local://file/drive',
+      JSON.stringify({
+        cells: [],
+        metadata: {},
+        nbformat: 4,
+        nbformat_minor: 5,
+      })
+    )
+    const store = createTestStore(driveStore, {
+      ipynbShadowStorage: shadowStorage,
+    })
     await store.files.put({
       id: 'local://file/drive',
-      name: 'untitled.json',
+      name: 'untitled.ipynb',
       remoteId: remoteUri,
       lastRemoteChecksum: '',
       lastSynced: '',
       doc: '',
       md5Checksum: '',
+      ipynbPreservation: {
+        upstreamFingerprint: '',
+        baselineNotebookChecksum: '',
+        shadowRef,
+        jupyterIdByRunmeRefId: {},
+        baselineCellHashes: {},
+        baselineOutputHashes: {},
+      },
     })
     await store.folders.put({
       id: 'local://folder/drive',
@@ -1316,6 +1412,9 @@ describe('LocalNotebooks moveToTrash', () => {
     expect(
       (await store.folders.get('local://folder/drive'))?.children
     ).not.toContain('local://file/drive')
+    await expect(shadowStorage.read(shadowRef)).rejects.toThrow(
+      'IPYNB shadow not found'
+    )
   })
 })
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -4,6 +4,7 @@ import { create, toJsonString } from '@bufbuild/protobuf'
 import md5 from 'md5'
 import { describe, expect, it, vi } from 'vitest'
 
+import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { MimeType, parser_pb } from '../runme/client'
 import { MemoryConflictDocStorage } from './conflictDocs'
 import type { DriveSyncCoordinator } from './driveSyncCoordinator'
@@ -11,6 +12,7 @@ import {
   EXCALIDRAW_MIME_TYPE,
   createInitialExcalidrawDocumentJson,
 } from './excalidraw'
+import { MemoryIpynbShadowStorage } from './ipynbShadows'
 import LocalNotebooks, {
   type LocalFileRecord,
   type LocalFolderRecord,
@@ -94,6 +96,7 @@ function createTestStore(
     files?: MockTable<LocalFileRecord>
     folders?: MockTable<LocalFolderRecord>
     driveSyncCoordinator?: DriveSyncCoordinator
+    ipynbShadowStorage?: MemoryIpynbShadowStorage
   } = {}
 ) {
   const localStore = Object.create(LocalNotebooks.prototype) as any
@@ -118,6 +121,8 @@ function createTestStore(
   localStore.markdownSyncSubjects = new Map()
   localStore.conflictDocStorage = new MemoryConflictDocStorage()
   localStore.revisionDocStorage = new MemoryRevisionDocStorage()
+  localStore.ipynbShadowStorage =
+    options.ipynbShadowStorage ?? new MemoryIpynbShadowStorage()
   return localStore as LocalNotebooks
 }
 
@@ -991,6 +996,168 @@ describe('LocalNotebooks pending Drive create', () => {
       parentRemoteIdWhenCreated: undefined,
       driveCreateOperationId: operationId,
     })
+  })
+})
+
+describe('LocalNotebooks ipynb conversion', () => {
+  it('keeps browser-local ipynb shadows current and accepts raw ipynb updates', async () => {
+    const store = createTestStore({})
+    await store.folders.put({
+      id: 'local://folder/local',
+      name: 'Local Notebooks',
+      remoteId: 'local://folder/local',
+      children: [],
+      lastSynced: '',
+    })
+    const item = await store.create(
+      'local://folder/local',
+      'browser-smoke.ipynb'
+    )
+    const notebook = await store.load(item.uri)
+    notebook.cells.push(
+      create(parser_pb.CellSchema, {
+        kind: parser_pb.CellKind.CODE,
+        languageId: 'javascript',
+        value: 'console.log("from Runme")',
+        metadata: { 'runme.dev/runnerName': 'appkernel-js' },
+      })
+    )
+
+    await store.save(item.uri, notebook)
+    await store.sync(item.uri)
+
+    const raw = JSON.parse(await store.loadContent(item.uri))
+    expect(raw).toMatchObject({
+      nbformat: 4,
+      cells: [
+        {
+          cell_type: 'code',
+          source: 'console.log("from Runme")',
+        },
+      ],
+    })
+    expect(raw.cells[0].metadata.runme.cell.metadata).toMatchObject({
+      'runme.dev/runnerName': 'appkernel-js',
+    })
+
+    raw.cells[0].source = 'console.log("from Jupyter")'
+    await store.saveContent(
+      item.uri,
+      `${JSON.stringify(raw, null, 2)}\n`,
+      IPYNB_MIME_TYPE
+    )
+    await expect(store.load(item.uri)).resolves.toMatchObject({
+      cells: [
+        expect.objectContaining({
+          value: 'console.log("from Jupyter")',
+          languageId: 'javascript',
+        }),
+      ],
+    })
+  })
+
+  it('loads and saves ipynb while preserving Jupyter-only fields in OPFS', async () => {
+    const localUri = 'local://file/ipynb'
+    const remoteUri = 'https://drive.google.com/file/d/ipynb123/view'
+    const source = {
+      cells: [
+        {
+          cell_type: 'code',
+          id: 'code-cell',
+          metadata: { trusted: true, vendor: { folded: false } },
+          execution_count: null,
+          source: 'print("before")\n',
+          outputs: [],
+          attachments: { unexpected_but_preserved: true },
+        },
+      ],
+      metadata: {
+        kernelspec: { name: 'python3', language: 'python' },
+        colab: { provenance: ['keep-me'] },
+      },
+      nbformat: 4,
+      nbformat_minor: 5,
+    }
+    const sourceText = `${JSON.stringify(source, null, 2)}\n`
+    let savedText = ''
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'shared.ipynb',
+        type: NotebookStoreItemType.File,
+        children: [],
+        mimeType: IPYNB_MIME_TYPE,
+        parents: [],
+      })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: savedText ? 'remote-2' : 'remote-1',
+        headRevisionId: savedText ? 'revision-2' : 'revision-1',
+      })),
+      loadContent: vi.fn(async () => sourceText),
+      saveContent: vi.fn(
+        async (_uri: string, content: string, _mimeType: string) => {
+          savedText = content
+        }
+      ),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: localUri,
+      name: 'shared.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.sync(localUri)
+    const notebook = await store.load(localUri)
+    expect(notebook.cells[0]?.value).toBe('print("before")\n')
+    expect(
+      (await store.files.get(localUri))?.ipynbPreservation?.shadowRef
+    ).toEqual(expect.objectContaining({ storage: 'opfs' }))
+
+    notebook.cells[0]!.value = 'print("after")\n'
+    await store.save(localUri, notebook)
+    await store.sync(localUri)
+
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      remoteUri,
+      expect.any(String),
+      IPYNB_MIME_TYPE
+    )
+    const saved = JSON.parse(savedText)
+    expect(saved.cells[0].source).toBe('print("after")\n')
+    expect(saved.cells[0].metadata).toMatchObject(source.cells[0].metadata)
+    expect(saved.cells[0].attachments).toEqual(source.cells[0].attachments)
+    expect(saved.metadata).toMatchObject(source.metadata)
+    await expect(store.files.get(localUri)).resolves.toMatchObject({
+      lastRemoteChecksum: 'remote-2',
+      lastUpstreamVersion: {
+        checksum: 'remote-2',
+        revisionId: 'revision-2',
+      },
+    })
+  })
+
+  it('rejects renaming a notebook across formats', async () => {
+    const store = createTestStore({})
+    await store.files.put({
+      id: 'local://file/ipynb',
+      name: 'shared.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: 'local://file/ipynb',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await expect(
+      store.rename('local://file/ipynb', 'shared.json')
+    ).rejects.toThrow('Changing notebook formats by rename')
   })
 })
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1213,9 +1213,114 @@ describe('LocalNotebooks ipynb conversion', () => {
         baselineNotebookChecksum: expect.any(String),
       },
     })
+    await expect(store.getSyncState(localUri)).resolves.toMatchObject({
+      status: 'synced',
+    })
     await expect(shadowStorage.read(firstShadow)).rejects.toThrow(
       'IPYNB shadow not found'
     )
+  })
+
+  it('loads uncached Drive ipynb bytes before creating a shadow', async () => {
+    const localUri = 'local://file/ipynb'
+    const remoteUri = 'https://drive.google.com/file/d/ipynb123/view'
+    const sourceText = `${JSON.stringify({
+      cells: [
+        {
+          cell_type: 'markdown',
+          id: 'intro',
+          metadata: { vendor: { folded: true } },
+          source: '# From Drive',
+        },
+      ],
+      metadata: { colab: { provenance: ['drive'] } },
+      nbformat: 4,
+      nbformat_minor: 5,
+    })}\n`
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceText),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'remote-checksum',
+        headRevisionId: 'remote-revision',
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: localUri,
+      name: 'shared.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await expect(store.loadContent(localUri)).resolves.toBe(sourceText)
+    expect(driveStore.loadContent).toHaveBeenCalledWith(remoteUri)
+    await expect(store.load(localUri)).resolves.toMatchObject({
+      cells: [expect.objectContaining({ value: '# From Drive' })],
+    })
+    await expect(store.files.get(localUri)).resolves.toMatchObject({
+      lastRemoteChecksum: 'remote-checksum',
+      lastUpstreamVersion: {
+        checksum: 'remote-checksum',
+        revisionId: 'remote-revision',
+      },
+      ipynbPreservation: {
+        upstreamFingerprint: 'remote-checksum',
+        baselineNotebookChecksum: expect.any(String),
+      },
+    })
+  })
+
+  it('merges filesystem ipynb changes from the freshly read shadow', async () => {
+    const localUri = 'local://file/ipynb'
+    const remoteUri = 'fs://workspace/test/file/notebook.ipynb'
+    const makeSource = (provenance: string) =>
+      `${JSON.stringify({
+        cells: [
+          {
+            cell_type: 'code',
+            id: 'code-cell',
+            metadata: { vendor: { folded: false } },
+            execution_count: null,
+            source: 'print("same model")\n',
+            outputs: [],
+          },
+        ],
+        metadata: { colab: { provenance: [provenance] } },
+        nbformat: 4,
+        nbformat_minor: 5,
+      })}\n`
+    let filesystemText = makeSource('original')
+    const filesystemStore = {
+      loadContent: vi.fn(async () => filesystemText),
+      saveContent: vi.fn(async (_uri: string, content: string) => {
+        filesystemText = content
+      }),
+    }
+    const store = createTestStore({})
+    store.setFilesystemStore(filesystemStore as never)
+    await store.files.put({
+      id: localUri,
+      name: 'notebook.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.sync(localUri)
+    filesystemText = makeSource('external-update')
+    await store.sync(localUri)
+
+    expect(filesystemStore.saveContent).toHaveBeenCalled()
+    expect(JSON.parse(filesystemText).metadata.colab.provenance).toEqual([
+      'external-update',
+    ])
   })
 
   it('rejects renaming a notebook across formats', async () => {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -4,8 +4,16 @@ import md5 from 'md5'
 import { Subject, debounceTime } from 'rxjs'
 import { v4 as uuidv4 } from 'uuid'
 
+import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { appLogger } from '../lib/logging/runtime'
 import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookToMarkdown'
+import {
+  createInitialNotebookFile,
+  decodeNotebookFile,
+  detectNotebookFileFormat,
+  encodeIpynbNotebook,
+  isNotebookFileName,
+} from '../lib/notebookFormat'
 import { appState } from '../lib/runtime/AppState'
 import { parser_pb } from '../runme/client'
 import {
@@ -24,6 +32,11 @@ import {
   browserDriveSyncCoordinator,
 } from './driveSyncCoordinator'
 import type { FilesystemNotebookStore } from './fs'
+import {
+  type IpynbPreservationState,
+  type IpynbShadowStorage,
+  createDefaultIpynbShadowStorage,
+} from './ipynbShadows'
 import { NotebookStoreItem, NotebookStoreItemType } from './notebook'
 import {
   type RevisionDocStorage,
@@ -90,6 +103,8 @@ export interface LocalFileRecord {
    * changes without re-hashing every file on each pass.
    */
   md5Checksum: string
+  /** Lossless .ipynb merge metadata. The complete shadow lives in OPFS. */
+  ipynbPreservation?: IpynbPreservationState
 }
 
 export interface UpstreamVersion {
@@ -210,6 +225,7 @@ export class LocalNotebooks extends Dexie {
   private filesystemStore: FilesystemNotebookStore | null = null
   private readonly conflictDocStorage: ConflictDocStorage
   private readonly revisionDocStorage: RevisionDocStorage
+  private readonly ipynbShadowStorage: IpynbShadowStorage
 
   private readonly syncSubjects = new Map<string, Subject<void>>()
   private readonly markdownSyncSubjects = new Map<string, Subject<void>>()
@@ -221,7 +237,8 @@ export class LocalNotebooks extends Dexie {
     databaseName: string = 'runme-local-notebooks',
     conflictDocStorage: ConflictDocStorage = createDefaultConflictDocStorage(),
     revisionDocStorage: RevisionDocStorage = createDefaultRevisionDocStorage(),
-    driveSyncCoordinator: DriveSyncCoordinator = browserDriveSyncCoordinator
+    driveSyncCoordinator: DriveSyncCoordinator = browserDriveSyncCoordinator,
+    ipynbShadowStorage: IpynbShadowStorage = createDefaultIpynbShadowStorage()
   ) {
     super(databaseName)
 
@@ -317,6 +334,7 @@ export class LocalNotebooks extends Dexie {
     this.driveSyncCoordinator = driveSyncCoordinator
     this.conflictDocStorage = conflictDocStorage
     this.revisionDocStorage = revisionDocStorage
+    this.ipynbShadowStorage = ipynbShadowStorage
 
     void this.ensureFolderRecord(LOCAL_FOLDER_URI, 'Local Notebooks')
   }
@@ -757,6 +775,17 @@ export class LocalNotebooks extends Dexie {
     if (!record) {
       throw new Error(`Local file record not found for ${uri}`)
     }
+    if (detectNotebookFileFormat(record.name) === 'ipynb') {
+      if (isLocalFileUpstream(record.remoteId, uri)) {
+        const preservation = await this.refreshLocalIpynbShadow(uri, record)
+        return this.ipynbShadowStorage.read(preservation.shadowRef)
+      }
+      if (record.ipynbPreservation) {
+        return this.ipynbShadowStorage.read(record.ipynbPreservation.shadowRef)
+      }
+      const preservation = await this.refreshLocalIpynbShadow(uri, record)
+      return this.ipynbShadowStorage.read(preservation.shadowRef)
+    }
     if (record.doc || !isDriveUri(record.remoteId)) {
       return record.doc ?? ''
     }
@@ -804,12 +833,37 @@ export class LocalNotebooks extends Dexie {
       throw new Error(`Local file record not found for ${uri}`)
     }
 
-    const checksum = md5(content)
-    await this.files.update(uri, {
-      doc: content,
-      md5Checksum: checksum,
-      mimeType,
-    })
+    if (detectNotebookFileFormat(record.name) === 'ipynb') {
+      const decoded = decodeNotebookFile(content, record.name)
+      if (!decoded.ipynb) {
+        throw new Error(`Expected ipynb content for ${record.name}`)
+      }
+      const serialized = serializeNotebook(decoded.notebook)
+      const shadowRef = await this.ipynbShadowStorage.write(uri, content)
+      const previousRef = record.ipynbPreservation?.shadowRef
+      await this.files.update(uri, {
+        doc: serialized,
+        md5Checksum: checksumForSerializedNotebook(serialized),
+        mimeType: IPYNB_MIME_TYPE,
+        ipynbPreservation: {
+          upstreamFingerprint: md5(content),
+          shadowRef,
+          jupyterIdByRunmeRefId: decoded.ipynb.jupyterIdByRunmeRefId,
+          baselineCellHashes: decoded.ipynb.baselineCellHashes,
+          baselineOutputHashes: decoded.ipynb.baselineOutputHashes,
+        },
+      })
+      if (previousRef && previousRef.path !== shadowRef.path) {
+        await this.ipynbShadowStorage.delete(previousRef).catch(() => {})
+      }
+    } else {
+      const checksum = md5(content)
+      await this.files.update(uri, {
+        doc: content,
+        md5Checksum: checksum,
+        mimeType,
+      })
+    }
     this.notifySync(uri)
     if (!record.conflict) {
       this.enqueueSync(uri)
@@ -856,17 +910,28 @@ export class LocalNotebooks extends Dexie {
     const localDoc =
       record.doc ||
       serializeNotebook(create(parser_pb.NotebookSchema, { cells: [] }))
-    await this.driveStore.saveContent(
-      record.remoteId,
-      localDoc,
-      'application/json'
-    )
+    if (detectNotebookFileFormat(record.name) === 'ipynb') {
+      await this.saveLocalDocToDrive(
+        localUri,
+        record.remoteId,
+        localDoc,
+        record.mimeType
+      )
+    } else {
+      await this.driveStore.saveContent(
+        record.remoteId,
+        localDoc,
+        NOTEBOOK_MIME_TYPE
+      )
+    }
 
     const updatedVersion = driveMetadataToUpstreamVersion(
       await this.driveStore.getVersionMetadata(record.remoteId)
     )
     const updatedChecksum =
       updatedVersion.checksum ?? checksumForSerializedNotebook(localDoc)
+    const refreshedPreservation = (await this.files.get(localUri))
+      ?.ipynbPreservation
     await this.files.update(localUri, {
       conflict: undefined,
       lastRemoteChecksum: updatedChecksum,
@@ -874,6 +939,12 @@ export class LocalNotebooks extends Dexie {
       md5Checksum: checksumForSerializedNotebook(localDoc),
       lastSynced: nowIsoString(),
       lastSyncError: undefined,
+      ipynbPreservation: refreshedPreservation
+        ? {
+            ...refreshedPreservation,
+            upstreamFingerprint: updatedChecksum,
+          }
+        : undefined,
     })
     await this.deleteConflictDoc(record.conflict)
     this.notifySync(localUri)
@@ -901,11 +972,15 @@ export class LocalNotebooks extends Dexie {
       )
     }
 
-    const upstreamNotebook = await this.driveStore.load(record.remoteId)
-    const upstreamDoc = serializeNotebook(upstreamNotebook)
     const upstreamVersion = driveMetadataToUpstreamVersion(
       await this.driveStore.getVersionMetadata(record.remoteId)
     )
+    const upstream = await this.loadDriveNotebookDocument(
+      localUri,
+      record,
+      upstreamVersion.checksum ?? ''
+    )
+    const upstreamDoc = upstream.serialized
     const upstreamChecksum =
       upstreamVersion.checksum ?? checksumForSerializedNotebook(upstreamDoc)
     const localChecksum = await this.getOrBackfillLocalChecksum(
@@ -980,13 +1055,16 @@ export class LocalNotebooks extends Dexie {
       }
     }
 
-    const upstreamNotebook = await this.driveStore.load(record.remoteId)
-    const upstreamDoc = serializeNotebook(upstreamNotebook)
     const upstreamVersion = driveMetadataToUpstreamVersion(
       await this.driveStore.getVersionMetadata(record.remoteId)
     )
+    const upstream = await this.loadDriveNotebookDocument(
+      localUri,
+      record,
+      upstreamVersion.checksum ?? ''
+    )
     return {
-      doc: upstreamDoc,
+      doc: upstream.serialized,
       version: upstreamVersion,
     }
   }
@@ -1032,11 +1110,23 @@ export class LocalNotebooks extends Dexie {
       // the exact Drive revision and storing it in OPFS for future diffs.
     }
 
-    const revisionNotebook = await this.driveStore.loadRevision(
-      record.remoteId,
-      normalizedRevisionId
-    )
-    const revisionDoc = serializeNotebook(revisionNotebook)
+    const revisionDoc =
+      detectNotebookFileFormat(record.name) === 'ipynb'
+        ? serializeNotebook(
+            decodeNotebookFile(
+              await this.driveStore.loadRevisionContent(
+                record.remoteId,
+                normalizedRevisionId
+              ),
+              record.name
+            ).notebook
+          )
+        : serializeNotebook(
+            await this.driveStore.loadRevision(
+              record.remoteId,
+              normalizedRevisionId
+            )
+          )
     await this.getRevisionDocStorage().write(
       localUri,
       normalizedRevisionId,
@@ -1120,8 +1210,9 @@ export class LocalNotebooks extends Dexie {
   }
 
   async create(parentUri: string, name: string): Promise<NotebookStoreItem> {
+    const format = detectNotebookFileFormat(name)
     return this.createLocalFile(parentUri, name, {
-      mimeType: NOTEBOOK_MIME_TYPE,
+      mimeType: format === 'ipynb' ? IPYNB_MIME_TYPE : NOTEBOOK_MIME_TYPE,
       content: '',
     })
   }
@@ -1151,7 +1242,25 @@ export class LocalNotebooks extends Dexie {
 
     const fileUri = this.generateLocalUri('file')
     const isDriveBackedParent = isDriveUri(parent.remoteId)
-    const checksum = options.content ? md5(options.content) : ''
+    let localContent = options.content
+    let ipynbPreservation: IpynbPreservationState | undefined
+    if (detectNotebookFileFormat(name) === 'ipynb') {
+      const initialIpynb = options.content || createInitialNotebookFile(name)
+      const decoded = decodeNotebookFile(initialIpynb, name)
+      localContent = serializeNotebook(decoded.notebook)
+      const shadowRef = await this.ipynbShadowStorage.write(
+        fileUri,
+        initialIpynb
+      )
+      ipynbPreservation = {
+        upstreamFingerprint: '',
+        shadowRef,
+        jupyterIdByRunmeRefId: decoded.ipynb?.jupyterIdByRunmeRefId ?? {},
+        baselineCellHashes: decoded.ipynb?.baselineCellHashes ?? {},
+        baselineOutputHashes: decoded.ipynb?.baselineOutputHashes ?? {},
+      }
+    }
+    const checksum = localContent ? md5(localContent) : ''
     const record: LocalFileRecord = {
       id: fileUri,
       name,
@@ -1163,8 +1272,9 @@ export class LocalNotebooks extends Dexie {
       driveCreateOperationId: isDriveBackedParent ? uuidv4() : undefined,
       lastRemoteChecksum: '',
       lastSynced: isDriveBackedParent ? '' : nowIsoString(),
-      doc: options.content,
+      doc: localContent,
       md5Checksum: checksum,
+      ipynbPreservation,
     }
     await this.files.put(record)
 
@@ -1339,12 +1449,25 @@ export class LocalNotebooks extends Dexie {
       throw new Error(`Local notebook record not found for ${uri}`)
     }
 
-    let nextName = name
+    const currentFormat = detectNotebookFileFormat(record.name)
+    const requestedFormat = detectNotebookFileFormat(name)
+    if (currentFormat && requestedFormat && currentFormat !== requestedFormat) {
+      throw new Error(
+        'Changing notebook formats by rename is not supported. Use Save as instead.'
+      )
+    }
+    if (currentFormat && !requestedFormat && /\.[^/]+$/.test(name.trim())) {
+      throw new Error(`Unsupported notebook file extension: ${name}`)
+    }
+    let nextName =
+      currentFormat && !requestedFormat
+        ? `${name.trim()}${currentFormat === 'ipynb' ? '.ipynb' : '.json'}`
+        : name
     let nextRemoteId = record.remoteId
 
     if (isDriveUri(record.remoteId)) {
-      const remoteItem = await this.driveStore.rename(record.remoteId, name)
-      nextName = remoteItem.name || name
+      const remoteItem = await this.driveStore.rename(record.remoteId, nextName)
+      nextName = remoteItem.name || nextName
       nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId
     }
 
@@ -1781,6 +1904,100 @@ export class LocalNotebooks extends Dexie {
     return record
   }
 
+  private async decodeUpstreamNotebook({
+    localUri,
+    record,
+    content,
+    upstreamFingerprint,
+  }: {
+    localUri: string
+    record: LocalFileRecord
+    content: string
+    upstreamFingerprint: string
+  }): Promise<{
+    notebook: parser_pb.Notebook
+    serialized: string
+    ipynbPreservation?: IpynbPreservationState
+  }> {
+    const decoded = decodeNotebookFile(content, record.name)
+    const serialized = serializeNotebook(decoded.notebook)
+    if (!decoded.ipynb) {
+      return { notebook: decoded.notebook, serialized }
+    }
+    const shadowRef = await this.ipynbShadowStorage.write(localUri, content)
+    return {
+      notebook: decoded.notebook,
+      serialized,
+      ipynbPreservation: {
+        upstreamFingerprint,
+        shadowRef,
+        jupyterIdByRunmeRefId: decoded.ipynb.jupyterIdByRunmeRefId,
+        baselineCellHashes: decoded.ipynb.baselineCellHashes,
+        baselineOutputHashes: decoded.ipynb.baselineOutputHashes,
+      },
+    }
+  }
+
+  private async refreshLocalIpynbShadow(
+    localUri: string,
+    record: LocalFileRecord
+  ): Promise<IpynbPreservationState> {
+    const parseResult = parseSerializedNotebook(record.doc ?? '')
+    if (!parseResult.ok) {
+      throw new Error(
+        `Refusing to encode unparsable Runme notebook as .ipynb: ${String(
+          parseResult.error
+        )}`
+      )
+    }
+    const previousRef = record.ipynbPreservation?.shadowRef
+    const shadowText = record.ipynbPreservation
+      ? await this.ipynbShadowStorage.read(record.ipynbPreservation.shadowRef)
+      : undefined
+    const encoded = encodeIpynbNotebook(
+      parseResult.notebook,
+      shadowText,
+      record.ipynbPreservation
+    )
+    const shadowRef = await this.ipynbShadowStorage.write(
+      localUri,
+      encoded.text
+    )
+    const preservation: IpynbPreservationState = {
+      upstreamFingerprint: md5(encoded.text),
+      shadowRef,
+      ...encoded.state,
+    }
+    await this.files.update(localUri, {
+      ipynbPreservation: preservation,
+    })
+    if (previousRef && previousRef.path !== shadowRef.path) {
+      await this.ipynbShadowStorage.delete(previousRef).catch(() => {})
+    }
+    return preservation
+  }
+
+  private async loadDriveNotebookDocument(
+    localUri: string,
+    record: LocalFileRecord,
+    upstreamFingerprint: string
+  ): Promise<{
+    notebook: parser_pb.Notebook
+    serialized: string
+    ipynbPreservation?: IpynbPreservationState
+  }> {
+    if (detectNotebookFileFormat(record.name) === 'ipynb') {
+      return this.decodeUpstreamNotebook({
+        localUri,
+        record,
+        content: await this.driveStore.loadContent(record.remoteId),
+        upstreamFingerprint,
+      })
+    }
+    const notebook = await this.driveStore.load(record.remoteId)
+    return { notebook, serialized: serializeNotebook(notebook) }
+  }
+
   /**
    * Derive a fallback display name from the tail of a remote URI. This is a
    * best-effort helper and may return null if no meaningful segment exists.
@@ -1876,6 +2093,9 @@ export class LocalNotebooks extends Dexie {
     }
 
     if (isLocalFileUpstream(record.remoteId, localUri)) {
+      if (detectNotebookFileFormat(record.name) === 'ipynb') {
+        await this.refreshLocalIpynbShadow(localUri, record)
+      }
       await this.files.update(localUri, {
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
@@ -1933,7 +2153,11 @@ export class LocalNotebooks extends Dexie {
     )
     let synced = false
 
-    if (record.mimeType && record.mimeType !== NOTEBOOK_MIME_TYPE) {
+    if (
+      record.mimeType &&
+      record.mimeType !== NOTEBOOK_MIME_TYPE &&
+      !isNotebookFileName(record.name)
+    ) {
       await this.saveLocalDocToDrive(
         localUri,
         remoteUri,
@@ -2034,8 +2258,12 @@ export class LocalNotebooks extends Dexie {
         return
       }
 
-      const remoteNotebook = await this.driveStore.load(remoteUri)
-      const serialized = serializeNotebook(remoteNotebook)
+      const remote = await this.loadDriveNotebookDocument(
+        localUri,
+        record,
+        currentRemoteChecksum
+      )
+      const serialized = remote.serialized
       logRemoteOverwriteLocalDoc({
         localUri,
         remoteUri,
@@ -2054,6 +2282,7 @@ export class LocalNotebooks extends Dexie {
         lastUpstreamVersion: currentVersion,
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
+        ipynbPreservation: remote.ipynbPreservation,
       })
       synced = true
       return
@@ -2064,8 +2293,12 @@ export class LocalNotebooks extends Dexie {
     // else updated the remote file and we simply need to refresh our cache.
     if (currentRemoteChecksum && currentRemoteChecksum !== lastReadChecksum) {
       if (localChecksum === lastReadChecksum) {
-        const remoteNotebook = await this.driveStore.load(remoteUri)
-        const serialized = serializeNotebook(remoteNotebook)
+        const remote = await this.loadDriveNotebookDocument(
+          localUri,
+          record,
+          currentRemoteChecksum
+        )
+        const serialized = remote.serialized
         logRemoteOverwriteLocalDoc({
           localUri,
           remoteUri,
@@ -2084,6 +2317,7 @@ export class LocalNotebooks extends Dexie {
           lastUpstreamVersion: currentVersion,
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
+          ipynbPreservation: remote.ipynbPreservation,
         })
         synced = true
         return
@@ -2146,8 +2380,62 @@ export class LocalNotebooks extends Dexie {
     localDoc: string,
     mimeType: string | undefined
   ): Promise<void> {
-    if (mimeType && mimeType !== NOTEBOOK_MIME_TYPE) {
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+    if (
+      mimeType &&
+      mimeType !== NOTEBOOK_MIME_TYPE &&
+      !isNotebookFileName(record.name)
+    ) {
       await this.driveStore.saveContent(remoteUri, localDoc, mimeType)
+      return
+    }
+
+    if (detectNotebookFileFormat(record.name) === 'ipynb') {
+      const parseResult = parseSerializedNotebook(localDoc)
+      if (!parseResult.ok) {
+        throw new Error(
+          `Refusing to save unparsable Runme notebook as .ipynb: ${String(
+            parseResult.error
+          )}`
+        )
+      }
+      let shadowText: string | undefined
+      if (record.ipynbPreservation) {
+        shadowText = await this.ipynbShadowStorage.read(
+          record.ipynbPreservation.shadowRef
+        )
+      }
+      const encoded = encodeIpynbNotebook(
+        parseResult.notebook,
+        shadowText,
+        record.ipynbPreservation
+      )
+      await this.driveStore.saveContent(
+        remoteUri,
+        encoded.text,
+        IPYNB_MIME_TYPE
+      )
+      const upstreamFingerprint =
+        (await this.driveStore.getVersionMetadata(remoteUri))?.md5Checksum ??
+        md5(encoded.text)
+      const shadowRef = await this.ipynbShadowStorage.write(
+        localUri,
+        encoded.text
+      )
+      const previousRef = record.ipynbPreservation?.shadowRef
+      await this.files.update(localUri, {
+        ipynbPreservation: {
+          upstreamFingerprint,
+          shadowRef,
+          ...encoded.state,
+        },
+      })
+      if (previousRef && previousRef.path !== shadowRef.path) {
+        await this.ipynbShadowStorage.delete(previousRef).catch(() => {})
+      }
       return
     }
 
@@ -2200,19 +2488,35 @@ export class LocalNotebooks extends Dexie {
       parentRemoteUri,
       createOperationId
     )
-    const newFile =
-      existingFile ??
-      (record.mimeType && record.mimeType !== NOTEBOOK_MIME_TYPE
-        ? await this.driveStore.createContent(
-            parentRemoteUri,
-            record.name,
-            record.doc ?? '',
-            record.mimeType,
-            { createOperationId }
-          )
-        : await this.driveStore.create(parentRemoteUri, record.name, {
-            createOperationId,
-          }))
+    let newFile = existingFile
+    if (!newFile && detectNotebookFileFormat(record.name) === 'ipynb') {
+      const shadow = record.ipynbPreservation
+        ? await this.ipynbShadowStorage.read(record.ipynbPreservation.shadowRef)
+        : createInitialNotebookFile(record.name)
+      newFile = await this.driveStore.createContent(
+        parentRemoteUri,
+        record.name,
+        shadow,
+        IPYNB_MIME_TYPE,
+        { createOperationId }
+      )
+    } else if (
+      !newFile &&
+      record.mimeType &&
+      record.mimeType !== NOTEBOOK_MIME_TYPE
+    ) {
+      newFile = await this.driveStore.createContent(
+        parentRemoteUri,
+        record.name,
+        record.doc ?? '',
+        record.mimeType ?? 'application/octet-stream',
+        { createOperationId }
+      )
+    } else if (!newFile) {
+      newFile = await this.driveStore.create(parentRemoteUri, record.name, {
+        createOperationId,
+      })
+    }
     let version: UpstreamVersion = {}
     try {
       version = driveMetadataToUpstreamVersion(
@@ -2275,6 +2579,8 @@ export class LocalNotebooks extends Dexie {
   private resolveSerializedNotebookStore(upstreamUri: string): {
     load(uri: string): Promise<parser_pb.Notebook>
     save(uri: string, notebook: parser_pb.Notebook): Promise<unknown>
+    loadContent?(uri: string): Promise<string>
+    saveContent?(uri: string, content: string): Promise<void>
   } | null {
     if (isFilesystemUri(upstreamUri)) {
       return this.filesystemStore
@@ -2308,10 +2614,27 @@ export class LocalNotebooks extends Dexie {
       record
     )
     const lastRemoteChecksum = record.lastRemoteChecksum ?? ''
+    const isIpynb = detectNotebookFileFormat(record.name) === 'ipynb'
+    const readUpstream = async () => {
+      if (isIpynb) {
+        if (!upstreamStore.loadContent) {
+          throw new Error('Filesystem store cannot read raw .ipynb content')
+        }
+        const content = await upstreamStore.loadContent(upstreamUri)
+        return this.decodeUpstreamNotebook({
+          localUri,
+          record,
+          content,
+          upstreamFingerprint: md5(content),
+        })
+      }
+      const notebook = await upstreamStore.load(upstreamUri)
+      return { notebook, serialized: serializeNotebook(notebook) }
+    }
 
     if (!localDoc) {
-      const upstreamNotebook = await upstreamStore.load(upstreamUri)
-      const upstreamDoc = serializeNotebook(upstreamNotebook)
+      const upstream = await readUpstream()
+      const upstreamDoc = upstream.serialized
       await this.files.update(localUri, {
         doc: upstreamDoc,
         md5Checksum: checksumForSerializedNotebook(upstreamDoc),
@@ -2321,12 +2644,13 @@ export class LocalNotebooks extends Dexie {
         },
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
+        ipynbPreservation: upstream.ipynbPreservation,
       })
       return
     }
 
-    const upstreamNotebook = await upstreamStore.load(upstreamUri)
-    const upstreamDoc = serializeNotebook(upstreamNotebook)
+    const upstream = await readUpstream()
+    const upstreamDoc = upstream.serialized
     const upstreamChecksum = checksumForSerializedNotebook(upstreamDoc)
 
     if (upstreamChecksum !== lastRemoteChecksum) {
@@ -2349,6 +2673,7 @@ export class LocalNotebooks extends Dexie {
           },
           lastSynced: nowIsoString(),
           lastSyncError: undefined,
+          ipynbPreservation: upstream.ipynbPreservation,
         })
         return
       }
@@ -2382,7 +2707,33 @@ export class LocalNotebooks extends Dexie {
       return
     }
 
-    await upstreamStore.save(upstreamUri, parseResult.notebook)
+    if (isIpynb) {
+      if (!upstreamStore.saveContent) {
+        throw new Error('Filesystem store cannot write raw .ipynb content')
+      }
+      const shadowText = record.ipynbPreservation
+        ? await this.ipynbShadowStorage.read(record.ipynbPreservation.shadowRef)
+        : undefined
+      const encoded = encodeIpynbNotebook(
+        parseResult.notebook,
+        shadowText,
+        record.ipynbPreservation
+      )
+      await upstreamStore.saveContent(upstreamUri, encoded.text)
+      const shadowRef = await this.ipynbShadowStorage.write(
+        localUri,
+        encoded.text
+      )
+      await this.files.update(localUri, {
+        ipynbPreservation: {
+          upstreamFingerprint: md5(encoded.text),
+          shadowRef,
+          ...encoded.state,
+        },
+      })
+    } else {
+      await upstreamStore.save(upstreamUri, parseResult.notebook)
+    }
     await this.files.update(localUri, {
       lastRemoteChecksum: localChecksum,
       lastUpstreamVersion: {
@@ -2409,8 +2760,12 @@ export class LocalNotebooks extends Dexie {
       )
     }
 
-    const upstreamNotebook = await this.driveStore.load(record.remoteId)
-    const upstreamDoc = serializeNotebook(upstreamNotebook)
+    const upstream = await this.loadDriveNotebookDocument(
+      localUri,
+      record,
+      upstreamVersion.checksum ?? ''
+    )
+    const upstreamDoc = upstream.serialized
     const upstreamChecksum =
       upstreamVersion.checksum || checksumForSerializedNotebook(upstreamDoc)
     const conflict = await this.createConflictState({
@@ -2743,12 +3098,18 @@ function resolveDocumentMimeType(
   name: string | undefined,
   mimeType: string | undefined
 ): string | undefined {
+  if (isExcalidrawFileName(name)) {
+    return EXCALIDRAW_MIME_TYPE
+  }
+  if (detectNotebookFileFormat(name ?? '') === 'ipynb') {
+    return IPYNB_MIME_TYPE
+  }
+  if (detectNotebookFileFormat(name ?? '') === 'runme-json') {
+    return NOTEBOOK_MIME_TYPE
+  }
   const trimmedMimeType = mimeType?.trim()
   if (trimmedMimeType) {
     return trimmedMimeType
-  }
-  if (isExcalidrawFileName(name)) {
-    return EXCALIDRAW_MIME_TYPE
   }
   return undefined
 }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -847,6 +847,8 @@ export class LocalNotebooks extends Dexie {
         mimeType: IPYNB_MIME_TYPE,
         ipynbPreservation: {
           upstreamFingerprint: md5(content),
+          baselineNotebookChecksum:
+            record.ipynbPreservation?.baselineNotebookChecksum,
           shadowRef,
           jupyterIdByRunmeRefId: decoded.ipynb.jupyterIdByRunmeRefId,
           baselineCellHashes: decoded.ipynb.baselineCellHashes,
@@ -1254,6 +1256,7 @@ export class LocalNotebooks extends Dexie {
       )
       ipynbPreservation = {
         upstreamFingerprint: '',
+        baselineNotebookChecksum: checksumForSerializedNotebook(localContent),
         shadowRef,
         jupyterIdByRunmeRefId: decoded.ipynb?.jupyterIdByRunmeRefId ?? {},
         baselineCellHashes: decoded.ipynb?.baselineCellHashes ?? {},
@@ -1649,6 +1652,11 @@ export class LocalNotebooks extends Dexie {
     }
     await this.deleteConflictDoc(record.conflict)
     await this.files.delete(uri)
+    if (record.ipynbPreservation) {
+      await this.ipynbShadowStorage
+        .delete(record.ipynbPreservation.shadowRef)
+        .catch(() => {})
+    }
   }
 
   /**
@@ -1930,6 +1938,7 @@ export class LocalNotebooks extends Dexie {
       serialized,
       ipynbPreservation: {
         upstreamFingerprint,
+        baselineNotebookChecksum: checksumForSerializedNotebook(serialized),
         shadowRef,
         jupyterIdByRunmeRefId: decoded.ipynb.jupyterIdByRunmeRefId,
         baselineCellHashes: decoded.ipynb.baselineCellHashes,
@@ -1965,6 +1974,9 @@ export class LocalNotebooks extends Dexie {
     )
     const preservation: IpynbPreservationState = {
       upstreamFingerprint: md5(encoded.text),
+      baselineNotebookChecksum: checksumForSerializedNotebook(
+        serializeNotebook(parseResult.notebook)
+      ),
       shadowRef,
       ...encoded.state,
     }
@@ -1975,6 +1987,15 @@ export class LocalNotebooks extends Dexie {
       await this.ipynbShadowStorage.delete(previousRef).catch(() => {})
     }
     return preservation
+  }
+
+  private async deleteReplacedIpynbShadow(
+    previous: IpynbPreservationState | undefined,
+    next: IpynbPreservationState | undefined
+  ): Promise<void> {
+    if (previous && previous.shadowRef.path !== next?.shadowRef.path) {
+      await this.ipynbShadowStorage.delete(previous.shadowRef).catch(() => {})
+    }
   }
 
   private async loadDriveNotebookDocument(
@@ -2146,6 +2167,13 @@ export class LocalNotebooks extends Dexie {
     }
 
     const lastReadChecksum = record.lastRemoteChecksum ?? ''
+    // Drive fingerprints the raw .ipynb bytes, while localChecksum fingerprints
+    // the Runme model. Keep a baseline in the same domain as localChecksum so
+    // a remote-only edit is not mistaken for a concurrent local edit.
+    const lastReadNotebookChecksum =
+      detectNotebookFileFormat(record.name) === 'ipynb'
+        ? record.ipynbPreservation?.baselineNotebookChecksum ?? lastReadChecksum
+        : lastReadChecksum
     const localDoc = record.doc ?? ''
     const localChecksum = await this.getOrBackfillLocalChecksum(
       localUri,
@@ -2284,6 +2312,10 @@ export class LocalNotebooks extends Dexie {
         lastSyncError: undefined,
         ipynbPreservation: remote.ipynbPreservation,
       })
+      await this.deleteReplacedIpynbShadow(
+        record.ipynbPreservation,
+        remote.ipynbPreservation
+      )
       synced = true
       return
     }
@@ -2292,7 +2324,7 @@ export class LocalNotebooks extends Dexie {
     // against. If our local content still matches the old checksum, someone
     // else updated the remote file and we simply need to refresh our cache.
     if (currentRemoteChecksum && currentRemoteChecksum !== lastReadChecksum) {
-      if (localChecksum === lastReadChecksum) {
+      if (localChecksum === lastReadNotebookChecksum) {
         const remote = await this.loadDriveNotebookDocument(
           localUri,
           record,
@@ -2319,6 +2351,10 @@ export class LocalNotebooks extends Dexie {
           lastSyncError: undefined,
           ipynbPreservation: remote.ipynbPreservation,
         })
+        await this.deleteReplacedIpynbShadow(
+          record.ipynbPreservation,
+          remote.ipynbPreservation
+        )
         synced = true
         return
       }
@@ -2429,6 +2465,7 @@ export class LocalNotebooks extends Dexie {
       await this.files.update(localUri, {
         ipynbPreservation: {
           upstreamFingerprint,
+          baselineNotebookChecksum: checksumForSerializedNotebook(localDoc),
           shadowRef,
           ...encoded.state,
         },
@@ -2646,6 +2683,10 @@ export class LocalNotebooks extends Dexie {
         lastSyncError: undefined,
         ipynbPreservation: upstream.ipynbPreservation,
       })
+      await this.deleteReplacedIpynbShadow(
+        record.ipynbPreservation,
+        upstream.ipynbPreservation
+      )
       return
     }
 
@@ -2675,6 +2716,10 @@ export class LocalNotebooks extends Dexie {
           lastSyncError: undefined,
           ipynbPreservation: upstream.ipynbPreservation,
         })
+        await this.deleteReplacedIpynbShadow(
+          record.ipynbPreservation,
+          upstream.ipynbPreservation
+        )
         return
       }
 
@@ -2724,13 +2769,19 @@ export class LocalNotebooks extends Dexie {
         localUri,
         encoded.text
       )
+      const preservation: IpynbPreservationState = {
+        upstreamFingerprint: md5(encoded.text),
+        baselineNotebookChecksum: localChecksum,
+        shadowRef,
+        ...encoded.state,
+      }
       await this.files.update(localUri, {
-        ipynbPreservation: {
-          upstreamFingerprint: md5(encoded.text),
-          shadowRef,
-          ...encoded.state,
-        },
+        ipynbPreservation: preservation,
       })
+      await this.deleteReplacedIpynbShadow(
+        record.ipynbPreservation,
+        preservation
+      )
     } else {
       await upstreamStore.save(upstreamUri, parseResult.notebook)
     }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -653,7 +653,10 @@ export class LocalNotebooks extends Dexie {
       localUri,
       record
     )
-    const upstreamChecksum = record.lastRemoteChecksum ?? ''
+    const upstreamChecksum =
+      detectNotebookFileFormat(record.name) === 'ipynb'
+        ? record.ipynbPreservation?.baselineNotebookChecksum ?? ''
+        : record.lastRemoteChecksum ?? ''
     return syncStateForRecord(
       { ...record, md5Checksum: localChecksum },
       localChecksum === upstreamChecksum ? 'synced' : 'pending'
@@ -782,6 +785,45 @@ export class LocalNotebooks extends Dexie {
       }
       if (record.ipynbPreservation) {
         return this.ipynbShadowStorage.read(record.ipynbPreservation.shadowRef)
+      }
+      if (isDriveUri(record.remoteId) && !record.doc) {
+        const content = await this.driveStore.loadContent(record.remoteId)
+        let upstreamVersion: UpstreamVersion = {}
+        try {
+          upstreamVersion = driveMetadataToUpstreamVersion(
+            await this.driveStore.getVersionMetadata(record.remoteId)
+          )
+        } catch (error) {
+          appLogger.warn(
+            'Failed to record version metadata for uncached Drive ipynb',
+            {
+              attrs: {
+                scope: 'storage.drive.sync',
+                localUri: uri,
+                remoteUri: record.remoteId,
+                error: String(error),
+              },
+            }
+          )
+        }
+        const upstreamFingerprint =
+          upstreamVersion.checksum ?? md5(content)
+        const decoded = await this.decodeUpstreamNotebook({
+          localUri: uri,
+          record,
+          content,
+          upstreamFingerprint,
+        })
+        await this.files.update(uri, {
+          doc: decoded.serialized,
+          md5Checksum: checksumForSerializedNotebook(decoded.serialized),
+          lastRemoteChecksum: upstreamFingerprint,
+          lastUpstreamVersion: upstreamVersion,
+          lastSynced: nowIsoString(),
+          lastSyncError: undefined,
+          ipynbPreservation: decoded.ipynbPreservation,
+        })
+        return content
       }
       const preservation = await this.refreshLocalIpynbShadow(uri, record)
       return this.ipynbShadowStorage.read(preservation.shadowRef)
@@ -2736,6 +2778,10 @@ export class LocalNotebooks extends Dexie {
           },
         }
       )
+      await this.deleteReplacedIpynbShadow(
+        upstream.ipynbPreservation,
+        record.ipynbPreservation
+      )
       return
     }
 
@@ -2756,13 +2802,15 @@ export class LocalNotebooks extends Dexie {
       if (!upstreamStore.saveContent) {
         throw new Error('Filesystem store cannot write raw .ipynb content')
       }
-      const shadowText = record.ipynbPreservation
-        ? await this.ipynbShadowStorage.read(record.ipynbPreservation.shadowRef)
+      const mergePreservation =
+        upstream.ipynbPreservation ?? record.ipynbPreservation
+      const shadowText = mergePreservation
+        ? await this.ipynbShadowStorage.read(mergePreservation.shadowRef)
         : undefined
       const encoded = encodeIpynbNotebook(
         parseResult.notebook,
         shadowText,
-        record.ipynbPreservation
+        mergePreservation
       )
       await upstreamStore.saveContent(upstreamUri, encoded.text)
       const shadowRef = await this.ipynbShadowStorage.write(
@@ -2780,6 +2828,10 @@ export class LocalNotebooks extends Dexie {
       })
       await this.deleteReplacedIpynbShadow(
         record.ipynbPreservation,
+        preservation
+      )
+      await this.deleteReplacedIpynbShadow(
+        upstream.ipynbPreservation,
         preservation
       )
     } else {


### PR DESCRIPTION
## Summary

- convert nbformat 4 notebooks to and from the Runme protocol while retaining the Runme notebook as the in-memory model
- preserve Jupyter-only notebook fields, cell metadata, attachments, and unchanged outputs in OPFS shadow documents
- select serialization by .json or .ipynb extension across local, filesystem, and Google Drive storage
- add a New Jupyter Notebook (.ipynb) option to the workspace explorer

## Verification

- pnpm -C app exec vitest run (73 files, 673 tests)
- runme run build test
- browser smoke test through the Runme AppKernel/WebMCP workflow: created an .ipynb from the explorer, edited and executed its Runme cell, inspected valid nbformat 4 bytes, imported a raw Jupyter edit, reloaded it into the Runme model, and verified OPFS preservation of Colab and vendor metadata

## Design

- https://drive.google.com/file/d/1D7xJ01JK35-EkrzS-FaeBbd6JU2MmMlc/view