### PR TITLE
Add Google Drive logout and account switching

### DIFF
--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -38,6 +38,7 @@ const startGoogleDriveOAuthMock = vi.fn(async () => ({
   authFlow: 'popup',
   mode: 'popup',
 }))
+const logoutGoogleDriveMock = vi.fn(async () => {})
 const loginWithRedirectMock = vi.fn()
 const logoutMock = vi.fn()
 const togglePanelMock = vi.fn()
@@ -86,6 +87,7 @@ vi.mock('../../contexts/CurrentDocContext', () => ({
 vi.mock('../../contexts/GoogleAuthContext', () => ({
   useGoogleAuth: () => ({
     ensureAccessToken: ensureAccessTokenMock,
+    logoutGoogleDrive: logoutGoogleDriveMock,
     startGoogleDriveOAuth: startGoogleDriveOAuthMock,
     isDriveSyncing,
   }),
@@ -132,6 +134,7 @@ describe('SidePanelToolbar drive status button', () => {
     notebookSnapshotState = null
     ensureAccessTokenMock.mockClear()
     startGoogleDriveOAuthMock.mockClear()
+    logoutGoogleDriveMock.mockClear()
     loginWithRedirectMock.mockClear()
     logoutMock.mockClear()
     togglePanelMock.mockClear()
@@ -184,6 +187,26 @@ describe('SidePanelToolbar drive status button', () => {
     })
     expect(setCurrentDocMock).toHaveBeenCalledWith('status://drive-sync')
     expect(ensureAccessTokenMock).not.toHaveBeenCalled()
+    expect(startGoogleDriveOAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('logs out of Google Drive from the Drive status context menu', async () => {
+    isDriveSyncing = true
+    render(<SidePanelToolbar />)
+
+    fireEvent.contextMenu(
+      screen.getByRole('button', {
+        name: 'Google Drive status: Syncing',
+      }),
+      { clientX: 20, clientY: 40 }
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Logout' }))
+      await Promise.resolve()
+    })
+
+    expect(logoutGoogleDriveMock).toHaveBeenCalledTimes(1)
     expect(startGoogleDriveOAuthMock).not.toHaveBeenCalled()
   })
 

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -229,7 +229,8 @@ export function SidePanelToolbar() {
   const { getCurrentDoc, setCurrentDoc } = useCurrentDoc()
   const authData = useBrowserAuthData()
   const browserAdapter = getBrowserAdapter()
-  const { isDriveSyncing, startGoogleDriveOAuth } = useGoogleAuth()
+  const { isDriveSyncing, logoutGoogleDrive, startGoogleDriveOAuth } =
+    useGoogleAuth()
   const { listRunners } = useRunners()
   const [driveContextMenu, setDriveContextMenu] = useState<{
     x: number
@@ -282,9 +283,14 @@ export function SidePanelToolbar() {
     }
   }, [startGoogleDriveOAuth])
 
+  const handleDriveLogout = useCallback(async () => {
+    setDriveContextMenu(null)
+    await logoutGoogleDrive()
+  }, [logoutGoogleDrive])
+
   const openDriveContextMenu = useCallback((x: number, y: number) => {
     const menuWidth = 140
-    const menuHeight = 40
+    const menuHeight = 80
     const maxX =
       typeof window === 'undefined' ? x : window.innerWidth - menuWidth
     const maxY =
@@ -498,6 +504,16 @@ export function SidePanelToolbar() {
               }}
             >
               Status
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="block w-full px-3 py-1.5 text-left text-nb-text hover:bg-nb-surface-2"
+              onClick={() => {
+                void handleDriveLogout()
+              }}
+            >
+              Logout
             </button>
           </div>
         ) : null}

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -11,6 +11,7 @@ const PKCE_RETURN_TO_KEY = 'runme/google-auth/pkce-return-to'
 const PKCE_ERROR_KEY = 'runme/google-auth/pkce-error'
 const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
 const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
+const SELECT_ACCOUNT_NEXT_KEY = 'runme/google-auth/select-account-next'
 const STORAGE_KEY = 'runme/google-auth/token'
 
 function CaptureAuth(props: {
@@ -84,6 +85,7 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       authFlow: 'implicit',
       authUxMode: 'popup',
     })
+    delete window.google
   })
 
   it('starts implicit redirect flow when authFlow=implicit and authUxMode=redirect', async () => {
@@ -155,6 +157,79 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe('none')
     expect(window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)).toBe('new_tab')
     expect(window.sessionStorage.getItem(PKCE_ERROR_KEY)).toBeNull()
+  })
+
+  it('clears and revokes Drive credentials, then asks Google to select an account', async () => {
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    const revoke = vi.fn((_accessToken: string, callback: () => void) => {
+      callback()
+    })
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: vi.fn(() => tokenClient),
+          revoke,
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+
+    await act(async () => {
+      auth.setAccessToken('original-access-token')
+    })
+    expect(window.localStorage.getItem(STORAGE_KEY)).toContain(
+      'original-access-token'
+    )
+
+    await act(async () => {
+      await auth.logoutGoogleDrive()
+    })
+
+    expect(revoke).toHaveBeenCalledWith(
+      'original-access-token',
+      expect.any(Function)
+    )
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    expect(window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY)).toBe('true')
+
+    await act(async () => {
+      await auth.startGoogleDriveOAuth()
+    })
+
+    expect(tokenClient.requestAccessToken).toHaveBeenCalledWith({
+      prompt: 'select_account',
+    })
+    expect(window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY)).toBeNull()
+  })
+
+  it('uses the Google account chooser for new-tab auth after logout', async () => {
+    googleClientManager.setOAuthClient({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(window as unknown as Window)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await act(async () => {
+      await auth.logoutGoogleDrive()
+      await auth.startGoogleDriveOAuth()
+    })
+
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    const authUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(authUrl.searchParams.get('prompt')).toBe('select_account')
+    expect(window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY)).toBeNull()
   })
 
   it('does not relaunch new-tab auth while a handoff is already in progress', async () => {

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -232,6 +232,118 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY)).toBeNull()
   })
 
+  it('does not restore credentials when a refresh finishes after logout', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        token: 'expired-access-token',
+        expiresAt: Date.now() - 1,
+        authFlow: 'implicit',
+        refreshToken: 'refresh-token',
+      })
+    )
+    const revoke = vi.fn((_accessToken: string, callback: () => void) => {
+      callback()
+    })
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: vi.fn(),
+          revoke,
+        },
+      },
+    }
+    let resolveRefresh!: (response: Response) => void
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveRefresh = resolve
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = await renderWithGoogleAuthProvider()
+
+    const pendingToken = auth.ensureAccessToken({ interactive: false })
+    const rejection = expect(pendingToken).rejects.toThrow(
+      'Google Drive session ended.'
+    )
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      await auth.logoutGoogleDrive()
+      resolveRefresh(
+        new Response(
+          JSON.stringify({
+            access_token: 'late-access-token',
+            expires_in: 3600,
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+    })
+
+    await rejection
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    expect(revoke).toHaveBeenCalledWith(
+      'expired-access-token',
+      expect.any(Function)
+    )
+  })
+
+  it('does not restore credentials when service account minting finishes after logout', async () => {
+    googleClientManager.setOAuthClient({
+      clientId: '',
+      authFlow: 'service_account',
+      authUxMode: 'new_tab',
+      serviceAccount: {
+        clientEmail: 'runme-drive-test@example.iam.gserviceaccount.com',
+        privateKey: await generatePrivateKeyPem(),
+      },
+    })
+    let resolveMint!: (response: Response) => void
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveMint = resolve
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = await renderWithGoogleAuthProvider()
+
+    const pendingToken = auth.ensureAccessToken({ interactive: false })
+    const rejection = expect(pendingToken).rejects.toThrow(
+      'Google Drive session ended.'
+    )
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      await auth.logoutGoogleDrive()
+      resolveMint(
+        new Response(
+          JSON.stringify({
+            access_token: 'late-service-account-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+    })
+
+    await rejection
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
   it('does not relaunch new-tab auth while a handoff is already in progress', async () => {
     googleClientManager.setOAuthClient({
       authFlow: 'implicit',

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -41,6 +41,7 @@ const PKCE_RETURN_TO_KEY = 'runme/google-auth/pkce-return-to'
 const PKCE_ERROR_KEY = 'runme/google-auth/pkce-error'
 const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
 const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
+const SELECT_ACCOUNT_NEXT_KEY = 'runme/google-auth/select-account-next'
 
 interface AccessTokenInfo {
   token: string
@@ -55,7 +56,7 @@ interface EnsureAccessTokenOptions {
 
 export interface StartGoogleDriveOAuthOptions {
   mode?: GoogleDriveAuthUxMode
-  prompt?: 'none' | 'consent'
+  prompt?: GoogleOAuthPrompt
 }
 
 export interface StartGoogleDriveOAuthResult {
@@ -67,6 +68,7 @@ export interface StartGoogleDriveOAuthResult {
 
 interface GoogleAuthContextType {
   ensureAccessToken: (options?: EnsureAccessTokenOptions) => Promise<string>
+  logoutGoogleDrive: () => Promise<void>
   startGoogleDriveOAuth: (
     options?: StartGoogleDriveOAuthOptions
   ) => Promise<StartGoogleDriveOAuthResult>
@@ -79,6 +81,8 @@ type GoogleRedirectUxMode = Extract<
   'redirect' | 'new_tab'
 >
 
+type GoogleOAuthPrompt = 'none' | 'consent' | 'select_account'
+
 type PendingHandlers = {
   resolve: (token: string) => void
   reject: (error: unknown) => void
@@ -86,7 +90,7 @@ type PendingHandlers = {
 
 interface TokenClient {
   callback: (response: AccessTokenResponse) => void
-  requestAccessToken: (options?: { prompt?: string }) => void
+  requestAccessToken: (options?: { prompt?: GoogleOAuthPrompt | '' }) => void
 }
 
 interface AccessTokenResponse {
@@ -105,6 +109,7 @@ interface GoogleOAuth {
     scope: string
     callback: (response: AccessTokenResponse) => void
   }) => TokenClient
+  revoke?: (accessToken: string, callback: () => void) => void
 }
 
 declare global {
@@ -270,6 +275,30 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     },
     []
   )
+
+  const requestAccountSelectionNext = useCallback(() => {
+    try {
+      window.localStorage.setItem(SELECT_ACCOUNT_NEXT_KEY, 'true')
+    } catch (error) {
+      console.error(
+        'Failed to remember Google account selection request',
+        error
+      )
+    }
+  }, [])
+
+  const consumeAccountSelectionRequest = useCallback(() => {
+    try {
+      const shouldSelectAccount =
+        window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY) === 'true'
+      if (shouldSelectAccount) {
+        window.localStorage.removeItem(SELECT_ACCOUNT_NEXT_KEY)
+      }
+      return shouldSelectAccount
+    } catch {
+      return false
+    }
+  }, [])
 
   const openAuthUrl = useCallback(
     (authUrl: URL, mode: GoogleRedirectUxMode) => {
@@ -502,7 +531,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
   ])
 
   const startPkceRedirect = useCallback(
-    async (mode: GoogleRedirectUxMode) => {
+    async (mode: GoogleRedirectUxMode, promptMode?: GoogleOAuthPrompt) => {
       const { clientId } = googleClientManager.getOAuthClient()
       if (!clientId?.trim()) {
         throw new Error('Google OAuth client is not configured.')
@@ -531,7 +560,9 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       authUrl.searchParams.set('access_type', 'offline')
 
       // Force consent only until we obtain a refresh token.
-      if (!tokenInfoRef.current?.refreshToken) {
+      if (promptMode) {
+        authUrl.searchParams.set('prompt', promptMode)
+      } else if (!tokenInfoRef.current?.refreshToken) {
         authUrl.searchParams.set('prompt', 'consent')
       }
 
@@ -542,7 +573,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
 
   const startImplicitRedirect = useCallback(
     (
-      promptMode: 'none' | 'consent' = 'none',
+      promptMode: GoogleOAuthPrompt = 'none',
       mode: GoogleRedirectUxMode = 'new_tab'
     ) => {
       const { clientId } = googleClientManager.getOAuthClient()
@@ -800,13 +831,59 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     return client
   }, [ensureScriptLoaded, setAccessToken])
 
+  const logoutGoogleDrive = useCallback(async () => {
+    const oauthClient = googleClientManager.getOAuthClient()
+    const accessToken = tokenInfoRef.current?.token
+
+    handlersRef.current?.reject(new Error('Google Drive session ended.'))
+    handlersRef.current = null
+    pendingPromiseRef.current = null
+    callbackErrorRef.current = null
+    clearPkceState()
+    setAccessToken('')
+    window.gapi?.client.setToken(null)
+
+    if (oauthClient.authFlow !== 'service_account') {
+      requestAccountSelectionNext()
+    }
+
+    if (!accessToken || oauthClient.authFlow === 'service_account') {
+      return
+    }
+
+    try {
+      await ensureScriptLoaded()
+      const revoke = window.google?.accounts?.oauth2?.revoke
+      if (!revoke) {
+        return
+      }
+      await new Promise<void>((resolve) => {
+        revoke(accessToken, resolve)
+      })
+    } catch (error) {
+      // Local credentials have already been cleared. Revocation is best effort
+      // because a network failure should not leave the app signed in.
+      appLogger.warn('Failed to revoke Google Drive access token', {
+        attrs: {
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_TOKEN_REVOKE_FAILED',
+          error: String(error),
+        },
+      })
+    }
+  }, [
+    clearPkceState,
+    ensureScriptLoaded,
+    requestAccountSelectionNext,
+    setAccessToken,
+  ])
+
   const startGoogleDriveOAuth = useCallback(
     async (
       options?: StartGoogleDriveOAuthOptions
     ): Promise<StartGoogleDriveOAuthResult> => {
       const oauthClient = googleClientManager.getOAuthClient()
       const requestedMode = options?.mode ?? oauthClient.authUxMode
-      const promptMode = options?.prompt ?? 'none'
 
       handlersRef.current?.reject(
         new Error('Google Drive OAuth flow restarted.')
@@ -830,10 +907,14 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
       }
 
+      const promptMode = consumeAccountSelectionRequest()
+        ? 'select_account'
+        : options?.prompt
+
       if (oauthClient.authFlow === 'pkce') {
         const mode: GoogleRedirectUxMode =
           requestedMode === 'redirect' ? 'redirect' : 'new_tab'
-        await startPkceRedirect(mode)
+        await startPkceRedirect(mode, promptMode)
         return {
           status: 'started',
           authFlow: oauthClient.authFlow,
@@ -842,7 +923,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       }
 
       if (requestedMode === 'redirect' || requestedMode === 'new_tab') {
-        startImplicitRedirect(promptMode, requestedMode)
+        startImplicitRedirect(promptMode ?? 'none', requestedMode)
         return {
           status: 'started',
           authFlow: oauthClient.authFlow,
@@ -871,7 +952,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           pendingResolve(response.access_token)
         }
         try {
-          client.requestAccessToken({ prompt: promptMode })
+          client.requestAccessToken({ prompt: promptMode ?? 'none' })
         } catch (error) {
           handlersRef.current = null
           reject(error)
@@ -887,6 +968,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     },
     [
       clearPkceState,
+      consumeAccountSelectionRequest,
       ensureTokenClient,
       mintServiceAccountAccessToken,
       setAccessToken,
@@ -908,7 +990,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     (options?: EnsureAccessTokenOptions) => {
       const interactive = options?.interactive ?? true
       const currentInfo = tokenInfoRef.current
-      if (canUseCachedToken(currentInfo)) {
+      if (currentInfo && canUseCachedToken(currentInfo)) {
         return Promise.resolve(currentInfo.token)
       }
 
@@ -940,7 +1022,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
 
         const refreshedInfo = tokenInfoRef.current
-        if (canUseCachedToken(refreshedInfo)) {
+        if (refreshedInfo && canUseCachedToken(refreshedInfo)) {
           return refreshedInfo.token
         }
 
@@ -980,21 +1062,31 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           )
         }
         if (oauthClient.authFlow === 'pkce') {
+          const promptMode = consumeAccountSelectionRequest()
+            ? 'select_account'
+            : undefined
           await startPkceRedirect(
-            oauthClient.authUxMode === 'redirect' ? 'redirect' : 'new_tab'
+            oauthClient.authUxMode === 'redirect' ? 'redirect' : 'new_tab',
+            promptMode
           )
           throw new Error(
             'Redirecting to Google OAuth for Drive authorization.'
           )
         }
         if (oauthClient.authUxMode === 'redirect') {
-          startImplicitRedirect('none', 'redirect')
+          const promptMode = consumeAccountSelectionRequest()
+            ? 'select_account'
+            : 'none'
+          startImplicitRedirect(promptMode, 'redirect')
           throw new Error(
             'Redirecting to Google OAuth for Drive authorization.'
           )
         }
         if (oauthClient.authUxMode === 'new_tab') {
-          startImplicitRedirect('none', 'new_tab')
+          const promptMode = consumeAccountSelectionRequest()
+            ? 'select_account'
+            : 'none'
+          startImplicitRedirect(promptMode, 'new_tab')
           throw new Error(
             'Redirecting to Google OAuth for Drive authorization.'
           )
@@ -1023,7 +1115,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           try {
             console.log('Requesting access token from Google OAuth')
             client.requestAccessToken({
-              prompt: currentInfo?.token ? '' : 'consent',
+              prompt: consumeAccountSelectionRequest()
+                ? 'select_account'
+                : currentInfo?.token
+                  ? ''
+                  : 'consent',
             })
           } catch (error) {
             handlersRef.current = null
@@ -1045,6 +1141,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     },
     [
       canUseCachedToken,
+      consumeAccountSelectionRequest,
       ensureTokenClient,
       hasRedirectAuthHandoffInProgress,
       mintServiceAccountAccessToken,
@@ -1062,10 +1159,17 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     () => ({
       ensureAccessToken,
       isDriveSyncing,
+      logoutGoogleDrive,
       startGoogleDriveOAuth,
       setAccessToken,
     }),
-    [ensureAccessToken, isDriveSyncing, startGoogleDriveOAuth, setAccessToken]
+    [
+      ensureAccessToken,
+      isDriveSyncing,
+      logoutGoogleDrive,
+      startGoogleDriveOAuth,
+      setAccessToken,
+    ]
   )
 
   return (

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -42,6 +42,7 @@ const PKCE_ERROR_KEY = 'runme/google-auth/pkce-error'
 const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
 const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
 const SELECT_ACCOUNT_NEXT_KEY = 'runme/google-auth/select-account-next'
+const AUTH_SESSION_EPOCH_KEY = 'runme/google-auth/session-epoch'
 
 interface AccessTokenInfo {
   token: string
@@ -82,6 +83,18 @@ type GoogleRedirectUxMode = Extract<
 >
 
 type GoogleOAuthPrompt = 'none' | 'consent' | 'select_account'
+
+type AuthOperationVersion = {
+  generation: number
+  sessionEpoch: string | null
+}
+
+class StaleGoogleAuthOperationError extends Error {
+  constructor() {
+    super('Google Drive session ended.')
+    this.name = 'StaleGoogleAuthOperationError'
+  }
+}
 
 type PendingHandlers = {
   resolve: (token: string) => void
@@ -210,6 +223,79 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
   const scriptPromiseRef = useRef<Promise<void> | null>(null)
   const callbackPromiseRef = useRef<Promise<void> | null>(null)
   const callbackErrorRef = useRef<unknown>(null)
+  // Every asynchronous authorization operation captures both this per-tab
+  // generation and the shared session epoch. Logout changes both values so a
+  // response already in flight cannot restore credentials after sign-out,
+  // including when the OAuth callback is running in another tab.
+  const authGenerationRef = useRef(0)
+
+  const readAuthSessionEpoch = useCallback(() => {
+    try {
+      return window.localStorage.getItem(AUTH_SESSION_EPOCH_KEY)
+    } catch {
+      return null
+    }
+  }, [])
+
+  const captureAuthOperation = useCallback(
+    (): AuthOperationVersion => ({
+      generation: authGenerationRef.current,
+      sessionEpoch: readAuthSessionEpoch(),
+    }),
+    [readAuthSessionEpoch]
+  )
+
+  const assertAuthOperationCurrent = useCallback(
+    (operation: AuthOperationVersion) => {
+      if (
+        operation.generation !== authGenerationRef.current ||
+        operation.sessionEpoch !== readAuthSessionEpoch()
+      ) {
+        throw new StaleGoogleAuthOperationError()
+      }
+    },
+    [readAuthSessionEpoch]
+  )
+
+  const invalidatePendingAuth = useCallback((message: string) => {
+    const hadPendingAuth = Boolean(
+      handlersRef.current ||
+        pendingPromiseRef.current ||
+        callbackPromiseRef.current
+    )
+    authGenerationRef.current += 1
+    handlersRef.current?.reject(new StaleGoogleAuthOperationError())
+    handlersRef.current = null
+    pendingPromiseRef.current = null
+    callbackPromiseRef.current = null
+    tokenClientRef.current = null
+    oauthClientIdRef.current = null
+    if (hadPendingAuth) {
+      appLogger.info(message, {
+        attrs: {
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_PENDING_INVALIDATED',
+        },
+      })
+    }
+  }, [])
+
+  const advanceAuthSessionEpoch = useCallback(() => {
+    const epoch = globalThis.crypto?.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random()}`
+    try {
+      window.localStorage.setItem(AUTH_SESSION_EPOCH_KEY, epoch)
+    } catch (error) {
+      appLogger.error('Failed to update Google Drive auth session epoch', {
+        attrs: {
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_SESSION_EPOCH_UPDATE_FAILED',
+          error: String(error),
+        },
+      })
+    }
+  }, [])
 
   // useCallback memoises the function instance so consumers receive a stable
   // reference between renders. That is important because the callback is passed
@@ -280,10 +366,13 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     try {
       window.localStorage.setItem(SELECT_ACCOUNT_NEXT_KEY, 'true')
     } catch (error) {
-      console.error(
-        'Failed to remember Google account selection request',
-        error
-      )
+      appLogger.error('Failed to remember Google account selection request', {
+        attrs: {
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_ACCOUNT_SELECTION_STATE_FAILED',
+          error: String(error),
+        },
+      })
     }
   }, [])
 
@@ -295,7 +384,14 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         window.localStorage.removeItem(SELECT_ACCOUNT_NEXT_KEY)
       }
       return shouldSelectAccount
-    } catch {
+    } catch (error) {
+      appLogger.error('Failed to read Google account selection request', {
+        attrs: {
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_ACCOUNT_SELECTION_STATE_READ_FAILED',
+          error: String(error),
+        },
+      })
       return false
     }
   }, [])
@@ -408,6 +504,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     if (window.location.pathname !== callbackPath) {
       return
     }
+    const authOperation = captureAuthOperation()
 
     const params = new URLSearchParams(window.location.search)
     const implicitToken = readImplicitRedirectTokenFromHash()
@@ -486,6 +583,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       const resolvedExpiresIn =
         Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600
       const handoffMode = window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)
+      assertAuthOperationCurrent(authOperation)
       setAccessToken(accessToken, resolvedExpiresIn, { refreshToken: null })
       clearPkceState()
       if (handoffMode === 'new_tab') {
@@ -501,6 +599,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     }
 
     const tokenResponse = await exchangeAuthorizationCode(code, codeVerifier)
+    assertAuthOperationCurrent(authOperation)
     if (tokenResponse.error || !tokenResponse.access_token) {
       clearPkceState()
       throw new Error(
@@ -524,6 +623,8 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     }
     window.location.replace(returnTo)
   }, [
+    assertAuthOperationCurrent,
+    captureAuthOperation,
     clearPkceState,
     exchangeAuthorizationCode,
     readImplicitRedirectTokenFromHash,
@@ -532,6 +633,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
 
   const startPkceRedirect = useCallback(
     async (mode: GoogleRedirectUxMode, promptMode?: GoogleOAuthPrompt) => {
+      const authOperation = captureAuthOperation()
       const { clientId } = googleClientManager.getOAuthClient()
       if (!clientId?.trim()) {
         throw new Error('Google OAuth client is not configured.')
@@ -539,6 +641,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
 
       const { code_verifier: codeVerifier, code_challenge: codeChallenge } =
         await pkceChallenge()
+      assertAuthOperationCurrent(authOperation)
       const state = globalThis.crypto?.randomUUID
         ? globalThis.crypto.randomUUID()
         : `${Date.now()}-${Math.random()}`
@@ -568,7 +671,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
 
       openAuthUrl(authUrl, mode)
     },
-    [openAuthUrl]
+    [assertAuthOperationCurrent, captureAuthOperation, openAuthUrl]
   )
 
   const startImplicitRedirect = useCallback(
@@ -610,6 +713,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     if (!refreshToken) {
       return null
     }
+    const authOperation = captureAuthOperation()
 
     const { clientId, clientSecret } = googleClientManager.getOAuthClient()
     if (!clientId?.trim()) {
@@ -639,6 +743,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     } catch {
       token = null
     }
+    assertAuthOperationCurrent(authOperation)
 
     if (!response.ok || token?.error || !token?.access_token) {
       if (token?.error === 'invalid_grant') {
@@ -655,7 +760,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       refreshToken: token.refresh_token ?? refreshToken,
     })
     return token.access_token
-  }, [setAccessToken])
+  }, [assertAuthOperationCurrent, captureAuthOperation, setAccessToken])
 
   const mintServiceAccountAccessToken = useCallback(async (): Promise<
     string | null
@@ -667,16 +772,18 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     if (!oauthClient.serviceAccount) {
       throw new Error('Google Drive service account credentials are missing.')
     }
+    const authOperation = captureAuthOperation()
 
     const token = await mintGoogleServiceAccountAccessToken(
       oauthClient.serviceAccount,
       DRIVE_SCOPES
     )
+    assertAuthOperationCurrent(authOperation)
     setAccessToken(token.access_token, token.expires_in ?? 3600, {
       refreshToken: null,
     })
     return token.access_token
-  }, [setAccessToken])
+  }, [assertAuthOperationCurrent, captureAuthOperation, setAccessToken])
 
   useEffect(() => {
     tokenInfoRef.current = tokenInfo
@@ -708,12 +815,21 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const handleStorage = (event: StorageEvent) => {
-      if (
-        event.storageArea !== window.localStorage ||
-        (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY)
-      ) {
+      if (event.storageArea !== window.localStorage) {
         return
       }
+      if (event.key === AUTH_SESSION_EPOCH_KEY) {
+        invalidatePendingAuth(
+          'Invalidated pending Google Drive authorization after logout in another tab'
+        )
+        return
+      }
+      if (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY) {
+        return
+      }
+      invalidatePendingAuth(
+        'Invalidated pending Google Drive authorization after credentials changed in another tab'
+      )
       const nextTokenInfo = loadStoredToken()
       tokenInfoRef.current = nextTokenInfo
       setTokenInfo(nextTokenInfo)
@@ -723,11 +839,14 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     return () => {
       window.removeEventListener('storage', handleStorage)
     }
-  }, [])
+  }, [invalidatePendingAuth])
 
   useEffect(() => {
     callbackErrorRef.current = null
     const pending = handleRedirectCallbackIfPresent().catch((error) => {
+      if (error instanceof StaleGoogleAuthOperationError) {
+        return
+      }
       callbackErrorRef.current = error
       try {
         window.sessionStorage.setItem(PKCE_ERROR_KEY, String(error))
@@ -801,8 +920,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     }
     tokenClientRef.current = null
     oauthClientIdRef.current = clientId
+    const authOperation = captureAuthOperation()
 
     await ensureScriptLoaded()
+    assertAuthOperationCurrent(authOperation)
 
     const oauth = window.google?.accounts?.oauth2
     if (!oauth?.initTokenClient) {
@@ -813,6 +934,14 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       client_id: clientId,
       scope: DRIVE_SCOPES.join(' '),
       callback: (response: AccessTokenResponse) => {
+        try {
+          assertAuthOperationCurrent(authOperation)
+        } catch (error) {
+          if (error instanceof StaleGoogleAuthOperationError) {
+            return
+          }
+          throw error
+        }
         if (!handlersRef.current) {
           return
         }
@@ -829,15 +958,21 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
 
     tokenClientRef.current = client
     return client
-  }, [ensureScriptLoaded, setAccessToken])
+  }, [
+    assertAuthOperationCurrent,
+    captureAuthOperation,
+    ensureScriptLoaded,
+    setAccessToken,
+  ])
 
   const logoutGoogleDrive = useCallback(async () => {
     const oauthClient = googleClientManager.getOAuthClient()
     const accessToken = tokenInfoRef.current?.token
 
-    handlersRef.current?.reject(new Error('Google Drive session ended.'))
-    handlersRef.current = null
-    pendingPromiseRef.current = null
+    advanceAuthSessionEpoch()
+    invalidatePendingAuth(
+      'Invalidated pending Google Drive authorization during logout'
+    )
     callbackErrorRef.current = null
     clearPkceState()
     setAccessToken('')
@@ -872,8 +1007,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       })
     }
   }, [
+    advanceAuthSessionEpoch,
     clearPkceState,
     ensureScriptLoaded,
+    invalidatePendingAuth,
     requestAccountSelectionNext,
     setAccessToken,
   ])
@@ -885,12 +1022,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       const oauthClient = googleClientManager.getOAuthClient()
       const requestedMode = options?.mode ?? oauthClient.authUxMode
 
-      handlersRef.current?.reject(
-        new Error('Google Drive OAuth flow restarted.')
+      invalidatePendingAuth(
+        'Invalidated pending Google Drive authorization before starting a fresh flow'
       )
-      handlersRef.current = null
-      pendingPromiseRef.current = null
       clearPkceState()
+      const authOperation = captureAuthOperation()
 
       if (oauthClient.authFlow === 'service_account') {
         const accessToken = await mintServiceAccountAccessToken()
@@ -932,9 +1068,18 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       }
 
       const client = await ensureTokenClient()
+      assertAuthOperationCurrent(authOperation)
       const accessToken = await new Promise<string>((resolve, reject) => {
         handlersRef.current = { resolve, reject }
         client.callback = (response: AccessTokenResponse) => {
+          try {
+            assertAuthOperationCurrent(authOperation)
+          } catch (error) {
+            if (error instanceof StaleGoogleAuthOperationError) {
+              return
+            }
+            throw error
+          }
           if (!handlersRef.current) {
             return
           }
@@ -967,9 +1112,12 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       }
     },
     [
+      assertAuthOperationCurrent,
+      captureAuthOperation,
       clearPkceState,
       consumeAccountSelectionRequest,
       ensureTokenClient,
+      invalidatePendingAuth,
       mintServiceAccountAccessToken,
       setAccessToken,
       startImplicitRedirect,
@@ -998,9 +1146,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         return pendingPromiseRef.current
       }
 
-      pendingPromiseRef.current = (async () => {
+      const authOperation = captureAuthOperation()
+      const pendingPromise = (async () => {
         if (callbackPromiseRef.current) {
           await callbackPromiseRef.current
+          assertAuthOperationCurrent(authOperation)
         }
         let callbackErrorFromStorage: string | null = null
         try {
@@ -1027,6 +1177,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
 
         const serviceAccountToken = await mintServiceAccountAccessToken()
+        assertAuthOperationCurrent(authOperation)
         if (serviceAccountToken) {
           return serviceAccountToken
         }
@@ -1037,6 +1188,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
             return refreshedToken
           }
         } catch (error) {
+          if (error instanceof StaleGoogleAuthOperationError) {
+            throw error
+          }
+          assertAuthOperationCurrent(authOperation)
           appLogger.error('Failed to refresh Google access token', {
             attrs: {
               scope: 'storage.drive.auth',
@@ -1055,6 +1210,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           throw new Error('Google Drive authorization is required.')
         }
 
+        assertAuthOperationCurrent(authOperation)
         const oauthClient = googleClientManager.getOAuthClient()
         if (hasRedirectAuthHandoffInProgress()) {
           throw new Error(
@@ -1093,9 +1249,18 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
 
         const client = await ensureTokenClient()
+        assertAuthOperationCurrent(authOperation)
         return await new Promise<string>((resolve, reject) => {
           handlersRef.current = { resolve, reject }
           client.callback = (response: AccessTokenResponse) => {
+            try {
+              assertAuthOperationCurrent(authOperation)
+            } catch (error) {
+              if (error instanceof StaleGoogleAuthOperationError) {
+                return
+              }
+              throw error
+            }
             if (!handlersRef.current) {
               return
             }
@@ -1133,14 +1298,27 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
             reject(error)
           }
         })
-      })().finally(() => {
-        pendingPromiseRef.current = null
-      })
+      })()
+      pendingPromiseRef.current = pendingPromise
+      void pendingPromise.then(
+        () => {
+          if (pendingPromiseRef.current === pendingPromise) {
+            pendingPromiseRef.current = null
+          }
+        },
+        () => {
+          if (pendingPromiseRef.current === pendingPromise) {
+            pendingPromiseRef.current = null
+          }
+        }
+      )
 
-      return pendingPromiseRef.current
+      return pendingPromise
     },
     [
+      assertAuthOperationCurrent,
       canUseCachedToken,
+      captureAuthOperation,
       consumeAccountSelectionRequest,
       ensureTokenClient,
       hasRedirectAuthHandoffInProgress,

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -90,7 +90,7 @@ interface GapiGlobal {
   load: (name: string, options: GapiLoadOptions) => void
   client: {
     load: (name: string, version: string) => Promise<void>
-    setToken: (token: { access_token: string }) => void
+    setToken: (token: { access_token: string } | null) => void
     getToken?: () => { access_token?: string } | null
     drive: {
       files: GapiDriveFileMethods

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -229,6 +229,13 @@ locally stored Drive OAuth handoff state from a previous redirect or new-tab
 attempt, then starts the flow configured by `googleDrive.authFlow` and
 `googleDrive.authUxMode`.
 
+To change Google accounts, right-click the Google Drive status icon and select
+**Logout**. This clears the app's cached Drive access and refresh credentials,
+clears the in-memory Google API token, and attempts to revoke the access token
+with Google. The next click on the Drive status icon explicitly opens Google's
+account chooser. This signs out of Drive in Runme without signing out of the
+Google account in the rest of the browser.
+
 Use this when the Drive status button appears stuck, when an agent needs to
 explicitly refresh Drive auth from App Console, or before asking a user to clear
 browser storage manually. `drive.refreshAuth()` is an alias for the same


### PR DESCRIPTION
## What changed

- add a **Logout** action to the Google Drive status icon context menu
- clear cached access/refresh credentials and the in-memory GAPI token on logout
- best-effort revoke the prior Google access token
- force Google's account chooser on the next Drive authorization across popup, redirect, new-tab, and PKCE flows
- document the account-switching workflow

## Why

Runme Web previously had no Drive-specific logout path. Clearing only the local token also did not reliably let users choose another Google account because the browser could silently reuse the active Google session.

## User impact

Users can now right-click the Drive status icon, select **Logout**, and click the Drive icon again to choose a different Google account without signing out of Google browser-wide.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run` (73 files, 694 tests)
- DCO sign-off included
