### PR TITLE
Add Colab links and IPYNB user docs

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1086,11 +1086,61 @@ describe('Actions tabs', () => {
       screen.getByRole('tab', { name: '202602a_tb_aws_codex_136.json' })
     )
     await screen.findByRole('button', { name: 'Copy Google Drive Link' })
+    expect(
+      screen.queryByRole('button', { name: 'Copy Google Colab Link' })
+    ).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Copy Markdown Link' }))
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(
         '[202602a_tb_aws_codex_136](http://localhost:3000/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV%2Fview)'
+      )
+    })
+  })
+
+  it('copies a Google Colab link for a Drive-backed ipynb tab', async () => {
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    const remoteUri =
+      'https://drive.google.com/file/d/1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV/view'
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: 'local://file/restored',
+        name: 'analysis.ipynb',
+        type: 'file',
+        children: [],
+        remoteUri,
+        parents: [],
+      })),
+      getSyncState: vi.fn(async () => ({
+        status: 'synced',
+        localUri: 'local://file/restored',
+        remoteId: remoteUri,
+      })),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.currentDoc = 'local://file/restored'
+    contextMocks.workspaceDocuments = [
+      {
+        uri: 'local://file/restored',
+        title: 'analysis.ipynb',
+      },
+    ]
+
+    render(<Actions />)
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: 'analysis.ipynb' }))
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Copy Google Colab Link' })
+    )
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        'https://colab.research.google.com/drive/1cDDvmvjrBKQDkZi6nojVC_CSAfTSj7EV'
       )
     })
   })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -43,6 +43,7 @@ import {
   type NotebookActiveCellState,
 } from '../../lib/notebookActiveCellState'
 import {
+  copyGoogleColabNotebookUrl,
   copyNotebookCellMarkdownLink,
   copyNotebookCellShareUrl,
   copyNotebookMarkdownLink,
@@ -50,6 +51,7 @@ import {
   parseNotebookCellFragment,
   parseNotebookShareLink,
 } from '../../lib/shareLinks'
+import { detectNotebookFileFormat } from '../../lib/notebookFormat'
 import { isHtmlLanguageId, isMarkdownLanguageId } from '../../lib/cellContent'
 import { PlayIcon, PlusIcon, SpinnerIcon, TrashIcon } from './icons'
 import { useCurrentDoc } from '../../contexts/CurrentDocContext'
@@ -2880,6 +2882,7 @@ export default function Actions() {
     title: string
     shareableUri: string
     googleDriveUri: string | null
+    isIpynb: boolean
     ownerSessionId: string | null
     canOpenUpstreamDiff: boolean
     readOnly?: boolean
@@ -3167,6 +3170,7 @@ export default function Actions() {
     const itemCount =
       4 +
       (tabContextMenu.googleDriveUri ? 1 : 0) +
+      (tabContextMenu.googleDriveUri && tabContextMenu.isIpynb ? 1 : 0) +
       (tabContextMenu.ownerSessionId ? 1 : 0) +
       (tabContextMenu.canOpenUpstreamDiff ? 1 : 0)
     const menuWidth = 220
@@ -3202,6 +3206,7 @@ export default function Actions() {
         googleDriveUri: isGoogleDriveFileUri(docUri)
           ? docUri
           : requestedDriveUri,
+        isIpynb: detectNotebookFileFormat(title) === 'ipynb',
         ownerSessionId: getNotebookOwnerSessionId(document?.owner),
         canOpenUpstreamDiff:
           docUri.startsWith('local://') && Boolean(requestedDriveUri),
@@ -3226,6 +3231,9 @@ export default function Actions() {
               googleDriveUri: isGoogleDriveFileUri(remoteUri)
                 ? remoteUri
                 : current.googleDriveUri,
+              isIpynb:
+                detectNotebookFileFormat(metadata?.name ?? current.title) ===
+                'ipynb',
               canOpenUpstreamDiff:
                 docUri.startsWith('local://') &&
                 isGoogleDriveFileUri(remoteUri),
@@ -3407,6 +3415,31 @@ export default function Actions() {
           attrs: {
             scope: 'storage.drive',
             code: 'TAB_COPY_GOOGLE_DRIVE_LINK_FAILED',
+            uri: tabContextMenu.googleDriveUri,
+            error: String(error),
+          },
+        }
+      )
+    } finally {
+      setTabContextMenu(null)
+    }
+  }, [tabContextMenu])
+
+  const handleCopyTabGoogleColabLink = useCallback(async () => {
+    if (!tabContextMenu?.googleDriveUri || !tabContextMenu.isIpynb) {
+      setTabContextMenu(null)
+      return
+    }
+    try {
+      const { id } = parseDriveItem(tabContextMenu.googleDriveUri)
+      await copyGoogleColabNotebookUrl(id)
+    } catch (error) {
+      appLogger.error(
+        'Failed to copy Google Colab link from tab context menu',
+        {
+          attrs: {
+            scope: 'storage.share',
+            code: 'TAB_COPY_GOOGLE_COLAB_LINK_FAILED',
             uri: tabContextMenu.googleDriveUri,
             error: String(error),
           },
@@ -3673,6 +3706,19 @@ export default function Actions() {
                   Copy Google Drive Link
                 </button>
               )}
+              {adjustedTabContextMenu.googleDriveUri &&
+                adjustedTabContextMenu.isIpynb && (
+                  <button
+                    type="button"
+                    className="ctx-menu-item"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      void handleCopyTabGoogleColabLink()
+                    }}
+                  >
+                    Copy Google Colab Link
+                  </button>
+                )}
               {adjustedTabContextMenu.canOpenUpstreamDiff && (
                 <button
                   type="button"

--- a/app/src/generated/documentationManifest.ts
+++ b/app/src/generated/documentationManifest.ts
@@ -138,4 +138,12 @@ export const DOCUMENTATION_MANIFEST = [
     order: 15,
     path: 'docs/16-notebook-diffs.md',
   },
+  {
+    name: 'ipynb-notebooks',
+    title: 'IPYNB Notebooks',
+    description:
+      'Use this guide to create, edit, save, and share Jupyter IPYNB notebooks in Runme Web. It explains extension-based format selection, conversion through the Runme protocol, preservation of Jupyter-only fields, Google Drive and Colab sharing, synchronization, and current compatibility boundaries.',
+    order: 17,
+    path: 'docs/17-ipynb-notebooks.md',
+  },
 ] as const satisfies readonly DocumentationManifestEntry[]

--- a/app/src/lib/shareLinks.test.ts
+++ b/app/src/lib/shareLinks.test.ts
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown'
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildGoogleColabNotebookUrl,
   buildNotebookCellFragment,
   buildNotebookCellMarkdownLink,
   buildNotebookCellShareUrl,
@@ -16,6 +17,23 @@ import {
   parseNotebookCellFragment,
   parseNotebookShareLink,
 } from './shareLinks'
+
+describe('buildGoogleColabNotebookUrl', () => {
+  it('builds a Colab URL from a Google Drive file ID', () => {
+    expect(buildGoogleColabNotebookUrl('shared-file-123')).toBe(
+      'https://colab.research.google.com/drive/shared-file-123'
+    )
+  })
+
+  it('encodes the file ID and rejects empty input', () => {
+    expect(buildGoogleColabNotebookUrl('file id')).toBe(
+      'https://colab.research.google.com/drive/file%20id'
+    )
+    expect(() => buildGoogleColabNotebookUrl('   ')).toThrow(
+      'A Google Drive file ID is required to build a Colab link'
+    )
+  })
+})
 
 describe('buildNotebookShareUrl', () => {
   it('builds a share URL from the current app location', () => {

--- a/app/src/lib/shareLinks.ts
+++ b/app/src/lib/shareLinks.ts
@@ -45,6 +45,15 @@ export function buildNotebookShareUrl(remoteUri: string): string {
   return url.toString()
 }
 
+export function buildGoogleColabNotebookUrl(driveFileId: string): string {
+  const trimmed = driveFileId.trim()
+  if (!trimmed) {
+    throw new Error('A Google Drive file ID is required to build a Colab link')
+  }
+
+  return `https://colab.research.google.com/drive/${encodeURIComponent(trimmed)}`
+}
+
 export function buildNotebookCellShareUrl(
   remoteUri: string,
   cellRefId: string
@@ -178,6 +187,22 @@ export async function copyNotebookShareUrl(remoteUri: string): Promise<string> {
   await window.navigator.clipboard.writeText(shareUrl)
   markOnboardingTaskComplete('share-notebook')
   return shareUrl
+}
+
+export async function copyGoogleColabNotebookUrl(
+  driveFileId: string
+): Promise<string> {
+  if (
+    typeof window === 'undefined' ||
+    !window.navigator?.clipboard?.writeText
+  ) {
+    throw new Error('Clipboard access is unavailable in this browser')
+  }
+
+  const colabUrl = buildGoogleColabNotebookUrl(driveFileId)
+  await window.navigator.clipboard.writeText(colabUrl)
+  markOnboardingTaskComplete('share-notebook')
+  return colabUrl
 }
 
 export async function copyNotebookCellShareUrl(

--- a/docs/02-workspace-explorer.md
+++ b/docs/02-workspace-explorer.md
@@ -29,7 +29,7 @@ It can show:
 - mount a Drive link,
 - import markdown as a notebook,
 - open a notebook,
-- create a new notebook in a folder,
+- create a new Runme JSON or Jupyter (`.ipynb`) notebook in a folder,
 - rename a notebook,
 - remove a mounted folder,
 - copy a notebook share link.
@@ -57,3 +57,5 @@ explorer.removeFolder(uri)
 - Opening a file from the explorer is the safest way to make it the current document.
 - Removing a folder from the explorer does not necessarily delete its upstream source.
 - Explorer items may have local URIs and separate `remoteUri` values.
+- The filename extension selects the notebook format: `.json` for Runme JSON
+  and `.ipynb` for Jupyter.

--- a/docs/06-sharing-and-opening-drive-links.md
+++ b/docs/06-sharing-and-opening-drive-links.md
@@ -40,6 +40,10 @@ explorer once coordination completes.
 ## Share-link actions
 
 The explorer can copy share links for remote items that retain a `remoteUri`.
+For a Drive-backed `.ipynb` notebook, open the notebook tab's context menu and
+choose **Copy Google Colab Link** to copy a link that opens the same Drive file
+in Colab. See [IPYNB Notebooks](17-ipynb-notebooks.md) for format and
+compatibility details.
 
 ## App Console helpers
 

--- a/docs/17-ipynb-notebooks.md
+++ b/docs/17-ipynb-notebooks.md
@@ -1,0 +1,110 @@
+---
+name: ipynb-notebooks
+title: IPYNB Notebooks
+order: 17
+description: >-
+  Use this guide to create, edit, save, and share Jupyter IPYNB notebooks in
+  Runme Web. It explains extension-based format selection, conversion through
+  the Runme protocol, preservation of Jupyter-only fields, Google Drive and
+  Colab sharing, synchronization, and current compatibility boundaries.
+---
+
+# IPYNB Notebooks
+
+## Purpose
+
+Runme Web can read and write Jupyter notebook (`.ipynb`) files. This makes
+notebooks easy to view and edit in Jupyter-compatible tools such as Google
+Colab while preserving Runme's editing and execution experience.
+
+Runme still uses the Runme protocol as its internal notebook model. On load,
+the app converts IPYNB content into that model. On save, it converts the
+current Runme notebook back to the Jupyter notebook format.
+
+## Creating and opening IPYNB files
+
+The filename extension selects the storage format:
+
+- `.ipynb` uses the Jupyter notebook format,
+- `.json` uses the native Runme JSON format.
+
+In the workspace explorer, open a folder's context menu and choose **New
+Jupyter Notebook (.ipynb)**. IPYNB notebooks can be created in Local Notebooks,
+a mounted filesystem folder, or Google Drive. Existing `.ipynb` files in those
+locations can be opened directly.
+
+Changing only a filename extension does not perform a separate export step.
+The app writes the notebook in the format selected by the resulting extension
+the next time it saves.
+
+## What is preserved
+
+The Runme protocol represents the fields Runme needs for editing and
+execution. IPYNB can also contain Jupyter-specific metadata, attachments,
+outputs, and cell fields that do not have direct Runme equivalents.
+
+To prevent those extra fields from disappearing during a Runme edit, the app
+keeps a browser-local shadow of the original IPYNB document in the Origin
+Private File System (OPFS). When saving, it merges the current Runme content
+back into that shadow. This preserves compatible Jupyter-only content while
+keeping the Runme protocol as the live internal model.
+
+The IPYNB file in its selected storage backend remains the authoritative
+shared document. The OPFS shadow belongs to the current browser profile and is
+supporting preservation data, not a second user-visible notebook or Markdown
+sidecar.
+
+## Sharing through Google Colab
+
+Google Colab can open an IPYNB file stored in Google Drive:
+
+1. Open the `.ipynb` notebook in Runme.
+2. Open the notebook tab's context menu.
+3. Choose **Copy Google Colab Link**.
+4. Send the copied link to collaborators.
+
+The Colab action is shown only when the `.ipynb` notebook has a Google Drive
+backing file. A browser-local or filesystem-only notebook must first be saved
+or copied to Drive before Colab can open it through a Drive link.
+
+The recipient still needs permission to access the Drive file. Changing a
+file's sharing permissions is a separate Google Drive action; copying the
+Colab link does not make the file public.
+
+Use **Copy Shareable Link** when the recipient should open the notebook in
+Runme Web instead.
+
+## Synchronization and concurrent edits
+
+Edits made in Colab update the same Drive file. Runme's Drive synchronization
+will detect the upstream change. If the notebook was also edited locally,
+Runme may report a conflict instead of silently overwriting either version.
+Use the notebook tab's **Compare with upstream** action to inspect differences
+before deciding which content to keep.
+
+Runme may also create a `.index.md` Drive sidecar for search and indexing. The
+`.ipynb` file is the notebook shared with Jupyter or Colab; the Markdown
+sidecar is not the preservation shadow and does not replace the notebook.
+
+## Execution compatibility
+
+IPYNB makes notebook content portable, but it does not make every runtime
+identical:
+
+- Runme executes cells through the runner selected in Runme.
+- Colab executes code in a Colab Jupyter runtime.
+- Dependencies, credentials, environment variables, working directories, and
+  available hardware can differ.
+- Runme-specific execution metadata may not affect how Colab runs a cell.
+
+For a portable notebook, include setup cells for required dependencies and
+avoid relying on files or credentials that exist only in one runtime.
+
+## Key facts
+
+- The extension determines the saved format.
+- The Runme protocol remains the internal data model.
+- Load and save convert between IPYNB and the Runme protocol.
+- OPFS preserves Jupyter-only fields that the Runme model cannot represent.
+- Only Drive-backed IPYNB notebooks expose a Google Colab link.
+- Drive permissions determine who can open the copied Colab link.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Current numbered docs:
 - [14-authentication-and-app-configuration.md](14-authentication-and-app-configuration.md)
 - [15-logs-diagnostics-and-troubleshooting.md](15-logs-diagnostics-and-troubleshooting.md)
 - [16-notebook-diffs.md](16-notebook-diffs.md)
+- [17-ipynb-notebooks.md](17-ipynb-notebooks.md)
 
 These docs intentionally exclude implementation-only material such as deployment
 internals and design proposals. Internal notes remain under `docs-dev/` and


### PR DESCRIPTION
## What changed

- add a tab context-menu action that copies a Google Colab URL for Drive-backed `.ipynb` notebooks
- keep the action hidden for Runme JSON and non-Drive notebooks
- add a user guide covering format conversion, OPFS preservation, Drive synchronization, Colab sharing, sidecars, and runtime differences
- cross-link IPYNB behavior from the explorer and sharing guides

## Why

IPYNB support makes Runme notebooks portable to Jupyter-compatible viewers. A direct Colab link makes the shared Drive file immediately usable without manually rewriting the Drive URL.

## User impact

Users can right-click a Drive-backed IPYNB tab and choose **Copy Google Colab Link**. Existing share actions and non-IPYNB notebooks are unchanged.

## Verification

- `pnpm -C app exec vitest run src/lib/shareLinks.test.ts src/components/Actions/Actions.test.tsx` (84 tests passed)
- `runme run build test`
- targeted ESLint: 0 errors (6 existing warnings)
- browser verification with Drive-backed `test.ipynb`: Colab action visible and IPYNB guide discoverable

## Known baseline

`pnpm -C app run typecheck` remains red on existing unrelated errors across auth, explorer, runners, and notebook output types; this change introduces no reported type error.