### PR TITLE
Expose notebook write access through WebMCP

### DIFF
--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -185,7 +185,7 @@ export default function AppConsole({
   const { updateRunner, deleteRunner, setDefaultRunner } = useRunners()
   const { getItems, addItem, removeItem } = useWorkspace()
   const { getCurrentDoc, getLastNotebookDoc, setCurrentDoc } = useCurrentDoc()
-  const { getNotebookData, openNotebook, useNotebookList } =
+  const { getNotebookData, openNotebook, requestWriteAccess, useNotebookList } =
     useNotebookContext()
   const { showDocument } = useWorkspaceDocumentContext()
   const openNotebooks = useNotebookList()
@@ -432,6 +432,7 @@ export default function AppConsole({
         setCurrentDoc(result.localUri)
       },
       resolveNotebook: resolveNotebookData,
+      requestNotebookWriteAccess: requestWriteAccess,
       listNotebooks: () =>
         openNotebooks.reduce<NotebookDataLike[]>((items, notebook) => {
           const resolved = getNotebookData(notebook.uri)
@@ -491,6 +492,7 @@ export default function AppConsole({
     getNotebookData,
     openNotebook,
     openNotebooks,
+    requestWriteAccess,
     removeItem,
     resolveNotebookData,
     resolveNotebookStore,

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -127,6 +127,17 @@ vi.mock("./runtime/sandboxJsKernel", () => ({
           this.hooks.onStdout?.(`${doc?.summary?.name ?? ""}\n`);
           this.hooks.onStdout?.(`${doc?.notebook?.cells?.length ?? 0}\n`);
         }
+        if (source.includes("notebooks.requestWriteAccess")) {
+          const doc = (await this.bridge.call(
+            "notebooks.requestWriteAccess",
+            [
+              {
+                target: { uri: "nb://test" },
+              },
+            ],
+          )) as { summary?: { name?: string } };
+          this.hooks.onStdout?.(`${doc?.summary?.name ?? ""}\n`);
+        }
         if (source.includes("notebooks.embed")) {
           const result = (await this.bridge.call("notebooks.embed", [
             "data:image/png;base64,AQID",
@@ -1078,6 +1089,53 @@ describe("NotebookData.runCodeCell", () => {
     expect(stdoutText).toContain("sandbox-notebooks-get.runme.md");
     expect(stdoutText).toContain("1");
   });
+
+  it.each([
+    ["browser", APPKERNEL_RUNNER_NAME],
+    ["sandbox", APPKERNEL_SANDBOX_RUNNER_NAME],
+  ])(
+    "requests notebook write access inside %s appkernel javascript cells",
+    async (_runtime, runnerName) => {
+      const cell = create(parser_pb.CellSchema, {
+        refId: `cell-appkernel-request-write-access-${_runtime}`,
+        kind: parser_pb.CellKind.CODE,
+        languageId: "javascript",
+        outputs: [],
+        metadata: {
+          [RunmeMetadataKey.RunnerName]: runnerName,
+        },
+        value: [
+          'const doc = await notebooks.requestWriteAccess({ target: { uri: "nb://test" } });',
+          "console.log(doc.summary.name);",
+        ].join("\n"),
+      });
+      const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
+      const requestNotebookWriteAccess = vi.fn(async () => undefined);
+      const model = new NotebookData({
+        notebook,
+        uri: "nb://test",
+        name: "request-write-access.runme.md",
+        notebookStore: null,
+        loaded: true,
+        requestNotebookWriteAccess,
+      });
+
+      model.runCodeCell(cell);
+      await waitForCondition(() => {
+        const snap = model.getCellSnapshot(cell.refId);
+        return snap?.metadata?.[RunmeMetadataKey.ExitCode] === "0";
+      });
+
+      expect(requestNotebookWriteAccess).toHaveBeenCalledWith("nb://test");
+      const updated = model.getCellSnapshot(cell.refId);
+      const stdoutText = (updated?.outputs ?? [])
+        .flatMap((o) => o.items)
+        .filter((i) => i.mime === MimeType.VSCodeNotebookStdOut)
+        .map((i) => new TextDecoder().decode(i.data))
+        .join("");
+      expect(stdoutText).toContain("request-write-access.runme.md");
+    },
+  );
 
   it("embeds images from sandbox appkernel javascript cells", async () => {
     vi.stubGlobal(

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -537,6 +537,9 @@ export class NotebookData {
     target?: unknown
   ) => NotebookDataLike | null
   private readonly listNotebooksForAppKernel: () => NotebookDataLike[]
+  private readonly requestNotebookWriteAccess?: (
+    uri: string
+  ) => Promise<unknown>
 
   constructor({
     notebook,
@@ -547,6 +550,7 @@ export class NotebookData {
     readOnly = false,
     resolveNotebookForAppKernel,
     listNotebooksForAppKernel,
+    requestNotebookWriteAccess,
   }: {
     notebook: parser_pb.Notebook
     uri: string
@@ -556,6 +560,7 @@ export class NotebookData {
     readOnly?: boolean
     resolveNotebookForAppKernel?: (target?: unknown) => NotebookDataLike | null
     listNotebooksForAppKernel?: () => NotebookDataLike[]
+    requestNotebookWriteAccess?: (uri: string) => Promise<unknown>
   }) {
     this.uri = uri
     this.name = name
@@ -579,6 +584,7 @@ export class NotebookData {
       (() => {
         return [this]
       })
+    this.requestNotebookWriteAccess = requestNotebookWriteAccess
   }
 
   private matchesNotebookTarget(target: unknown): boolean {
@@ -1185,6 +1191,7 @@ export class NotebookData {
       runme: runmeApi,
       resolveNotebook: this.resolveNotebookForAppKernel,
       listNotebooks: this.listNotebooksForAppKernel,
+      requestNotebookWriteAccess: this.requestNotebookWriteAccess,
       signal: abortController.signal,
     })
     const notebooksApiBridgeServer = createNotebooksApiBridgeServer({

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -662,6 +662,8 @@ export class NotebookDataController {
         return this.getReadableNotebookData(targetUri)
       },
       listNotebooksForAppKernel: () => this.listNotebookDataLike(uri),
+      requestNotebookWriteAccess: (targetUri: string) =>
+        this.requestWriteAccess(targetUri),
     })
     const unsubscribe = data.subscribe(() => {
       this.updateOpenEntryName(data.getUri(), data.getName())

--- a/app/src/lib/runtime/aiAgentInstructions.test.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.test.ts
@@ -39,6 +39,7 @@ describe('readInstructionsForAIAgents', () => {
     expect(instructions).toContain('await app.getSessionID()')
     expect(instructions).toContain('local://')
     expect(instructions).toContain("kind: 'markup'")
+    expect(instructions).toContain('notebooks.requestWriteAccess')
     expect(instructions).toContain('expectedRevision')
     expect(instructions).toContain('NOTEBOOK_UPDATE_FAILED')
     expect(instructions).toContain('verify')

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -69,6 +69,23 @@ console.log(JSON.stringify({
 
 If the user's notebook reference is ambiguous, ask which notebook to use before making a change.
 
+## Request write access when needed
+
+If \`doc.summary.readOnly\` is true because another Runme session owns the notebook, request a cooperative takeover before mutating it:
+
+\`\`\`js
+const writable = await notebooks.requestWriteAccess({
+  target: { uri: notebookUri },
+})
+console.log(JSON.stringify({
+  uri: writable.handle?.uri,
+  revision: writable.handle?.revision,
+  readOnly: writable.summary?.readOnly,
+}))
+\`\`\`
+
+Continue only when the returned document has \`summary.readOnly === false\`. The current owner saves pending changes before releasing its lock. Always pass the concrete notebook URI; do not request access to whichever notebook is currently selected.
+
 ## Make safe notebook changes
 
 - Inspect \`await notebooks.help()\` when helper availability is uncertain.

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -203,6 +203,28 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     )
   })
 
+  it('exposes notebook write access requests through the App Console globals', async () => {
+    const notebook = new FakeNotebookData(
+      'local://file/current',
+      'Current.json'
+    )
+    const requestNotebookWriteAccess = vi.fn(async () => undefined)
+    const globals = createAppJsGlobals({
+      runme: createRunme(notebook),
+      requestNotebookWriteAccess,
+    })
+
+    const document = await globals.notebooks.requestWriteAccess({
+      target: { uri: notebook.getUri() },
+    })
+
+    expect(requestNotebookWriteAccess).toHaveBeenCalledWith(notebook.getUri())
+    expect(document.summary.uri).toBe(notebook.getUri())
+    await expect(
+      globals.notebooks.help('requestWriteAccess')
+    ).resolves.toContain('notebooks.requestWriteAccess({ target })')
+  })
+
   it('resolves object image targets to the requested notebook URI', async () => {
     const current = new FakeNotebookData('local://file/current', 'Current.json')
     const requested = new FakeNotebookData(

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -351,6 +351,7 @@ export function createAppJsGlobals({
   runnerSync,
   resolveNotebook,
   listNotebooks,
+  requestNotebookWriteAccess,
   ensureAccessToken,
   opfsApi,
   networkApi,
@@ -365,6 +366,7 @@ export function createAppJsGlobals({
   runnerSync?: RunnerSync
   resolveNotebook?: (target?: unknown) => NotebookDataLike | null
   listNotebooks?: () => NotebookDataLike[]
+  requestNotebookWriteAccess?: (uri: string) => Promise<unknown>
   ensureAccessToken?: EnsureAccessToken
   opfsApi?: AppKernelOpfsApi
   networkApi?: AppKernelNetworkApi
@@ -427,6 +429,7 @@ export function createAppJsGlobals({
   const notebooksApi = createNotebooksApi({
     resolveNotebook: resolveNotebook ?? (() => runme.getCurrentNotebook()),
     listNotebooks,
+    requestNotebookWriteAccess,
   })
   const notebookDiffApi = createNotebookDiffRuntimeApi({
     notebooksApi,

--- a/app/src/lib/runtime/codeModeExecutor.test.ts
+++ b/app/src/lib/runtime/codeModeExecutor.test.ts
@@ -172,6 +172,48 @@ describe('codeModeExecutor', () => {
     expect(fetchMock).toHaveBeenCalled()
   })
 
+  it('bridges notebook write access requests in sandbox mode', async () => {
+    const notebook = createNotebook()
+    const requestNotebookWriteAccess = vi.fn(async () => undefined)
+    let result: unknown
+    vi.spyOn(SandboxJSKernel.prototype, 'run').mockImplementation(
+      async function (this: SandboxJSKernel) {
+        const bridge = (
+          this as unknown as {
+            bridge: {
+              call: (method: string, args: unknown[]) => Promise<unknown>
+            }
+          }
+        ).bridge
+        result = await bridge.call('notebooks.requestWriteAccess', [
+          { target: { uri: 'local://test.runme.md' } },
+        ])
+      }
+    )
+    const executor = createCodeModeExecutor({
+      mode: 'sandbox',
+      resolveNotebook: () => notebook,
+      listNotebooks: () => [notebook],
+      requestNotebookWriteAccess,
+    })
+
+    await executor.execute({
+      source: 'webmcp',
+      code: "await notebooks.requestWriteAccess({ target: { uri: 'local://test.runme.md' } })",
+    })
+
+    expect(requestNotebookWriteAccess).toHaveBeenCalledWith(
+      'local://test.runme.md'
+    )
+    expect(result).toEqual(
+      expect.objectContaining({
+        summary: expect.objectContaining({
+          uri: 'local://test.runme.md',
+        }),
+      })
+    )
+  })
+
   it('preserves Blob sources for top-level sandbox embed calls', async () => {
     const notebook = create(parser_pb.NotebookSchema, { cells: [] })
     const notebookData = {

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -106,6 +106,7 @@ export function createCodeModeExecutor(options: {
   maxCodeBytes?: number
   resolveNotebook: (target?: unknown) => NotebookDataLike | null
   listNotebooks?: () => NotebookDataLike[]
+  requestNotebookWriteAccess?: (uri: string) => Promise<unknown>
 }): CodeModeExecutor {
   const mode = options.mode ?? 'sandbox'
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
@@ -155,6 +156,7 @@ export function createCodeModeExecutor(options: {
       const hostNotebooksApi = createHostNotebooksApi({
         resolveNotebook,
         listNotebooks,
+        requestNotebookWriteAccess: options.requestNotebookWriteAccess,
       })
       const notebookDiffApi = createNotebookDiffRuntimeApi({
         notebooksApi: hostNotebooksApi,
@@ -196,6 +198,7 @@ export function createCodeModeExecutor(options: {
         },
         resolveNotebook,
         listNotebooks,
+        requestNotebookWriteAccess: options.requestNotebookWriteAccess,
         opfsApi,
         networkApi,
         signal: abortController.signal,

--- a/app/src/lib/runtime/jsKernel.ts
+++ b/app/src/lib/runtime/jsKernel.ts
@@ -125,6 +125,7 @@ export class JSKernel {
               "- notebooks.get([target]): get notebook document and handle; omitted target = current UI notebook",
               "- notebooks.update({ target, operations, ... }): apply notebook mutations",
               "- notebooks.execute({ target, refIds }): run selected cells",
+              "- notebooks.requestWriteAccess({ target }): cooperatively acquire notebook write access",
               "- help(): show this message",
             ].join("\n") + "\n",
           )),

--- a/app/src/lib/runtime/notebooksApiBridge.test.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.test.ts
@@ -141,6 +141,9 @@ function createBridgeServer(
     execute: vi.fn(async () => {
       throw new Error('not implemented')
     }),
+    requestWriteAccess: vi.fn(async () => {
+      throw new Error('not implemented')
+    }),
     ...overrides,
   }
 
@@ -209,6 +212,41 @@ describe('createNotebooksApiBridgeServer', () => {
       title: 'demo',
     })
     expect(resolve).toHaveBeenCalledWith('local://file/demo')
+  })
+
+  it('delegates write access requests to the host notebook API', async () => {
+    const requestWriteAccess = vi.fn(async () => ({
+      summary: {
+        uri: 'local://file/demo',
+        name: 'demo.json',
+        isOpen: true,
+        readOnly: false,
+        source: 'local' as const,
+      },
+      handle: {
+        uri: 'local://file/demo',
+        revision: 'revision-after-takeover',
+      },
+      notebook: create(parser_pb.NotebookSchema, { cells: [] }),
+    }))
+    const bridgeServer = createBridgeServer({ requestWriteAccess })
+
+    await expect(
+      bridgeServer.handleMessage({
+        method: 'notebooks.requestWriteAccess',
+        args: [{ target: { uri: 'local://file/demo' } }],
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        summary: expect.objectContaining({
+          uri: 'local://file/demo',
+          readOnly: false,
+        }),
+      })
+    )
+    expect(requestWriteAccess).toHaveBeenCalledWith({
+      target: { uri: 'local://file/demo' },
+    })
   })
 
   it('returns JSON-safe get and update results for notebooks with BigInt timing fields', async () => {

--- a/app/src/lib/runtime/notebooksApiBridge.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.ts
@@ -23,6 +23,7 @@ export const SANDBOX_NOTEBOOKS_API_METHODS = [
   'notebooks.update',
   'notebooks.delete',
   'notebooks.execute',
+  'notebooks.requestWriteAccess',
   'notebooks.resolve',
   'notebooks.show',
   'notebooks.shareUrl',
@@ -55,13 +56,16 @@ function requireReferenceMethod<T extends keyof Required<NotebookReferenceApi>>(
 export function createHostNotebooksApi({
   resolveNotebook,
   listNotebooks,
+  requestNotebookWriteAccess,
 }: {
   resolveNotebook: (target?: unknown) => NotebookDataLike | null
   listNotebooks?: () => NotebookDataLike[]
+  requestNotebookWriteAccess?: (uri: string) => Promise<unknown>
 }): NotebooksApi {
   return createNotebooksApi({
     resolveNotebook,
     listNotebooks,
+    requestNotebookWriteAccess,
   })
 }
 
@@ -112,6 +116,12 @@ export function createNotebooksApiBridgeServer({
                 | undefined) ?? {
                 refIds: [],
               }
+            )
+          )
+        case 'notebooks.requestWriteAccess':
+          return callJsonSafe(() =>
+            notebooksApi.requestWriteAccess(
+              args[0] as Parameters<NotebooksApi['requestWriteAccess']>[0]
             )
           )
         case 'notebooks.resolve':

--- a/app/src/lib/runtime/runmeConsole.test.ts
+++ b/app/src/lib/runtime/runmeConsole.test.ts
@@ -990,4 +990,60 @@ describe('createNotebooksApi', () => {
       })
     ).rejects.toThrow('notebooks.execute requires an explicit target notebook.')
   })
+
+  it('requests write access for an explicitly targeted notebook', async () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [codeCell('cell-a', 'echo a')],
+    })
+    const readOnlyModel = new FakeNotebookData(
+      'local://one',
+      'One',
+      notebook,
+      new Set(),
+      new Map(),
+      true
+    )
+    const writableModel = new FakeNotebookData('local://one', 'One', notebook)
+    let currentModel = readOnlyModel
+    const requestNotebookWriteAccess = vi.fn(async (uri: string) => {
+      expect(uri).toBe('local://one')
+      currentModel = writableModel
+    })
+    const api = createNotebooksApi({
+      resolveNotebook: () => currentModel,
+      listNotebooks: () => [currentModel],
+      requestNotebookWriteAccess,
+    })
+
+    const document = await api.requestWriteAccess({
+      target: { uri: 'local://one' },
+    })
+
+    expect(requestNotebookWriteAccess).toHaveBeenCalledWith('local://one')
+    expect(document.summary.uri).toBe('local://one')
+    expect(document.summary.readOnly).toBe(false)
+    await expect(api.help('requestWriteAccess')).resolves.toContain(
+      'notebooks.requestWriteAccess({ target })'
+    )
+  })
+
+  it('rejects write access requests without an explicit target', async () => {
+    const notebook = create(parser_pb.NotebookSchema, { cells: [] })
+    const model = new FakeNotebookData(
+      'local://one',
+      'One',
+      notebook,
+      new Set(),
+      new Map(),
+      true
+    )
+    const api = createNotebooksApi({
+      resolveNotebook: () => model,
+      requestNotebookWriteAccess: vi.fn(async () => undefined),
+    })
+
+    await expect(api.requestWriteAccess({} as any)).rejects.toThrow(
+      'notebooks.requestWriteAccess requires an explicit target notebook.'
+    )
+  })
 })

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -159,7 +159,13 @@ export class NotebookUpdateError extends Error {
   }
 }
 
-export type NotebookMethod = 'list' | 'get' | 'update' | 'delete' | 'execute'
+export type NotebookMethod =
+  | 'list'
+  | 'get'
+  | 'update'
+  | 'delete'
+  | 'execute'
+  | 'requestWriteAccess'
 
 export type NotebooksApi = {
   help: (topic?: NotebookMethod) => Promise<string>
@@ -176,6 +182,9 @@ export type NotebooksApi = {
     target?: NotebookTarget
     refIds: string[]
   }) => Promise<{ handle: NotebookHandle; cells: parser_pb.Cell[] }>
+  requestWriteAccess: (args: {
+    target: NotebookTarget
+  }) => Promise<NotebookDocument>
 }
 
 export type RunmeConsoleApi = {
@@ -315,7 +324,7 @@ export function resolveNotebookTargetUri(
 }
 
 function formatMissingTargetError(
-  method: 'update' | 'delete' | 'execute'
+  method: 'update' | 'delete' | 'execute' | 'requestWriteAccess'
 ): string {
   if (method === 'update') {
     return (
@@ -327,6 +336,13 @@ function formatMissingTargetError(
   if (method === 'execute') {
     return (
       'notebooks.execute requires an explicit target notebook. ' +
+      'Pass target: { handle: doc.handle } after const doc = await notebooks.get(), ' +
+      'or target: { uri: "local://..." }.'
+    )
+  }
+  if (method === 'requestWriteAccess') {
+    return (
+      'notebooks.requestWriteAccess requires an explicit target notebook. ' +
       'Pass target: { handle: doc.handle } after const doc = await notebooks.get(), ' +
       'or target: { uri: "local://..." }.'
     )
@@ -645,9 +661,11 @@ function createNotebookUpdateError({
 export function createNotebooksApi({
   resolveNotebook,
   listNotebooks,
+  requestNotebookWriteAccess,
 }: {
   resolveNotebook: (target?: unknown) => NotebookDataLike | null
   listNotebooks?: () => NotebookDataLike[]
+  requestNotebookWriteAccess?: (uri: string) => Promise<unknown>
 }): NotebooksApi {
   const resolveNotebookByTarget = (
     target?: NotebookTarget
@@ -661,7 +679,7 @@ export function createNotebooksApi({
   }
 
   const resolveNotebookByRequiredTarget = (
-    method: 'update' | 'delete' | 'execute',
+    method: 'update' | 'delete' | 'execute' | 'requestWriteAccess',
     target?: NotebookTarget
   ): NotebookDataLike => {
     if (target === undefined) {
@@ -695,6 +713,9 @@ export function createNotebooksApi({
     if (topic === 'execute') {
       return 'notebooks.execute({ target, refIds: string[] }): Promise<{ handle, cells }>. target is required.'
     }
+    if (topic === 'requestWriteAccess') {
+      return 'notebooks.requestWriteAccess({ target }): Promise<NotebookDocument>. Cooperatively asks the current owner to save and release the notebook, then returns the refreshed document. target is required.'
+    }
     return [
       'Notebook SDK methods:',
       '- notebooks.list(query?)',
@@ -702,6 +723,7 @@ export function createNotebooksApi({
       '- notebooks.update({ target, expectedRevision?, operations })',
       '- notebooks.delete(target)',
       '- notebooks.execute({ target, refIds })',
+      '- notebooks.requestWriteAccess({ target })',
       '- notebooks.help(topic?)',
     ].join('\n')
   }
@@ -856,6 +878,20 @@ export function createNotebooksApi({
         handle: makeHandle(notebook),
         cells: executedCells,
       }
+    },
+    requestWriteAccess: async (args) => {
+      const notebook = resolveNotebookByRequiredTarget(
+        'requestWriteAccess',
+        args?.target
+      )
+      if (!requestNotebookWriteAccess) {
+        throw new Error(
+          'notebooks.requestWriteAccess is not available in this runtime.'
+        )
+      }
+      const uri = notebook.getUri()
+      await requestNotebookWriteAccess(uri)
+      return makeDocument(resolveNotebookByTarget({ uri }))
     },
   }
 }

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -23,6 +23,7 @@ type Scenario =
   | 'documentation'
   | 'notebooksCreate'
   | 'notebooksEmbed'
+  | 'notebooksWriteAccess'
   | 'notebooksUpdateError'
 
 class MockSandboxPort {
@@ -186,6 +187,13 @@ class MockSandboxPort {
           method: 'notebooks.embed',
           args: ['data:image/png;base64,AQID', undefined],
         })
+      } else if (this.scenario === 'notebooksWriteAccess') {
+        this.emit({
+          type: 'host-call',
+          callId: 1,
+          method: 'notebooks.requestWriteAccess',
+          args: [{ target: { uri: 'local://file/demo' } }],
+        })
       } else if (this.scenario === 'notebooksUpdateError') {
         this.emit({
           type: 'host-call',
@@ -302,6 +310,14 @@ class MockSandboxPort {
         this.emit({
           type: 'stdout',
           data: `${JSON.stringify(this.hostResults.get(2) ?? null)}\n`,
+        })
+        this.emit({ type: 'exit', exitCode: 0 })
+        return
+      }
+      if (this.scenario === 'notebooksWriteAccess' && this.hostResults.has(1)) {
+        this.emit({
+          type: 'stdout',
+          data: `${JSON.stringify(this.hostResults.get(1) ?? null)}\n`,
         })
         this.emit({ type: 'exit', exitCode: 0 })
         return
@@ -766,6 +782,52 @@ describe('SandboxJSKernel', () => {
     ])
     expect(stdout).toContain('Renamed Folder')
     expect(stdout).toContain('Editing name: local://folder/drive')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  it('supports notebook write access requests through the sandbox bridge', async () => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode = -1
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'notebooks.requestWriteAccess') {
+        return {
+          summary: {
+            uri: 'local://file/demo',
+            readOnly: false,
+          },
+        }
+      }
+      return null
+    })
+
+    const kernel = new TestableSandboxJSKernel(
+      new MockSandboxPort('notebooksWriteAccess'),
+      {
+        bridge: { call: bridgeCall },
+        hooks: {
+          onStdout: (data) => {
+            stdout += data
+          },
+          onStderr: (data) => {
+            stderr += data
+          },
+          onExit: (code) => {
+            exitCode = code
+          },
+        },
+      }
+    )
+
+    await kernel.run(
+      "console.log(await notebooks.requestWriteAccess({ target: { uri: 'local://file/demo' } }));"
+    )
+
+    expect(bridgeCall).toHaveBeenCalledWith('notebooks.requestWriteAccess', [
+      { target: { uri: 'local://file/demo' } },
+    ])
+    expect(stdout).toContain('"readOnly":false')
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
   })

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -332,6 +332,7 @@ export function buildSandboxSrcDoc(options: {
           update: (args) => callHost("notebooks.update", [args]),
           delete: (target) => callHost("notebooks.delete", [target]),
           execute: (args) => callHost("notebooks.execute", [args]),
+          requestWriteAccess: (args) => callHost("notebooks.requestWriteAccess", [args]),
           createLocal: (name, options) => callHost("notebooks.createLocal", [name, options]),
           appendCell: (args) => callHost("notebooks.appendCell", [args]),
           embed: (source, options) => callHost("notebooks.embed", [source, options]),
@@ -432,6 +433,7 @@ export function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.get([target]) # omitted target = current UI notebook");
           consoleProxy.log("- notebooks.update({ target, expectedRevision?, operations })");
           consoleProxy.log("- notebooks.execute({ target, refIds })");
+          consoleProxy.log("- notebooks.requestWriteAccess({ target })");
           consoleProxy.log("- notebooks.createLocal(name, options?)");
           consoleProxy.log("- notebooks.appendCell({ target?, at?, kind, languageId?, value?, metadata?, execute?, reason? })");
           consoleProxy.log("- notebooks.embed(source, { target?, alt?, name? })");

--- a/app/src/lib/runtime/useCodeModeExecutor.ts
+++ b/app/src/lib/runtime/useCodeModeExecutor.ts
@@ -51,7 +51,8 @@ export function useCodeModeExecutor(options?: {
   mode?: CodeModeRunnerMode
 }): CodeModeExecutor {
   const mode = options?.mode ?? 'sandbox'
-  const { getNotebookData, useNotebookList } = useNotebookContext()
+  const { getNotebookData, requestWriteAccess, useNotebookList } =
+    useNotebookContext()
   const { getCurrentDoc } = useCurrentDoc()
   const currentDocUri = getCurrentDoc()
   const openNotebookList = useNotebookList()
@@ -93,6 +94,7 @@ export function useCodeModeExecutor(options?: {
       createCodeModeExecutor({
         mode,
         resolveNotebook: resolveCodeModeNotebook,
+        requestNotebookWriteAccess: requestWriteAccess,
         listNotebooks: () => {
           const uris = new Set<string>()
           for (const notebook of openNotebookListRef.current) {
@@ -114,6 +116,6 @@ export function useCodeModeExecutor(options?: {
             )
         },
       }),
-    [mode, resolveCodeModeNotebook]
+    [mode, requestWriteAccess, resolveCodeModeNotebook]
   )
 }

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -131,6 +131,41 @@ and use that URI or its handle for later operations.
 Do not rely on the current notebook after the initial resolution. The user may
 switch notebooks while an external controller is working.
 
+## Requesting write access
+
+`notebooks.get(...)` and `notebooks.list(...)` report `readOnly: true` when
+another Runme session currently owns the notebook's write lock. Before
+mutating that notebook, an external controller can request a cooperative
+takeover through the same WebMCP `ExecuteCode` path:
+
+```js
+const doc = await notebooks.get({
+  uri: 'local://file/demo.runme.md',
+})
+
+if (doc.summary.readOnly) {
+  const writable = await notebooks.requestWriteAccess({
+    target: { uri: doc.handle.uri },
+  })
+  console.log(
+    JSON.stringify({
+      uri: writable.handle.uri,
+      revision: writable.handle.revision,
+      readOnly: writable.summary.readOnly,
+    })
+  )
+}
+```
+
+The target is required. Runme asks the current owner session to save pending
+changes and release its lock, then retries normal ownership acquisition and
+returns the refreshed notebook document. Continue with notebook mutations only
+when the returned document has `summary.readOnly === false`.
+
+This is cooperative lock transfer, not lock stealing. The request can time out
+or lose a race to another session; in those cases the call returns or throws
+with the same ownership outcome surfaced by the **Request write access** UI.
+
 ## Drive-backed notebook lookup
 
 When a user identifies a Drive-backed notebook by name or metadata rather than

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -89,6 +89,21 @@ await notebooks.show(
 )
 ```
 
+Request write access when another Runme session owns a notebook:
+
+```js
+const doc = await notebooks.get()
+const writable = await notebooks.requestWriteAccess({
+  target: { uri: doc.handle.uri },
+})
+console.log(writable.summary.readOnly)
+```
+
+The request uses the same cooperative takeover path as the
+**Request write access** button. The owner saves pending changes before
+releasing its lock. Continue mutating the notebook only when the returned
+document has `summary.readOnly === false`.
+
 Discover and read versioned Runme documentation:
 
 ```js


### PR DESCRIPTION
## Summary

- expose the existing cooperative notebook takeover flow as `notebooks.requestWriteAccess({ target })`
- wire the action through App Console, WebMCP code mode, the sandbox client, allowlist, and host bridge
- require an explicit notebook target and return the refreshed `NotebookDocument` so agents can verify `summary.readOnly === false`
- document the workflow in the agent instructions, WebMCP guide, and App Console reference

## Why

The UI already allowed a read-only tab to request write access, but the same domain action was not reachable from App Console or WebMCP. AI agents therefore could inspect a read-only notebook but could not programmatically ask the owner session to save and release its lock.

This change reuses `NotebookDataController.requestWriteAccess` rather than introducing a separate ownership path, preserving the existing cooperative save-before-release semantics and single-writer guarantee.

## Validation

- `runme run build` — passed
- `runme run test` — passed (7 tests)
- `pnpm -C app exec vitest run` — passed (73 files, 689 tests)
- focused runtime/WebMCP suite — passed (86 tests)
- `git diff --check` — passed

## Runme notebook

[20260730a_ai_request_write_access.ipynb](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1yAYLDlebtw4EhEhOWAQEWWDxzTcQjso6%2Fview#cell=markup_908d5c65339e4d16babec5f68a3dcecb)
