### PR TITLE
Surface cell execution errors

### DIFF
--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { Code } from "@buf/googleapis_googleapis.bufbuild_es/google/rpc/code_pb";
-import type { StreamsLike } from "@runmedev/renderers";
+import { RunIntent, type StreamsLike } from "@runmedev/renderers";
 import { Subject } from "rxjs";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -283,7 +283,13 @@ describe("bindStreamsToCell", () => {
     };
 
     const fake = makeFakeStreams();
-    bindStreamsToCell({ refId, streams: fake, getCell, updateCell });
+    bindStreamsToCell({
+      refId,
+      streams: fake,
+      intent: RunIntent.START,
+      getCell,
+      updateCell,
+    });
 
     fake.stdout$.next(new TextEncoder().encode("hello"));
     fake.stdout$.next(new TextEncoder().encode(" world"));
@@ -321,7 +327,13 @@ describe("bindStreamsToCell", () => {
     };
 
     const fake = makeFakeStreams();
-    bindStreamsToCell({ refId, streams: fake, getCell, updateCell });
+    bindStreamsToCell({
+      refId,
+      streams: fake,
+      intent: RunIntent.START,
+      getCell,
+      updateCell,
+    });
 
     fake.pid$.next(123);
     expect(current.metadata?.[RunmeMetadataKey.Pid]).toBe("123");
@@ -350,6 +362,7 @@ describe("bindStreamsToCell", () => {
     bindStreamsToCell({
       refId,
       streams: fake,
+      intent: RunIntent.RESUME,
       getCell: () => current,
       updateCell: (next) => {
         current = next;
@@ -382,6 +395,7 @@ describe("bindStreamsToCell", () => {
     bindStreamsToCell({
       refId,
       streams: fake,
+      intent: RunIntent.RESUME,
       getCell: () => current,
       updateCell: (next) => {
         current = next;
@@ -402,6 +416,48 @@ describe("bindStreamsToCell", () => {
     expect(
       new TextDecoder().decode(stderr?.data ?? new Uint8Array()),
     ).toContain("Execution monitoring was interrupted");
+  });
+
+  it("surfaces an initial runner protocol error in cell output", () => {
+    const refId = "cell-start-protocol-error";
+    const cell = create(parser_pb.CellSchema, {
+      refId,
+      kind: parser_pb.CellKind.CODE,
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "run-protocol-error",
+        [RunmeMetadataKey.ExecutionState]: RunmeExecutionState.Running,
+      },
+    });
+
+    let current = cell;
+    const fake = makeFakeStreams();
+    bindStreamsToCell({
+      refId,
+      streams: fake,
+      intent: RunIntent.START,
+      getCell: () => current,
+      updateCell: (next) => {
+        current = next;
+      },
+    });
+
+    fake.errors$.next({
+      code: Code.INVALID_ARGUMENT,
+      message: 'proto: unknown field "openRunRequest"',
+    });
+
+    expect(current.metadata?.[RunmeMetadataKey.Pid]).toBeUndefined();
+    expect(current.metadata?.[RunmeMetadataKey.ExitCode]).toBe("1");
+    expect(current.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Completed,
+    );
+    const stderr = current.outputs
+      .flatMap((output) => output.items)
+      .find((item) => item.mime === MimeType.VSCodeNotebookStdErr);
+    expect(
+      new TextDecoder().decode(stderr?.data ?? new Uint8Array()),
+    ).toContain('Cell execution failed: proto: unknown field "openRunRequest"');
   });
 });
 
@@ -586,7 +642,10 @@ describe("NotebookData.runCodeCell", () => {
       refId: "cell-no-runner",
       kind: parser_pb.CellKind.CODE,
       outputs: [],
-      metadata: {},
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: "stale-run",
+        [RunmeMetadataKey.Sequence]: "7",
+      },
       value: "echo hello",
     });
     const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
@@ -611,6 +670,21 @@ describe("NotebookData.runCodeCell", () => {
       },
     );
     expect(trackCellExecuted).not.toHaveBeenCalled();
+    const updated = model.getCellSnapshot(cell.refId);
+    expect(updated?.metadata?.[RunmeMetadataKey.ExitCode]).toBe("1");
+    expect(updated?.metadata?.[RunmeMetadataKey.ExecutionState]).toBe(
+      RunmeExecutionState.Completed,
+    );
+    expect(updated?.metadata?.[RunmeMetadataKey.LastRunID]).toBeUndefined();
+    expect(updated?.metadata?.[RunmeMetadataKey.Sequence]).toBeUndefined();
+    const stderr = (updated?.outputs ?? [])
+      .flatMap((output) => output.items)
+      .find((item) => item.mime === MimeType.VSCodeNotebookStdErr);
+    expect(
+      new TextDecoder().decode(stderr?.data ?? new Uint8Array()),
+    ).toContain(
+      "Runme backend server is not running. Please start it and try again.",
+    );
     logError.mockRestore();
   });
 

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -688,6 +688,41 @@ describe("NotebookData.runCodeCell", () => {
     logError.mockRestore();
   });
 
+  it("closes an existing stream before recording a no-runner failure", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-runner-removed",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "bash",
+      outputs: [],
+      metadata: {},
+      value: "sleep 30",
+    });
+    const model = new NotebookData({
+      notebook: create(parser_pb.NotebookSchema, { cells: [cell] }),
+      uri: "nb://test",
+      name: "test",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    expect(model.runCodeCell(cell)).toBe("run-generated");
+    const stream = model.getActiveStream(cell.refId) as
+      | (StreamsLike & { close: ReturnType<typeof vi.fn> })
+      | undefined;
+    expect(stream).toBeTruthy();
+
+    getWithFallback.mockReturnValueOnce(undefined);
+    expect(model.runCodeCell(cell)).toBe("");
+
+    expect(stream?.close).toHaveBeenCalledTimes(1);
+    expect(model.getActiveStream(cell.refId)).toBeUndefined();
+    expect(
+      model.getCellSnapshot(cell.refId)?.metadata?.[
+        RunmeMetadataKey.ExecutionState
+      ],
+    ).toBe(RunmeExecutionState.Completed);
+  });
+
   it("returns empty run id for html content cells", () => {
     const trackCellExecuted = vi.spyOn(
       googleAnalytics,

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -939,6 +939,17 @@ export class NotebookData {
     const useJupyterKernel =
       normalizedLanguage === 'jupyter' || normalizedLanguage === 'ipython'
     const runner = useAppKernel ? undefined : this.getRunner(cell)
+
+    // Stop any previous execution before handling the new attempt. This must
+    // happen before the no-runner early return so an old stream cannot keep
+    // mutating the cell after we record the setup failure.
+    const existing = this.activeStreams.get(cell.refId)
+    existing?.close()
+    this.activeStreams.delete(cell.refId)
+    const existingJupyterSocket = this.activeJupyterSockets.get(cell.refId)
+    existingJupyterSocket?.socket.close()
+    this.activeJupyterSockets.delete(cell.refId)
+
     if (!useAppKernel && (!runner || !runner.endpoint)) {
       console.error('No runner available for cell', cell.refId)
       appLogger.error(RUNNER_BACKEND_UNAVAILABLE_MESSAGE, {
@@ -966,15 +977,6 @@ export class NotebookData {
       this.updateCell(cell)
       return ''
     }
-
-    // If there is an existing active stream for this cell, close it before
-    // starting a new run to avoid leaking sockets.
-    const existing = this.activeStreams.get(cell.refId)
-    existing?.close()
-    this.activeStreams.delete(cell.refId)
-    const existingJupyterSocket = this.activeJupyterSockets.get(cell.refId)
-    existingJupyterSocket?.socket.close()
-    this.activeJupyterSockets.delete(cell.refId)
 
     // Bump sequence and attach to metadata.
     this.sequence += 1

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -138,6 +138,21 @@ function isRunNotFoundError(err: unknown): boolean {
   )
 }
 
+function getExecutionErrorMessage(err: unknown): string {
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as { message?: unknown }).message === 'string'
+  ) {
+    const message = (err as { message: string }).message.trim()
+    if (message.length > 0) {
+      return message
+    }
+  }
+  return String(err)
+}
+
 function decodeBase64ToBytes(value: string): Uint8Array {
   try {
     const binary = globalThis.atob(value)
@@ -156,6 +171,7 @@ type Listener = () => void
 export type StreamBinder = (args: {
   refId: string
   streams: StreamsLike
+  intent: RunIntent
   getCell: (refId: string) => parser_pb.Cell | null
   updateCell: (cell: parser_pb.Cell, options?: { transient?: boolean }) => void
   onClose?: (refId: string) => void
@@ -172,6 +188,7 @@ export type StreamBinder = (args: {
 export const bindStreamsToCell: StreamBinder = ({
   refId,
   streams,
+  intent,
   getCell,
   updateCell,
   onClose,
@@ -415,8 +432,12 @@ export const bindStreamsToCell: StreamBinder = ({
         },
       })
       const updated = getCell(refId)
+      const hasPid =
+        typeof updated?.metadata?.[RunmeMetadataKey.Pid] === 'string' &&
+        updated.metadata[RunmeMetadataKey.Pid].length > 0
       if (
         isRunNotFoundError(err) &&
+        hasPid &&
         updated?.metadata &&
         typeof updated.metadata[RunmeMetadataKey.ExitCode] !== 'string'
       ) {
@@ -426,6 +447,20 @@ export const bindStreamsToCell: StreamBinder = ({
         updated.outputs = [
           ...updated.outputs,
           ...createStdTextOutputs('', EXECUTION_MONITOR_INTERRUPTED_MESSAGE),
+        ]
+        updateCell(updated)
+      } else if (updated && intent === RunIntent.START && !hasPid) {
+        updated.metadata ??= {}
+        updated.metadata[RunmeMetadataKey.ExitCode] = '1'
+        updated.metadata[RunmeMetadataKey.ExecutionState] =
+          RunmeExecutionState.Completed
+        delete updated.metadata[RunmeMetadataKey.Pid]
+        updated.outputs = [
+          ...updated.outputs,
+          ...createStdTextOutputs(
+            '',
+            `Cell execution failed: ${getExecutionErrorMessage(err)}\n`
+          ),
         ]
         updateCell(updated)
       }
@@ -913,6 +948,22 @@ export class NotebookData {
           runnerName: requestedRunnerName || DEFAULT_RUNNER_PLACEHOLDER,
         },
       })
+      cell.metadata ??= {}
+      cell.metadata[RunmeMetadataKey.ExitCode] = '1'
+      cell.metadata[RunmeMetadataKey.ExecutionState] =
+        RunmeExecutionState.Completed
+      delete cell.metadata[RunmeMetadataKey.Pid]
+      delete cell.metadata[RunmeMetadataKey.LastRunID]
+      delete cell.metadata[RunmeMetadataKey.Sequence]
+      cell.outputs = [
+        ...cell.outputs.filter((output) =>
+          output.items.some(
+            (item) => item.mime === MimeType.StatefulRunmeTerminal
+          )
+        ),
+        ...createStdTextOutputs('', `${RUNNER_BACKEND_UNAVAILABLE_MESSAGE}\n`),
+      ]
+      this.updateCell(cell)
       return ''
     }
 
@@ -1823,6 +1874,7 @@ export class NotebookData {
     bindStreamsToCell({
       refId: cell.refId,
       streams,
+      intent,
       getCell: (ref) =>
         this.executionGeneration === generation && !this.releasePending
           ? this.getCellProto(ref)

--- a/docs-dev/design/20260729_cell_execution_errors.md
+++ b/docs-dev/design/20260729_cell_execution_errors.md
@@ -1,0 +1,186 @@
+# Surface Cell Execution Errors In Cell Output
+
+- **Author:** Jeremy Lewi
+- **Date:** 2026-07-29
+- **Status:** Draft
+
+## TL;DR
+
+Runme Web currently logs some cell execution failures without showing them in
+the cell. This affects attempts with no configured runner and runner protocol
+negotiation failures such as an unsupported `OpenRunRequest`.
+
+We will write these failures to the cell's stderr output and mark initial
+execution attempts as completed with exit code `1`. Resume failures retain the
+existing monitoring semantics: a missing run becomes `unknown`, while a
+non-authoritative connection failure remains `running`.
+
+## Problem
+
+Running a backend cell can fail before the runner accepts the command:
+
+1. No runner is configured.
+2. The WebSocket connects, but runner protocol negotiation fails.
+3. The runner rejects the execution request before reporting a PID.
+
+`NotebookData.runCodeCell` currently logs the first case and returns an empty run
+ID. `bindStreamsToCell` logs stream errors and only adds cell output for a
+missing resumed run. The notebook therefore provides no visible explanation for
+most initial execution failures.
+
+The browser console and application logs are diagnostic surfaces. They are not
+an acceptable substitute for cell output because the user initiated the action
+from the cell.
+
+## Requirements
+
+- Show an actionable error in the output of the cell that failed to execute.
+- Mark a rejected initial execution as completed with a nonzero exit code.
+- Clear stale PID metadata when an initial execution fails.
+- Preserve the runner's error message, including protocol parsing details.
+- Preserve resume semantics from the execution monitoring design.
+- Keep stdout and stderr output compatible with existing notebook renderers.
+
+## Non-Goals
+
+- Add a new runner protocol message.
+- Treat a transport outage as proof that an already-started process failed.
+- Replace application logs or runner diagnostics.
+- Add a toast for execution failures.
+- Change AppKernel or Jupyter error handling.
+
+## Proposal
+
+### No runner configured
+
+When runner resolution fails, `runCodeCell` will:
+
+1. retain stateful terminal output and clear stale text output;
+2. append `Runme backend server is not running. Please start it and try again.`
+   as stderr;
+3. set `runme.dev/exitCode` to `1`;
+4. set `runme.dev/executionState` to `completed`;
+5. clear stale `runme.dev/pid`, `runme.dev/lastRunID`, and
+   `runme.dev/sequence`;
+6. update and persist the cell;
+7. return an empty run ID because no runner accepted the execution.
+
+### Initial runner negotiation failure
+
+`createAndBindStreams` will pass its `RunIntent` to `bindStreamsToCell`.
+
+When a stream created with `RUN_INTENT_START` reports an error before reporting
+a PID, the binder will:
+
+1. extract the error's `message` field when available;
+2. append `Cell execution failed: <message>` as stderr;
+3. set exit code `1` and execution state `completed`;
+4. clear the PID;
+5. persist the cell and close the stream.
+
+This includes protocol mismatches such as a runner rejecting an unknown
+`openRunRequest` field.
+
+### Resume failures
+
+Resume behavior remains distinct because a connection error does not prove that
+the remote process failed.
+
+| Intent and progress   | Error                           | Cell state              | Cell output                             |
+| --------------------- | ------------------------------- | ----------------------- | --------------------------------------- |
+| `START`, before PID   | Any terminal stream error       | `completed`, exit `1`   | Execution error on stderr               |
+| Any intent, after PID | Run not found                   | `unknown`, no exit code | Existing monitoring-interrupted warning |
+| Any intent, after PID | Other connection/protocol error | `running`, no exit code | Existing output unchanged               |
+| `RESUME`, before PID  | Other connection/protocol error | `running`, no exit code | Existing output unchanged               |
+
+## UX
+
+The error appears in the normal output area below the cell. It uses stderr so
+the existing `ActionOutputItems` renderer applies the same presentation used
+for command failures. The user does not need to open Logs or browser developer
+tools.
+
+The message identifies the failure and preserves the runner's detail:
+
+```text
+Cell execution failed: proto: unknown field "openRunRequest"
+```
+
+The no-runner case uses the existing actionable message:
+
+```text
+Runme backend server is not running. Please start it and try again.
+```
+
+## Implementation
+
+- `app/src/lib/notebookData.ts`
+  - add a helper that extracts a useful message from `Error` and
+    `WebsocketStatus` values;
+  - record a visible failure in the no-runner branch;
+  - pass `RunIntent` into `bindStreamsToCell`;
+  - record visible stderr and terminal metadata for `START` errors.
+- `app/src/lib/notebookData.test.ts`
+  - assert no-runner attempts write stderr and terminal failure metadata;
+  - assert a `START` protocol error writes the runner message;
+  - assert `RESUME` monitoring errors retain current behavior;
+  - assert a missing resumed run still becomes `unknown`.
+
+## Alternatives
+
+### Show only a toast
+
+We will not use a toast as the primary surface. Toasts disappear, are detached
+from the failing cell, and are not persisted with the notebook.
+
+### Mark every stream error as failed
+
+We will not mark resume connection errors as failed. A running process can
+survive a browser-to-runner transport outage. Synthesizing exit code `1` would
+misrepresent an unknown remote outcome.
+
+### Change `runCodeCell` to throw
+
+We will not require UI callers to catch execution setup errors. The cell model
+already owns outputs and execution metadata, and notebook automation also uses
+this path. Recording the failure in the model gives every caller the same
+result.
+
+## Test Plan
+
+### Automated
+
+- Run focused `notebookData` tests.
+- Run `runme run build test` as required by the repository.
+
+### Browser
+
+1. Start the development server.
+2. Open a notebook with a backend code cell and no configured runner.
+3. Execute the cell.
+4. Verify the cell output shows the actionable no-runner error and the cell is
+   not left running.
+5. Reproduce a runner protocol rejection using the existing mismatched-runner
+   notebook.
+6. Verify the runner's protocol message appears in the failing cell.
+7. Capture screenshots of both visible failure states.
+
+## Validation
+
+- `pnpm -C app exec vitest run src/lib/notebookData.test.ts`: 33 tests passed.
+- `runme run build test`: build and repository test tasks passed.
+- Browser no-runner reproduction: the cell showed the actionable backend
+  message and completed with exit code `1`.
+- Browser runner-rejection reproduction: the cell showed the runner's
+  authorization error and completed with exit code `1`.
+- The focused protocol test verifies that
+  `proto: unknown field "openRunRequest"` is preserved in cell stderr.
+
+## Risks
+
+Persisting setup failures changes notebook content. This is intentional: output
+from a user-initiated execution attempt should remain attached to the cell.
+
+Runner messages may be technical. Preserving them is useful for protocol
+failures, while the `Cell execution failed:` prefix gives the message context.
+We can add stable user-facing mappings for common runner status codes later.

--- a/docs-dev/design/20260729_cell_execution_errors.md
+++ b/docs-dev/design/20260729_cell_execution_errors.md
@@ -55,15 +55,16 @@ from the cell.
 
 When runner resolution fails, `runCodeCell` will:
 
-1. retain stateful terminal output and clear stale text output;
-2. append `Runme backend server is not running. Please start it and try again.`
+1. close and remove any stream or Jupyter socket from the previous execution;
+2. retain stateful terminal output and clear stale text output;
+3. append `Runme backend server is not running. Please start it and try again.`
    as stderr;
-3. set `runme.dev/exitCode` to `1`;
-4. set `runme.dev/executionState` to `completed`;
-5. clear stale `runme.dev/pid`, `runme.dev/lastRunID`, and
+4. set `runme.dev/exitCode` to `1`;
+5. set `runme.dev/executionState` to `completed`;
+6. clear stale `runme.dev/pid`, `runme.dev/lastRunID`, and
    `runme.dev/sequence`;
-6. update and persist the cell;
-7. return an empty run ID because no runner accepted the execution.
+7. update and persist the cell;
+8. return an empty run ID because no runner accepted the execution.
 
 ### Initial runner negotiation failure
 


### PR DESCRIPTION
## Summary

- surface a visible stderr message in the cell output when no Runme runner is available
- surface initial stream/open failures (including protocol-version mismatches) in the cell output
- preserve the existing semantics for failures while monitoring a previously-started run
- add a design document and regression coverage for both failure paths

## Root cause

The no-runner and initial stream-error branches only logged failures to the browser console. They did not append output to the cell, so execution appeared to do nothing.

## UX

Failed starts now complete the cell with exit code 1 and readable stderr. The no-runner case keeps the existing actionable backend message; other start failures use `Cell execution failed: <reason>`.

## Validation

- `pnpm -C app exec vitest run src/lib/notebookData.test.ts` — 33 tests passed
- `runme run build test` — passed
- Browser: verified no-runner failure appears in cell output
- Browser: verified runner rejection appears in cell output
- Unit test: verified exact protocol mismatch `proto: unknown field "openRunRequest"` appears in stderr
