### PR TITLE
Remember the Google Drive account for implicit OAuth

### DIFF
--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -553,9 +553,13 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       )
     })
 
-    expect(fetch).toHaveBeenCalledWith(DRIVE_ABOUT_URL, {
-      headers: { Authorization: 'Bearer existing-access-token' },
-    })
+    expect(fetch).toHaveBeenCalledWith(
+      DRIVE_ABOUT_URL,
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer existing-access-token' },
+        signal: expect.any(AbortSignal),
+      })
+    )
     await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
       'existing-access-token'
     )
@@ -599,6 +603,56 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       'replacement-access-token'
     )
     expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBeNull()
+  })
+
+  it('accepts the implicit token before a stalled account lookup times out', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => undefined))
+    )
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: vi.fn(() => tokenClient),
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+    vi.useFakeTimers()
+
+    try {
+      let resultPromise:
+        | ReturnType<typeof auth.startGoogleDriveOAuth>
+        | undefined
+      await act(async () => {
+        resultPromise = auth.startGoogleDriveOAuth()
+        await Promise.resolve()
+      })
+
+      expect(window.localStorage.getItem(STORAGE_KEY)).toContain(
+        'replacement-access-token'
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+      })
+      await expect(resultPromise!).resolves.toMatchObject({
+        status: 'authorized',
+        accessToken: 'replacement-access-token',
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not reuse a cached OAuth token for service account auth', async () => {

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -308,6 +308,47 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     })
   })
 
+  it('retries silent popup authorization with consent when login is required', async () => {
+    window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      if (tokenClient.requestAccessToken.mock.calls.length === 1) {
+        tokenClient.callback({ error: 'login_required' })
+        return
+      }
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    const initTokenClient = vi.fn(() => tokenClient)
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient,
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+
+    let accessToken = ''
+    await act(async () => {
+      accessToken = await auth.ensureAccessToken({ interactive: true })
+    })
+
+    expect(accessToken).toBe('replacement-access-token')
+    expect(tokenClient.requestAccessToken.mock.calls).toEqual([
+      [{ prompt: 'none' }],
+      [{ prompt: 'consent' }],
+    ])
+    expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
+      'jlewi@openai.com'
+    )
+  })
+
   it('adopts a remembered Drive account changed by another tab', async () => {
     window.localStorage.setItem(
       STORED_DRIVE_ACCOUNT_KEY,

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -300,7 +300,7 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
 
     expect(initTokenClient).toHaveBeenCalledWith(
       expect.objectContaining({
-        login_hint: 'jlewi@openai.com',
+        hint: 'jlewi@openai.com',
       })
     )
     expect(tokenClient.requestAccessToken).toHaveBeenCalledWith({
@@ -350,7 +350,7 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
 
     expect(initTokenClient).toHaveBeenCalledWith(
       expect.objectContaining({
-        login_hint: 'new-account@example.com',
+        hint: 'new-account@example.com',
       })
     )
   })

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -355,6 +355,71 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     )
   })
 
+  it('finishes implicit authorization when another tab stores its account hint', async () => {
+    let resolveAccountLookup!: (response: Response) => void
+    const accountLookup = new Promise<Response>((resolve) => {
+      resolveAccountLookup = resolve
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => accountLookup)
+    )
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: vi.fn(() => tokenClient),
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+    const resultPromise = auth.startGoogleDriveOAuth()
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        DRIVE_ABOUT_URL,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer replacement-access-token' },
+        })
+      )
+    })
+
+    await act(async () => {
+      window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: STORED_DRIVE_ACCOUNT_KEY,
+          newValue: 'jlewi@openai.com',
+          storageArea: window.localStorage,
+        })
+      )
+      resolveAccountLookup(
+        new Response(
+          JSON.stringify({ user: { emailAddress: 'jlewi@openai.com' } }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      await resultPromise
+    })
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'authorized',
+      accessToken: 'replacement-access-token',
+    })
+  })
+
   it('uses the Google account chooser for new-tab auth after logout', async () => {
     googleClientManager.setOAuthClient({
       authFlow: 'implicit',

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -310,21 +310,27 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
 
   it('retries silent popup authorization with consent when login is required', async () => {
     window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
-    const tokenClient = {
+    const hintedTokenClient = {
       callback: vi.fn(),
       requestAccessToken: vi.fn(),
     }
-    tokenClient.requestAccessToken.mockImplementation(() => {
-      if (tokenClient.requestAccessToken.mock.calls.length === 1) {
-        tokenClient.callback({ error: 'login_required' })
-        return
-      }
-      tokenClient.callback({
+    const consentTokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    hintedTokenClient.requestAccessToken.mockImplementation(() => {
+      hintedTokenClient.callback({ error: 'login_required' })
+    })
+    consentTokenClient.requestAccessToken.mockImplementation(() => {
+      consentTokenClient.callback({
         access_token: 'replacement-access-token',
         expires_in: 3600,
       })
     })
-    const initTokenClient = vi.fn(() => tokenClient)
+    const initTokenClient = vi
+      .fn()
+      .mockReturnValueOnce(hintedTokenClient)
+      .mockReturnValueOnce(consentTokenClient)
     window.google = {
       accounts: {
         oauth2: {
@@ -340,13 +346,74 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     })
 
     expect(accessToken).toBe('replacement-access-token')
-    expect(tokenClient.requestAccessToken.mock.calls).toEqual([
-      [{ prompt: 'none' }],
-      [{ prompt: 'consent' }],
-    ])
+    expect(hintedTokenClient.requestAccessToken).toHaveBeenCalledWith({
+      prompt: 'none',
+    })
+    expect(consentTokenClient.requestAccessToken).toHaveBeenCalledWith({
+      prompt: 'consent',
+    })
+    expect(initTokenClient.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ hint: 'jlewi@openai.com' })
+    )
+    expect(initTokenClient.mock.calls[1]?.[0]).not.toHaveProperty('hint')
     expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
       'jlewi@openai.com'
     )
+  })
+
+  it('recreates the popup client without a stale hint before explicit consent', async () => {
+    window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
+    const hintedTokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    const consentTokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    hintedTokenClient.requestAccessToken.mockImplementation(() => {
+      hintedTokenClient.callback({ error: 'interaction_required' })
+    })
+    consentTokenClient.requestAccessToken.mockImplementation(() => {
+      consentTokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    const initTokenClient = vi
+      .fn()
+      .mockReturnValueOnce(hintedTokenClient)
+      .mockReturnValueOnce(consentTokenClient)
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient,
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+
+    let result: Awaited<ReturnType<typeof auth.startGoogleDriveOAuth>> | null =
+      null
+    await act(async () => {
+      result = await auth.startGoogleDriveOAuth()
+    })
+
+    expect(result).toMatchObject({
+      status: 'authorized',
+      accessToken: 'replacement-access-token',
+    })
+
+    expect(hintedTokenClient.requestAccessToken).toHaveBeenCalledWith({
+      prompt: 'none',
+    })
+    expect(consentTokenClient.requestAccessToken).toHaveBeenCalledWith({
+      prompt: 'consent',
+    })
+    expect(initTokenClient.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ hint: 'jlewi@openai.com' })
+    )
+    expect(initTokenClient.mock.calls[1]?.[0]).not.toHaveProperty('hint')
   })
 
   it('adopts a remembered Drive account changed by another tab', async () => {
@@ -669,6 +736,102 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
       'existing-access-token'
     )
+  })
+
+  it('does not let an old token migration overwrite a newer account', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        token: 'old-access-token',
+        expiresAt: Date.now() + 30 * 60 * 1000,
+        authFlow: 'implicit',
+      })
+    )
+    let resolveOldLookup!: (response: Response) => void
+    let resolveNewLookup!: (response: Response) => void
+    const oldLookup = new Promise<Response>((resolve) => {
+      resolveOldLookup = resolve
+    })
+    const newLookup = new Promise<Response>((resolve) => {
+      resolveNewLookup = resolve
+    })
+    const fetchMock = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get('Authorization')
+        return authorization === 'Bearer old-access-token'
+          ? oldLookup
+          : newLookup
+      }
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        DRIVE_ABOUT_URL,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer old-access-token' },
+        })
+      )
+    })
+
+    await act(async () => {
+      auth.setAccessToken('new-access-token')
+    })
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        DRIVE_ABOUT_URL,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer new-access-token' },
+        })
+      )
+    })
+
+    await act(async () => {
+      resolveNewLookup(
+        new Response(
+          JSON.stringify({ user: { emailAddress: 'new@example.com' } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    })
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
+        'new@example.com'
+      )
+    })
+
+    await act(async () => {
+      resolveOldLookup(
+        new Response(
+          JSON.stringify({ user: { emailAddress: 'old@example.com' } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      await Promise.resolve()
+    })
+    expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
+      'new@example.com'
+    )
+  })
+
+  it('does not migrate a stored service-account token as a browser account', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        token: 'service-account-token',
+        expiresAt: Date.now() + 30 * 60 * 1000,
+        authFlow: 'service_account',
+      })
+    )
+
+    await renderWithGoogleAuthProvider()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBeNull()
   })
 
   it('keeps implicit authorization usable when account discovery fails', async () => {

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -217,6 +217,78 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(window.sessionStorage.getItem(PKCE_ERROR_KEY)).toBeNull()
   })
 
+  it('replaces an implicit account hint after PKCE authorizes another account', async () => {
+    googleClientManager.setOAuthClient({
+      authFlow: 'pkce',
+      authUxMode: 'new_tab',
+    })
+    window.localStorage.setItem(
+      STORED_DRIVE_ACCOUNT_KEY,
+      'implicit-account@example.com'
+    )
+    window.localStorage.setItem(PKCE_STATE_KEY, 'pkce-state')
+    window.localStorage.setItem(PKCE_CODE_VERIFIER_KEY, 'pkce-verifier')
+    window.localStorage.setItem(PKCE_RETURN_TO_KEY, '/')
+    window.history.replaceState(
+      null,
+      '',
+      '/gdrive/callback?code=pkce-code&state=pkce-state'
+    )
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      if (String(input) === 'https://oauth2.googleapis.com/token') {
+        return new Response(
+          JSON.stringify({
+            access_token: 'pkce-access-token',
+            expires_in: 3600,
+            refresh_token: 'pkce-refresh-token',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+      if (String(input) === DRIVE_ABOUT_URL) {
+        return new Response(
+          JSON.stringify({
+            user: { emailAddress: 'pkce-account@example.com' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(window as unknown as Window)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
+        'pkce-account@example.com'
+      )
+      expect(window.localStorage.getItem(PKCE_STATE_KEY)).toBeNull()
+    })
+
+    window.history.replaceState(null, '', '/')
+    googleClientManager.setOAuthClient({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    await act(async () => {
+      await auth.startGoogleDriveOAuth()
+    })
+
+    const authUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(authUrl.searchParams.get('login_hint')).toBe(
+      'pkce-account@example.com'
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      DRIVE_ABOUT_URL,
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer pkce-access-token' },
+      })
+    )
+  })
+
   it('clears and revokes Drive credentials, then asks Google to select an account', async () => {
     const tokenClient = {
       callback: vi.fn(),

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -13,6 +13,9 @@ const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
 const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
 const SELECT_ACCOUNT_NEXT_KEY = 'runme/google-auth/select-account-next'
 const STORAGE_KEY = 'runme/google-auth/token'
+const STORED_DRIVE_ACCOUNT_KEY = 'runme/google-auth/drive-account'
+const DRIVE_ABOUT_URL =
+  'https://www.googleapis.com/drive/v3/about?fields=user(emailAddress)'
 
 function CaptureAuth(props: {
   onReady: (auth: ReturnType<typeof useGoogleAuth>) => void
@@ -77,6 +80,7 @@ async function generatePrivateKeyPem(): Promise<string> {
 describe('GoogleAuthProvider implicit redirect flow', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
     window.localStorage.clear()
     window.sessionStorage.clear()
     window.history.replaceState(null, '', '/')
@@ -86,6 +90,20 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       authUxMode: 'popup',
     })
     delete window.google
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            user: { emailAddress: 'jlewi@openai.com' },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      })
+    )
   })
 
   it('starts implicit redirect flow when authFlow=implicit and authUxMode=redirect', async () => {
@@ -124,6 +142,46 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(window.localStorage.getItem(PKCE_RETURN_TO_KEY)).toBe('/')
     expect(window.localStorage.getItem(IMPLICIT_PROMPT_MODE_KEY)).toBe('none')
     expect(window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)).toBeNull()
+  })
+
+  it('uses the remembered Drive account for silent new-tab authorization', async () => {
+    googleClientManager.setOAuthClient({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(window as unknown as Window)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await expect(auth.startGoogleDriveOAuth()).resolves.toMatchObject({
+      status: 'started',
+      authFlow: 'implicit',
+      mode: 'new_tab',
+    })
+
+    const authUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(authUrl.searchParams.get('prompt')).toBe('none')
+    expect(authUrl.searchParams.get('login_hint')).toBe('jlewi@openai.com')
+  })
+
+  it('preserves the remembered Drive account when consent is required', async () => {
+    googleClientManager.setOAuthClient({
+      authFlow: 'implicit',
+      authUxMode: 'new_tab',
+    })
+    window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(window as unknown as Window)
+    const auth = await renderWithGoogleAuthProvider()
+
+    await auth.startGoogleDriveOAuth({ prompt: 'consent' })
+
+    const authUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(authUrl.searchParams.get('prompt')).toBe('consent')
+    expect(authUrl.searchParams.get('login_hint')).toBe('jlewi@openai.com')
   })
 
   it('starts a fresh implicit auth flow and replaces stale handoff state', async () => {
@@ -209,6 +267,92 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       prompt: 'select_account',
     })
     expect(window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY)).toBeNull()
+    expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
+      'jlewi@openai.com'
+    )
+  })
+
+  it('initializes popup OAuth with the remembered Drive account', async () => {
+    window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    const initTokenClient = vi.fn(() => tokenClient)
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient,
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+
+    await act(async () => {
+      await auth.startGoogleDriveOAuth()
+    })
+
+    expect(initTokenClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        login_hint: 'jlewi@openai.com',
+      })
+    )
+    expect(tokenClient.requestAccessToken).toHaveBeenCalledWith({
+      prompt: 'none',
+    })
+  })
+
+  it('adopts a remembered Drive account changed by another tab', async () => {
+    window.localStorage.setItem(
+      STORED_DRIVE_ACCOUNT_KEY,
+      'old-account@example.com'
+    )
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    const initTokenClient = vi.fn(() => tokenClient)
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient,
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+
+    await act(async () => {
+      window.localStorage.setItem(
+        STORED_DRIVE_ACCOUNT_KEY,
+        'new-account@example.com'
+      )
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: STORED_DRIVE_ACCOUNT_KEY,
+          newValue: 'new-account@example.com',
+          storageArea: window.localStorage,
+        })
+      )
+      await auth.startGoogleDriveOAuth()
+    })
+
+    expect(initTokenClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        login_hint: 'new-account@example.com',
+      })
+    )
   })
 
   it('uses the Google account chooser for new-tab auth after logout', async () => {
@@ -216,6 +360,7 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       authFlow: 'implicit',
       authUxMode: 'new_tab',
     })
+    window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, 'jlewi@openai.com')
     const openSpy = vi
       .spyOn(window, 'open')
       .mockReturnValue(window as unknown as Window)
@@ -229,6 +374,8 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(openSpy).toHaveBeenCalledTimes(1)
     const authUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
     expect(authUrl.searchParams.get('prompt')).toBe('select_account')
+    expect(authUrl.searchParams.get('login_hint')).toBeNull()
+    expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBeNull()
     expect(window.localStorage.getItem(SELECT_ACCOUNT_NEXT_KEY)).toBeNull()
   })
 
@@ -387,6 +534,71 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
       'test-access-token'
     )
+  })
+
+  it('migrates an existing implicit session to a remembered Drive account', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        token: 'existing-access-token',
+        expiresAt: Date.now() + 30 * 60 * 1000,
+        authFlow: 'implicit',
+      })
+    )
+    const auth = await renderWithGoogleAuthProvider()
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBe(
+        'jlewi@openai.com'
+      )
+    })
+
+    expect(fetch).toHaveBeenCalledWith(DRIVE_ABOUT_URL, {
+      headers: { Authorization: 'Bearer existing-access-token' },
+    })
+    await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
+      'existing-access-token'
+    )
+  })
+
+  it('keeps implicit authorization usable when account discovery fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 503 }))
+    )
+    const tokenClient = {
+      callback: vi.fn(),
+      requestAccessToken: vi.fn(),
+    }
+    tokenClient.requestAccessToken.mockImplementation(() => {
+      tokenClient.callback({
+        access_token: 'replacement-access-token',
+        expires_in: 3600,
+      })
+    })
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: vi.fn(() => tokenClient),
+        },
+      },
+    }
+    const auth = await renderWithGoogleAuthProvider()
+
+    let result: Awaited<ReturnType<typeof auth.startGoogleDriveOAuth>> | null =
+      null
+    await act(async () => {
+      result = await auth.startGoogleDriveOAuth()
+    })
+
+    expect(result).toMatchObject({
+      status: 'authorized',
+      accessToken: 'replacement-access-token',
+    })
+    expect(window.localStorage.getItem(STORAGE_KEY)).toContain(
+      'replacement-access-token'
+    )
+    expect(window.localStorage.getItem(STORED_DRIVE_ACCOUNT_KEY)).toBeNull()
   })
 
   it('does not reuse a cached OAuth token for service account auth', async () => {

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -204,6 +204,20 @@ function buildImplicitAuthorizationUrl(options: {
   return authUrl
 }
 
+// A remembered account can outlive its Google browser session or consent.
+// Retry these silent-auth failures once with an interactive consent prompt.
+function shouldRetryImplicitPopupWithConsent(
+  response: AccessTokenResponse,
+  prompt: GoogleOAuthPrompt | ''
+): boolean {
+  return (
+    prompt === 'none' &&
+    (response.error === 'login_required' ||
+      response.error === 'interaction_required' ||
+      response.error === 'consent_required')
+  )
+}
+
 // GoogleAuthProvider owns all OAuth state for the app. It exposes a small
 // surface (ensureAccessToken / setAccessToken) through context so the rest of
 // the codebase never has to think about how tokens are minted, refreshed, or
@@ -1280,6 +1294,8 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       const client = await ensureTokenClient()
       assertAuthOperationCurrent(authOperation)
       const accessToken = await new Promise<string>((resolve, reject) => {
+        let requestedPrompt: GoogleOAuthPrompt | '' = promptMode ?? 'none'
+        let retriedWithConsent = false
         handlersRef.current = { resolve, reject }
         client.callback = (response: AccessTokenResponse) => {
           try {
@@ -1291,6 +1307,21 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
             throw error
           }
           if (!handlersRef.current) {
+            return
+          }
+          if (
+            !retriedWithConsent &&
+            shouldRetryImplicitPopupWithConsent(response, requestedPrompt)
+          ) {
+            retriedWithConsent = true
+            requestedPrompt = 'consent'
+            persistStoredDriveAccount(null)
+            try {
+              client.requestAccessToken({ prompt: requestedPrompt })
+            } catch (error) {
+              handlersRef.current = null
+              reject(error)
+            }
             return
           }
           const { resolve: pendingResolve, reject: pendingReject } =
@@ -1311,7 +1342,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           ).then(() => pendingResolve(accessToken), pendingReject)
         }
         try {
-          client.requestAccessToken({ prompt: promptMode ?? 'none' })
+          client.requestAccessToken({ prompt: requestedPrompt })
         } catch (error) {
           handlersRef.current = null
           reject(error)
@@ -1470,6 +1501,14 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         const client = await ensureTokenClient()
         assertAuthOperationCurrent(authOperation)
         return await new Promise<string>((resolve, reject) => {
+          let requestedPrompt: GoogleOAuthPrompt | '' = shouldSelectAccount
+            ? 'select_account'
+            : storedDriveAccountRef.current
+              ? 'none'
+              : currentInfo?.token
+                ? ''
+                : 'consent'
+          let retriedWithConsent = false
           handlersRef.current = { resolve, reject }
           client.callback = (response: AccessTokenResponse) => {
             try {
@@ -1481,6 +1520,21 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
               throw error
             }
             if (!handlersRef.current) {
+              return
+            }
+            if (
+              !retriedWithConsent &&
+              shouldRetryImplicitPopupWithConsent(response, requestedPrompt)
+            ) {
+              retriedWithConsent = true
+              requestedPrompt = 'consent'
+              persistStoredDriveAccount(null)
+              try {
+                client.requestAccessToken({ prompt: requestedPrompt })
+              } catch (error) {
+                handlersRef.current = null
+                reject(error)
+              }
               return
             }
             const { resolve: pendingResolve, reject: pendingReject } =
@@ -1502,15 +1556,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           }
           try {
             console.log('Requesting access token from Google OAuth')
-            client.requestAccessToken({
-              prompt: shouldSelectAccount
-                ? 'select_account'
-                : storedDriveAccountRef.current
-                  ? 'none'
-                  : currentInfo?.token
-                    ? ''
-                    : 'consent',
-            })
+            client.requestAccessToken({ prompt: requestedPrompt })
           } catch (error) {
             handlersRef.current = null
             appLogger.error('Failed to request Google access token', {

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -129,7 +129,7 @@ interface GoogleOAuth {
   initTokenClient: (options: {
     client_id: string
     scope: string
-    login_hint?: string
+    hint?: string
     callback: (response: AccessTokenResponse) => void
   }) => TokenClient
   revoke?: (accessToken: string, callback: () => void) => void
@@ -1133,7 +1133,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     const client = oauth.initTokenClient({
       client_id: clientId,
       scope: DRIVE_SCOPES.join(' '),
-      ...(loginHint ? { login_hint: loginHint } : {}),
+      ...(loginHint ? { hint: loginHint } : {}),
       callback: (response: AccessTokenResponse) => {
         try {
           assertAuthOperationCurrent(authOperation)

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -494,6 +494,9 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       }
 
       assertAuthOperationCurrent(authOperation)
+      if (tokenInfoRef.current?.token !== accessToken) {
+        return
+      }
       persistStoredDriveAccount(account)
     },
     [assertAuthOperationCurrent, persistStoredDriveAccount]
@@ -969,6 +972,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     if (
       !tokenInfo?.token ||
       tokenInfo.expiresAt <= Date.now() ||
+      tokenInfo.authFlow !== 'implicit' ||
       storedDriveAccountRef.current ||
       googleClientManager.getOAuthClient().authFlow !== 'implicit'
     ) {
@@ -1297,7 +1301,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         let requestedPrompt: GoogleOAuthPrompt | '' = promptMode ?? 'none'
         let retriedWithConsent = false
         handlersRef.current = { resolve, reject }
-        client.callback = (response: AccessTokenResponse) => {
+        const handleResponse = (response: AccessTokenResponse) => {
           try {
             assertAuthOperationCurrent(authOperation)
           } catch (error) {
@@ -1316,12 +1320,22 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
             retriedWithConsent = true
             requestedPrompt = 'consent'
             persistStoredDriveAccount(null)
-            try {
-              client.requestAccessToken({ prompt: requestedPrompt })
-            } catch (error) {
-              handlersRef.current = null
-              reject(error)
-            }
+            void ensureTokenClient().then(
+              (retryClient) => {
+                try {
+                  assertAuthOperationCurrent(authOperation)
+                  retryClient.callback = handleResponse
+                  retryClient.requestAccessToken({ prompt: requestedPrompt })
+                } catch (error) {
+                  handlersRef.current = null
+                  reject(error)
+                }
+              },
+              (error) => {
+                handlersRef.current = null
+                reject(error)
+              }
+            )
             return
           }
           const { resolve: pendingResolve, reject: pendingReject } =
@@ -1341,6 +1355,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
             authOperation
           ).then(() => pendingResolve(accessToken), pendingReject)
         }
+        client.callback = handleResponse
         try {
           client.requestAccessToken({ prompt: requestedPrompt })
         } catch (error) {
@@ -1510,7 +1525,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
                 : 'consent'
           let retriedWithConsent = false
           handlersRef.current = { resolve, reject }
-          client.callback = (response: AccessTokenResponse) => {
+          const handleResponse = (response: AccessTokenResponse) => {
             try {
               assertAuthOperationCurrent(authOperation)
             } catch (error) {
@@ -1529,12 +1544,24 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
               retriedWithConsent = true
               requestedPrompt = 'consent'
               persistStoredDriveAccount(null)
-              try {
-                client.requestAccessToken({ prompt: requestedPrompt })
-              } catch (error) {
-                handlersRef.current = null
-                reject(error)
-              }
+              void ensureTokenClient().then(
+                (retryClient) => {
+                  try {
+                    assertAuthOperationCurrent(authOperation)
+                    retryClient.callback = handleResponse
+                    retryClient.requestAccessToken({
+                      prompt: requestedPrompt,
+                    })
+                  } catch (error) {
+                    handlersRef.current = null
+                    reject(error)
+                  }
+                },
+                (error) => {
+                  handlersRef.current = null
+                  reject(error)
+                }
+              )
               return
             }
             const { resolve: pendingResolve, reject: pendingReject } =
@@ -1554,6 +1581,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
               authOperation
             ).then(() => pendingResolve(accessToken), pendingReject)
           }
+          client.callback = handleResponse
           try {
             console.log('Requesting access token from Google OAuth')
             client.requestAccessToken({ prompt: requestedPrompt })

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -43,6 +43,9 @@ const IMPLICIT_PROMPT_MODE_KEY = 'runme/google-auth/implicit-prompt-mode'
 const AUTH_HANDOFF_MODE_KEY = 'runme/google-auth/handoff-mode'
 const SELECT_ACCOUNT_NEXT_KEY = 'runme/google-auth/select-account-next'
 const AUTH_SESSION_EPOCH_KEY = 'runme/google-auth/session-epoch'
+const STORED_DRIVE_ACCOUNT_KEY = 'runme/google-auth/drive-account'
+const DRIVE_ABOUT_URL =
+  'https://www.googleapis.com/drive/v3/about?fields=user(emailAddress)'
 
 interface AccessTokenInfo {
   token: string
@@ -116,10 +119,17 @@ interface AccessTokenResponse {
   error_description?: string
 }
 
+interface DriveAboutResponse {
+  user?: {
+    emailAddress?: string
+  }
+}
+
 interface GoogleOAuth {
   initTokenClient: (options: {
     client_id: string
     scope: string
+    login_hint?: string
     callback: (response: AccessTokenResponse) => void
   }) => TokenClient
   revoke?: (accessToken: string, callback: () => void) => void
@@ -149,6 +159,49 @@ export function useGoogleAuth() {
 }
 
 const REFRESH_MARGIN_MS = 60_000
+
+// Google accepts an email address as login_hint and uses it to choose the
+// matching browser session. The hint is intentionally kept separate from the
+// expiring access token so it survives routine implicit-token renewal.
+function loadStoredDriveAccount(): string | null {
+  try {
+    const account = window.localStorage
+      .getItem(STORED_DRIVE_ACCOUNT_KEY)
+      ?.trim()
+    return account || null
+  } catch (error) {
+    appLogger.error('Failed to read the stored Google Drive account', {
+      attrs: {
+        scope: 'storage.drive.auth',
+        code: 'DRIVE_AUTH_ACCOUNT_READ_FAILED',
+        error: String(error),
+      },
+    })
+    return null
+  }
+}
+
+// Both the initial implicit request and the consent fallback must use the same
+// URL construction so the remembered account cannot be dropped on retry.
+function buildImplicitAuthorizationUrl(options: {
+  clientId: string
+  state: string
+  promptMode: GoogleOAuthPrompt
+  loginHint?: string | null
+}): URL {
+  const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+  authUrl.searchParams.set('client_id', options.clientId)
+  authUrl.searchParams.set('redirect_uri', getGoogleDriveOAuthCallbackUrl())
+  authUrl.searchParams.set('response_type', 'token')
+  authUrl.searchParams.set('scope', DRIVE_SCOPES.join(' '))
+  authUrl.searchParams.set('state', options.state)
+  authUrl.searchParams.set('include_granted_scopes', 'true')
+  authUrl.searchParams.set('prompt', options.promptMode)
+  if (options.loginHint) {
+    authUrl.searchParams.set('login_hint', options.loginHint)
+  }
+  return authUrl
+}
 
 // GoogleAuthProvider owns all OAuth state for the app. It exposes a small
 // surface (ensureAccessToken / setAccessToken) through context so the rest of
@@ -218,6 +271,8 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
   const tokenInfoRef = useRef<AccessTokenInfo | null>(null)
   const tokenClientRef = useRef<TokenClient | null>(null)
   const oauthClientIdRef = useRef<string | null>(null)
+  const oauthLoginHintRef = useRef<string | null>(null)
+  const storedDriveAccountRef = useRef<string | null>(loadStoredDriveAccount())
   const handlersRef = useRef<PendingHandlers | null>(null)
   const pendingPromiseRef = useRef<Promise<string> | null>(null)
   const scriptPromiseRef = useRef<Promise<void> | null>(null)
@@ -270,6 +325,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     callbackPromiseRef.current = null
     tokenClientRef.current = null
     oauthClientIdRef.current = null
+    oauthLoginHintRef.current = null
     if (hadPendingAuth) {
       appLogger.info(message, {
         attrs: {
@@ -342,6 +398,91 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       markOnboardingTaskComplete('sign-in-google-drive')
     },
     []
+  )
+
+  // Updating the remembered account also invalidates the cached GIS token
+  // client because login_hint is part of that client's initialization.
+  const persistStoredDriveAccount = useCallback((account: string | null) => {
+    const normalizedAccount = account?.trim() || null
+    storedDriveAccountRef.current = normalizedAccount
+    tokenClientRef.current = null
+    oauthClientIdRef.current = null
+    oauthLoginHintRef.current = null
+    try {
+      if (normalizedAccount) {
+        window.localStorage.setItem(STORED_DRIVE_ACCOUNT_KEY, normalizedAccount)
+      } else {
+        window.localStorage.removeItem(STORED_DRIVE_ACCOUNT_KEY)
+      }
+    } catch (error) {
+      appLogger.error('Failed to persist the Google Drive account', {
+        attrs: {
+          scope: 'storage.drive.auth',
+          code: 'DRIVE_AUTH_ACCOUNT_PERSIST_FAILED',
+          error: String(error),
+        },
+      })
+    }
+  }, [])
+
+  // Drive's about resource exposes the requesting user's email using the
+  // Drive scope we already request. This avoids adding identity scopes solely
+  // to populate Google's login_hint parameter.
+  const rememberDriveAccountForToken = useCallback(
+    async (accessToken: string, authOperation: AuthOperationVersion) => {
+      let account: string | null = null
+      try {
+        const response = await fetch(DRIVE_ABOUT_URL, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        if (!response.ok) {
+          throw new Error(
+            `Google Drive about request failed (${response.status})`
+          )
+        }
+        const about = (await response.json()) as DriveAboutResponse
+        account = about.user?.emailAddress?.trim() || null
+        if (!account) {
+          throw new Error(
+            'Google Drive about response did not include an email'
+          )
+        }
+      } catch (error) {
+        appLogger.warn(
+          'Failed to remember the authorized Google Drive account',
+          {
+            attrs: {
+              scope: 'storage.drive.auth',
+              code: 'DRIVE_AUTH_ACCOUNT_DISCOVERY_FAILED',
+              error: String(error),
+            },
+          }
+        )
+        return
+      }
+
+      assertAuthOperationCurrent(authOperation)
+      persistStoredDriveAccount(account)
+    },
+    [assertAuthOperationCurrent, persistStoredDriveAccount]
+  )
+
+  // Implicit OAuth responses do not contain the selected account identity.
+  // Discover and persist it before publishing the new token so another tab
+  // receives the login hint before it observes the credential update.
+  const acceptImplicitAccessToken = useCallback(
+    async (
+      accessToken: string,
+      expiresIn: number,
+      authOperation: AuthOperationVersion
+    ) => {
+      await rememberDriveAccountForToken(accessToken, authOperation)
+      assertAuthOperationCurrent(authOperation)
+      setAccessToken(accessToken, expiresIn, { refreshToken: null })
+    },
+    [assertAuthOperationCurrent, rememberDriveAccountForToken, setAccessToken]
   )
 
   const clearPkceState = useCallback(
@@ -534,17 +675,12 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         window.localStorage.setItem(IMPLICIT_PROMPT_MODE_KEY, 'consent')
         window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY)
 
-        const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
-        authUrl.searchParams.set('client_id', clientId)
-        authUrl.searchParams.set(
-          'redirect_uri',
-          getGoogleDriveOAuthCallbackUrl()
-        )
-        authUrl.searchParams.set('response_type', 'token')
-        authUrl.searchParams.set('scope', DRIVE_SCOPES.join(' '))
-        authUrl.searchParams.set('state', state)
-        authUrl.searchParams.set('include_granted_scopes', 'true')
-        authUrl.searchParams.set('prompt', 'consent')
+        const authUrl = buildImplicitAuthorizationUrl({
+          clientId,
+          state,
+          promptMode: 'consent',
+          loginHint: storedDriveAccountRef.current,
+        })
         window.location.assign(authUrl.toString())
         return
       }
@@ -584,7 +720,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600
       const handoffMode = window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)
       assertAuthOperationCurrent(authOperation)
-      setAccessToken(accessToken, resolvedExpiresIn, { refreshToken: null })
+      await acceptImplicitAccessToken(
+        accessToken,
+        resolvedExpiresIn,
+        authOperation
+      )
       clearPkceState()
       if (handoffMode === 'new_tab') {
         window.close()
@@ -623,6 +763,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     }
     window.location.replace(returnTo)
   }, [
+    acceptImplicitAccessToken,
     assertAuthOperationCurrent,
     captureAuthOperation,
     clearPkceState,
@@ -694,14 +835,15 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       window.localStorage.setItem(IMPLICIT_PROMPT_MODE_KEY, promptMode)
       window.localStorage.removeItem(PKCE_CODE_VERIFIER_KEY)
 
-      const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
-      authUrl.searchParams.set('client_id', clientId)
-      authUrl.searchParams.set('redirect_uri', getGoogleDriveOAuthCallbackUrl())
-      authUrl.searchParams.set('response_type', 'token')
-      authUrl.searchParams.set('scope', DRIVE_SCOPES.join(' '))
-      authUrl.searchParams.set('state', state)
-      authUrl.searchParams.set('include_granted_scopes', 'true')
-      authUrl.searchParams.set('prompt', promptMode)
+      const authUrl = buildImplicitAuthorizationUrl({
+        clientId,
+        state,
+        promptMode,
+        loginHint:
+          promptMode === 'select_account'
+            ? null
+            : storedDriveAccountRef.current,
+      })
 
       openAuthUrl(authUrl, mode)
     },
@@ -789,6 +931,34 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     tokenInfoRef.current = tokenInfo
   }, [tokenInfo])
 
+  // Existing sessions created before account hints were introduced are
+  // migrated while their current implicit token is still usable. Failure is
+  // non-fatal; the next successful authorization will try again.
+  useEffect(() => {
+    if (
+      !tokenInfo?.token ||
+      tokenInfo.expiresAt <= Date.now() ||
+      storedDriveAccountRef.current ||
+      googleClientManager.getOAuthClient().authFlow !== 'implicit'
+    ) {
+      return
+    }
+    const authOperation = captureAuthOperation()
+    void rememberDriveAccountForToken(tokenInfo.token, authOperation).catch(
+      (error) => {
+        if (!(error instanceof StaleGoogleAuthOperationError)) {
+          appLogger.warn('Failed to migrate the Google Drive account hint', {
+            attrs: {
+              scope: 'storage.drive.auth',
+              code: 'DRIVE_AUTH_ACCOUNT_MIGRATION_FAILED',
+              error: String(error),
+            },
+          })
+        }
+      }
+    )
+  }, [captureAuthOperation, rememberDriveAccountForToken, tokenInfo])
+
   useEffect(() => {
     const intervalId = window.setInterval(() => {
       setNowMs(Date.now())
@@ -822,6 +992,13 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         invalidatePendingAuth(
           'Invalidated pending Google Drive authorization after logout in another tab'
         )
+        return
+      }
+      if (event.key === STORED_DRIVE_ACCOUNT_KEY) {
+        invalidatePendingAuth(
+          'Invalidated pending Google Drive authorization after the account hint changed in another tab'
+        )
+        storedDriveAccountRef.current = loadStoredDriveAccount()
         return
       }
       if (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY) {
@@ -912,14 +1089,20 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
   // so subsequent callers reuse the same object.
   const ensureTokenClient = useCallback(async () => {
     const { clientId } = googleClientManager.getOAuthClient()
+    const loginHint = storedDriveAccountRef.current
     if (!clientId?.trim()) {
       throw new Error('Google OAuth client is not configured.')
     }
-    if (tokenClientRef.current && oauthClientIdRef.current === clientId) {
+    if (
+      tokenClientRef.current &&
+      oauthClientIdRef.current === clientId &&
+      oauthLoginHintRef.current === loginHint
+    ) {
       return tokenClientRef.current
     }
     tokenClientRef.current = null
     oauthClientIdRef.current = clientId
+    oauthLoginHintRef.current = loginHint
     const authOperation = captureAuthOperation()
 
     await ensureScriptLoaded()
@@ -933,6 +1116,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     const client = oauth.initTokenClient({
       client_id: clientId,
       scope: DRIVE_SCOPES.join(' '),
+      ...(loginHint ? { login_hint: loginHint } : {}),
       callback: (response: AccessTokenResponse) => {
         try {
           assertAuthOperationCurrent(authOperation)
@@ -947,22 +1131,26 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         }
         const { resolve, reject } = handlersRef.current
         handlersRef.current = null
-        if (response.error || !response.access_token) {
+        const accessToken = response.access_token
+        if (response.error || !accessToken) {
           reject(response.error ?? new Error('Failed to obtain access token'))
           return
         }
-        setAccessToken(response.access_token, response.expires_in ?? 3600)
-        resolve(response.access_token)
+        void acceptImplicitAccessToken(
+          accessToken,
+          response.expires_in ?? 3600,
+          authOperation
+        ).then(() => resolve(accessToken), reject)
       },
     })
 
     tokenClientRef.current = client
     return client
   }, [
+    acceptImplicitAccessToken,
     assertAuthOperationCurrent,
     captureAuthOperation,
     ensureScriptLoaded,
-    setAccessToken,
   ])
 
   const logoutGoogleDrive = useCallback(async () => {
@@ -975,6 +1163,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     )
     callbackErrorRef.current = null
     clearPkceState()
+    persistStoredDriveAccount(null)
     setAccessToken('')
     window.gapi?.client.setToken(null)
 
@@ -1011,6 +1200,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     clearPkceState,
     ensureScriptLoaded,
     invalidatePendingAuth,
+    persistStoredDriveAccount,
     requestAccountSelectionNext,
     setAccessToken,
   ])
@@ -1046,6 +1236,9 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       const promptMode = consumeAccountSelectionRequest()
         ? 'select_account'
         : options?.prompt
+      if (promptMode === 'select_account') {
+        persistStoredDriveAccount(null)
+      }
 
       if (oauthClient.authFlow === 'pkce') {
         const mode: GoogleRedirectUxMode =
@@ -1087,14 +1280,18 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
             handlersRef.current
           handlersRef.current = null
 
-          if (response.error || !response.access_token) {
+          const accessToken = response.access_token
+          if (response.error || !accessToken) {
             pendingReject(
               response.error ?? new Error('Failed to obtain access token')
             )
             return
           }
-          setAccessToken(response.access_token, response.expires_in ?? 3600)
-          pendingResolve(response.access_token)
+          void acceptImplicitAccessToken(
+            accessToken,
+            response.expires_in ?? 3600,
+            authOperation
+          ).then(() => pendingResolve(accessToken), pendingReject)
         }
         try {
           client.requestAccessToken({ prompt: promptMode ?? 'none' })
@@ -1112,6 +1309,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       }
     },
     [
+      acceptImplicitAccessToken,
       assertAuthOperationCurrent,
       captureAuthOperation,
       clearPkceState,
@@ -1119,7 +1317,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       ensureTokenClient,
       invalidatePendingAuth,
       mintServiceAccountAccessToken,
-      setAccessToken,
+      persistStoredDriveAccount,
       startImplicitRedirect,
       startPkceRedirect,
     ]
@@ -1248,6 +1446,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           )
         }
 
+        const shouldSelectAccount = consumeAccountSelectionRequest()
+        if (shouldSelectAccount) {
+          persistStoredDriveAccount(null)
+        }
         const client = await ensureTokenClient()
         assertAuthOperationCurrent(authOperation)
         return await new Promise<string>((resolve, reject) => {
@@ -1268,23 +1470,29 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
               handlersRef.current
             handlersRef.current = null
 
-            if (response.error || !response.access_token) {
+            const accessToken = response.access_token
+            if (response.error || !accessToken) {
               pendingReject(
                 response.error ?? new Error('Failed to obtain access token')
               )
               return
             }
-            setAccessToken(response.access_token, response.expires_in ?? 3600)
-            pendingResolve(response.access_token)
+            void acceptImplicitAccessToken(
+              accessToken,
+              response.expires_in ?? 3600,
+              authOperation
+            ).then(() => pendingResolve(accessToken), pendingReject)
           }
           try {
             console.log('Requesting access token from Google OAuth')
             client.requestAccessToken({
-              prompt: consumeAccountSelectionRequest()
+              prompt: shouldSelectAccount
                 ? 'select_account'
-                : currentInfo?.token
-                  ? ''
-                  : 'consent',
+                : storedDriveAccountRef.current
+                  ? 'none'
+                  : currentInfo?.token
+                    ? ''
+                    : 'consent',
             })
           } catch (error) {
             handlersRef.current = null
@@ -1316,6 +1524,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       return pendingPromise
     },
     [
+      acceptImplicitAccessToken,
       assertAuthOperationCurrent,
       canUseCachedToken,
       captureAuthOperation,
@@ -1323,8 +1532,8 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       ensureTokenClient,
       hasRedirectAuthHandoffInProgress,
       mintServiceAccountAccessToken,
+      persistStoredDriveAccount,
       refreshAccessToken,
-      setAccessToken,
       startImplicitRedirect,
       startPkceRedirect,
     ]

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -783,6 +783,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       )
     }
 
+    persistStoredDriveAccount(null)
     setAccessToken(
       tokenResponse.access_token,
       tokenResponse.expires_in ?? 3600,
@@ -790,6 +791,11 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         refreshToken: tokenResponse.refresh_token,
       }
     )
+    await rememberDriveAccountForToken(
+      tokenResponse.access_token,
+      authOperation
+    )
+    assertAuthOperationCurrent(authOperation)
     const handoffMode = window.localStorage.getItem(AUTH_HANDOFF_MODE_KEY)
     clearPkceState()
     if (handoffMode === 'new_tab') {
@@ -802,7 +808,9 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
     captureAuthOperation,
     clearPkceState,
     exchangeAuthorizationCode,
+    persistStoredDriveAccount,
     readImplicitRedirectTokenFromHash,
+    rememberDriveAccountForToken,
     setAccessToken,
   ])
 

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -159,6 +159,7 @@ export function useGoogleAuth() {
 }
 
 const REFRESH_MARGIN_MS = 60_000
+const DRIVE_ACCOUNT_DISCOVERY_TIMEOUT_MS = 3_000
 
 // Google accepts an email address as login_hint and uses it to choose the
 // matching browser session. The hint is intentionally kept separate from the
@@ -431,12 +432,23 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
   const rememberDriveAccountForToken = useCallback(
     async (accessToken: string, authOperation: AuthOperationVersion) => {
       let account: string | null = null
+      const controller = new AbortController()
+      let timeoutId: number | undefined
       try {
-        const response = await fetch(DRIVE_ABOUT_URL, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        })
+        const response = await Promise.race([
+          fetch(DRIVE_ABOUT_URL, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+            signal: controller.signal,
+          }),
+          new Promise<never>((_, reject) => {
+            timeoutId = window.setTimeout(() => {
+              controller.abort()
+              reject(new Error('Google Drive account discovery timed out'))
+            }, DRIVE_ACCOUNT_DISCOVERY_TIMEOUT_MS)
+          }),
+        ])
         if (!response.ok) {
           throw new Error(
             `Google Drive about request failed (${response.status})`
@@ -461,6 +473,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           }
         )
         return
+      } finally {
+        if (timeoutId !== undefined) {
+          window.clearTimeout(timeoutId)
+        }
       }
 
       assertAuthOperationCurrent(authOperation)
@@ -478,9 +494,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       expiresIn: number,
       authOperation: AuthOperationVersion
     ) => {
-      await rememberDriveAccountForToken(accessToken, authOperation)
       assertAuthOperationCurrent(authOperation)
       setAccessToken(accessToken, expiresIn, { refreshToken: null })
+      await rememberDriveAccountForToken(accessToken, authOperation)
+      assertAuthOperationCurrent(authOperation)
     },
     [assertAuthOperationCurrent, rememberDriveAccountForToken, setAccessToken]
   )

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -1012,10 +1012,10 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
         return
       }
       if (event.key === STORED_DRIVE_ACCOUNT_KEY) {
-        invalidatePendingAuth(
-          'Invalidated pending Google Drive authorization after the account hint changed in another tab'
-        )
         storedDriveAccountRef.current = loadStoredDriveAccount()
+        tokenClientRef.current = null
+        oauthClientIdRef.current = null
+        oauthLoginHintRef.current = null
         return
       }
       if (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY) {


### PR DESCRIPTION
## Summary

- remember the account selected by a successful Google Drive implicit authorization using Drive `about.get`
- pass the stored account as OAuth `login_hint` for redirects and GIS `hint` for popup authorization
- silently renew the remembered account, with a one-time interactive consent fallback that recreates the GIS client without a stale hint
- clear the hint on explicit logout so the next authorization deliberately shows account selection
- synchronize the hint and cached OAuth client across tabs while keeping token/session events authoritative for auth invalidation
- migrate existing valid implicit sessions while excluding service-account tokens and ignoring stale lookup results
- replace an old implicit account hint when PKCE authorizes a different Drive account
- store successful tokens immediately and bound best-effort account discovery with an aborting timeout

## Why

With multiple Google sessions in the browser, an implicit authorization request without an account hint is ambiguous and Google shows Choose an account. Remembering the Drive account lets routine credential renewal target the existing session while preserving explicit account switching after logout.

## Validation

- `runme run build test`
- `pnpm -C app exec vitest run` (73 files, 709 tests)
- focused Google auth context suite (25 tests)
- `pnpm -C app exec prettier --check src/contexts/GoogleAuthContext.tsx src/contexts/GoogleAuthContext.test.tsx`
- `git diff --check`
