### PR TITLE
Use direct Jupyter kernels and add management UI

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -215,6 +215,13 @@ vi.mock('../../lib/toast', () => ({
 vi.mock('../../lib/imageEmbedding', () => imageEmbeddingMocks)
 
 vi.mock('../../lib/runtime/jupyterManager', () => ({
+  DEFAULT_JUPYTER_KERNEL_ARGV: [
+    'python3',
+    '-m',
+    'ipykernel_launcher',
+    '-f',
+    '{connection_file}',
+  ],
   getJupyterManager: () => ({
     subscribe: () => () => {},
     getVersion: () => 0,

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../lib/notebookDiff/registry'
 import {
   APP_CONSOLE_DOCUMENT_URI,
+  getRunnerKernelsDocumentUri,
   LOGS_DOCUMENT_URI,
   VERSION_INFO_DOCUMENT_URI,
 } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
@@ -219,6 +220,11 @@ vi.mock('../../lib/runtime/jupyterManager', () => ({
     getVersion: () => 0,
     ensureRunnerData: async () => {},
     getKernelOptionsForRunner: () => [],
+    getKernelsForRunner: () => [],
+    listKernels: async () => [],
+    startKernel: async () => ({ id: 'kernel-1', name: 'python3' }),
+    restartKernel: async () => ({ id: 'kernel-1', name: 'python3' }),
+    stopKernel: async () => {},
     getKernelOptionKey: (runnerName: string, kernelId: string) =>
       `${runnerName}:${kernelId}`,
     parseKernelOptionKey: (key: string) => {
@@ -1539,6 +1545,20 @@ describe('Actions tabs', () => {
       screen.getByTestId('app-console-mock').getAttribute('data-show-header')
     ).toBe('false')
     expect(screen.getByTestId('logs-pane-mock')).toBeTruthy()
+  })
+
+  it('renders a runner kernel status workspace document as a tab', async () => {
+    const uri = getRunnerKernelsDocumentUri('default')
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [{ uri, title: 'Kernels · default' }]
+
+    render(<Actions />)
+
+    expect(screen.getByRole('tab', { name: 'Kernels · default' })).toBeTruthy()
+    expect(screen.getByText('Jupyter Kernels')).toBeTruthy()
+    expect(
+      await screen.findByText('No kernels are running on this runner.')
+    ).toBeTruthy()
   })
 })
 

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -219,13 +219,13 @@ vi.mock('../../lib/runtime/jupyterManager', () => ({
     getVersion: () => 0,
     ensureRunnerData: async () => {},
     getKernelOptionsForRunner: () => [],
-    getKernelOptionKey: (serverName: string, kernelId: string) =>
-      `${serverName}:${kernelId}`,
+    getKernelOptionKey: (runnerName: string, kernelId: string) =>
+      `${runnerName}:${kernelId}`,
     parseKernelOptionKey: (key: string) => {
       if (!key.includes(':')) return null
-      const [serverName, kernelId] = key.split(':', 2)
-      if (!serverName || !kernelId) return null
-      return { serverName, kernelId }
+      const [runnerName, kernelId] = key.split(':', 2)
+      if (!runnerName || !kernelId) return null
+      return { runnerName, kernelId }
     },
   }),
 }))

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1164,31 +1164,23 @@ export function Action({
     )
   }, [jupyterManager, jupyterRunnerNames, jupyterVersion, showKernelSelector])
   const selectedKernelKey = useMemo(() => {
-    const serverName =
-      (cell?.metadata?.[RunmeMetadataKey.JupyterServerName] as
-        | string
-        | undefined) ?? ''
     const kernelID =
       (cell?.metadata?.[RunmeMetadataKey.JupyterKernelID] as
         | string
         | undefined) ?? ''
-    if (!serverName || !kernelID) {
+    if (!kernelID) {
       return ''
     }
     const runnerName =
       (cell?.metadata?.[RunmeMetadataKey.RunnerName] as string | undefined) ??
       ''
     if (runnerName && !isAppKernelRunnerName(runnerName)) {
-      return jupyterManager.getKernelOptionKey(serverName, kernelID, runnerName)
+      return jupyterManager.getKernelOptionKey(runnerName, kernelID)
     }
     if (resolvedRunnerName) {
-      return jupyterManager.getKernelOptionKey(
-        serverName,
-        kernelID,
-        resolvedRunnerName
-      )
+      return jupyterManager.getKernelOptionKey(resolvedRunnerName, kernelID)
     }
-    return jupyterManager.getKernelOptionKey(serverName, kernelID)
+    return ''
   }, [cell, jupyterManager, resolvedRunnerName])
 
   useEffect(() => {
@@ -1211,7 +1203,6 @@ export function Action({
     }
     cellData.setJupyterKernel({
       runnerName: option.runnerName,
-      serverName: parsed.serverName,
       kernelId: parsed.kernelId,
       kernelName: option.label,
     })
@@ -1792,7 +1783,6 @@ export function Action({
                     }
                     cellData.setJupyterKernel({
                       runnerName: option.runnerName,
-                      serverName: parsed.serverName,
                       kernelId: parsed.kernelId,
                       kernelName: option.label,
                     })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -81,6 +81,7 @@ import {
   isNotebookDocumentUri,
   isVersionInfoUri,
   isRunnerStatusUri,
+  parseRunnerKernelsDocumentUri,
   type WorkspaceDocument,
 } from '../../lib/workspaceDocuments/workspaceDocumentTypes'
 import {
@@ -113,6 +114,7 @@ import {
 import DriveLinkStatusTab from '../DriveLinkStatusTab'
 import DriveSyncStatusTab from '../DriveSyncStatusTab'
 import RunnerStatusTab from '../RunnerStatusTab'
+import KernelStatusTab from '../KernelStatusTab'
 import { NotebookDiffContent } from '../NotebookDiff/NotebookDiffView'
 import VersionInfoTab from '../VersionInfoTab'
 import { NotebookCommentsPanel } from '../NotebookCommentsPanel'
@@ -2812,6 +2814,11 @@ function renderWorkspaceDocument({
 
   if (isRunnerStatusUri(document.uri)) {
     return <RunnerStatusTab />
+  }
+
+  const runnerKernels = parseRunnerKernelsDocumentUri(document.uri)
+  if (runnerKernels) {
+    return <KernelStatusTab runnerName={runnerKernels.runnerName} />
   }
 
   if (isAppConsoleUri(document.uri)) {

--- a/app/src/components/CurrentDocInitializer.test.tsx
+++ b/app/src/components/CurrentDocInitializer.test.tsx
@@ -128,6 +128,25 @@ describe('CurrentDocInitializer', () => {
     expect(window.location.hash).toBe('#section')
   })
 
+  it('opens a runner kernel status document from a doc param', async () => {
+    setDocUrl('status://runners/local%20runner/kernels')
+
+    render(<CurrentDocInitializer />)
+
+    await waitFor(() => {
+      expect(mocks.setCurrentDoc).toHaveBeenCalledWith(
+        'status://runners/local%20runner/kernels'
+      )
+    })
+    expect(mocks.openNotebook).not.toHaveBeenCalled()
+    expect(mocks.showDocument).toHaveBeenCalledWith(
+      'status://runners/local%20runner/kernels',
+      { title: 'Kernels · local runner' }
+    )
+    expect(window.location.search).toBe('?existing=1')
+    expect(window.location.hash).toBe('#section')
+  })
+
   it('opens the Drive sync status document from a doc param', async () => {
     setDocUrl('status://drive-sync')
 

--- a/app/src/components/CurrentDocInitializer.tsx
+++ b/app/src/components/CurrentDocInitializer.tsx
@@ -9,6 +9,7 @@ import {
   isDocumentationDocumentUri,
   isDriveSyncStatusUri,
   isLogsUri,
+  isRunnerKernelsUri,
   isRunnerStatusUri,
 } from '../lib/workspaceDocuments/workspaceDocumentTypes'
 import {
@@ -48,6 +49,7 @@ export function CurrentDocInitializer() {
     }
     if (
       isRunnerStatusUri(docParam) ||
+      isRunnerKernelsUri(docParam) ||
       isDriveSyncStatusUri(docParam) ||
       isAppConsoleUri(docParam) ||
       isLogsUri(docParam)

--- a/app/src/components/KernelStatusTab.test.tsx
+++ b/app/src/components/KernelStatusTab.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Kernel = {
+  id: string
+  name: string
+  label: string
+  execution_state?: string
+  connections?: number
+  last_activity?: string
+}
+
+let kernels: Kernel[] = []
+let version = 0
+const listeners = new Set<() => void>()
+
+function bumpVersion() {
+  version += 1
+  listeners.forEach((listener) => listener())
+}
+
+const listKernels = vi.fn(async () => {
+  bumpVersion()
+  return kernels
+})
+const startKernel = vi.fn(
+  async (
+    _runnerName: string,
+    options: { kernelSpec?: string; name?: string }
+  ) => {
+    const kernel = {
+      id: 'kernel-2',
+      name: options.kernelSpec || 'python3',
+      label: options.name || options.kernelSpec || 'python3',
+      execution_state: 'starting',
+      connections: 0,
+    }
+    kernels = [...kernels, kernel]
+    bumpVersion()
+    return kernel
+  }
+)
+const restartKernel = vi.fn(async (_runnerName: string, kernelID: string) => {
+  kernels = kernels.map((kernel) =>
+    kernel.id === kernelID
+      ? { ...kernel, execution_state: 'restarting' }
+      : kernel
+  )
+  bumpVersion()
+  return kernels.find((kernel) => kernel.id === kernelID)
+})
+const stopKernel = vi.fn(async (_runnerName: string, kernelID: string) => {
+  kernels = kernels.filter((kernel) => kernel.id !== kernelID)
+  bumpVersion()
+})
+
+vi.mock('../lib/runtime/jupyterManager', () => ({
+  getJupyterManager: () => ({
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getVersion: () => version,
+    getKernelsForRunner: () => kernels,
+    listKernels,
+    startKernel,
+    restartKernel,
+    stopKernel,
+  }),
+}))
+
+import { KernelStatusTab } from './KernelStatusTab'
+
+describe('KernelStatusTab', () => {
+  beforeEach(() => {
+    kernels = [
+      {
+        id: 'kernel-1',
+        name: 'python3',
+        label: 'analysis',
+        execution_state: 'idle',
+        connections: 2,
+        last_activity: '2026-08-05T10:00:00Z',
+      },
+    ]
+    version = 0
+    listeners.clear()
+    listKernels.mockClear()
+    startKernel.mockClear()
+    restartKernel.mockClear()
+    stopKernel.mockClear()
+  })
+
+  it('loads and displays runner-owned kernels', async () => {
+    render(<KernelStatusTab runnerName="default" />)
+
+    await waitFor(() => expect(listKernels).toHaveBeenCalledWith('default'))
+    expect(screen.getByText('Jupyter Kernels')).toBeTruthy()
+    expect(screen.getByText('analysis')).toBeTruthy()
+    expect(screen.getByText('kernel-1')).toBeTruthy()
+    expect(screen.getByText('idle')).toBeTruthy()
+    expect(screen.getByText('2')).toBeTruthy()
+  })
+
+  it('starts, restarts, and stops kernels', async () => {
+    render(<KernelStatusTab runnerName="default" />)
+    await waitFor(() => expect(listKernels).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Kernel spec' }), {
+      target: { value: 'python-custom' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Display name' }), {
+      target: { value: 'training' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start kernel' }))
+
+    await waitFor(() =>
+      expect(startKernel).toHaveBeenCalledWith('default', {
+        kernelSpec: 'python-custom',
+        name: 'training',
+      })
+    )
+    expect(await screen.findByText('training')).toBeTruthy()
+
+    const restartButtons = screen.getAllByRole('button', { name: 'Restart' })
+    fireEvent.click(restartButtons[0])
+    await waitFor(() =>
+      expect(restartKernel).toHaveBeenCalledWith('default', 'kernel-1')
+    )
+
+    const stopButtons = screen.getAllByRole('button', { name: 'Stop' })
+    fireEvent.click(stopButtons[0])
+    await waitFor(() =>
+      expect(stopKernel).toHaveBeenCalledWith('default', 'kernel-1')
+    )
+    await waitFor(() => expect(screen.queryByText('kernel-1')).toBeNull())
+  })
+})

--- a/app/src/components/KernelStatusTab.test.tsx
+++ b/app/src/components/KernelStatusTab.test.tsx
@@ -2,6 +2,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const createSessionId = vi.hoisted(() => vi.fn())
+
 type Kernel = {
   id: string
   name: string
@@ -77,6 +79,8 @@ vi.mock('../lib/runtime/jupyterManager', () => ({
   }),
 }))
 
+vi.mock('../lib/tabIdentity', () => ({ createSessionId }))
+
 import { KernelStatusTab } from './KernelStatusTab'
 
 describe('KernelStatusTab', () => {
@@ -97,6 +101,10 @@ describe('KernelStatusTab', () => {
     startKernel.mockClear()
     restartKernel.mockClear()
     stopKernel.mockClear()
+    createSessionId
+      .mockReset()
+      .mockReturnValueOnce('silver-wind')
+      .mockReturnValueOnce('wise-beacon')
   })
 
   it('loads and displays runner-owned kernels', async () => {
@@ -155,5 +163,32 @@ describe('KernelStatusTab', () => {
       expect(stopKernel).toHaveBeenCalledWith('default', 'kernel-1')
     )
     await waitFor(() => expect(screen.queryByText('kernel-1')).toBeNull())
+  })
+
+  it('provides a fresh memorable display name after starting a kernel', async () => {
+    render(<KernelStatusTab runnerName="default" />)
+    await waitFor(() => expect(listKernels).toHaveBeenCalled())
+
+    const displayName = screen.getByRole('textbox', { name: 'Display name' })
+    expect((displayName as HTMLInputElement).value).toBe('silver-wind')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start kernel' }))
+
+    await waitFor(() =>
+      expect(startKernel).toHaveBeenCalledWith('default', {
+        kernelSpec: 'python3',
+        name: 'silver-wind',
+        argv: [
+          'python3',
+          '-m',
+          'ipykernel_launcher',
+          '-f',
+          '{connection_file}',
+        ],
+      })
+    )
+    await waitFor(() =>
+      expect((displayName as HTMLInputElement).value).toBe('wise-beacon')
+    )
   })
 })

--- a/app/src/components/KernelStatusTab.test.tsx
+++ b/app/src/components/KernelStatusTab.test.tsx
@@ -27,7 +27,7 @@ const listKernels = vi.fn(async () => {
 const startKernel = vi.fn(
   async (
     _runnerName: string,
-    options: { kernelSpec?: string; name?: string }
+    options: { kernelSpec?: string; name?: string; argv?: string[] }
   ) => {
     const kernel = {
       id: 'kernel-2',
@@ -56,6 +56,13 @@ const stopKernel = vi.fn(async (_runnerName: string, kernelID: string) => {
 })
 
 vi.mock('../lib/runtime/jupyterManager', () => ({
+  DEFAULT_JUPYTER_KERNEL_ARGV: [
+    'python3',
+    '-m',
+    'ipykernel_launcher',
+    '-f',
+    '{connection_file}',
+  ],
   getJupyterManager: () => ({
     subscribe: (listener: () => void) => {
       listeners.add(listener)
@@ -110,6 +117,12 @@ describe('KernelStatusTab', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Kernel spec' }), {
       target: { value: 'python-custom' },
     })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Kernel command' }), {
+      target: {
+        value:
+          '["/workspace/.venv/bin/python","-m","ipykernel_launcher","-f","{connection_file}"]',
+      },
+    })
     fireEvent.change(screen.getByRole('textbox', { name: 'Display name' }), {
       target: { value: 'training' },
     })
@@ -119,6 +132,13 @@ describe('KernelStatusTab', () => {
       expect(startKernel).toHaveBeenCalledWith('default', {
         kernelSpec: 'python-custom',
         name: 'training',
+        argv: [
+          '/workspace/.venv/bin/python',
+          '-m',
+          'ipykernel_launcher',
+          '-f',
+          '{connection_file}',
+        ],
       })
     )
     expect(await screen.findByText('training')).toBeTruthy()

--- a/app/src/components/KernelStatusTab.tsx
+++ b/app/src/components/KernelStatusTab.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_JUPYTER_KERNEL_ARGV,
   getJupyterManager,
 } from '../lib/runtime/jupyterManager'
+import { createSessionId } from '../lib/tabIdentity'
 
 const defaultKernelArgv = JSON.stringify(DEFAULT_JUPYTER_KERNEL_ARGV)
 
@@ -77,7 +78,7 @@ export function KernelStatusTab({ runnerName }: { runnerName: string }) {
   )
   const [kernelSpec, setKernelSpec] = useState('python3')
   const [kernelArgv, setKernelArgv] = useState(defaultKernelArgv)
-  const [alias, setAlias] = useState('')
+  const [alias, setAlias] = useState(createSessionId)
   const [loading, setLoading] = useState(true)
   const [operation, setOperation] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState('')
@@ -119,7 +120,7 @@ export function KernelStatusTab({ runnerName }: { runnerName: string }) {
         argv: requestedArgv,
         ...(alias.trim() ? { name: alias.trim() } : {}),
       })
-      setAlias('')
+      setAlias(createSessionId())
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : String(error))
     } finally {

--- a/app/src/components/KernelStatusTab.tsx
+++ b/app/src/components/KernelStatusTab.tsx
@@ -1,4 +1,4 @@
-import { Button, ScrollArea, Text, TextField } from '@radix-ui/themes'
+import { Button, ScrollArea, Text, TextArea, TextField } from '@radix-ui/themes'
 import {
   useCallback,
   useEffect,
@@ -7,7 +7,39 @@ import {
   useSyncExternalStore,
 } from 'react'
 
-import { getJupyterManager } from '../lib/runtime/jupyterManager'
+import {
+  DEFAULT_JUPYTER_KERNEL_ARGV,
+  getJupyterManager,
+} from '../lib/runtime/jupyterManager'
+
+const defaultKernelArgv = JSON.stringify(DEFAULT_JUPYTER_KERNEL_ARGV)
+
+function parseKernelArgv(value: string): string[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    throw new Error('Kernel command must be a valid JSON array.')
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    parsed.some((argument) => typeof argument !== 'string')
+  ) {
+    throw new Error('Kernel command must be a non-empty JSON array of strings.')
+  }
+  const placeholderCount = parsed.reduce(
+    (count, argument) =>
+      count + argument.split('{connection_file}').length - 1,
+    0
+  )
+  if (placeholderCount !== 1) {
+    throw new Error(
+      'Kernel command must contain exactly one {connection_file} placeholder.'
+    )
+  }
+  return parsed
+}
 
 function formatLastActivity(value?: string): string {
   if (!value) {
@@ -44,6 +76,7 @@ export function KernelStatusTab({ runnerName }: { runnerName: string }) {
     [manager, runnerName, version]
   )
   const [kernelSpec, setKernelSpec] = useState('python3')
+  const [kernelArgv, setKernelArgv] = useState(defaultKernelArgv)
   const [alias, setAlias] = useState('')
   const [loading, setLoading] = useState(true)
   const [operation, setOperation] = useState<string | null>(null)
@@ -71,11 +104,19 @@ export function KernelStatusTab({ runnerName }: { runnerName: string }) {
       setErrorMessage('Kernel spec is required.')
       return
     }
+    let requestedArgv: string[]
+    try {
+      requestedArgv = parseKernelArgv(kernelArgv)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error))
+      return
+    }
     setOperation('start')
     setErrorMessage('')
     try {
       await manager.startKernel(runnerName, {
         kernelSpec: requestedKernelSpec,
+        argv: requestedArgv,
         ...(alias.trim() ? { name: alias.trim() } : {}),
       })
       setAlias('')
@@ -84,7 +125,7 @@ export function KernelStatusTab({ runnerName }: { runnerName: string }) {
     } finally {
       setOperation(null)
     }
-  }, [alias, kernelSpec, manager, runnerName])
+  }, [alias, kernelArgv, kernelSpec, manager, runnerName])
 
   const restartKernel = useCallback(
     async (kernelID: string) => {
@@ -148,6 +189,27 @@ export function KernelStatusTab({ runnerName }: { runnerName: string }) {
             Start a kernel
           </Text>
           <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)_auto] sm:items-end">
+            <label className="space-y-1 sm:col-span-3">
+              <Text
+                size="1"
+                as="p"
+                className="font-semibold text-nb-text-muted"
+              >
+                Kernel command (JSON argv)
+              </Text>
+              <TextArea
+                aria-label="Kernel command"
+                value={kernelArgv}
+                disabled={operation !== null}
+                onChange={(event) => setKernelArgv(event.target.value)}
+                resize="vertical"
+              />
+              <Text size="1" as="p" className="text-nb-text-faint">
+                Paths are resolved on the runner host. Include exactly one{' '}
+                <span className="font-mono">{'{connection_file}'}</span>{' '}
+                placeholder.
+              </Text>
+            </label>
             <label className="space-y-1">
               <Text
                 size="1"

--- a/app/src/components/KernelStatusTab.tsx
+++ b/app/src/components/KernelStatusTab.tsx
@@ -1,0 +1,297 @@
+import { Button, ScrollArea, Text, TextField } from '@radix-ui/themes'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+
+import { getJupyterManager } from '../lib/runtime/jupyterManager'
+
+function formatLastActivity(value?: string): string {
+  if (!value) {
+    return '—'
+  }
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+function stateClassName(state?: string): string {
+  switch (state?.toLowerCase()) {
+    case 'idle':
+      return 'bg-emerald-50 text-emerald-700'
+    case 'busy':
+    case 'starting':
+    case 'restarting':
+      return 'bg-amber-50 text-amber-700'
+    case 'dead':
+      return 'bg-red-50 text-red-700'
+    default:
+      return 'bg-nb-surface-2 text-nb-text-muted'
+  }
+}
+
+export function KernelStatusTab({ runnerName }: { runnerName: string }) {
+  const manager = useMemo(() => getJupyterManager(), [])
+  const version = useSyncExternalStore(
+    useCallback((listener) => manager.subscribe(listener), [manager]),
+    useCallback(() => manager.getVersion(), [manager]),
+    useCallback(() => manager.getVersion(), [manager])
+  )
+  const kernels = useMemo(
+    () => manager.getKernelsForRunner(runnerName),
+    [manager, runnerName, version]
+  )
+  const [kernelSpec, setKernelSpec] = useState('python3')
+  const [alias, setAlias] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [operation, setOperation] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setErrorMessage('')
+    try {
+      await manager.listKernels(runnerName)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [manager, runnerName])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const startKernel = useCallback(async () => {
+    const requestedKernelSpec = kernelSpec.trim()
+    if (!requestedKernelSpec) {
+      setErrorMessage('Kernel spec is required.')
+      return
+    }
+    setOperation('start')
+    setErrorMessage('')
+    try {
+      await manager.startKernel(runnerName, {
+        kernelSpec: requestedKernelSpec,
+        ...(alias.trim() ? { name: alias.trim() } : {}),
+      })
+      setAlias('')
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setOperation(null)
+    }
+  }, [alias, kernelSpec, manager, runnerName])
+
+  const restartKernel = useCallback(
+    async (kernelID: string) => {
+      setOperation(`restart:${kernelID}`)
+      setErrorMessage('')
+      try {
+        await manager.restartKernel(runnerName, kernelID)
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : String(error))
+      } finally {
+        setOperation(null)
+      }
+    },
+    [manager, runnerName]
+  )
+
+  const stopKernel = useCallback(
+    async (kernelID: string) => {
+      setOperation(`stop:${kernelID}`)
+      setErrorMessage('')
+      try {
+        await manager.stopKernel(runnerName, kernelID)
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : String(error))
+      } finally {
+        setOperation(null)
+      }
+    },
+    [manager, runnerName]
+  )
+
+  return (
+    <ScrollArea
+      type="auto"
+      scrollbars="vertical"
+      className="flex-1 p-4"
+      data-testid="kernel-status-scroll"
+    >
+      <div className="mx-auto flex h-full max-w-6xl flex-col gap-6 text-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <Text size="5" weight="bold" as="p" className="text-nb-text">
+              Jupyter Kernels
+            </Text>
+            <Text size="2" as="p" className="text-nb-text-muted">
+              Manage kernels owned by runner{' '}
+              <span className="font-mono font-semibold">{runnerName}</span>.
+            </Text>
+          </div>
+          <Button
+            variant="soft"
+            disabled={loading || operation !== null}
+            onClick={() => void refresh()}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </Button>
+        </div>
+
+        <div className="rounded-lg border border-nb-border bg-white p-4">
+          <Text size="3" weight="bold" as="p" className="text-nb-text">
+            Start a kernel
+          </Text>
+          <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)_auto] sm:items-end">
+            <label className="space-y-1">
+              <Text
+                size="1"
+                as="p"
+                className="font-semibold text-nb-text-muted"
+              >
+                Kernel spec
+              </Text>
+              <TextField.Root
+                aria-label="Kernel spec"
+                value={kernelSpec}
+                disabled={operation !== null}
+                onChange={(event) => setKernelSpec(event.target.value)}
+                placeholder="python3"
+              />
+            </label>
+            <label className="space-y-1">
+              <Text
+                size="1"
+                as="p"
+                className="font-semibold text-nb-text-muted"
+              >
+                Display name (optional)
+              </Text>
+              <TextField.Root
+                aria-label="Display name"
+                value={alias}
+                disabled={operation !== null}
+                onChange={(event) => setAlias(event.target.value)}
+                placeholder="analysis"
+              />
+            </label>
+            <Button
+              disabled={operation !== null || !kernelSpec.trim()}
+              onClick={() => void startKernel()}
+            >
+              {operation === 'start' ? 'Starting…' : 'Start kernel'}
+            </Button>
+          </div>
+        </div>
+
+        {errorMessage && (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          >
+            {errorMessage}
+          </div>
+        )}
+
+        <div className="rounded-lg border border-nb-border bg-white p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Text size="3" weight="bold" as="p" className="text-nb-text">
+              Running kernels
+            </Text>
+            <span className="rounded-full bg-nb-surface-2 px-2.5 py-1 text-xs font-semibold text-nb-text-muted">
+              {kernels.length} {kernels.length === 1 ? 'kernel' : 'kernels'}
+            </span>
+          </div>
+
+          {!loading && kernels.length === 0 ? (
+            <Text size="2" as="p" className="mt-4 text-nb-text-muted">
+              No kernels are running on this runner.
+            </Text>
+          ) : (
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-nb-border bg-nb-surface-2 text-xs font-semibold uppercase tracking-wide text-nb-text-muted">
+                    <th className="whitespace-nowrap px-3 py-2">Name</th>
+                    <th className="whitespace-nowrap px-3 py-2">Kernel ID</th>
+                    <th className="whitespace-nowrap px-3 py-2">State</th>
+                    <th className="whitespace-nowrap px-3 py-2">Connections</th>
+                    <th className="whitespace-nowrap px-3 py-2">
+                      Last activity
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {kernels.map((kernel) => {
+                    const restarting = operation === `restart:${kernel.id}`
+                    const stopping = operation === `stop:${kernel.id}`
+                    return (
+                      <tr
+                        key={kernel.id}
+                        className="border-b border-nb-border last:border-0"
+                      >
+                        <td className="px-3 py-3 font-medium text-nb-text">
+                          {kernel.label}
+                          {kernel.label !== kernel.name && (
+                            <div className="mt-1 text-xs font-normal text-nb-text-faint">
+                              {kernel.name}
+                            </div>
+                          )}
+                        </td>
+                        <td className="max-w-[280px] break-all px-3 py-3 font-mono text-xs text-nb-text-muted">
+                          {kernel.id}
+                        </td>
+                        <td className="px-3 py-3">
+                          <span
+                            className={`rounded-full px-2 py-1 text-xs font-semibold ${stateClassName(kernel.execution_state)}`}
+                          >
+                            {kernel.execution_state || 'unknown'}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3 text-nb-text-muted">
+                          {kernel.connections ?? 0}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-3 text-nb-text-muted">
+                          {formatLastActivity(kernel.last_activity)}
+                        </td>
+                        <td className="px-3 py-3">
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              size="1"
+                              variant="soft"
+                              disabled={operation !== null}
+                              onClick={() => void restartKernel(kernel.id)}
+                            >
+                              {restarting ? 'Restarting…' : 'Restart'}
+                            </Button>
+                            <Button
+                              size="1"
+                              variant="soft"
+                              color="red"
+                              disabled={operation !== null}
+                              onClick={() => void stopKernel(kernel.id)}
+                            >
+                              {stopping ? 'Stopping…' : 'Stop'}
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </ScrollArea>
+  )
+}
+
+export default KernelStatusTab

--- a/app/src/components/RunnerStatusTab.test.tsx
+++ b/app/src/components/RunnerStatusTab.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 let runnersState: { name: string; endpoint: string; reconnect: boolean }[] = []
 let defaultRunnerName: string | null = null
+const showDocument = vi.fn()
+const setCurrentDoc = vi.fn()
 
 vi.mock('../contexts/RunnersContext', () => ({
   useRunners: () => ({
@@ -12,12 +14,22 @@ vi.mock('../contexts/RunnersContext', () => ({
   }),
 }))
 
+vi.mock('../contexts/CurrentDocContext', () => ({
+  useCurrentDoc: () => ({ setCurrentDoc }),
+}))
+
+vi.mock('../contexts/WorkspaceDocumentContext', () => ({
+  useWorkspaceDocumentContext: () => ({ showDocument }),
+}))
+
 import { RunnerStatusTab } from './RunnerStatusTab'
 
 describe('RunnerStatusTab', () => {
   beforeEach(() => {
     runnersState = []
     defaultRunnerName = null
+    showDocument.mockClear()
+    setCurrentDoc.mockClear()
   })
 
   it('shows configured runner availability in a table', () => {
@@ -39,6 +51,17 @@ describe('RunnerStatusTab', () => {
     expect(screen.getByRole('columnheader', { name: 'Endpoint' })).toBeTruthy()
     expect(screen.getByText('ws://localhost:8080/ws')).toBeTruthy()
     expect(screen.getByText('Enabled')).toBeTruthy()
+    expect(screen.getByRole('columnheader', { name: 'Kernels' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage kernels' }))
+
+    expect(showDocument).toHaveBeenCalledWith(
+      'status://runners/default/kernels',
+      { title: 'Kernels · default' }
+    )
+    expect(setCurrentDoc).toHaveBeenCalledWith(
+      'status://runners/default/kernels'
+    )
   })
 
   it('shows unavailable state when no runner endpoint is configured', () => {
@@ -54,5 +77,12 @@ describe('RunnerStatusTab', () => {
     ).toBeTruthy()
     expect(screen.getAllByText('Unavailable').length).toBeGreaterThan(0)
     expect(screen.getByText('No endpoint configured')).toBeTruthy()
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Manage kernels',
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true)
   })
 })

--- a/app/src/components/RunnerStatusTab.tsx
+++ b/app/src/components/RunnerStatusTab.tsx
@@ -1,6 +1,12 @@
-import { ScrollArea, Text } from '@radix-ui/themes'
+import { Button, ScrollArea, Text } from '@radix-ui/themes'
 
+import { useCurrentDoc } from '../contexts/CurrentDocContext'
 import { useRunners } from '../contexts/RunnersContext'
+import { useWorkspaceDocumentContext } from '../contexts/WorkspaceDocumentContext'
+import {
+  deriveWorkspaceDocumentTitle,
+  getRunnerKernelsDocumentUri,
+} from '../lib/workspaceDocuments/workspaceDocumentTypes'
 
 function formatReconnect(reconnect: boolean): string {
   return reconnect ? 'Enabled' : 'Disabled'
@@ -8,6 +14,8 @@ function formatReconnect(reconnect: boolean): string {
 
 export function RunnerStatusTab() {
   const { defaultRunnerName, listRunners } = useRunners()
+  const { setCurrentDoc } = useCurrentDoc()
+  const { showDocument } = useWorkspaceDocumentContext()
   const runners = listRunners()
   const availableRunners = runners.filter((runner) => runner.endpoint.trim())
   const availableCount = availableRunners.length
@@ -56,20 +64,23 @@ export function RunnerStatusTab() {
               <table className="w-full table-fixed border-collapse text-left text-sm">
                 <thead>
                   <tr className="border-b border-nb-border bg-nb-surface-2 text-xs font-semibold uppercase tracking-wide text-nb-text-muted">
-                    <th className="w-[17%] whitespace-nowrap px-3 py-2">
+                    <th className="w-[14%] whitespace-nowrap px-3 py-2">
                       Name
                     </th>
-                    <th className="w-[17%] whitespace-nowrap px-3 py-2">
+                    <th className="w-[14%] whitespace-nowrap px-3 py-2">
                       Status
                     </th>
-                    <th className="w-[32%] whitespace-nowrap px-3 py-2">
+                    <th className="w-[27%] whitespace-nowrap px-3 py-2">
                       Endpoint
                     </th>
-                    <th className="w-[14%] whitespace-nowrap px-3 py-2">
+                    <th className="w-[11%] whitespace-nowrap px-3 py-2">
                       Default
                     </th>
-                    <th className="w-[20%] whitespace-nowrap px-3 py-2">
+                    <th className="w-[14%] whitespace-nowrap px-3 py-2">
                       Reconnect
+                    </th>
+                    <th className="w-[20%] whitespace-nowrap px-3 py-2">
+                      Kernels
                     </th>
                   </tr>
                 </thead>
@@ -105,6 +116,24 @@ export function RunnerStatusTab() {
                         </td>
                         <td className="px-3 py-3 text-nb-text-muted">
                           {formatReconnect(runner.reconnect)}
+                        </td>
+                        <td className="px-3 py-3">
+                          <Button
+                            size="1"
+                            variant="soft"
+                            disabled={!hasEndpoint}
+                            onClick={() => {
+                              const uri = getRunnerKernelsDocumentUri(
+                                runner.name
+                              )
+                              showDocument(uri, {
+                                title: deriveWorkspaceDocumentTitle(uri),
+                              })
+                              setCurrentDoc(uri)
+                            }}
+                          >
+                            Manage kernels
+                          </Button>
                         </td>
                       </tr>
                     )

--- a/app/src/generated/documentationManifest.ts
+++ b/app/src/generated/documentationManifest.ts
@@ -94,7 +94,7 @@ export const DOCUMENTATION_MANIFEST = [
     name: 'jupyter-runners',
     title: 'Jupyter Runners',
     description:
-      "Use this guide when notebook cells must execute through a Jupyter kernel. It covers Runme's direct kernel lifecycle helpers, selection guidance, and user-visible behavior. Use the AppKernel guide for browser JavaScript and the local Runme guide for WebSocket backend execution.",
+      "Use this guide when notebook cells must execute through a Jupyter kernel. It covers Runme's kernel-management UI, direct lifecycle helpers, kernel selection, runner scoping, and troubleshooting. Use the AppKernel guide for browser JavaScript and the local Runme guide for WebSocket backend execution.",
     order: 10,
     path: 'docs/10-jupyter-runners.md',
   },

--- a/app/src/generated/documentationManifest.ts
+++ b/app/src/generated/documentationManifest.ts
@@ -94,7 +94,7 @@ export const DOCUMENTATION_MANIFEST = [
     name: 'jupyter-runners',
     title: 'Jupyter Runners',
     description:
-      "Use this guide when notebook cells must execute through a Jupyter server and kernel. It covers Jupyter's relationship to Runme runners, server and kernel lifecycle helpers, configuration, selection guidance, and user-visible behavior. Use the AppKernel guide for browser JavaScript and the local Runme guide for WebSocket backend execution.",
+      "Use this guide when notebook cells must execute through a Jupyter kernel. It covers Runme's direct kernel lifecycle helpers, selection guidance, and user-visible behavior. Use the AppKernel guide for browser JavaScript and the local Runme guide for WebSocket backend execution.",
     order: 10,
     path: 'docs/10-jupyter-runners.md',
   },

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -8,7 +8,6 @@ import {
   genRunID,
 } from '@runmedev/renderers'
 
-import { getBrowserAdapter } from '../browserAdapter.client'
 import {
   MimeType,
   RunmeExecutionState,
@@ -35,6 +34,7 @@ import {
 import { JSKernel } from './runtime/jsKernel'
 import {
   buildJupyterChannelsWebSocketURL,
+  getJupyterAuthorization,
   getJupyterManager,
 } from './runtime/jupyterManager'
 import {
@@ -513,7 +513,6 @@ export class NotebookData {
     {
       socket: WebSocket
       runnerName: string
-      serverName: string
       kernelID: string
     }
   >()
@@ -856,7 +855,6 @@ export class NotebookData {
     const interrupts = jupyterExecutions.map((execution, index) =>
       getJupyterManager().interruptKernel(
         execution.runnerName,
-        execution.serverName,
         execution.kernelID,
         { signal: interruptControllers[index]?.signal }
       )
@@ -1014,7 +1012,7 @@ export class NotebookData {
     }
 
     if (useJupyterKernel) {
-      this.runCodeCellWithJupyterKernel(cell, runID, runner!, generation)
+      void this.runCodeCellWithJupyterKernel(cell, runID, runner!, generation)
       return runID
     }
 
@@ -1414,18 +1412,14 @@ export class NotebookData {
     }
   }
 
-  private runCodeCellWithJupyterKernel(
+  private async runCodeCellWithJupyterKernel(
     cell: parser_pb.Cell,
     runID: string,
     runner: Runner,
     generation: number
-  ): void {
+  ): Promise<void> {
     const refId = cell.refId
     const source = cell.value ?? ''
-    const serverName =
-      (cell.metadata?.[RunmeMetadataKey.JupyterServerName] as
-        | string
-        | undefined) ?? ''
     const selectedKernelID =
       (cell.metadata?.[RunmeMetadataKey.JupyterKernelID] as
         | string
@@ -1435,7 +1429,7 @@ export class NotebookData {
         | string
         | undefined) ?? ''
 
-    if (!serverName || !selectedKernelID) {
+    if (!selectedKernelID) {
       showToast({
         message: 'Select a Jupyter kernel before running a Jupyter cell.',
         tone: 'error',
@@ -1458,12 +1452,11 @@ export class NotebookData {
 
     let channelsURL: string
     try {
-      const idToken = getBrowserAdapter().simpleAuth?.idToken?.trim() ?? ''
+      const authorization = await getJupyterAuthorization()
       channelsURL = buildJupyterChannelsWebSocketURL({
         runnerEndpoint: runner.endpoint,
-        serverName,
         kernelId: selectedKernelID,
-        authorization: idToken ? `Bearer ${idToken}` : '',
+        authorization,
       })
     } catch (error) {
       showToast({
@@ -1491,7 +1484,6 @@ export class NotebookData {
     this.activeJupyterSockets.set(refId, {
       socket,
       runnerName: runner.name,
-      serverName,
       kernelID: selectedKernelID,
     })
     const isCurrentExecution = () =>
@@ -1858,7 +1850,6 @@ export class NotebookData {
         scope: 'jupyter.runner',
         refId,
         runID,
-        serverName,
         kernelID: selectedKernelID,
         kernelName: selectedKernelName,
       },
@@ -2148,15 +2139,13 @@ export class CellData {
 
   setJupyterKernel(selection: {
     runnerName?: string
-    serverName: string
     kernelId: string
     kernelName: string
   }): void {
     const snap = this.snapshot
     if (!snap) return
     snap.metadata ??= {}
-    ;(snap.metadata as any)[RunmeMetadataKey.JupyterServerName] =
-      selection.serverName
+    delete (snap.metadata as any)[RunmeMetadataKey.JupyterServerName]
     ;(snap.metadata as any)[RunmeMetadataKey.JupyterKernelID] =
       selection.kernelId
     ;(snap.metadata as any)[RunmeMetadataKey.JupyterKernelName] =

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -1350,44 +1350,19 @@ export function createAppJsGlobals({
       },
     },
     jupyter: {
-      servers: {
-        get: async (runnerName: string) => {
-          if (!runnerName?.trim()) {
-            throw new Error('Usage: jupyter.servers.get(runnerName)')
-          }
-          try {
-            const servers = await jupyterManager.listServers(runnerName)
-            const message =
-              servers.length === 0
-                ? 'No Jupyter servers configured.'
-                : JSON.stringify(servers, null, 2)
-            emitLine(sendOutput, message)
-            return servers
-          } catch (error) {
-            const message = `Failed to list Jupyter servers: ${String(error)}`
-            emitLine(sendOutput, message)
-            throw error
-          }
-        },
-      },
       kernels: {
         start: async (
           runnerName: string,
-          serverName: string,
-          options?: { kernelSpec?: string; name?: string; path?: string }
+          options?: { kernelSpec?: string; name?: string }
         ) => {
-          if (!runnerName?.trim() || !serverName?.trim()) {
+          if (!runnerName?.trim()) {
             throw new Error(
-              'Usage: jupyter.kernels.start(runnerName, serverName, options?)'
+              'Usage: jupyter.kernels.start(runnerName, { kernelSpec? })'
             )
           }
           try {
-            const kernel = await jupyterManager.startKernel(
-              runnerName,
-              serverName,
-              options
-            )
-            const message = `Started kernel ${kernel.id} on ${runnerName}/${serverName} (${kernel.name})`
+            const kernel = await jupyterManager.startKernel(runnerName, options)
+            const message = `Started kernel ${kernel.id} on ${runnerName} (${kernel.name})`
             emitLine(sendOutput, message)
             emitLine(sendOutput, JSON.stringify(kernel, null, 2))
             return kernel
@@ -1397,20 +1372,15 @@ export function createAppJsGlobals({
             throw error
           }
         },
-        get: async (runnerName: string, serverName: string) => {
-          if (!runnerName?.trim() || !serverName?.trim()) {
-            throw new Error(
-              'Usage: jupyter.kernels.get(runnerName, serverName)'
-            )
+        get: async (runnerName: string) => {
+          if (!runnerName?.trim()) {
+            throw new Error('Usage: jupyter.kernels.get(runnerName)')
           }
           try {
-            const kernels = await jupyterManager.listKernels(
-              runnerName,
-              serverName
-            )
+            const kernels = await jupyterManager.listKernels(runnerName)
             const message =
               kernels.length === 0
-                ? `No kernels running on ${runnerName}/${serverName}.`
+                ? `No kernels running on ${runnerName}.`
                 : JSON.stringify(kernels, null, 2)
             emitLine(sendOutput, message)
             return kernels
@@ -1420,27 +1390,15 @@ export function createAppJsGlobals({
             throw error
           }
         },
-        stop: async (
-          runnerName: string,
-          serverName: string,
-          kernelNameOrId: string
-        ) => {
-          if (
-            !runnerName?.trim() ||
-            !serverName?.trim() ||
-            !kernelNameOrId?.trim()
-          ) {
+        stop: async (runnerName: string, kernelNameOrId: string) => {
+          if (!runnerName?.trim() || !kernelNameOrId?.trim()) {
             throw new Error(
-              'Usage: jupyter.kernels.stop(runnerName, serverName, kernelNameOrId)'
+              'Usage: jupyter.kernels.stop(runnerName, kernelNameOrId)'
             )
           }
           try {
-            await jupyterManager.stopKernel(
-              runnerName,
-              serverName,
-              kernelNameOrId
-            )
-            const message = `Stopped kernel ${kernelNameOrId} on ${runnerName}/${serverName}`
+            await jupyterManager.stopKernel(runnerName, kernelNameOrId)
+            const message = `Stopped kernel ${kernelNameOrId} on ${runnerName}`
             emitLine(sendOutput, message)
             return message
           } catch (error) {
@@ -1448,6 +1406,30 @@ export function createAppJsGlobals({
             emitLine(sendOutput, message)
             throw error
           }
+        },
+        interrupt: async (runnerName: string, kernelId: string) => {
+          if (!runnerName?.trim() || !kernelId?.trim()) {
+            throw new Error(
+              'Usage: jupyter.kernels.interrupt(runnerName, kernelId)'
+            )
+          }
+          await jupyterManager.interruptKernel(runnerName, kernelId)
+          const message = `Interrupted kernel ${kernelId} on ${runnerName}`
+          emitLine(sendOutput, message)
+          return message
+        },
+        restart: async (runnerName: string, kernelId: string) => {
+          if (!runnerName?.trim() || !kernelId?.trim()) {
+            throw new Error(
+              'Usage: jupyter.kernels.restart(runnerName, kernelId)'
+            )
+          }
+          const kernel = await jupyterManager.restartKernel(
+            runnerName,
+            kernelId
+          )
+          emitLine(sendOutput, JSON.stringify(kernel, null, 2))
+          return kernel
         },
       },
     },
@@ -1631,7 +1613,7 @@ export function createAppJsGlobals({
         '  net             - Browser network helpers',
         '  explorer        - Manage workspace folders and notebooks',
         '  runmeRunners    - Configure runner endpoints',
-        '  jupyter         - Manage Jupyter servers and kernels',
+        '  jupyter         - Manage runner-owned Jupyter kernels',
         '  agent           - Configure the backend endpoint',
         '  files           - Import local files and access their bytes',
         '  drive           - List/create/copy/update Google Drive notebook files',

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -1353,11 +1353,11 @@ export function createAppJsGlobals({
       kernels: {
         start: async (
           runnerName: string,
-          options?: { kernelSpec?: string; name?: string }
+          options?: { kernelSpec?: string; name?: string; argv?: string[] }
         ) => {
           if (!runnerName?.trim()) {
             throw new Error(
-              'Usage: jupyter.kernels.start(runnerName, { kernelSpec? })'
+              'Usage: jupyter.kernels.start(runnerName, { kernelSpec?, name?, argv? })'
             )
           }
           try {

--- a/app/src/lib/runtime/jupyterManager.test.ts
+++ b/app/src/lib/runtime/jupyterManager.test.ts
@@ -83,7 +83,16 @@ describe('jupyterManager direct kernel API', () => {
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
-        body: JSON.stringify({ name: 'python3' }),
+        body: JSON.stringify({
+          name: 'python3',
+          argv: [
+            'python3',
+            '-m',
+            'ipykernel_launcher',
+            '-f',
+            '{connection_file}',
+          ],
+        }),
       })
     )
     expect(new Headers(init?.headers).get('Authorization')).toBe(

--- a/app/src/lib/runtime/jupyterManager.test.ts
+++ b/app/src/lib/runtime/jupyterManager.test.ts
@@ -1,206 +1,200 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 type Kernel = {
-  id: string;
-  name: string;
-  execution_state?: string;
-};
+  id: string
+  name: string
+  execution_state?: string
+}
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
     status,
-    headers: { "Content-Type": "application/json" },
-  });
+    headers: { 'Content-Type': 'application/json' },
+  })
 }
 
-describe("jupyterManager aliases", () => {
+function mockRuntime(idToken = '') {
+  vi.doMock('./runnersManager', () => ({
+    DEFAULT_RUNNER_PLACEHOLDER: '<default>',
+    getRunnersManager: () => ({
+      getDefaultRunnerName: () => 'dev',
+      getWithFallback: () => ({
+        name: 'dev',
+        endpoint: 'http://127.0.0.1:5191',
+      }),
+    }),
+  }))
+  vi.doMock('../../token', () => ({
+    getAuthData: vi.fn(async () => (idToken ? { idToken } : null)),
+  }))
+  vi.doMock('../../browserAdapter.client', () => ({
+    getBrowserAdapter: () => ({ simpleAuth: {} }),
+  }))
+}
+
+describe('jupyterManager direct kernel API', () => {
   beforeEach(() => {
-    vi.resetModules();
-    vi.restoreAllMocks();
-    window.localStorage.clear();
-  });
+    vi.resetModules()
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
 
-  it("persists kernel aliases and restores labels after manager reload", async () => {
-    const kernels: Kernel[] = [];
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      const method = init?.method ?? "GET";
-      if (url.endsWith("/v1/jupyter/servers")) {
-        return jsonResponse([
-          { name: "port-8888", runner: "dev", base_url: "http://127.0.0.1:8888", has_token: true },
-        ]);
-      }
-      if (url.endsWith("/v1/jupyter/servers/port-8888/kernels") && method === "GET") {
-        return jsonResponse(kernels);
-      }
-      if (url.endsWith("/v1/jupyter/servers/port-8888/kernels") && method === "POST") {
-        const body = init?.body ? JSON.parse(String(init.body)) : {};
-        const created = {
-          id: "kernel-1",
-          name: typeof body.name === "string" ? body.name : "python3",
-          execution_state: "starting",
-        };
-        kernels.push(created);
-        return jsonResponse(created);
-      }
-      throw new Error(`Unexpected request: ${method} ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
+  it('starts a kernel with the current OIDC ID token and caches it for selection', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse(
+          {
+            id: 'kernel-direct-1',
+            name: 'python3',
+            execution_state: 'starting',
+          },
+          201
+        )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    mockRuntime('test-id-token')
 
-    vi.doMock("./runnersManager", () => ({
-      DEFAULT_RUNNER_PLACEHOLDER: "<default>",
-      getRunnersManager: () => ({
-        getDefaultRunnerName: () => "dev",
-        getWithFallback: () => ({ name: "dev", endpoint: "http://127.0.0.1:5191" }),
+    const { getJupyterManager } = await import('./jupyterManager')
+    const manager = getJupyterManager()
+    const kernel = await manager.startKernel('dev', {
+      kernelSpec: 'python3',
+    })
+
+    expect(kernel.id).toBe('kernel-direct-1')
+    expect(manager.getKernelOptionsForRunner('dev')).toEqual([
+      expect.objectContaining({
+        key: 'dev:kernel-direct-1',
+        runnerName: 'dev',
+        kernelId: 'kernel-direct-1',
+        kernelName: 'python3',
       }),
-    }));
-    vi.doMock("../../token", () => ({
-      getAuthData: vi.fn(async () => null),
-    }));
-    vi.doMock("../../browserAdapter.client", () => ({
-      getBrowserAdapter: () => ({ simpleAuth: {} }),
-    }));
+    ])
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toBe('http://127.0.0.1:5191/v1/jupyter/kernels')
+    expect(init).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ name: 'python3' }),
+      })
+    )
+    expect(new Headers(init?.headers).get('Authorization')).toBe(
+      'Bearer test-id-token'
+    )
+  })
 
-    const firstModule = await import("./jupyterManager");
-    const firstManager = firstModule.getJupyterManager();
-    await firstManager.startKernel("dev", "port-8888", {
-      kernelSpec: "python3",
-      name: "py3-local-1",
-    });
-    const persistedRaw = window.localStorage.getItem("runme/jupyterKernelAliases");
-    expect(persistedRaw).toContain("py3-local-1");
-
-    vi.resetModules();
-    vi.doMock("./runnersManager", () => ({
-      DEFAULT_RUNNER_PLACEHOLDER: "<default>",
-      getRunnersManager: () => ({
-        getDefaultRunnerName: () => "dev",
-        getWithFallback: () => ({ name: "dev", endpoint: "http://127.0.0.1:5191" }),
-      }),
-    }));
-    vi.doMock("../../token", () => ({
-      getAuthData: vi.fn(async () => null),
-    }));
-    vi.doMock("../../browserAdapter.client", () => ({
-      getBrowserAdapter: () => ({ simpleAuth: {} }),
-    }));
-
-    const secondModule = await import("./jupyterManager");
-    const secondManager = secondModule.getJupyterManager();
-    await secondManager.listKernels("dev", "port-8888");
-    const options = secondManager.getKernelOptionsForRunner("dev");
-    expect(options).toHaveLength(1);
-    expect(options[0].label).toBe("py3-local-1");
-  });
-
-  it("rejects duplicate aliases on kernel start", async () => {
-    const kernels: Kernel[] = [];
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      const method = init?.method ?? "GET";
-      if (url.endsWith("/v1/jupyter/servers")) {
-        return jsonResponse([
-          { name: "port-8888", runner: "dev", base_url: "http://127.0.0.1:8888", has_token: true },
-        ]);
+  it('persists kernel aliases and restores labels after manager reload', async () => {
+    const kernels: Kernel[] = []
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        const method = init?.method ?? 'GET'
+        if (url.endsWith('/v1/jupyter/kernels') && method === 'GET') {
+          return jsonResponse(kernels)
+        }
+        if (url.endsWith('/v1/jupyter/kernels') && method === 'POST') {
+          const body = init?.body ? JSON.parse(String(init.body)) : {}
+          const created = {
+            id: 'kernel-1',
+            name: typeof body.name === 'string' ? body.name : 'python3',
+            execution_state: 'starting',
+          }
+          kernels.push(created)
+          return jsonResponse(created, 201)
+        }
+        throw new Error(`Unexpected request: ${method} ${url}`)
       }
-      if (url.endsWith("/v1/jupyter/servers/port-8888/kernels") && method === "GET") {
-        return jsonResponse(kernels);
-      }
-      if (url.endsWith("/v1/jupyter/servers/port-8888/kernels") && method === "POST") {
-        const body = init?.body ? JSON.parse(String(init.body)) : {};
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    mockRuntime()
+
+    const firstModule = await import('./jupyterManager')
+    await firstModule.getJupyterManager().startKernel('dev', {
+      kernelSpec: 'python3',
+      name: 'py3-local-1',
+    })
+    expect(window.localStorage.getItem('runme/jupyterKernelAliases')).toContain(
+      'py3-local-1'
+    )
+
+    vi.resetModules()
+    mockRuntime()
+    const secondModule = await import('./jupyterManager')
+    const secondManager = secondModule.getJupyterManager()
+    await secondManager.listKernels('dev')
+    expect(secondManager.getKernelOptionsForRunner('dev')[0]?.label).toBe(
+      'py3-local-1'
+    )
+  })
+
+  it('rejects duplicate aliases on kernel start', async () => {
+    const kernels: Kernel[] = []
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return jsonResponse(kernels)
+        }
+        const body = init?.body ? JSON.parse(String(init.body)) : {}
         const created = {
           id: `kernel-${kernels.length + 1}`,
-          name: typeof body.name === "string" ? body.name : "python3",
-          execution_state: "starting",
-        };
-        kernels.push(created);
-        return jsonResponse(created);
+          name: typeof body.name === 'string' ? body.name : 'python3',
+        }
+        kernels.push(created)
+        return jsonResponse(created, 201)
       }
-      throw new Error(`Unexpected request: ${method} ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    mockRuntime()
 
-    vi.doMock("./runnersManager", () => ({
-      DEFAULT_RUNNER_PLACEHOLDER: "<default>",
-      getRunnersManager: () => ({
-        getDefaultRunnerName: () => "dev",
-        getWithFallback: () => ({ name: "dev", endpoint: "http://127.0.0.1:5191" }),
-      }),
-    }));
-    vi.doMock("../../token", () => ({
-      getAuthData: vi.fn(async () => null),
-    }));
-    vi.doMock("../../browserAdapter.client", () => ({
-      getBrowserAdapter: () => ({ simpleAuth: {} }),
-    }));
-
-    const { getJupyterManager } = await import("./jupyterManager");
-    const manager = getJupyterManager();
-
-    await manager.startKernel("dev", "port-8888", {
-      kernelSpec: "python3",
-      name: "openai2",
-    });
+    const { getJupyterManager } = await import('./jupyterManager')
+    const manager = getJupyterManager()
+    await manager.startKernel('dev', {
+      kernelSpec: 'python3',
+      name: 'openai2',
+    })
 
     await expect(
-      manager.startKernel("dev", "port-8888", {
-        kernelSpec: "python3",
-        name: "openai2",
-      }),
-    ).rejects.toThrow('Kernel alias "openai2" already exists');
-  });
+      manager.startKernel('dev', {
+        kernelSpec: 'python3',
+        name: 'openai2',
+      })
+    ).rejects.toThrow('Kernel alias "openai2" already exists')
+  })
 
-  it("interrupts a running kernel through the runner API", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      const method = init?.method ?? "GET";
-      if (url.endsWith("/v1/jupyter/servers")) {
-        return jsonResponse([
-          { name: "port-8888", runner: "dev", base_url: "http://127.0.0.1:8888" },
-        ]);
-      }
-      if (url.endsWith("/v1/jupyter/servers/port-8888/kernels") && method === "GET") {
-        return jsonResponse([{ id: "kernel-1", name: "python3" }]);
-      }
-      if (
-        url.endsWith(
-          "/v1/jupyter/servers/port-8888/kernels/kernel-1:interrupt",
-        ) && method === "POST"
-      ) {
-        return new Response(null, { status: 204 });
-      }
-      throw new Error(`Unexpected request: ${method} ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
+  it('interrupts a running kernel through the direct route', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+    mockRuntime()
 
-    vi.doMock("./runnersManager", () => ({
-      DEFAULT_RUNNER_PLACEHOLDER: "<default>",
-      getRunnersManager: () => ({
-        getDefaultRunnerName: () => "dev",
-        getWithFallback: () => ({ name: "dev", endpoint: "http://127.0.0.1:5191" }),
-      }),
-    }));
-    vi.doMock("../../token", () => ({
-      getAuthData: vi.fn(async () => null),
-    }));
-    vi.doMock("../../browserAdapter.client", () => ({
-      getBrowserAdapter: () => ({ simpleAuth: {} }),
-    }));
-
-    const { getJupyterManager } = await import("./jupyterManager");
-    const manager = getJupyterManager();
-    const abortController = new AbortController();
-    await manager.interruptKernel("dev", "port-8888", "kernel-1", {
+    const { getJupyterManager } = await import('./jupyterManager')
+    const abortController = new AbortController()
+    await getJupyterManager().interruptKernel('dev', 'kernel-1', {
       signal: abortController.signal,
-    });
+    })
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:5191/v1/jupyter/servers/port-8888/kernels/kernel-1:interrupt",
+      'http://127.0.0.1:5191/v1/jupyter/kernels/kernel-1/interrupt',
       expect.objectContaining({
-        method: "POST",
+        method: 'POST',
         signal: abortController.signal,
-      }),
-    );
-  });
-});
+      })
+    )
+  })
+
+  it('builds the direct kernel channels URL', async () => {
+    const { buildJupyterChannelsWebSocketURL } = await import(
+      './jupyterManager'
+    )
+    expect(
+      buildJupyterChannelsWebSocketURL({
+        runnerEndpoint: 'http://127.0.0.1:5191',
+        kernelId: 'kernel/1',
+        authorization: 'Bearer token',
+      })
+    ).toBe(
+      'ws://127.0.0.1:5191/v1/jupyter/kernels/kernel%2F1/channels?authorization=Bearer+token'
+    )
+  })
+})

--- a/app/src/lib/runtime/jupyterManager.test.ts
+++ b/app/src/lib/runtime/jupyterManager.test.ts
@@ -70,6 +70,13 @@ describe('jupyterManager direct kernel API', () => {
         kernelName: 'python3',
       }),
     ])
+    expect(manager.getKernelsForRunner('dev')).toEqual([
+      expect.objectContaining({
+        id: 'kernel-direct-1',
+        label: 'python3',
+        execution_state: 'starting',
+      }),
+    ])
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toBe('http://127.0.0.1:5191/v1/jupyter/kernels')
     expect(init).toEqual(
@@ -87,7 +94,7 @@ describe('jupyterManager direct kernel API', () => {
   it('persists kernel aliases and restores labels after manager reload', async () => {
     const kernels: Kernel[] = []
     const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
+      async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input)
         const method = init?.method ?? 'GET'
         if (url.endsWith('/v1/jupyter/kernels') && method === 'GET') {

--- a/app/src/lib/runtime/jupyterManager.ts
+++ b/app/src/lib/runtime/jupyterManager.ts
@@ -1,699 +1,671 @@
-import { getRunnersManager, DEFAULT_RUNNER_PLACEHOLDER } from "./runnersManager";
-import { getAuthData } from "../../token";
-import { getBrowserAdapter } from "../../browserAdapter.client";
-import { appLogger } from "../logging/runtime";
+import { getBrowserAdapter } from '../../browserAdapter.client'
+import { getAuthData } from '../../token'
+import { appLogger } from '../logging/runtime'
+import { DEFAULT_RUNNER_PLACEHOLDER, getRunnersManager } from './runnersManager'
 
-const KERNEL_ALIASES_STORAGE_KEY = "runme/jupyterKernelAliases";
-
-export type JupyterServerRecord = {
-  name: string;
-  runner: string;
-  base_url: string;
-  has_token: boolean;
-};
+const KERNEL_ALIASES_STORAGE_KEY = 'runme/jupyterKernelAliases'
 
 export type JupyterKernelModel = {
-  id: string;
-  name: string;
-  last_activity?: string;
-  execution_state?: string;
-  connections?: number;
-};
+  id: string
+  name: string
+  last_activity?: string
+  execution_state?: string
+  connections?: number
+}
+
+export type JupyterKernelStartOptions = {
+  kernelSpec?: string
+  name?: string
+}
 
 export type JupyterKernelOption = {
-  key: string;
-  label: string;
-  runnerName: string;
-  serverName: string;
-  kernelId: string;
-  kernelName: string;
-};
+  key: string
+  label: string
+  runnerName: string
+  kernelId: string
+  kernelName: string
+}
 
 type KernelCacheEntry = {
-  model: JupyterKernelModel;
-  label: string;
-};
+  model: JupyterKernelModel
+  label: string
+}
 
 function normalizeKernelName(value: string): string {
-  return value.trim().toLowerCase();
+  return value.trim().toLowerCase()
 }
 
 function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
+  return encodeURIComponent(value)
 }
 
 function decodePathSegment(value: string): string {
   try {
-    return decodeURIComponent(value);
+    return decodeURIComponent(value)
   } catch {
-    return value;
+    return value
   }
 }
 
 export function runnerEndpointToHttpBase(runnerEndpoint: string): string {
-  const parsed = new URL(runnerEndpoint);
-  if (parsed.protocol === "ws:") {
-    parsed.protocol = "http:";
-  } else if (parsed.protocol === "wss:") {
-    parsed.protocol = "https:";
+  const parsed = new URL(runnerEndpoint)
+  if (parsed.protocol === 'ws:') {
+    parsed.protocol = 'http:'
+  } else if (parsed.protocol === 'wss:') {
+    parsed.protocol = 'https:'
   }
-  parsed.pathname = "";
-  parsed.search = "";
-  parsed.hash = "";
-  return parsed.toString().replace(/\/$/, "");
+  parsed.pathname = ''
+  parsed.search = ''
+  parsed.hash = ''
+  return parsed.toString().replace(/\/$/, '')
 }
 
 export function buildJupyterChannelsWebSocketURL(args: {
-  runnerEndpoint: string;
-  serverName: string;
-  kernelId: string;
-  authorization?: string;
+  runnerEndpoint: string
+  kernelId: string
+  authorization?: string
 }): string {
-  const parsed = new URL(args.runnerEndpoint);
-  if (parsed.protocol === "http:") {
-    parsed.protocol = "ws:";
-  } else if (parsed.protocol === "https:") {
-    parsed.protocol = "wss:";
+  const parsed = new URL(args.runnerEndpoint)
+  if (parsed.protocol === 'http:') {
+    parsed.protocol = 'ws:'
+  } else if (parsed.protocol === 'https:') {
+    parsed.protocol = 'wss:'
   }
-  parsed.pathname = `/v1/jupyter/servers/${encodePathSegment(args.serverName)}/kernels/${encodePathSegment(args.kernelId)}/channels`;
-  parsed.search = "";
+  parsed.pathname = `/v1/jupyter/kernels/${encodePathSegment(args.kernelId)}/channels`
+  parsed.search = ''
   if (args.authorization && args.authorization.trim()) {
-    parsed.searchParams.set("authorization", args.authorization.trim());
+    parsed.searchParams.set('authorization', args.authorization.trim())
   }
-  parsed.hash = "";
-  return parsed.toString();
+  parsed.hash = ''
+  return parsed.toString()
+}
+
+export async function getJupyterAuthorization(): Promise<string> {
+  const authData = await getAuthData().catch(() => null)
+  const token =
+    authData?.idToken?.trim() ||
+    getBrowserAdapter().simpleAuth?.idToken?.trim() ||
+    ''
+  return token ? `Bearer ${token}` : ''
 }
 
 class JupyterManager {
-  private static singleton: JupyterManager | null = null;
-  private static readonly compositeKeySeparator = "\u001f";
+  private static singleton: JupyterManager | null = null
+  private static readonly compositeKeySeparator = '\u001f'
 
-  private version = 0;
-  private listeners = new Set<() => void>();
-  private serversByKey = new Map<string, JupyterServerRecord>();
-  private kernelsByServerKey = new Map<string, KernelCacheEntry[]>();
-  private kernelAliases = new Map<string, string>();
-  private persistedKernelAliasesByKernel = new Map<string, string>();
-  private ensureRunnerPromises = new Map<string, Promise<void>>();
+  private version = 0
+  private listeners = new Set<() => void>()
+  private kernelsByRunner = new Map<string, KernelCacheEntry[]>()
+  private kernelAliases = new Map<string, string>()
+  private persistedKernelAliasesByKernel = new Map<string, string>()
+  private ensureRunnerPromises = new Map<string, Promise<void>>()
 
   private constructor() {
-    this.loadKernelAliasesFromStorage();
+    this.loadKernelAliasesFromStorage()
   }
 
   static getInstance(): JupyterManager {
     if (!JupyterManager.singleton) {
-      JupyterManager.singleton = new JupyterManager();
+      JupyterManager.singleton = new JupyterManager()
     }
-    return JupyterManager.singleton;
+    return JupyterManager.singleton
   }
 
   subscribe(listener: () => void): () => void {
-    this.listeners.add(listener);
+    this.listeners.add(listener)
     return () => {
-      this.listeners.delete(listener);
-    };
+      this.listeners.delete(listener)
+    }
   }
 
   getVersion(): number {
-    return this.version;
+    return this.version
   }
 
   private bumpVersion(): void {
-    this.version += 1;
+    this.version += 1
     this.listeners.forEach((listener) => {
       try {
-        listener();
+        listener()
       } catch (error) {
-        console.error("Jupyter manager listener failed", error);
+        console.error('Jupyter manager listener failed', error)
       }
-    });
+    })
   }
 
   private normalizeRunnerName(runnerName: string): string {
-    const mgr = getRunnersManager();
-    const normalizedRunnerName = runnerName.trim();
+    const mgr = getRunnersManager()
+    const normalizedRunnerName = runnerName.trim()
     const effectiveName =
       normalizedRunnerName === DEFAULT_RUNNER_PLACEHOLDER
-        ? mgr.getDefaultRunnerName() ?? ""
-        : normalizedRunnerName;
+        ? (mgr.getDefaultRunnerName() ?? '')
+        : normalizedRunnerName
     if (!effectiveName) {
-      throw new Error("Runner name is required.");
+      throw new Error('Runner name is required.')
     }
-    return effectiveName;
+    return effectiveName
   }
 
   private resolveRunnerEndpoint(runnerName: string): string {
-    const effectiveName = this.normalizeRunnerName(runnerName);
-    const mgr = getRunnersManager();
-    const runner = effectiveName ? mgr.getWithFallback(effectiveName) : undefined;
+    const effectiveName = this.normalizeRunnerName(runnerName)
+    const mgr = getRunnersManager()
+    const runner = effectiveName
+      ? mgr.getWithFallback(effectiveName)
+      : undefined
     if (!runner?.endpoint) {
-      throw new Error(`No runner endpoint configured for ${effectiveName}.`);
+      throw new Error(`No runner endpoint configured for ${effectiveName}.`)
     }
-    return runner.endpoint;
+    return runner.endpoint
   }
 
-  private getServerKey(runnerName: string, serverName: string): string {
-    return `${runnerName}${JupyterManager.compositeKeySeparator}${serverName}`;
+  private getAliasKey(runnerName: string, alias: string): string {
+    return `${runnerName}${JupyterManager.compositeKeySeparator}${alias}`
   }
 
-  private isServerKeyForRunner(serverKey: string, runnerName: string): boolean {
-    return serverKey.startsWith(`${runnerName}${JupyterManager.compositeKeySeparator}`);
-  }
-
-  private getServerNameFromKey(serverKey: string): string {
-    const [, serverName = ""] = serverKey.split(JupyterManager.compositeKeySeparator, 2);
-    return serverName;
-  }
-
-  private getAliasKey(runnerName: string, serverName: string, alias: string): string {
-    return `${runnerName}${JupyterManager.compositeKeySeparator}${serverName}${JupyterManager.compositeKeySeparator}${alias}`;
-  }
-
-  private getKernelAliasKey(runnerName: string, serverName: string, kernelID: string): string {
-    return `${runnerName}${JupyterManager.compositeKeySeparator}${serverName}${JupyterManager.compositeKeySeparator}${kernelID}`;
+  private getKernelAliasKey(runnerName: string, kernelID: string): string {
+    return `${runnerName}${JupyterManager.compositeKeySeparator}${kernelID}`
   }
 
   private parseKernelAliasKey(
-    key: string,
-  ): { runnerName: string; serverName: string; kernelId: string } | null {
-    const parts = key.split(JupyterManager.compositeKeySeparator);
-    if (parts.length !== 3) {
-      return null;
+    key: string
+  ): { runnerName: string; kernelId: string } | null {
+    const parts = key.split(JupyterManager.compositeKeySeparator)
+    const runnerName = parts[0]
+    const kernelId = parts.length === 2 ? parts[1] : parts[2]
+    if (
+      !runnerName ||
+      !kernelId ||
+      (parts.length !== 2 && parts.length !== 3)
+    ) {
+      return null
     }
-    const [runnerName, serverName, kernelId] = parts;
-    if (!runnerName || !serverName || !kernelId) {
-      return null;
-    }
-    return { runnerName, serverName, kernelId };
+    return { runnerName, kernelId }
   }
 
   private loadKernelAliasesFromStorage(): void {
-    if (typeof window === "undefined") {
-      return;
+    if (typeof window === 'undefined') {
+      return
     }
     try {
-      const raw = window.localStorage.getItem(KERNEL_ALIASES_STORAGE_KEY);
+      const raw = window.localStorage.getItem(KERNEL_ALIASES_STORAGE_KEY)
       if (!raw) {
-        return;
+        return
       }
-      const parsed = JSON.parse(raw);
+      const parsed = JSON.parse(raw)
       if (!Array.isArray(parsed)) {
-        return;
+        return
       }
       parsed.forEach((entry) => {
         if (
           entry &&
-          typeof entry === "object" &&
-          typeof (entry as any).runnerName === "string" &&
-          typeof (entry as any).serverName === "string" &&
-          typeof (entry as any).kernelId === "string" &&
-          typeof (entry as any).alias === "string"
+          typeof entry === 'object' &&
+          typeof (entry as any).runnerName === 'string' &&
+          typeof (entry as any).kernelId === 'string' &&
+          typeof (entry as any).alias === 'string'
         ) {
-          const runnerName = (entry as any).runnerName.trim();
-          const serverName = (entry as any).serverName.trim();
-          const kernelId = (entry as any).kernelId.trim();
-          const alias = (entry as any).alias.trim();
-          if (runnerName && serverName && kernelId && alias) {
+          const runnerName = (entry as any).runnerName.trim()
+          const kernelId = (entry as any).kernelId.trim()
+          const alias = (entry as any).alias.trim()
+          if (runnerName && kernelId && alias) {
             this.persistedKernelAliasesByKernel.set(
-              this.getKernelAliasKey(runnerName, serverName, kernelId),
-              alias,
-            );
+              this.getKernelAliasKey(runnerName, kernelId),
+              alias
+            )
           }
-          return;
+          return
         }
         // Backwards compatibility with old storage shape: { key, alias }.
         if (
           entry &&
-          typeof entry === "object" &&
-          typeof (entry as any).key === "string" &&
-          typeof (entry as any).alias === "string"
+          typeof entry === 'object' &&
+          typeof (entry as any).key === 'string' &&
+          typeof (entry as any).alias === 'string'
         ) {
-          const key = (entry as any).key.trim();
-          const alias = (entry as any).alias.trim();
-          if (key && alias) {
-            this.persistedKernelAliasesByKernel.set(key, alias);
+          const key = (entry as any).key.trim()
+          const alias = (entry as any).alias.trim()
+          const parsedKey = this.parseKernelAliasKey(key)
+          if (parsedKey && alias) {
+            this.persistedKernelAliasesByKernel.set(
+              this.getKernelAliasKey(parsedKey.runnerName, parsedKey.kernelId),
+              alias
+            )
           }
         }
-      });
+      })
     } catch (error) {
-      console.error("Failed to load Jupyter kernel aliases from storage", error);
+      console.error('Failed to load Jupyter kernel aliases from storage', error)
     }
   }
 
   private persistKernelAliasesToStorage(): void {
-    if (typeof window === "undefined") {
-      return;
+    if (typeof window === 'undefined') {
+      return
     }
     try {
       const serialized = [...this.persistedKernelAliasesByKernel.entries()].map(
         ([key, alias]) => ({
           ...(this.parseKernelAliasKey(key) ?? { key }),
           alias,
-        }),
-      );
-      window.localStorage.setItem(KERNEL_ALIASES_STORAGE_KEY, JSON.stringify(serialized));
+        })
+      )
+      window.localStorage.setItem(
+        KERNEL_ALIASES_STORAGE_KEY,
+        JSON.stringify(serialized)
+      )
     } catch (error) {
-      console.error("Failed to persist Jupyter kernel aliases to storage", error);
+      console.error(
+        'Failed to persist Jupyter kernel aliases to storage',
+        error
+      )
     }
   }
 
   private setPersistedKernelAlias(
     runnerName: string,
-    serverName: string,
     kernelID: string,
-    alias: string,
+    alias: string
   ): void {
-    const key = this.getKernelAliasKey(runnerName, serverName, kernelID);
-    const trimmedAlias = alias.trim();
+    const key = this.getKernelAliasKey(runnerName, kernelID)
+    const trimmedAlias = alias.trim()
     if (!trimmedAlias) {
-      this.persistedKernelAliasesByKernel.delete(key);
+      this.persistedKernelAliasesByKernel.delete(key)
     } else {
-      this.persistedKernelAliasesByKernel.set(key, trimmedAlias);
+      this.persistedKernelAliasesByKernel.set(key, trimmedAlias)
     }
-    this.persistKernelAliasesToStorage();
+    this.persistKernelAliasesToStorage()
   }
 
   private getPersistedKernelAlias(
     runnerName: string,
-    serverName: string,
-    kernelID: string,
+    kernelID: string
   ): string {
-    return this.persistedKernelAliasesByKernel.get(
-      this.getKernelAliasKey(runnerName, serverName, kernelID),
-    ) ?? "";
+    return (
+      this.persistedKernelAliasesByKernel.get(
+        this.getKernelAliasKey(runnerName, kernelID)
+      ) ?? ''
+    )
   }
 
-  private rebuildAliasLookupForServer(
+  private rebuildAliasLookupForRunner(
     runnerName: string,
-    serverName: string,
-    entries: KernelCacheEntry[],
+    entries: KernelCacheEntry[]
   ): void {
-    const prefix = `${runnerName}${JupyterManager.compositeKeySeparator}${serverName}${JupyterManager.compositeKeySeparator}`;
+    const prefix = `${runnerName}${JupyterManager.compositeKeySeparator}`
     for (const key of this.kernelAliases.keys()) {
       if (key.startsWith(prefix)) {
-        this.kernelAliases.delete(key);
+        this.kernelAliases.delete(key)
       }
     }
     entries.forEach((entry) => {
-      const label = entry.label?.trim() ?? "";
-      const modelName = entry.model.name?.trim() ?? "";
-      if (!label || normalizeKernelName(label) === normalizeKernelName(modelName)) {
-        return;
+      const label = entry.label?.trim() ?? ''
+      const modelName = entry.model.name?.trim() ?? ''
+      if (
+        !label ||
+        normalizeKernelName(label) === normalizeKernelName(modelName)
+      ) {
+        return
       }
-      this.kernelAliases.set(this.getAliasKey(runnerName, serverName, label), entry.model.id);
-    });
+      this.kernelAliases.set(
+        this.getAliasKey(runnerName, label),
+        entry.model.id
+      )
+    })
   }
 
   private clearRunnerCache(runnerName: string): void {
-    for (const serverKey of this.serversByKey.keys()) {
-      if (this.isServerKeyForRunner(serverKey, runnerName)) {
-        this.serversByKey.delete(serverKey);
-      }
-    }
-    for (const serverKey of this.kernelsByServerKey.keys()) {
-      if (this.isServerKeyForRunner(serverKey, runnerName)) {
-        this.kernelsByServerKey.delete(serverKey);
-      }
-    }
+    this.kernelsByRunner.delete(runnerName)
     for (const aliasKey of this.kernelAliases.keys()) {
-      if (aliasKey.startsWith(`${runnerName}${JupyterManager.compositeKeySeparator}`)) {
-        this.kernelAliases.delete(aliasKey);
+      if (
+        aliasKey.startsWith(
+          `${runnerName}${JupyterManager.compositeKeySeparator}`
+        )
+      ) {
+        this.kernelAliases.delete(aliasKey)
       }
     }
   }
 
   private async fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
-    const authData = await getAuthData().catch(() => null);
-    const token =
-      authData?.idToken?.trim() ??
-      getBrowserAdapter().simpleAuth?.idToken?.trim() ??
-      "";
-    const method = (init?.method ?? "GET").toUpperCase();
-    const headers = new Headers(init?.headers);
-    if (token) {
-      headers.set("Authorization", `Bearer ${token}`);
+    const authorization = await getJupyterAuthorization()
+    const method = (init?.method ?? 'GET').toUpperCase()
+    const headers = new Headers(init?.headers)
+    if (authorization) {
+      headers.set('Authorization', authorization)
     }
-    let response: Response;
+    let response: Response
     try {
       response = await fetch(url, {
         ...init,
-        credentials: "include",
+        credentials: 'include',
         headers,
-      });
+      })
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      appLogger.error("Jupyter request failed before receiving a response", {
+      const message = error instanceof Error ? error.message : String(error)
+      appLogger.error('Jupyter request failed before receiving a response', {
         attrs: {
-          scope: "jupyter.fetch",
+          scope: 'jupyter.fetch',
           method,
           url,
-          hasAuthToken: Boolean(token),
+          hasAuthToken: Boolean(authorization),
           error: message,
         },
-      });
-      throw new Error(`Jupyter request failed (${method} ${url}): ${message}`);
+      })
+      throw new Error(`Jupyter request failed (${method} ${url}): ${message}`)
     }
     if (!response.ok) {
-      const text = await response.text();
-      const bodyPreview = text.slice(0, 400);
-      appLogger.error("Jupyter request returned non-success response", {
+      const text = await response.text()
+      const bodyPreview = text.slice(0, 400)
+      appLogger.error('Jupyter request returned non-success response', {
         attrs: {
-          scope: "jupyter.fetch",
+          scope: 'jupyter.fetch',
           method,
           url,
           status: response.status,
           statusText: response.statusText,
           bodyPreview,
         },
-      });
+      })
       throw new Error(
         `Jupyter request failed (${method} ${url}) with ${response.status} ${response.statusText}: ${
-          bodyPreview || "<empty body>"
-        }`,
-      );
+          bodyPreview || '<empty body>'
+        }`
+      )
     }
     if (response.status === 204 || response.status === 205) {
-      return undefined as T;
+      return undefined as T
     }
-    const text = await response.text();
+    const text = await response.text()
     if (!text.trim()) {
-      return undefined as T;
+      return undefined as T
     }
     try {
-      return JSON.parse(text) as T;
+      return JSON.parse(text) as T
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const bodyPreview = text.slice(0, 400);
-      appLogger.error("Jupyter response was not valid JSON", {
+      const message = error instanceof Error ? error.message : String(error)
+      const bodyPreview = text.slice(0, 400)
+      appLogger.error('Jupyter response was not valid JSON', {
         attrs: {
-          scope: "jupyter.fetch",
+          scope: 'jupyter.fetch',
           method,
           url,
           error: message,
           bodyPreview,
         },
-      });
+      })
       throw new Error(
-        `Invalid JSON from Jupyter request (${method} ${url}): ${message}. Body: ${bodyPreview}`,
-      );
+        `Invalid JSON from Jupyter request (${method} ${url}): ${message}. Body: ${bodyPreview}`
+      )
     }
   }
 
   private resolveDefaultRunnerName(): string {
-    return getRunnersManager().getDefaultRunnerName() ?? "";
-  }
-
-  async listServers(runnerName: string): Promise<JupyterServerRecord[]> {
-    const effectiveRunner = this.normalizeRunnerName(runnerName);
-    const runnerEndpoint = this.resolveRunnerEndpoint(effectiveRunner);
-    const baseURL = runnerEndpointToHttpBase(runnerEndpoint);
-    const serversResponse = await this.fetchJSON<JupyterServerRecord[]>(
-      `${baseURL}/v1/jupyter/servers`,
-    );
-    this.clearRunnerCache(effectiveRunner);
-    const servers = serversResponse.map((server) => ({
-      ...server,
-      runner: effectiveRunner,
-    }));
-    servers.forEach((server) => {
-      this.serversByKey.set(
-        this.getServerKey(effectiveRunner, server.name),
-        server,
-      );
-    });
-    this.bumpVersion();
-    return servers;
+    return getRunnersManager().getDefaultRunnerName() ?? ''
   }
 
   async ensureRunnerData(runnerName: string): Promise<void> {
-    const requestedRunner = runnerName.trim();
-    const effectiveRunner =
-      requestedRunner || this.resolveDefaultRunnerName();
+    const requestedRunner = runnerName.trim()
+    const effectiveRunner = requestedRunner || this.resolveDefaultRunnerName()
     if (!effectiveRunner) {
-      return;
+      return
     }
-    const existing = this.ensureRunnerPromises.get(effectiveRunner);
+    const existing = this.ensureRunnerPromises.get(effectiveRunner)
     if (existing) {
-      await existing;
-      return;
+      await existing
+      return
     }
-    const promise = (async () => {
-      const servers = await this.listServers(effectiveRunner);
-      await Promise.all(
-        servers.map(async (server) => {
-          await this.listKernels(effectiveRunner, server.name);
-        }),
-      );
-    })().finally(() => {
-      this.ensureRunnerPromises.delete(effectiveRunner);
-    });
-    this.ensureRunnerPromises.set(effectiveRunner, promise);
-    await promise;
+    const promise = this.listKernels(effectiveRunner)
+      .then(() => undefined)
+      .finally(() => {
+        this.ensureRunnerPromises.delete(effectiveRunner)
+      })
+    this.ensureRunnerPromises.set(effectiveRunner, promise)
+    await promise
   }
 
-  private async ensureServerLoaded(
-    runnerName: string,
-    serverName: string,
-  ): Promise<void> {
-    const serverKey = this.getServerKey(runnerName, serverName);
-    if (this.serversByKey.has(serverKey)) {
-      return;
-    }
-    await this.listServers(runnerName);
-    // Do not fail hard here. The backend registry supports reload-on-miss
-    // for server names that may not be present in the current list snapshot.
-  }
-
-  async listKernels(runnerName: string, serverName: string): Promise<JupyterKernelModel[]> {
-    const effectiveRunner = this.normalizeRunnerName(runnerName);
-    await this.ensureServerLoaded(effectiveRunner, serverName);
-    const baseURL = runnerEndpointToHttpBase(this.resolveRunnerEndpoint(effectiveRunner));
+  async listKernels(runnerName: string): Promise<JupyterKernelModel[]> {
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
+    const baseURL = runnerEndpointToHttpBase(
+      this.resolveRunnerEndpoint(effectiveRunner)
+    )
     const kernels = await this.fetchJSON<JupyterKernelModel[]>(
-      `${baseURL}/v1/jupyter/servers/${encodePathSegment(serverName)}/kernels`,
-    );
-    const serverKey = this.getServerKey(effectiveRunner, serverName);
-    const existingLabels = new Map<string, string>();
-    (this.kernelsByServerKey.get(serverKey) ?? []).forEach((entry) => {
-      existingLabels.set(entry.model.id, entry.label);
-    });
+      `${baseURL}/v1/jupyter/kernels`
+    )
+    const existingLabels = new Map<string, string>()
+    ;(this.kernelsByRunner.get(effectiveRunner) ?? []).forEach((entry) => {
+      existingLabels.set(entry.model.id, entry.label)
+    })
     const next = kernels.map((model) => {
-      const aliasLabel = existingLabels.get(model.id) ||
-        this.getPersistedKernelAlias(effectiveRunner, serverName, model.id);
-      const label = aliasLabel && aliasLabel.trim() ? aliasLabel : model.name || model.id;
-      return { model, label };
-    });
-    this.kernelsByServerKey.set(serverKey, next);
-    this.rebuildAliasLookupForServer(effectiveRunner, serverName, next);
-    this.bumpVersion();
-    return kernels;
+      const aliasLabel =
+        existingLabels.get(model.id) ||
+        this.getPersistedKernelAlias(effectiveRunner, model.id)
+      const label =
+        aliasLabel && aliasLabel.trim() ? aliasLabel : model.name || model.id
+      return { model, label }
+    })
+    this.clearRunnerCache(effectiveRunner)
+    this.kernelsByRunner.set(effectiveRunner, next)
+    this.rebuildAliasLookupForRunner(effectiveRunner, next)
+    this.bumpVersion()
+    return kernels
   }
 
   async startKernel(
     runnerName: string,
-    serverName: string,
-    options?: { kernelSpec?: string; name?: string; path?: string },
+    options?: JupyterKernelStartOptions
   ): Promise<JupyterKernelModel> {
-    const effectiveRunner = this.normalizeRunnerName(runnerName);
-    await this.ensureServerLoaded(effectiveRunner, serverName);
-    const baseURL = runnerEndpointToHttpBase(this.resolveRunnerEndpoint(effectiveRunner));
-    const alias = options?.name?.trim() ?? "";
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
+    const baseURL = runnerEndpointToHttpBase(
+      this.resolveRunnerEndpoint(effectiveRunner)
+    )
+    const alias = options?.name?.trim() ?? ''
     if (alias) {
-      const existing = await this.listKernels(effectiveRunner, serverName);
-      const requestedKey = normalizeKernelName(alias);
+      const existing = await this.listKernels(effectiveRunner)
+      const requestedKey = normalizeKernelName(alias)
       const duplicate = existing.find((kernel) => {
-        if (normalizeKernelName(kernel.name || "") === requestedKey) {
-          return true;
+        if (normalizeKernelName(kernel.name || '') === requestedKey) {
+          return true
         }
-        const serverKey = this.getServerKey(effectiveRunner, serverName);
-        const cached = this.kernelsByServerKey.get(serverKey) ?? [];
-        const cacheHit = cached.find((entry) => entry.model.id === kernel.id);
-        return normalizeKernelName(cacheHit?.label || "") === requestedKey;
-      });
+        const cached = this.kernelsByRunner.get(effectiveRunner) ?? []
+        const cacheHit = cached.find((entry) => entry.model.id === kernel.id)
+        return normalizeKernelName(cacheHit?.label || '') === requestedKey
+      })
       if (duplicate) {
         throw new Error(
-          `Kernel alias "${alias}" already exists on ${effectiveRunner}/${serverName}.`,
-        );
+          `Kernel alias "${alias}" already exists on ${effectiveRunner}.`
+        )
       }
     }
 
-    const payload: Record<string, unknown> = {};
+    const payload: Record<string, unknown> = {}
     if (options?.kernelSpec?.trim()) {
-      payload.name = options.kernelSpec.trim();
+      payload.name = options.kernelSpec.trim()
     }
-    if (options?.path?.trim()) {
-      payload.path = options.path.trim();
-    }
-
     const kernel = await this.fetchJSON<JupyterKernelModel>(
-      `${baseURL}/v1/jupyter/servers/${encodePathSegment(serverName)}/kernels`,
+      `${baseURL}/v1/jupyter/kernels`,
       {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify(payload),
-      },
-    );
+      }
+    )
 
-    const label = alias || kernel.name || kernel.id;
+    const label = alias || kernel.name || kernel.id
     if (alias) {
-      this.setPersistedKernelAlias(effectiveRunner, serverName, kernel.id, alias);
+      this.setPersistedKernelAlias(effectiveRunner, kernel.id, alias)
     } else {
-      this.setPersistedKernelAlias(effectiveRunner, serverName, kernel.id, "");
+      this.setPersistedKernelAlias(effectiveRunner, kernel.id, '')
     }
-    const serverKey = this.getServerKey(effectiveRunner, serverName);
-    const existing = this.kernelsByServerKey.get(serverKey) ?? [];
-    const filtered = existing.filter((entry) => entry.model.id !== kernel.id);
+    const existing = this.kernelsByRunner.get(effectiveRunner) ?? []
+    const filtered = existing.filter((entry) => entry.model.id !== kernel.id)
     filtered.push({
       model: kernel,
       label,
-    });
-    this.kernelsByServerKey.set(serverKey, filtered);
-    this.rebuildAliasLookupForServer(effectiveRunner, serverName, filtered);
-    this.bumpVersion();
-    return kernel;
+    })
+    this.kernelsByRunner.set(effectiveRunner, filtered)
+    this.rebuildAliasLookupForRunner(effectiveRunner, filtered)
+    this.bumpVersion()
+    return kernel
   }
 
-  async stopKernel(runnerName: string, serverName: string, kernelNameOrId: string): Promise<void> {
-    const effectiveRunner = this.normalizeRunnerName(runnerName);
-    const kernelID = await this.resolveKernelID(effectiveRunner, serverName, kernelNameOrId);
-    if (!kernelID) {
-      throw new Error(`Kernel ${kernelNameOrId} was not found.`);
+  async getKernel(
+    runnerName: string,
+    kernelID: string
+  ): Promise<JupyterKernelModel> {
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
+    if (!kernelID.trim()) {
+      throw new Error('Kernel ID is required.')
     }
-    const baseURL = runnerEndpointToHttpBase(this.resolveRunnerEndpoint(effectiveRunner));
+    const baseURL = runnerEndpointToHttpBase(
+      this.resolveRunnerEndpoint(effectiveRunner)
+    )
+    return this.fetchJSON<JupyterKernelModel>(
+      `${baseURL}/v1/jupyter/kernels/${encodePathSegment(kernelID)}`
+    )
+  }
+
+  async stopKernel(runnerName: string, kernelNameOrId: string): Promise<void> {
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
+    const kernelID = await this.resolveKernelID(effectiveRunner, kernelNameOrId)
+    if (!kernelID) {
+      throw new Error(`Kernel ${kernelNameOrId} was not found.`)
+    }
+    const baseURL = runnerEndpointToHttpBase(
+      this.resolveRunnerEndpoint(effectiveRunner)
+    )
     await this.fetchJSON<unknown>(
-      `${baseURL}/v1/jupyter/servers/${encodePathSegment(serverName)}/kernels/${encodePathSegment(kernelID)}`,
+      `${baseURL}/v1/jupyter/kernels/${encodePathSegment(kernelID)}`,
       {
-        method: "DELETE",
-      },
-    );
-    const serverKey = this.getServerKey(effectiveRunner, serverName);
-    const existing = this.kernelsByServerKey.get(serverKey) ?? [];
-    const remaining = existing.filter((entry) => entry.model.id !== kernelID);
-    this.kernelsByServerKey.set(serverKey, remaining);
-    this.setPersistedKernelAlias(effectiveRunner, serverName, kernelID, "");
-    this.rebuildAliasLookupForServer(effectiveRunner, serverName, remaining);
-    this.bumpVersion();
+        method: 'DELETE',
+      }
+    )
+    const existing = this.kernelsByRunner.get(effectiveRunner) ?? []
+    const remaining = existing.filter((entry) => entry.model.id !== kernelID)
+    this.kernelsByRunner.set(effectiveRunner, remaining)
+    this.setPersistedKernelAlias(effectiveRunner, kernelID, '')
+    this.rebuildAliasLookupForRunner(effectiveRunner, remaining)
+    this.bumpVersion()
   }
 
   async interruptKernel(
     runnerName: string,
-    serverName: string,
     kernelID: string,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal }
   ): Promise<void> {
-    const effectiveRunner = this.normalizeRunnerName(runnerName);
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
     if (!kernelID.trim()) {
-      throw new Error("Kernel ID is required.");
+      throw new Error('Kernel ID is required.')
     }
-    const baseURL = runnerEndpointToHttpBase(this.resolveRunnerEndpoint(effectiveRunner));
+    const baseURL = runnerEndpointToHttpBase(
+      this.resolveRunnerEndpoint(effectiveRunner)
+    )
     await this.fetchJSON<unknown>(
-      `${baseURL}/v1/jupyter/servers/${encodePathSegment(serverName)}/kernels/${encodePathSegment(kernelID)}:interrupt`,
+      `${baseURL}/v1/jupyter/kernels/${encodePathSegment(kernelID)}/interrupt`,
       {
-        method: "POST",
+        method: 'POST',
         signal: options?.signal,
-      },
-    );
+      }
+    )
+  }
+
+  async restartKernel(
+    runnerName: string,
+    kernelID: string
+  ): Promise<JupyterKernelModel> {
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
+    if (!kernelID.trim()) {
+      throw new Error('Kernel ID is required.')
+    }
+    const baseURL = runnerEndpointToHttpBase(
+      this.resolveRunnerEndpoint(effectiveRunner)
+    )
+    const kernel = await this.fetchJSON<JupyterKernelModel>(
+      `${baseURL}/v1/jupyter/kernels/${encodePathSegment(kernelID)}/restart`,
+      { method: 'POST' }
+    )
+    const existing = this.kernelsByRunner.get(effectiveRunner) ?? []
+    const next = existing.map((entry) =>
+      entry.model.id === kernel.id ? { ...entry, model: kernel } : entry
+    )
+    this.kernelsByRunner.set(effectiveRunner, next)
+    this.bumpVersion()
+    return kernel
   }
 
   async resolveKernelID(
     runnerName: string,
-    serverName: string,
-    kernelNameOrId: string,
+    kernelNameOrId: string
   ): Promise<string> {
-    const effectiveRunner = this.normalizeRunnerName(runnerName);
-    const trimmed = kernelNameOrId.trim();
+    const effectiveRunner = this.normalizeRunnerName(runnerName)
+    const trimmed = kernelNameOrId.trim()
     if (!trimmed) {
-      return "";
+      return ''
     }
-    const aliasID = this.kernelAliases.get(this.getAliasKey(effectiveRunner, serverName, trimmed));
+    const aliasID = this.kernelAliases.get(
+      this.getAliasKey(effectiveRunner, trimmed)
+    )
     if (aliasID) {
-      return aliasID;
+      return aliasID
     }
-    const serverKey = this.getServerKey(effectiveRunner, serverName);
-    const cached = this.kernelsByServerKey.get(serverKey) ?? [];
+    const cached = this.kernelsByRunner.get(effectiveRunner) ?? []
     const fromCached =
       cached.find((entry) => entry.model.id === trimmed)?.model.id ??
       cached.find((entry) => entry.label === trimmed)?.model.id ??
-      cached.find((entry) => entry.model.name === trimmed)?.model.id;
+      cached.find((entry) => entry.model.name === trimmed)?.model.id
     if (fromCached) {
-      return fromCached;
+      return fromCached
     }
-    await this.listKernels(effectiveRunner, serverName);
-    const refreshed = this.kernelsByServerKey.get(serverKey) ?? [];
+    await this.listKernels(effectiveRunner)
+    const refreshed = this.kernelsByRunner.get(effectiveRunner) ?? []
     return (
       refreshed.find((entry) => entry.model.id === trimmed)?.model.id ??
       refreshed.find((entry) => entry.label === trimmed)?.model.id ??
       refreshed.find((entry) => entry.model.name === trimmed)?.model.id ??
-      ""
-    );
+      ''
+    )
   }
 
   getKernelOptionsForRunner(runnerName: string): JupyterKernelOption[] {
-    const resolvedRunner = this.normalizeRunnerName(runnerName);
-    const options: JupyterKernelOption[] = [];
-    for (const [serverKey] of this.serversByKey.entries()) {
-      if (!this.isServerKeyForRunner(serverKey, resolvedRunner)) {
-        continue;
-      }
-      const serverName = this.getServerNameFromKey(serverKey);
-      const kernels = this.kernelsByServerKey.get(serverKey) ?? [];
-      kernels.forEach((entry) => {
-        const kernelID = entry.model.id;
-        const label = entry.label || entry.model.name || kernelID;
-        options.push({
-          key: this.getKernelOptionKey(serverName, kernelID, resolvedRunner),
+    const resolvedRunner = this.normalizeRunnerName(runnerName)
+    const options = (this.kernelsByRunner.get(resolvedRunner) ?? []).map(
+      (entry) => {
+        const kernelID = entry.model.id
+        const label = entry.label || entry.model.name || kernelID
+        return {
+          key: this.getKernelOptionKey(resolvedRunner, kernelID),
           label,
           runnerName: resolvedRunner,
-          serverName,
           kernelId: kernelID,
           kernelName: entry.model.name || label,
-        });
-      });
-    }
-    options.sort((a, b) => a.label.localeCompare(b.label));
-    return options;
+        }
+      }
+    )
+    options.sort((a, b) => a.label.localeCompare(b.label))
+    return options
   }
 
   parseKernelOptionKey(
-    key: string,
-  ): { runnerName?: string; serverName: string; kernelId: string } | null {
-    if (!key || !key.includes(":")) {
-      return null;
+    key: string
+  ): { runnerName: string; kernelId: string } | null {
+    if (!key || !key.includes(':')) {
+      return null
     }
-    const parts = key.split(":");
-    if (parts.length === 2) {
-      const [serverEncoded, kernelEncoded] = parts;
-      if (!serverEncoded || !kernelEncoded) {
-        return null;
-      }
-      return {
-        serverName: decodePathSegment(serverEncoded),
-        kernelId: decodePathSegment(kernelEncoded),
-      };
+    const [runnerEncoded, kernelEncoded, ...rest] = key.split(':')
+    if (!runnerEncoded || !kernelEncoded || rest.length > 0) {
+      return null
     }
-    if (parts.length === 3) {
-      const [runnerEncoded, serverEncoded, kernelEncoded] = parts;
-      if (!runnerEncoded || !serverEncoded || !kernelEncoded) {
-        return null;
-      }
-      return {
-        runnerName: decodePathSegment(runnerEncoded),
-        serverName: decodePathSegment(serverEncoded),
-        kernelId: decodePathSegment(kernelEncoded),
-      };
+    return {
+      runnerName: decodePathSegment(runnerEncoded),
+      kernelId: decodePathSegment(kernelEncoded),
     }
-    return null;
   }
 
-  getKernelOptionKey(serverName: string, kernelId: string, runnerName?: string): string {
-    if (runnerName && runnerName.trim()) {
-      return `${encodePathSegment(runnerName)}:${encodePathSegment(serverName)}:${encodePathSegment(kernelId)}`;
-    }
-    return `${encodePathSegment(serverName)}:${encodePathSegment(kernelId)}`;
+  getKernelOptionKey(runnerName: string, kernelId: string): string {
+    return `${encodePathSegment(runnerName)}:${encodePathSegment(kernelId)}`
   }
 }
 
 export function getJupyterManager(): JupyterManager {
-  return JupyterManager.getInstance();
+  return JupyterManager.getInstance()
 }

--- a/app/src/lib/runtime/jupyterManager.ts
+++ b/app/src/lib/runtime/jupyterManager.ts
@@ -26,6 +26,10 @@ export type JupyterKernelOption = {
   kernelName: string
 }
 
+export type JupyterKernelStatus = JupyterKernelModel & {
+  label: string
+}
+
 type KernelCacheEntry = {
   model: JupyterKernelModel
   label: string
@@ -643,6 +647,18 @@ class JupyterManager {
     )
     options.sort((a, b) => a.label.localeCompare(b.label))
     return options
+  }
+
+  getKernelsForRunner(runnerName: string): JupyterKernelStatus[] {
+    const resolvedRunner = this.normalizeRunnerName(runnerName)
+    return (this.kernelsByRunner.get(resolvedRunner) ?? [])
+      .map((entry) => ({
+        ...entry.model,
+        label: entry.label || entry.model.name || entry.model.id,
+      }))
+      .sort(
+        (a, b) => a.label.localeCompare(b.label) || a.id.localeCompare(b.id)
+      )
   }
 
   parseKernelOptionKey(

--- a/app/src/lib/runtime/jupyterManager.ts
+++ b/app/src/lib/runtime/jupyterManager.ts
@@ -5,6 +5,14 @@ import { DEFAULT_RUNNER_PLACEHOLDER, getRunnersManager } from './runnersManager'
 
 const KERNEL_ALIASES_STORAGE_KEY = 'runme/jupyterKernelAliases'
 
+export const DEFAULT_JUPYTER_KERNEL_ARGV = [
+  'python3',
+  '-m',
+  'ipykernel_launcher',
+  '-f',
+  '{connection_file}',
+] as const
+
 export type JupyterKernelModel = {
   id: string
   name: string
@@ -16,6 +24,7 @@ export type JupyterKernelModel = {
 export type JupyterKernelStartOptions = {
   kernelSpec?: string
   name?: string
+  argv?: string[]
 }
 
 export type JupyterKernelOption = {
@@ -480,9 +489,17 @@ class JupyterManager {
       }
     }
 
-    const payload: Record<string, unknown> = {}
-    if (options?.kernelSpec?.trim()) {
-      payload.name = options.kernelSpec.trim()
+    const kernelSpec = options?.kernelSpec?.trim() || 'python3'
+    const argv = options?.argv ?? [...DEFAULT_JUPYTER_KERNEL_ARGV]
+    if (
+      argv.length === 0 ||
+      argv.some((argument) => typeof argument !== 'string')
+    ) {
+      throw new Error('Kernel argv must be a non-empty array of strings.')
+    }
+    const payload: Record<string, unknown> = {
+      name: kernelSpec,
+      argv,
     }
     const kernel = await this.fetchJSON<JupyterKernelModel>(
       `${baseURL}/v1/jupyter/kernels`,

--- a/app/src/lib/tabIdentity.ts
+++ b/app/src/lib/tabIdentity.ts
@@ -86,7 +86,7 @@ function randomIndex(maxExclusive: number): number {
   return Math.floor(Math.random() * maxExclusive);
 }
 
-function createSessionId(): string {
+export function createSessionId(): string {
   return [
     SESSION_PREFIXES[randomIndex(SESSION_PREFIXES.length)],
     SESSION_NOUNS[randomIndex(SESSION_NOUNS.length)],

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceDocumentController } from "./workspaceDocumentController";
 import {
   deriveWorkspaceDocumentTitle,
+  getRunnerKernelsDocumentUri,
+  parseRunnerKernelsDocumentUri,
   type WorkspaceDocument,
 } from "./workspaceDocumentTypes";
 import { EXCALIDRAW_MIME_TYPE } from "../../storage/excalidraw";
@@ -114,5 +116,15 @@ describe("WorkspaceDocumentController", () => {
   it("derives titles for App Console and Logs documents", () => {
     expect(deriveWorkspaceDocumentTitle("app://console")).toBe("App Console");
     expect(deriveWorkspaceDocumentTitle("app://logs")).toBe("Logs");
+  });
+
+  it("creates and parses runner-scoped kernel status documents", () => {
+    const uri = getRunnerKernelsDocumentUri("local runner");
+
+    expect(uri).toBe("status://runners/local%20runner/kernels");
+    expect(parseRunnerKernelsDocumentUri(uri)).toEqual({
+      runnerName: "local runner",
+    });
+    expect(deriveWorkspaceDocumentTitle(uri)).toBe("Kernels · local runner");
   });
 });

--- a/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentTypes.ts
@@ -8,6 +8,8 @@ export const DRIVE_LINK_STATUS_DOCUMENT_URI = 'status://drive-link'
 export const DRIVE_SYNC_STATUS_DOCUMENT_URI = 'status://drive-sync'
 export const VERSION_INFO_DOCUMENT_URI = 'app://version'
 export const RUNNER_STATUS_DOCUMENT_URI = 'status://runners'
+const RUNNER_KERNELS_DOCUMENT_PREFIX = `${RUNNER_STATUS_DOCUMENT_URI}/`
+const RUNNER_KERNELS_DOCUMENT_SUFFIX = '/kernels'
 export const APP_CONSOLE_DOCUMENT_URI = 'app://console'
 export const LOGS_DOCUMENT_URI = 'app://logs'
 
@@ -66,6 +68,43 @@ export function isRunnerStatusUri(uri: string | null | undefined): boolean {
   return uri === RUNNER_STATUS_DOCUMENT_URI
 }
 
+export function getRunnerKernelsDocumentUri(runnerName: string): string {
+  const normalizedRunnerName = runnerName.trim()
+  if (!normalizedRunnerName) {
+    throw new Error('Runner name is required.')
+  }
+  return `${RUNNER_KERNELS_DOCUMENT_PREFIX}${encodeURIComponent(normalizedRunnerName)}${RUNNER_KERNELS_DOCUMENT_SUFFIX}`
+}
+
+export function parseRunnerKernelsDocumentUri(
+  uri: string | null | undefined
+): { runnerName: string } | null {
+  if (
+    typeof uri !== 'string' ||
+    !uri.startsWith(RUNNER_KERNELS_DOCUMENT_PREFIX) ||
+    !uri.endsWith(RUNNER_KERNELS_DOCUMENT_SUFFIX)
+  ) {
+    return null
+  }
+  const encodedRunnerName = uri.slice(
+    RUNNER_KERNELS_DOCUMENT_PREFIX.length,
+    -RUNNER_KERNELS_DOCUMENT_SUFFIX.length
+  )
+  if (!encodedRunnerName || encodedRunnerName.includes('/')) {
+    return null
+  }
+  try {
+    const runnerName = decodeURIComponent(encodedRunnerName).trim()
+    return runnerName ? { runnerName } : null
+  } catch {
+    return null
+  }
+}
+
+export function isRunnerKernelsUri(uri: string | null | undefined): boolean {
+  return parseRunnerKernelsDocumentUri(uri) !== null
+}
+
 export function isAppConsoleUri(uri: string | null | undefined): boolean {
   return uri === APP_CONSOLE_DOCUMENT_URI
 }
@@ -107,6 +146,10 @@ export function deriveWorkspaceDocumentTitle(uri: string): string {
   }
   if (isRunnerStatusUri(documentUri)) {
     return 'Notebook Runner Status'
+  }
+  const runnerKernels = parseRunnerKernelsDocumentUri(documentUri)
+  if (runnerKernels) {
+    return `Kernels · ${runnerKernels.runnerName}`
   }
   if (isAppConsoleUri(documentUri)) {
     return 'App Console'

--- a/docs/10-jupyter-runners.md
+++ b/docs/10-jupyter-runners.md
@@ -44,6 +44,9 @@ jupyter.kernels.stop('default', 'kernelIdOrName')
 - stdout and errors may be translated from Jupyter protocol messages,
 - the kernel dropdown lists live kernels from each configured runner,
 - starting a kernel immediately refreshes the dropdown cache,
+- Notebook Runner Status includes a **Manage kernels** action for each available
+  runner. The resulting tab shows kernel IDs, state, connection count, and last
+  activity, and provides start, restart, stop, and refresh controls,
 - kernel lifecycle matters separately from notebook tabs,
 - misconfiguration can look like execution failure even when the UI itself is healthy.
 

--- a/docs/10-jupyter-runners.md
+++ b/docs/10-jupyter-runners.md
@@ -40,9 +40,13 @@ an isolated stateful session even when both kernels use the same spec.
    when that runner does not have an endpoint.
 3. Use the runner-scoped kernel tab to inspect kernel name, full kernel ID,
    execution state, active connection count, and last activity.
-4. Enter an allowlisted kernel spec, normally `python3`, and optionally a
-   display name. Select **Start kernel**.
-5. Use **Refresh** when another client or process may have changed the runner's
+4. Enter the kernel command as a JSON `argv` array. The default launches
+   `python3`; replace its first element with a virtual-environment interpreter,
+   such as `/workspace/.venv/bin/python`. Paths are resolved on the runner
+   host. Keep exactly one `{connection_file}` placeholder.
+5. Enter a kernel name and, optionally, a browser-local display name. Select
+   **Start kernel**.
+6. Use **Refresh** when another client or process may have changed the runner's
    kernels.
 
 The lifecycle controls have these effects:
@@ -75,6 +79,13 @@ kernel-management tab or App Console.
 const analysis = await jupyter.kernels.start('default', {
   kernelSpec: 'python3',
   name: 'analysis',
+  argv: [
+    '/workspace/.venv/bin/python',
+    '-m',
+    'ipykernel_launcher',
+    '-f',
+    '{connection_file}',
+  ],
 })
 jupyter.kernels.get('default')
 jupyter.kernels.interrupt('default', analysis.id)
@@ -90,7 +101,8 @@ attached correctly.
 
 - Python notebooks,
 - notebook kernels that need Jupyter semantics,
-- environments exposed by an allowlisted kernel profile on the Runme runner.
+- Python virtual environments and other Jupyter kernels installed on the Runme
+  runner.
 
 ## User-visible behavior
 
@@ -117,11 +129,34 @@ WS     /v1/jupyter/kernels/{kernel_id}/channels
 These routes manage Runme-owned kernels directly. The old
 `/v1/jupyter/servers/...` registry and proxy routes are not part of this model.
 
+Kernel creation uses the Jupyter kernelspec `argv` convention:
+
+```json
+{
+  "name": "project-venv",
+  "argv": [
+    "/workspace/.venv/bin/python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ]
+}
+```
+
+The server validates the array, replaces the single `{connection_file}`
+placeholder with an owner-only file, and starts the executable directly without
+a shell. Restart reuses the stored launch specification. The command is not
+returned in kernel models or written to lifecycle logs.
+
 ## Key facts
 
 - A valid backend runner is required because it owns the kernel processes and
   performs WebSocket-to-ZeroMQ bridging.
 - The web app authenticates kernel HTTP requests with the current OIDC ID token.
+- `RunnerUserRole` authorizes starting client-specified kernel processes as the
+  runner's operating-system user. Treat that role as host code-execution
+  permission.
 - The initial channels implementation supports Jupyter's JSON WebSocket
   messages. Binary buffers and the `v1.kernel.websocket.jupyter.org`
   subprotocol are rejected explicitly until binary protocol support is added.

--- a/docs/10-jupyter-runners.md
+++ b/docs/10-jupyter-runners.md
@@ -4,9 +4,9 @@ title: Jupyter Runners
 order: 10
 description: >-
   Use this guide when notebook cells must execute through a Jupyter kernel. It
-  covers Runme's direct kernel lifecycle helpers, selection guidance, and
-  user-visible behavior. Use the AppKernel guide for browser JavaScript and the
-  local Runme guide for WebSocket backend execution.
+  covers Runme's kernel-management UI, direct lifecycle helpers, kernel
+  selection, runner scoping, and troubleshooting. Use the AppKernel guide for
+  browser JavaScript and the local Runme guide for WebSocket backend execution.
 ---
 
 # Jupyter Runners
@@ -23,15 +23,68 @@ The app treats Jupyter as a runner-backed execution family. Each runner exposes
 its own kernel collection at `/v1/jupyter/kernels`, and kernel IDs are scoped to
 that runner.
 
+A kernel is identified by the pair `(runner name, kernel ID)`. The backend
+assigns the kernel ID when it starts the process. Display names are optional,
+browser-local aliases that make otherwise identical kernel specs easier to tell
+apart; they are not substitutes for the kernel ID.
+
+Multiple notebook cells can select the same kernel and share its variables,
+imports, working state, and execution history. Starting another kernel creates
+an isolated stateful session even when both kernels use the same spec.
+
+## Manage kernels in the UI
+
+1. Open **Notebook Runner Status** from the runner status button in the app
+   toolbar.
+2. Find the target runner and select **Manage kernels**. The action is disabled
+   when that runner does not have an endpoint.
+3. Use the runner-scoped kernel tab to inspect kernel name, full kernel ID,
+   execution state, active connection count, and last activity.
+4. Enter an allowlisted kernel spec, normally `python3`, and optionally a
+   display name. Select **Start kernel**.
+5. Use **Refresh** when another client or process may have changed the runner's
+   kernels.
+
+The lifecycle controls have these effects:
+
+- **Restart** replaces the underlying kernel process while preserving its
+  logical kernel ID. In-memory state is lost, but cells that selected that ID
+  remain associated with the restarted kernel.
+- **Stop** terminates the kernel and removes its ID from the runner. Cells that
+  selected it must choose a running kernel before executing again.
+- **Interrupt** cancels current kernel work without discarding kernel state. It
+  is invoked automatically by notebook interruption and is also available
+  through the App Console helper.
+
+## Select a kernel for a cell
+
+1. Set the cell language to **Jupyter**.
+2. Choose a kernel from the kernel dropdown. The app lists kernels from all
+   configured runners and stores both the runner name and kernel ID in cell
+   metadata.
+3. Reuse the same selection on multiple cells when they should share state, or
+   select different kernel IDs for isolation.
+
+If exactly one kernel is available, Runme selects it automatically. When
+multiple kernels use the same spec, give them distinct display names in the
+kernel-management tab or App Console.
+
 ## Useful App Console commands
 
 ```js
-jupyter.kernels.start('default', { kernelSpec: 'python3' })
+const analysis = await jupyter.kernels.start('default', {
+  kernelSpec: 'python3',
+  name: 'analysis',
+})
 jupyter.kernels.get('default')
-jupyter.kernels.interrupt('default', 'kernelId')
-jupyter.kernels.restart('default', 'kernelId')
-jupyter.kernels.stop('default', 'kernelIdOrName')
+jupyter.kernels.interrupt('default', analysis.id)
+jupyter.kernels.restart('default', analysis.id)
+jupyter.kernels.stop('default', analysis.id)
 ```
+
+The helpers send authenticated requests through the configured runner. Prefer
+them over raw `fetch` calls from notebook cells so the current OIDC token is
+attached correctly.
 
 ## When to use Jupyter
 
@@ -44,16 +97,33 @@ jupyter.kernels.stop('default', 'kernelIdOrName')
 - stdout and errors may be translated from Jupyter protocol messages,
 - the kernel dropdown lists live kernels from each configured runner,
 - starting a kernel immediately refreshes the dropdown cache,
-- Notebook Runner Status includes a **Manage kernels** action for each available
-  runner. The resulting tab shows kernel IDs, state, connection count, and last
-  activity, and provides start, restart, stop, and refresh controls,
 - kernel lifecycle matters separately from notebook tabs,
 - misconfiguration can look like execution failure even when the UI itself is healthy.
+
+## Direct runner API
+
+Runme Web uses the following authenticated endpoints on each runner:
+
+```text
+POST   /v1/jupyter/kernels
+GET    /v1/jupyter/kernels
+GET    /v1/jupyter/kernels/{kernel_id}
+DELETE /v1/jupyter/kernels/{kernel_id}
+POST   /v1/jupyter/kernels/{kernel_id}/interrupt
+POST   /v1/jupyter/kernels/{kernel_id}/restart
+WS     /v1/jupyter/kernels/{kernel_id}/channels
+```
+
+These routes manage Runme-owned kernels directly. The old
+`/v1/jupyter/servers/...` registry and proxy routes are not part of this model.
 
 ## Key facts
 
 - A valid backend runner is required because it owns the kernel processes and
   performs WebSocket-to-ZeroMQ bridging.
 - The web app authenticates kernel HTTP requests with the current OIDC ID token.
+- The initial channels implementation supports Jupyter's JSON WebSocket
+  messages. Binary buffers and the `v1.kernel.websocket.jupyter.org`
+  subprotocol are rejected explicitly until binary protocol support is added.
 - If the user says "Jupyter does not run," verify the runner endpoint and the
   direct kernel state; there is no separate Jupyter Server registry to inspect.

--- a/docs/10-jupyter-runners.md
+++ b/docs/10-jupyter-runners.md
@@ -3,49 +3,54 @@ name: jupyter-runners
 title: Jupyter Runners
 order: 10
 description: >-
-  Use this guide when notebook cells must execute through a Jupyter server and
-  kernel. It covers Jupyter's relationship to Runme runners, server and kernel
-  lifecycle helpers, configuration, selection guidance, and user-visible
-  behavior. Use the AppKernel guide for browser JavaScript and the local Runme
-  guide for WebSocket backend execution.
+  Use this guide when notebook cells must execute through a Jupyter kernel. It
+  covers Runme's direct kernel lifecycle helpers, selection guidance, and
+  user-visible behavior. Use the AppKernel guide for browser JavaScript and the
+  local Runme guide for WebSocket backend execution.
 ---
 
 # Jupyter Runners
 
 ## Purpose
 
-Jupyter integration lets the web app execute cells through a Jupyter server and
-kernel via the Runme proxy path.
+Jupyter integration lets the web app execute cells through kernels owned by the
+configured Runme runner. Runme bridges the browser channels WebSocket directly
+to the kernel's ZeroMQ channels; a separate Jupyter Server is not required.
 
 ## Practical model
 
-The app treats Jupyter as a runner-backed execution family, but kernel lifecycle
-is managed separately from normal backend runner configuration.
+The app treats Jupyter as a runner-backed execution family. Each runner exposes
+its own kernel collection at `/v1/jupyter/kernels`, and kernel IDs are scoped to
+that runner.
 
 ## Useful App Console commands
 
 ```js
-jupyter.servers.get('default')
-jupyter.kernels.start('default', 'serverName', { kernelSpec: 'python3' })
-jupyter.kernels.get('default', 'serverName')
-jupyter.kernels.stop('default', 'serverName', 'kernelIdOrName')
+jupyter.kernels.start('default', { kernelSpec: 'python3' })
+jupyter.kernels.get('default')
+jupyter.kernels.interrupt('default', 'kernelId')
+jupyter.kernels.restart('default', 'kernelId')
+jupyter.kernels.stop('default', 'kernelIdOrName')
 ```
 
 ## When to use Jupyter
 
 - Python notebooks,
 - notebook kernels that need Jupyter semantics,
-- environments already managed by a Jupyter server.
+- environments exposed by an allowlisted kernel profile on the Runme runner.
 
 ## User-visible behavior
 
 - stdout and errors may be translated from Jupyter protocol messages,
+- the kernel dropdown lists live kernels from each configured runner,
+- starting a kernel immediately refreshes the dropdown cache,
 - kernel lifecycle matters separately from notebook tabs,
 - misconfiguration can look like execution failure even when the UI itself is healthy.
 
 ## Key facts
 
-- A valid backend runner is usually still part of the setup story because the
-  Runme proxy sits between the web app and Jupyter.
-- If the user says "Jupyter does not run," verify both the runner endpoint and
-  the Jupyter server/kernel state.
+- A valid backend runner is required because it owns the kernel processes and
+  performs WebSocket-to-ZeroMQ bridging.
+- The web app authenticates kernel HTTP requests with the current OIDC ID token.
+- If the user says "Jupyter does not run," verify the runner endpoint and the
+  direct kernel state; there is no separate Jupyter Server registry to inspect.


### PR DESCRIPTION
## Summary

- migrate Runme Web from the Jupyter Server registry/proxy API to runner-owned `/v1/jupyter/kernels` routes
- attach the current OIDC ID token to kernel lifecycle requests and authenticated channels WebSockets
- let the client send a Jupyter kernelspec-style `argv` when starting a kernel, including a virtual-environment Python path
- validate kernel commands in the start UI as JSON argv with exactly one `{connection_file}` placeholder
- list and select kernels by `(runner name, kernel ID)`, while preserving optional browser-local display names
- add a **Kernels** column to Notebook Runner Status and a runner-scoped management tab with refresh, start, restart, and stop controls
- document kernel identity, client-supplied commands, `RunnerUserRole` authorization, lifecycle behavior, direct routes, and current JSON-channels limitations

## Why

The previous web integration assumed a separately managed Jupyter Server and proxy routes. Runme now owns kernel processes and bridges browser WebSockets directly to kernel ZeroMQ channels, so the web app uses the direct lifecycle API and authenticates those requests itself.

Kernel commands belong to the client rather than runner configuration. A user can select a virtual environment by changing the executable in the launch argv, for example `/workspace/.venv/bin/python`, without restarting or reconfiguring the Runme server.

## Server dependency

Depends on draft server PR [runmedev/runme#1280](https://github.com/runmedev/runme/pull/1280), which replaces the Jupyter Server proxy with the direct kernel API and authorizes client-supplied launches with `RunnerUserRole`.

## User impact

- Jupyter cells can select live kernels from configured runners without a Jupyter Server registry.
- Users can launch `ipykernel` from a specific Python virtual environment on the runner host.
- Multiple kernels are distinguished by runner and kernel ID; optional display names improve readability.
- Users can manage kernels from Notebook Runner Status and share one kernel across cells when state should persist.

## Validation

- `runme run build test`
- focused Vitest coverage for the direct Jupyter manager and kernel-management UI
- `pnpm -C app run check:documentation`
- live authenticated browser verification from the original direct-kernel rollout: list, start, restart, execute against, and stop runner-owned kernels
