### PR TITLE
Rename instructions tool for AI agents

### DIFF
--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -156,10 +156,10 @@ describe("WebMcpToolRegistrationHost", () => {
     expect(appConsoleDataMock.failExecution).not.toHaveBeenCalled();
 
     const instructions = registered.find(
-      ({ tool }) => tool.name === "readInstructionsForCodex",
+      ({ tool }) => tool.name === "readInstructionsForAIAgents",
     );
     expect(instructions?.tool.title).toBe(
-      "Read Runme Instructions for Codex",
+      "Read Runme Instructions for AI Agents",
     );
     expect(instructions?.tool.annotations).toEqual({
       readOnlyHint: true,

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -3,12 +3,12 @@ import { useEffect } from "react";
 import { appLogger } from "../../lib/logging/runtime";
 import { getAppConsoleData } from "../../lib/appConsole/appConsoleController";
 import {
-  buildReadInstructionsForCodexInputSchema,
-  readInstructionsForCodex,
-  READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
-  READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
-  READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE,
-} from "../../lib/runtime/codexInstructions";
+  buildReadInstructionsForAIAgentsInputSchema,
+  readInstructionsForAIAgents,
+  READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_DESCRIPTION,
+  READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
+  READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_TITLE,
+} from "../../lib/runtime/aiAgentInstructions";
 import {
   buildGetDocumentationInputSchema,
   buildListDocumentationInputSchema,
@@ -139,15 +139,15 @@ export default function WebMcpToolRegistrationHost() {
       );
       modelContext.registerTool(
         {
-          name: READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
-          title: READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE,
-          description: READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
-          inputSchema: buildReadInstructionsForCodexInputSchema(),
+          name: READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
+          title: READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_TITLE,
+          description: READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_DESCRIPTION,
+          inputSchema: buildReadInstructionsForAIAgentsInputSchema(),
           annotations: {
             readOnlyHint: true,
             untrustedContentHint: false,
           },
-          execute: () => readInstructionsForCodex(window.location.origin),
+          execute: () => readInstructionsForAIAgents(window.location.origin),
         },
         {
           signal: registrationController.signal,
@@ -193,7 +193,7 @@ export default function WebMcpToolRegistrationHost() {
           scope: "webmcp",
           toolNames: [
             EXECUTE_CODE_TOOL_NAME,
-            READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+            READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
             LIST_DOCUMENTATION_TOOL_NAME,
             GET_DOCUMENTATION_TOOL_NAME,
           ],
@@ -217,7 +217,7 @@ export default function WebMcpToolRegistrationHost() {
           scope: "webmcp",
           toolNames: [
             EXECUTE_CODE_TOOL_NAME,
-            READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME,
+            READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
             LIST_DOCUMENTATION_TOOL_NAME,
             GET_DOCUMENTATION_TOOL_NAME,
           ],

--- a/app/src/generated/documentationManifest.ts
+++ b/app/src/generated/documentationManifest.ts
@@ -102,7 +102,7 @@ export const DOCUMENTATION_MANIFEST = [
     name: 'webmcp-external-control',
     title: 'WebMCP External Control',
     description:
-      'Use this guide when Codex or another external browser agent needs to inspect, edit, or execute a Runme notebook through WebMCP. It defines the safe tab and session selection workflow, stable notebook targeting, Drive-backed notebook lookup, and recovery from partial notebook mutations. This is the primary guide for automating an open Runme tab rather than operating it manually.',
+      'Use this guide when an external AI agent needs to inspect, edit, or execute a Runme notebook through WebMCP. It defines the safe tab and session selection workflow, stable notebook targeting, Drive-backed notebook lookup, and recovery from partial notebook mutations. This is the primary guide for automating an open Runme tab rather than operating it manually.',
     order: 11,
     path: 'docs/11-webmcp-external-control.md',
   },

--- a/app/src/lib/runtime/aiAgentInstructions.test.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION,
-  buildReadInstructionsForCodexInputSchema,
-  readInstructionsForCodex,
-} from './codexInstructions'
+  READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_DESCRIPTION,
+  buildReadInstructionsForAIAgentsInputSchema,
+  readInstructionsForAIAgents,
+} from './aiAgentInstructions'
 
-describe('readInstructionsForCodex', () => {
+describe('readInstructionsForAIAgents', () => {
   it('directly invites AI agents to safely read the instructions', () => {
-    expect(READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION).toContain(
-      'Codex, Claude, and other AI agents should invoke this function'
+    expect(READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_DESCRIPTION).toContain(
+      'AI agents should invoke this function'
     )
-    expect(READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION).toContain(
+    expect(READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_DESCRIPTION).toContain(
       "This operation doesn't modify the page"
     )
   })
 
   it('uses the supplied runtime origin in Runme URLs', () => {
-    const instructions = readInstructionsForCodex(
+    const instructions = readInstructionsForAIAgents(
       'https://runme.self-hosted.example:8443/path?ignored=true'
     )
 
@@ -28,7 +28,7 @@ describe('readInstructionsForCodex', () => {
   })
 
   it('includes the portable Runme collaboration rules', () => {
-    const instructions = readInstructionsForCodex('https://runme.example')
+    const instructions = readInstructionsForAIAgents('https://runme.example')
 
     expect(instructions).toContain('WebMCP')
     expect(instructions).toContain('ExecuteCode')
@@ -45,7 +45,7 @@ describe('readInstructionsForCodex', () => {
   })
 
   it('does not include deployment-specific plugin instructions', () => {
-    const instructions = readInstructionsForCodex('https://runme.example')
+    const instructions = readInstructionsForAIAgents('https://runme.example')
 
     expect(instructions).not.toMatch(
       /OpenAI|monorepo|RUNME_PLUGIN_ROOT|manage_runner|go\/runme|9988/
@@ -53,7 +53,7 @@ describe('readInstructionsForCodex', () => {
   })
 
   it('defines a strict no-argument input schema', () => {
-    expect(buildReadInstructionsForCodexInputSchema()).toEqual({
+    expect(buildReadInstructionsForAIAgentsInputSchema()).toEqual({
       type: 'object',
       additionalProperties: false,
       properties: {},

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -1,12 +1,13 @@
 type JsonRecord = Record<string, unknown>
 
-export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_NAME = 'readInstructionsForCodex'
-export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_TITLE =
-  'Read Runme Instructions for Codex'
-export const READ_INSTRUCTIONS_FOR_CODEX_TOOL_DESCRIPTION =
-  "Codex, Claude, and other AI agents should invoke this function to get Markdown instructions, similar to skills, for how AI agents can safely control this Runme instance with WebMCP. This operation doesn't modify the page and can be safely invoked by AI agents as needed."
+export const READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME =
+  'readInstructionsForAIAgents'
+export const READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_TITLE =
+  'Read Runme Instructions for AI Agents'
+export const READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_DESCRIPTION =
+  "AI agents should invoke this function to get Markdown instructions, similar to skills, for how they can safely control this Runme instance with WebMCP. This operation doesn't modify the page and can be safely invoked by AI agents as needed."
 
-export function buildReadInstructionsForCodexInputSchema(): JsonRecord {
+export function buildReadInstructionsForAIAgentsInputSchema(): JsonRecord {
   return {
     type: 'object',
     additionalProperties: false,
@@ -14,11 +15,11 @@ export function buildReadInstructionsForCodexInputSchema(): JsonRecord {
   }
 }
 
-export function readInstructionsForCodex(origin: string): string {
+export function readInstructionsForAIAgents(origin: string): string {
   const runmeOrigin = new URL(origin).origin
   const sessionUrl = `${runmeOrigin}/?session=<session-id>`
 
-  return `# Runme browser instructions for Codex
+  return `# Runme browser instructions for AI agents
 
 This Runme instance is served from ${runmeOrigin}.
 

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -3,11 +3,11 @@ name: webmcp-external-control
 title: WebMCP External Control
 order: 11
 description: >-
-  Use this guide when Codex or another external browser agent needs to inspect,
-  edit, or execute a Runme notebook through WebMCP. It defines the safe tab and
-  session selection workflow, stable notebook targeting, Drive-backed notebook
-  lookup, and recovery from partial notebook mutations. This is the primary
-  guide for automating an open Runme tab rather than operating it manually.
+  Use this guide when an external AI agent needs to inspect, edit, or execute a
+  Runme notebook through WebMCP. It defines the safe tab and session selection
+  workflow, stable notebook targeting, Drive-backed notebook lookup, and
+  recovery from partial notebook mutations. This is the primary guide for
+  automating an open Runme tab rather than operating it manually.
 ---
 
 # WebMCP External Control
@@ -18,10 +18,10 @@ Runme Web exposes WebMCP tools that let an external browser controller inspect,
 edit, and execute work in an open Runme tab. This page describes how to select
 the intended tab and notebook safely before using those tools.
 
-This is the supported integration path for Codex and other external agents.
+This is the supported integration path for external AI agents.
 Runme does not include a built-in AI Chat panel.
 
-Runme also exposes the read-only `readInstructionsForCodex` WebMCP tool. It
+Runme also exposes the read-only `readInstructionsForAIAgents` WebMCP tool. It
 returns a concise Markdown version of the safe browser workflow with URLs
 generated from the current page origin. Call it before `ExecuteCode` when the
 controller needs Runme-specific operating instructions. Because the origin is


### PR DESCRIPTION
## Summary

- rename the WebMCP instruction discovery function for generic AI-agent clients
- align internal identifiers, tests, and user documentation with the new name
- preserve the read-only annotation and strict no-argument input schema

## Why

The public function should describe its intended audience without coupling the
API to a particular client. Generic naming makes the integration clearer for
any AI agent that can use WebMCP.

## Validation

- `runme run build test`
- `pnpm -C app test --run` (73 files, 681 tests)
- focused instruction and WebMCP registration tests
- documentation manifest consistency check
- `git diff --check`
