### PR TITLE
Preserve canonical notebook cell identities

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -147,11 +147,13 @@ jobs:
           sudo apt-get install -y ffmpeg
           ffmpeg -version
 
-      - name: Checkout Runme (main)
+      - name: Checkout Runme (direct Jupyter bridge)
         uses: actions/checkout@v4
         with:
           repository: runmedev/runme
-          ref: main
+          # The Web client uses the direct /v1/jupyter/kernels API from
+          # runmedev/runme#1280. Return this to main after that PR merges.
+          ref: refs/pull/1280/head
           path: runme-src
           fetch-depth: 1
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -1999,13 +1999,23 @@ function NotebookTabContent({
     })
     return labels
   }, [cellDatas])
+  const commentCellIdentities = useMemo(
+    () =>
+      cellDatas.flatMap((cellData) => {
+        const cell = cellData.snapshot
+        return cell?.refId
+          ? [{ refId: cell.refId, metadata: cell.metadata }]
+          : []
+      }),
+    [cellDatas]
+  )
   const commentsByCell = useMemo(
-    () => groupCommentsByCell(comments),
-    [comments]
+    () => groupCommentsByCell(comments, commentCellIdentities),
+    [commentCellIdentities, comments]
   )
   const commentThreads = useMemo(
-    () => toCellCommentThreads(comments, new Set(cellLabels.keys())),
-    [cellLabels, comments]
+    () => toCellCommentThreads(comments, commentCellIdentities),
+    [commentCellIdentities, comments]
   )
 
   const findCellElement = useCallback((cellId: string) => {

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -258,6 +258,20 @@ describe('NotebookCommentsPanel', () => {
 
     expect(onSelectCell).not.toHaveBeenCalled()
   })
+
+  it('surfaces ambiguous legacy comment anchors without selecting a cell', () => {
+    const onSelectCell = vi.fn()
+    const ambiguous = thread('ambiguous comment', 'legacy-cell', {
+      id: 'comment-ambiguous',
+    })
+    ambiguous.ambiguous = true
+
+    renderPanel({ threads: [ambiguous], onSelectCell })
+
+    expect(screen.getByText('Ambiguous cell')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Cell' })).toBeNull()
+    expect(onSelectCell).not.toHaveBeenCalled()
+  })
 })
 
 function thread(
@@ -268,6 +282,7 @@ function thread(
   return {
     cellId,
     orphaned: false,
+    ambiguous: false,
     comment: {
       id: overrides.id,
       content,

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -9,6 +9,7 @@ type CommentsPanelItem = {
   key: string
   cellId: string | null
   orphaned: boolean
+  ambiguous: boolean
   threads: CellCommentThread[]
   draftCellId?: string
 }
@@ -72,7 +73,8 @@ export function NotebookCommentsPanel({
       return null
     }
     const activeItem = panelItems.find(
-      (item) => item.cellId === activeCellId && !item.orphaned
+      (item) =>
+        item.cellId === activeCellId && !item.orphaned && !item.ambiguous
     )
     return activeItem?.key ?? null
   }, [activeCellId, panelItems])
@@ -101,7 +103,8 @@ export function NotebookCommentsPanel({
     }
     const targetCommentId = findReplyTargetCommentId(
       sortedThreads.filter(
-        (thread) => thread.cellId === draftCellId && !thread.orphaned
+        (thread) =>
+          thread.cellId === draftCellId && !thread.orphaned && !thread.ambiguous
       )
     )
     const submit = targetCommentId
@@ -118,7 +121,7 @@ export function NotebookCommentsPanel({
     const targetCommentId = findReplyTargetCommentId(item.threads)
     const submit = targetCommentId
       ? onReply(targetCommentId, content)
-      : item.cellId && !item.orphaned
+      : item.cellId && !item.orphaned && !item.ambiguous
         ? onCreateComment(item.cellId, content)
         : Promise.resolve()
     void submit.then(() => {
@@ -235,10 +238,14 @@ export function NotebookCommentsPanel({
                 Boolean(
                   activeCellId &&
                     activeCellId === item.cellId &&
-                    !item.orphaned
+                    !item.orphaned &&
+                    !item.ambiguous
                 )
               const isActiveCell = Boolean(
-                activeCellId && item.cellId === activeCellId && !item.orphaned
+                activeCellId &&
+                  item.cellId === activeCellId &&
+                  !item.orphaned &&
+                  !item.ambiguous
               )
               const canEditThread = isActiveThread && !item.draftCellId
               const replyDraft = replyDrafts[item.key] ?? ''
@@ -258,7 +265,7 @@ export function NotebookCommentsPanel({
                   }`}
                   onClick={() => {
                     setActiveThreadKey(item.key)
-                    if (item.cellId && !item.orphaned) {
+                    if (item.cellId && !item.orphaned && !item.ambiguous) {
                       onSelectCell(item.cellId)
                     }
                   }}
@@ -271,7 +278,7 @@ export function NotebookCommentsPanel({
                     }
                     event.preventDefault()
                     setActiveThreadKey(item.key)
-                    if (item.cellId && !item.orphaned) {
+                    if (item.cellId && !item.orphaned && !item.ambiguous) {
                       onSelectCell(item.cellId)
                     }
                   }}
@@ -286,7 +293,7 @@ export function NotebookCommentsPanel({
                       cellLabels={cellLabels}
                       isActiveCell={isActiveCell}
                       onSelectCell={() => {
-                        if (item.cellId && !item.orphaned) {
+                        if (item.cellId && !item.orphaned && !item.ambiguous) {
                           setActiveThreadKey(item.key)
                           onSelectCell(item.cellId)
                         }
@@ -462,7 +469,7 @@ function ThreadLocation({
   isActiveCell: boolean
   onSelectCell: () => void
 }) {
-  if (item.cellId && !item.orphaned) {
+  if (item.cellId && !item.orphaned && !item.ambiguous) {
     return (
       <button
         type="button"
@@ -480,11 +487,16 @@ function ThreadLocation({
       </button>
     )
   }
-  if (item.cellId && item.orphaned) {
+  if (item.cellId && item.ambiguous) {
     return (
       <div className="text-xs font-medium text-nb-text-faint">
-        Deleted cell
+        Ambiguous cell
       </div>
+    )
+  }
+  if (item.cellId && item.orphaned) {
+    return (
+      <div className="text-xs font-medium text-nb-text-faint">Deleted cell</div>
     )
   }
   return (
@@ -602,7 +614,7 @@ function sortCommentPanelItems(
   const itemsByCell = new Map<string, CommentsPanelItem>()
 
   sortedThreads.forEach((thread) => {
-    if (thread.cellId && !thread.orphaned) {
+    if (thread.cellId && !thread.orphaned && !thread.ambiguous) {
       const key = getCellThreadKey(thread.cellId)
       let item = itemsByCell.get(key)
       if (!item) {
@@ -611,6 +623,7 @@ function sortCommentPanelItems(
           key,
           cellId: thread.cellId,
           orphaned: false,
+          ambiguous: false,
           threads: [],
         }
         itemsByCell.set(key, item)
@@ -625,6 +638,7 @@ function sortCommentPanelItems(
       key: `thread:${getThreadKey(thread)}`,
       cellId: thread.cellId,
       orphaned: thread.orphaned,
+      ambiguous: thread.ambiguous,
       threads: [thread],
     })
   })
@@ -646,11 +660,12 @@ function sortCommentPanelItems(
     key: draftKey,
     cellId: draftCellId,
     orphaned: false,
+    ambiguous: false,
     threads: [],
     draftCellId,
   }
   const insertionIndex = items.findIndex((item) => {
-    if (!item.cellId || item.orphaned) {
+    if (!item.cellId || item.orphaned || item.ambiguous) {
       return true
     }
     return cellIndex(cellLabels, item.cellId) > draftIndex
@@ -667,13 +682,16 @@ function sortCommentPanelItems(
 }
 
 function threadGroup(thread: CellCommentThread): number {
-  if (thread.cellId && !thread.orphaned) {
+  if (thread.cellId && !thread.orphaned && !thread.ambiguous) {
     return 0
   }
-  if (thread.orphaned) {
+  if (thread.ambiguous) {
     return 1
   }
-  return 2
+  if (thread.orphaned) {
+    return 2
+  }
+  return 3
 }
 
 function cellIndex(cellLabels: Map<string, string>, cellId: string): number {

--- a/app/src/lib/cellIdentity.test.ts
+++ b/app/src/lib/cellIdentity.test.ts
@@ -1,0 +1,113 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import { parser_pb } from '../runme/client'
+import {
+  LEGACY_CELL_REF_IDS_METADATA_KEY,
+  assertCanonicalNotebookCellIds,
+  migrateNotebookCellIds,
+} from './cellIdentity'
+
+describe('cell identity', () => {
+  it('migrates invalid and duplicate legacy ids deterministically', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, { refId: 'invalid id' }),
+        create(parser_pb.CellSchema, { refId: 'invalid id' }),
+        create(parser_pb.CellSchema, { refId: '' }),
+      ],
+    })
+
+    migrateNotebookCellIds(notebook)
+
+    expect(notebook.cells.map((cell) => cell.refId)).toEqual([
+      'invalid-id',
+      'invalid-id-2',
+      'cell-3',
+    ])
+    expect(notebook.cells[0]?.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY]).toBe(
+      '["invalid id"]'
+    )
+    expect(notebook.cells[1]?.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY]).toBe(
+      '["invalid id"]'
+    )
+    expect(migrateNotebookCellIds(notebook).changed).toBe(false)
+  })
+
+  it('uses old IPYNB preservation mappings without persisting a prefix alias', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [create(parser_pb.CellSchema, { refId: 'markup_intro' })],
+    })
+
+    migrateNotebookCellIds(notebook, { markup_intro: 'intro' })
+
+    expect(notebook.cells[0]?.refId).toBe('intro')
+    expect(
+      notebook.cells[0]?.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY]
+    ).toBeUndefined()
+  })
+
+  it('promotes a legacy metadata id to the canonical refId', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          metadata: { 'runme.dev/id': 'legacy-id' },
+        }),
+      ],
+    })
+
+    migrateNotebookCellIds(notebook)
+
+    expect(notebook.cells[0]?.refId).toBe('legacy-id')
+  })
+
+  it('removes the obsolete internal IPYNB id copy', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'canonical-id',
+          metadata: { 'runme.dev/ipynbCellId': 'canonical-id' },
+        }),
+      ],
+    })
+
+    migrateNotebookCellIds(notebook)
+
+    expect(notebook.cells[0]?.metadata['runme.dev/ipynbCellId']).toBeUndefined()
+  })
+
+  it('uses an obsolete internal IPYNB id copy to migrate a prefixed refId', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'code_source-id',
+          metadata: { 'runme.dev/ipynbCellId': 'source-id' },
+        }),
+      ],
+    })
+
+    migrateNotebookCellIds(notebook)
+
+    expect(notebook.cells[0]?.refId).toBe('source-id')
+    expect(notebook.cells[0]?.metadata['runme.dev/ipynbCellId']).toBeUndefined()
+  })
+
+  it('rejects invalid or duplicate canonical ids before IPYNB encoding', () => {
+    const invalid = create(parser_pb.NotebookSchema, {
+      cells: [create(parser_pb.CellSchema, { refId: 'invalid id' })],
+    })
+    expect(() => assertCanonicalNotebookCellIds(invalid)).toThrow(
+      'invalid canonical refId'
+    )
+
+    const duplicate = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, { refId: 'same' }),
+        create(parser_pb.CellSchema, { refId: 'same' }),
+      ],
+    })
+    expect(() => assertCanonicalNotebookCellIds(duplicate)).toThrow(
+      'Duplicate canonical cell refId: same'
+    )
+  })
+})

--- a/app/src/lib/cellIdentity.ts
+++ b/app/src/lib/cellIdentity.ts
@@ -1,0 +1,132 @@
+import type { parser_pb } from '../runme/client'
+
+export const LEGACY_CELL_REF_IDS_METADATA_KEY = 'runme.dev/legacyCellRefIds'
+export const LEGACY_IPYNB_CELL_ID_METADATA_KEY = 'runme.dev/ipynbCellId'
+
+const CELL_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
+
+export type CellIdentityMigration = {
+  changed: boolean
+}
+
+export function isCanonicalCellId(value: unknown): value is string {
+  return typeof value === 'string' && CELL_ID_PATTERN.test(value)
+}
+
+export function uniqueCanonicalCellId(
+  value: unknown,
+  index: number,
+  used: Set<string>
+): string {
+  const fallback = `cell-${index + 1}`
+  const base = legalCellId(value, fallback)
+  let candidate = base
+  let suffix = 2
+  while (used.has(candidate)) {
+    const tail = `-${suffix++}`
+    candidate = `${base.slice(0, 64 - tail.length)}${tail}`
+  }
+  used.add(candidate)
+  return candidate
+}
+
+export function legacyCellRefIds(
+  metadata: Record<string, string> | undefined
+): string[] {
+  const value = metadata?.[LEGACY_CELL_REF_IDS_METADATA_KEY]
+  if (!value) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (candidate): candidate is string =>
+            typeof candidate === 'string' && candidate.length > 0
+        )
+      : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Migrates legacy notebook identities in place. `preferredIdsByRefId` is used
+ * when an older IPYNB preservation record still maps a kind-prefixed Runme ID
+ * to the canonical Jupyter cell ID.
+ */
+export function migrateNotebookCellIds(
+  notebook: parser_pb.Notebook,
+  preferredIdsByRefId: Record<string, string> = {}
+): CellIdentityMigration {
+  const used = new Set<string>()
+  let changed = false
+
+  notebook.cells.forEach((cell, index) => {
+    const legacyIpynbId = cell.metadata[LEGACY_IPYNB_CELL_ID_METADATA_KEY]
+    if (LEGACY_IPYNB_CELL_ID_METADATA_KEY in cell.metadata) {
+      delete cell.metadata[LEGACY_IPYNB_CELL_ID_METADATA_KEY]
+      changed = true
+    }
+    const current = cell.refId
+    const legacyMetadataId = cell.metadata['runme.dev/id']
+    const original =
+      current ||
+      (typeof legacyMetadataId === 'string' ? legacyMetadataId.trim() : '')
+    const metadataIpynbId =
+      typeof legacyIpynbId === 'string' &&
+      (current === `code_${legacyIpynbId}` ||
+        current === `markup_${legacyIpynbId}`)
+        ? legacyIpynbId
+        : undefined
+    const preferred =
+      preferredIdsByRefId[current] ?? metadataIpynbId ?? original
+    const canonical = uniqueCanonicalCellId(preferred, index, used)
+
+    if (canonical === current) {
+      return
+    }
+
+    changed = true
+    cell.refId = canonical
+    if (original && original !== canonical) {
+      // Kind-prefixed IPYNB identities are recoverable from the canonical ID
+      // and should not become permanent per-cell metadata. Other legacy IDs
+      // need an explicit alias so Drive comments can continue to resolve.
+      if (preferred === original) {
+        const aliases = new Set([...legacyCellRefIds(cell.metadata), original])
+        aliases.delete(canonical)
+        cell.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY] = JSON.stringify([
+          ...aliases,
+        ])
+      }
+    }
+  })
+
+  return { changed }
+}
+
+export function assertCanonicalNotebookCellIds(
+  notebook: parser_pb.Notebook
+): void {
+  const used = new Set<string>()
+  notebook.cells.forEach((cell, index) => {
+    if (!isCanonicalCellId(cell.refId)) {
+      throw new Error(
+        `Cell ${index + 1} has an invalid canonical refId: ${JSON.stringify(cell.refId)}`
+      )
+    }
+    if (used.has(cell.refId)) {
+      throw new Error(`Duplicate canonical cell refId: ${cell.refId}`)
+    }
+    used.add(cell.refId)
+  })
+}
+
+function legalCellId(value: unknown, fallback: string): string {
+  const candidate =
+    typeof value === 'string'
+      ? value.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 64)
+      : ''
+  return candidate || fallback.slice(0, 64)
+}

--- a/app/src/lib/ipynb.test.ts
+++ b/app/src/lib/ipynb.test.ts
@@ -3,7 +3,6 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  IPYNB_CELL_ID_METADATA_KEY,
   IPYNB_RAW_CELL_METADATA_KEY,
   decodeIpynb,
   encodeIpynb,
@@ -67,13 +66,18 @@ describe('ipynb codec', () => {
     const decoded = decodeIpynb(text)
 
     expect(decoded.notebook.cells).toHaveLength(3)
+    expect(decoded.notebook.cells.map((cell) => cell.refId)).toEqual([
+      'intro',
+      'raw-cell',
+      'code-cell',
+    ])
     expect(decoded.notebook.cells[0]?.value).toBe('# Hello\nworld')
     expect(
       decoded.notebook.cells[1]?.metadata?.[IPYNB_RAW_CELL_METADATA_KEY]
     ).toBe('true')
     expect(
-      decoded.notebook.cells[2]?.metadata?.[IPYNB_CELL_ID_METADATA_KEY]
-    ).toBe('code-cell')
+      decoded.notebook.cells[2]?.metadata?.['runme.dev/ipynbCellId']
+    ).toBeUndefined()
     expect(decoded.notebook.cells[2]?.outputs).toHaveLength(2)
 
     decoded.notebook.cells[2]!.value = 'print("edited")\n'
@@ -95,6 +99,11 @@ describe('ipynb codec', () => {
       sourceNotebook.cells[2].outputs
     )
     expect(roundTripped.metadata).toMatchObject(sourceNotebook.metadata)
+    expect(roundTripped.cells[2].id).toBe('code-cell')
+    expect(roundTripped.cells[2].metadata.runme.cell.refId).toBeUndefined()
+    expect(
+      decodeIpynb(encoded.text).notebook.cells.map((cell) => cell.refId)
+    ).toEqual(['intro', 'raw-cell', 'code-cell'])
   })
 
   it('repairs duplicate and invalid cell ids without losing cell metadata', () => {
@@ -113,8 +122,34 @@ describe('ipynb codec', () => {
     )
 
     expect(ids).toEqual(['invalid-id', 'invalid-id-2', 'code-cell'])
+    expect(decoded.notebook.cells.map((cell) => cell.refId)).toEqual(ids)
     expect(JSON.parse(encoded.text).cells[0].metadata).toMatchObject(
       sourceNotebook.cells[0].metadata
+    )
+  })
+
+  it('preserves identity when a cell changes kind', () => {
+    const decoded = decodeIpynb(JSON.stringify(sourceNotebook))
+    decoded.notebook.cells[0]!.kind = decoded.notebook.cells[2]!.kind
+
+    const encoded = encodeIpynb(
+      decoded.notebook,
+      JSON.stringify(sourceNotebook),
+      decoded
+    )
+    const cell = JSON.parse(encoded.text).cells[0]
+
+    expect(cell.cell_type).toBe('code')
+    expect(cell.id).toBe('intro')
+    expect(decodeIpynb(encoded.text).notebook.cells[0]?.refId).toBe('intro')
+  })
+
+  it('rejects non-canonical Runme identities instead of creating aliases', () => {
+    const decoded = decodeIpynb(JSON.stringify(sourceNotebook))
+    decoded.notebook.cells[0]!.refId = 'invalid id'
+
+    expect(() => encodeIpynb(decoded.notebook)).toThrow(
+      'invalid canonical refId'
     )
   })
 

--- a/app/src/lib/ipynb.ts
+++ b/app/src/lib/ipynb.ts
@@ -2,10 +2,14 @@ import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 import md5 from 'md5'
 
 import { MimeType, parser_pb } from '../runme/client'
+import {
+  LEGACY_IPYNB_CELL_ID_METADATA_KEY,
+  assertCanonicalNotebookCellIds,
+  uniqueCanonicalCellId,
+} from './cellIdentity'
 
 export const IPYNB_MIME_TYPE = 'application/x-ipynb+json'
 export const IPYNB_RAW_CELL_METADATA_KEY = 'runme.dev/ipynbRawCell'
-export const IPYNB_CELL_ID_METADATA_KEY = 'runme.dev/ipynbCellId'
 
 const IPYNB_OUTPUT_TYPE = 'runme.dev/ipynbOutputType'
 const IPYNB_OUTPUT_METADATA = 'runme.dev/ipynbOutputMetadata'
@@ -123,7 +127,7 @@ function runmeCellEnvelope(cell: parser_pb.Cell): JsonObject {
   delete json.refId
   const metadata = optionalObject(json.metadata)
   if (metadata) {
-    delete metadata[IPYNB_CELL_ID_METADATA_KEY]
+    delete metadata[LEGACY_IPYNB_CELL_ID_METADATA_KEY]
     delete metadata[IPYNB_RAW_CELL_METADATA_KEY]
     if (Object.keys(metadata).length === 0) {
       delete json.metadata
@@ -158,30 +162,6 @@ function sourceText(source: unknown): string {
     return source.join('')
   }
   throw new Error('Jupyter cell source must be a string or string array')
-}
-
-function legalCellId(value: unknown, fallback: string): string {
-  const candidate =
-    typeof value === 'string'
-      ? value.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 64)
-      : ''
-  return candidate || fallback.slice(0, 64)
-}
-
-function uniqueCellId(
-  value: unknown,
-  index: number,
-  used: Set<string>
-): string {
-  const base = legalCellId(value, `cell-${index + 1}`)
-  let candidate = base
-  let suffix = 2
-  while (used.has(candidate)) {
-    const tail = `-${suffix++}`
-    candidate = `${base.slice(0, 64 - tail.length)}${tail}`
-  }
-  used.add(candidate)
-  return candidate
 }
 
 function languageIdForNotebook(metadata: JsonObject): string {
@@ -422,7 +402,7 @@ export function decodeIpynb(text: string): DecodedIpynb {
       sourceCell.metadata,
       `Jupyter cell ${index} metadata`
     )
-    const id = uniqueCellId(sourceCell.id, index, usedIds)
+    const id = uniqueCanonicalCellId(sourceCell.id, index, usedIds)
     // Treat nbformat cell IDs as repairable input. Keeping the repaired value
     // in the shadow makes the next save both valid and lossless for the rest
     // of the cell object.
@@ -432,11 +412,11 @@ export function decodeIpynb(text: string): DecodedIpynb {
       sourceCell.cell_type === 'code'
         ? parser_pb.CellKind.CODE
         : parser_pb.CellKind.MARKUP
-    const refId = `${kind === parser_pb.CellKind.CODE ? 'code' : 'markup'}_${id}`
+    const refId = id
     const metadata: Record<string, string> = {
       ...(preservedCell?.metadata ?? {}),
-      [IPYNB_CELL_ID_METADATA_KEY]: id,
     }
+    delete metadata[LEGACY_IPYNB_CELL_ID_METADATA_KEY]
     if (sourceCell.cell_type === 'raw') {
       metadata[IPYNB_RAW_CELL_METADATA_KEY] = 'true'
     }
@@ -494,18 +474,12 @@ export function decodeIpynb(text: string): DecodedIpynb {
   }
 }
 
-function newJupyterId(cell: parser_pb.Cell, index: number): string {
-  return legalCellId(
-    cell.metadata?.[IPYNB_CELL_ID_METADATA_KEY] || cell.refId,
-    `cell-${index + 1}`
-  )
-}
-
 export function encodeIpynb(
   notebook: parser_pb.Notebook,
   shadowText?: string,
   previousState?: Partial<IpynbMergeState>
 ): EncodedIpynb {
+  assertCanonicalNotebookCellIds(notebook)
   const shadow = shadowText
     ? validateNotebook(JSON.parse(shadowText))
     : createEmptyIpynb()
@@ -514,21 +488,27 @@ export function encodeIpynb(
       .filter((cell) => typeof cell.id === 'string')
       .map((cell) => [cell.id as string, cell])
   )
-  const usedIds = new Set<string>()
   const jupyterIdByRunmeRefId: Record<string, string> = {}
   const baselineCellHashes: Record<string, string> = {}
   const baselineOutputHashes: Record<string, string> = {}
-
-  const cells = notebook.cells.map((cell, index): IpynbCell => {
-    const mappedId = previousState?.jupyterIdByRunmeRefId?.[cell.refId]
-    const id = uniqueCellId(
-      mappedId ?? newJupyterId(cell, index),
-      index,
-      usedIds
+  const previousRefIdByJupyterId = new Map(
+    Object.entries(previousState?.jupyterIdByRunmeRefId ?? {}).map(
+      ([refId, jupyterId]) => [jupyterId, refId]
     )
-    const matched = mappedId ? sourceById.get(mappedId) : undefined
+  )
+
+  const cells = notebook.cells.map((cell): IpynbCell => {
+    const id = cell.refId
+    const matched = sourceById.get(id)
+    const previousRefId = previousRefIdByJupyterId.get(id)
+    const baselineRefId =
+      previousState?.baselineOutputHashes?.[cell.refId] !== undefined
+        ? cell.refId
+        : previousRefId
     const outputUnchanged =
-      previousState?.baselineOutputHashes?.[cell.refId] === outputHash(cell)
+      (baselineRefId
+        ? previousState?.baselineOutputHashes?.[baselineRefId]
+        : undefined) === outputHash(cell)
     const raw = cell.metadata?.[IPYNB_RAW_CELL_METADATA_KEY] === 'true'
     const cellType: IpynbCell['cell_type'] =
       cell.kind === parser_pb.CellKind.CODE ? 'code' : raw ? 'raw' : 'markdown'

--- a/app/src/lib/markdownImport.test.ts
+++ b/app/src/lib/markdownImport.test.ts
@@ -49,6 +49,7 @@ describe("deserializeMarkdownToNotebook", () => {
     expect(notebook.cells).toHaveLength(1);
     expect(notebook.cells[0]?.kind).toBe(parser_pb.CellKind.MARKUP);
     expect(notebook.cells[0]?.value).toBe("# Title\ncontent");
+    expect(notebook.cells[0]?.refId).toMatch(/^[0-9a-f]{32}$/);
   });
 
   it("returns parser output when deserialization succeeds", async () => {

--- a/app/src/lib/markdownImport.ts
+++ b/app/src/lib/markdownImport.ts
@@ -45,7 +45,7 @@ function createSingleMarkupCellNotebook(markdownText: string): parser_pb.Noteboo
         kind: parser_pb.CellKind.MARKUP,
         role: parser_pb.CellRole.USER,
         languageId: "markdown",
-        refId: `markup_${crypto.randomUUID().replace(/-/g, "")}`,
+        refId: crypto.randomUUID().replace(/-/g, ""),
         value: markdownText,
         metadata: {},
       }),

--- a/app/src/lib/notebookComments.test.ts
+++ b/app/src/lib/notebookComments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { LEGACY_CELL_REF_IDS_METADATA_KEY } from './cellIdentity'
 import {
   createCellCommentAnchor,
   groupCommentsByCell,
@@ -14,8 +15,9 @@ describe('notebook comment anchors', () => {
     expect(parseCellCommentAnchor(anchor)).toEqual({
       type: 'cell',
       cellId: 'cell-123',
-      cellIdKind: 'runme-ref-id',
+      version: 2,
     })
+    expect(JSON.parse(anchor).runme).not.toHaveProperty('cellIdKind')
   })
 
   it('parses legacy cell anchors written by earlier local builds', () => {
@@ -28,6 +30,7 @@ describe('notebook comment anchors', () => {
     ).toEqual({
       type: 'cell',
       cellId: 'cell-legacy',
+      version: 1,
       cellIdKind: 'runme-ref-id',
     })
   })
@@ -52,7 +55,7 @@ describe('notebook comment anchors', () => {
           content: 'open',
         },
       ],
-      new Set(['cell-2'])
+      [{ refId: 'cell-2' }]
     )
 
     expect(thread).toMatchObject({
@@ -83,5 +86,74 @@ describe('notebook comment anchors', () => {
     expect(grouped.get('cell-1')?.map((comment) => comment.id)).toEqual([
       'comment-1',
     ])
+  })
+
+  it('resolves legacy kind-prefixed anchors to canonical cell ids', () => {
+    const comments = [
+      {
+        id: 'legacy-comment',
+        anchor: JSON.stringify({
+          runme: {
+            version: 1,
+            type: 'cell',
+            cellId: 'markup_intro',
+            cellIdKind: 'runme-ref-id',
+          },
+        }),
+        content: 'legacy',
+      },
+    ]
+
+    expect(
+      groupCommentsByCell(comments, [{ refId: 'intro' }]).get('intro')
+    ).toHaveLength(1)
+    expect(
+      toCellCommentThreads(comments, [{ refId: 'intro' }])[0]
+    ).toMatchObject({
+      cellId: 'intro',
+      orphaned: false,
+      ambiguous: false,
+    })
+  })
+
+  it('prefers exact canonical ids over legacy alias interpretations', () => {
+    const comments = [
+      {
+        id: 'exact-comment',
+        anchor: createCellCommentAnchor('markup_intro'),
+        content: 'exact',
+      },
+    ]
+    const cells = [{ refId: 'markup_intro' }, { refId: 'intro' }]
+
+    expect(toCellCommentThreads(comments, cells)[0]).toMatchObject({
+      cellId: 'markup_intro',
+      orphaned: false,
+      ambiguous: false,
+    })
+  })
+
+  it('surfaces ambiguous legacy aliases instead of grouping them', () => {
+    const comments = [
+      {
+        id: 'ambiguous-comment',
+        anchor: createCellCommentAnchor('legacy id'),
+        content: 'ambiguous',
+      },
+    ]
+    const metadata = {
+      [LEGACY_CELL_REF_IDS_METADATA_KEY]: JSON.stringify(['legacy id']),
+    }
+    const cells = [
+      { refId: 'first', metadata },
+      { refId: 'second', metadata },
+    ]
+
+    expect(groupCommentsByCell(comments, cells).size).toBe(0)
+    expect(toCellCommentThreads(comments, cells)[0]).toMatchObject({
+      cellId: 'legacy id',
+      orphaned: false,
+      ambiguous: true,
+    })
   })
 })

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -1,11 +1,18 @@
 import type { DriveComment } from '../storage/drive'
+import { legacyCellRefIds } from './cellIdentity'
 
-const RUNME_COMMENT_ANCHOR_VERSION = 1
+const RUNME_COMMENT_ANCHOR_VERSION = 2
 
 export type CellCommentAnchor = {
   type: 'cell'
   cellId: string
-  cellIdKind: 'runme-ref-id' | 'ipynb-cell-id'
+  version: 1 | 2
+  cellIdKind?: 'runme-ref-id' | 'ipynb-cell-id'
+}
+
+export type CommentCellIdentity = {
+  refId: string
+  metadata?: Record<string, string>
 }
 
 type RunmeCommentAnchorPayload = {
@@ -22,6 +29,13 @@ export type CellCommentThread = {
   comment: DriveComment
   cellId: string | null
   orphaned: boolean
+  ambiguous: boolean
+}
+
+type CellAnchorResolution = {
+  cellId: string
+  orphaned: boolean
+  ambiguous: boolean
 }
 
 export function createCellCommentAnchor(cellId: string): string {
@@ -30,7 +44,6 @@ export function createCellCommentAnchor(cellId: string): string {
       version: RUNME_COMMENT_ANCHOR_VERSION,
       type: 'cell',
       cellId,
-      cellIdKind: 'runme-ref-id',
     },
   })
 }
@@ -44,22 +57,37 @@ export function parseCellCommentAnchor(
 
   try {
     const parsed = JSON.parse(anchor) as RunmeCommentAnchorPayload
-    const anchorType = parsed.runme?.type ?? parsed.runme?.kind
-    const cellIdKind = parsed.runme?.cellIdKind ?? 'runme-ref-id'
+    const version = parsed.runme?.version
+    const anchorType =
+      version === 1
+        ? (parsed.runme?.type ?? parsed.runme?.kind)
+        : parsed.runme?.type
     if (
-      parsed.runme?.version !== RUNME_COMMENT_ANCHOR_VERSION ||
+      (version !== 1 && version !== RUNME_COMMENT_ANCHOR_VERSION) ||
       anchorType !== 'cell' ||
-      typeof parsed.runme.cellId !== 'string' ||
-      !parsed.runme.cellId.trim() ||
-      (cellIdKind !== 'runme-ref-id' && cellIdKind !== 'ipynb-cell-id')
+      typeof parsed.runme?.cellId !== 'string' ||
+      !parsed.runme.cellId.trim()
     ) {
       return null
+    }
+
+    if (version === 1) {
+      const cellIdKind = parsed.runme.cellIdKind ?? 'runme-ref-id'
+      if (cellIdKind !== 'runme-ref-id' && cellIdKind !== 'ipynb-cell-id') {
+        return null
+      }
+      return {
+        type: 'cell',
+        cellId: parsed.runme.cellId,
+        version,
+        cellIdKind,
+      }
     }
 
     return {
       type: 'cell',
       cellId: parsed.runme.cellId,
-      cellIdKind,
+      version,
     }
   } catch {
     return null
@@ -67,8 +95,10 @@ export function parseCellCommentAnchor(
 }
 
 export function groupCommentsByCell(
-  comments: DriveComment[]
+  comments: DriveComment[],
+  cells: Iterable<CommentCellIdentity> = []
 ): Map<string, DriveComment[]> {
+  const identities = [...cells]
   const byCell = new Map<string, DriveComment[]>()
   comments.forEach((comment) => {
     if (comment.deleted || comment.resolved) {
@@ -78,29 +108,78 @@ export function groupCommentsByCell(
     if (!anchor) {
       return
     }
-    const existing = byCell.get(anchor.cellId) ?? []
+    const resolution = resolveCellAnchor(anchor.cellId, identities)
+    if (resolution.orphaned || resolution.ambiguous) {
+      return
+    }
+    const existing = byCell.get(resolution.cellId) ?? []
     existing.push(comment)
-    byCell.set(anchor.cellId, existing)
+    byCell.set(resolution.cellId, existing)
   })
   return byCell
 }
 
 export function toCellCommentThreads(
   comments: DriveComment[],
-  knownCellIds: Set<string> = new Set()
+  cells: Iterable<CommentCellIdentity> = []
 ): CellCommentThread[] {
+  const identities = [...cells]
   return comments
     .filter((comment) => !comment.deleted)
     .map((comment) => {
       const anchor = parseCellCommentAnchor(comment.anchor)
+      if (!anchor) {
+        return {
+          comment,
+          cellId: null,
+          orphaned: false,
+          ambiguous: false,
+        }
+      }
+      const resolution = resolveCellAnchor(anchor.cellId, identities)
       return {
         comment,
-        cellId: anchor?.cellId ?? null,
-        orphaned: Boolean(
-          anchor?.cellId &&
-            knownCellIds.size > 0 &&
-            !knownCellIds.has(anchor.cellId)
-        ),
+        cellId: resolution.cellId,
+        orphaned: resolution.orphaned,
+        ambiguous: resolution.ambiguous,
       }
     })
+}
+
+function resolveCellAnchor(
+  anchoredCellId: string,
+  cells: CommentCellIdentity[]
+): CellAnchorResolution {
+  if (cells.length === 0) {
+    return { cellId: anchoredCellId, orphaned: false, ambiguous: false }
+  }
+
+  const exact = cells.find((cell) => cell.refId === anchoredCellId)
+  if (exact) {
+    return { cellId: exact.refId, orphaned: false, ambiguous: false }
+  }
+
+  const candidates = new Set<string>()
+  for (const cell of cells) {
+    const aliases = [
+      `code_${cell.refId}`,
+      `markup_${cell.refId}`,
+      ...legacyCellRefIds(cell.metadata),
+    ]
+    if (aliases.includes(anchoredCellId)) {
+      candidates.add(cell.refId)
+    }
+  }
+
+  if (candidates.size === 1) {
+    return {
+      cellId: [...candidates][0]!,
+      orphaned: false,
+      ambiguous: false,
+    }
+  }
+  if (candidates.size > 1) {
+    return { cellId: anchoredCellId, orphaned: false, ambiguous: true }
+  }
+  return { cellId: anchoredCellId, orphaned: true, ambiguous: false }
 }

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -560,6 +560,7 @@ describe("NotebookData cell defaults", () => {
 
     expect(cell.languageId).toBe("markdown");
     expect(cell.kind).toBe(parser_pb.CellKind.CODE);
+    expect(cell.refId).toMatch(/^[0-9a-f]{32}$/);
   });
 });
 

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -1149,8 +1149,7 @@ export class NotebookData {
       normalizedLanguage && normalizedLanguage.length > 0
         ? normalizedLanguage
         : 'markdown'
-    const refPrefix = isMarkup ? 'markup' : 'code'
-    const refID = `${refPrefix}_${crypto.randomUUID().replace(/-/g, '')}`
+    const refID = crypto.randomUUID().replace(/-/g, '')
     const now = new Date().toISOString()
     return create(parser_pb.CellSchema, {
       metadata: {

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -1,6 +1,7 @@
 import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 
 import { parser_pb } from '../runme/client'
+import { migrateNotebookCellIds } from './cellIdentity'
 import {
   type DecodedIpynb,
   type EncodedIpynb,
@@ -50,14 +51,13 @@ export function decodeNotebookFile(
     const ipynb = decodeIpynb(text)
     return { format, notebook: ipynb.notebook, ipynb }
   }
-  return {
-    format,
-    notebook: text
-      ? fromJsonString(parser_pb.NotebookSchema, text, {
-          ignoreUnknownFields: true,
-        })
-      : create(parser_pb.NotebookSchema, { cells: [] }),
-  }
+  const notebook = text
+    ? fromJsonString(parser_pb.NotebookSchema, text, {
+        ignoreUnknownFields: true,
+      })
+    : create(parser_pb.NotebookSchema, { cells: [] })
+  migrateNotebookCellIds(notebook)
+  return { format, notebook }
 }
 
 export function encodeRunmeNotebook(notebook: parser_pb.Notebook): string {

--- a/app/src/lib/runtime/aiAgentInstructions.test.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.test.ts
@@ -38,6 +38,12 @@ describe('readInstructionsForAIAgents', () => {
     expect(instructions).toContain('documentation.get(name)')
     expect(instructions).toContain('await app.getSessionID()')
     expect(instructions).toContain('local://')
+    expect(instructions).toContain('opaque canonical identifier')
+    expect(instructions).toContain('IPYNB `cell.id`')
+    expect(instructions).toContain(
+      'Do not infer the cell kind or storage format'
+    )
+    expect(instructions).toContain('reuse the exact `refId`')
     expect(instructions).toContain("kind: 'markup'")
     expect(instructions).toContain('notebooks.requestWriteAccess')
     expect(instructions).toContain('expectedRevision')

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -175,6 +175,13 @@ console.log(JSON.stringify({
 
 If the user's notebook reference is ambiguous, ask which notebook to use before making a change.
 
+## Preserve cell identity
+
+- Treat a cell's \`refId\` as an opaque canonical identifier. Do not infer the cell kind or storage format from prefixes such as \`code_\` or \`markup_\`.
+- Runme JSON \`Cell.refId\` and IPYNB \`cell.id\` are the same identity serialized under format-specific field names.
+- Do not add, remove, or rewrite a cell ID unless the user explicitly requests an identity migration or the notebook API repairs invalid legacy data.
+- When updating or executing cells, reuse the exact \`refId\` returned by \`notebooks.get({ uri })\`.
+
 ## Request write access when needed
 
 If \`doc.summary.readOnly\` is true because another Runme session owns the notebook, request a cooperative takeover before mutating it:

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 
+import { migrateNotebookCellIds } from '../lib/cellIdentity'
 import { IPYNB_MIME_TYPE, type IpynbMergeState } from '../lib/ipynb'
 import {
   createInitialNotebookFile,
@@ -158,29 +159,6 @@ function notebookNameForRename(oldName: string, name: string): string {
     throw new Error(`Unsupported notebook file extension: ${name}`)
   }
   return `${trimmed}${oldFormat === 'ipynb' ? '.ipynb' : '.json'}`
-}
-
-/**
- * Normalizes notebook cells loaded from JSON by ensuring every cell has a
- * stable `refId`. Some fixtures only include the legacy `runme.dev/id` metadata
- * entry, which the UI cannot render without converting to `refId`.
- */
-function ensureCellRefIds(notebook: parser_pb.Notebook): void {
-  for (const cell of notebook.cells ?? []) {
-    if (cell?.refId) {
-      continue;
-    }
-    const metadata = cell.metadata ?? {};
-    const legacyId = metadata["runme.dev/id"];
-    const fallbackId =
-      typeof legacyId === "string" && legacyId.trim().length > 0
-        ? legacyId
-        : `cell_${crypto.randomUUID().replace(/-/g, "")}`;
-    cell.refId = fallbackId;
-    if (!cell.metadata) {
-      cell.metadata = metadata;
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -421,7 +399,6 @@ export class FilesystemNotebookStore {
         state: decoded.ipynb,
       })
     }
-    ensureCellRefIds(notebook)
     return notebook
   }
 
@@ -451,6 +428,7 @@ export class FilesystemNotebookStore {
       }
     }
 
+    migrateNotebookCellIds(notebook)
     let json: string
     if (detectNotebookFileFormat(parsed.relativePath) === 'ipynb') {
       let preservation = this.ipynbState.get(recId)

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1000,6 +1000,65 @@ describe('LocalNotebooks pending Drive create', () => {
 })
 
 describe('LocalNotebooks ipynb conversion', () => {
+  it('migrates cached kind-prefixed identities through the preservation map', async () => {
+    const shadowStorage = new MemoryIpynbShadowStorage()
+    const shadowText = JSON.stringify({
+      cells: [
+        {
+          cell_type: 'markdown',
+          id: 'intro',
+          metadata: {},
+          source: '# Intro',
+        },
+      ],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 5,
+    })
+    const shadowRef = await shadowStorage.write(
+      'local://file/cached-ipynb',
+      shadowText
+    )
+    const store = createTestStore({}, { ipynbShadowStorage: shadowStorage })
+    const cached = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'markup_intro',
+          kind: parser_pb.CellKind.MARKUP,
+          value: '# Intro',
+        }),
+      ],
+    })
+    await store.files.put({
+      id: 'local://file/cached-ipynb',
+      name: 'cached.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: 'local://file/cached-ipynb',
+      lastRemoteChecksum: '',
+      lastSynced: new Date().toISOString(),
+      doc: toJsonString(
+        parser_pb.NotebookSchema,
+        cached,
+        NOTEBOOK_JSON_WRITE_OPTIONS
+      ),
+      md5Checksum: '',
+      ipynbPreservation: {
+        upstreamFingerprint: md5(shadowText),
+        shadowRef,
+        jupyterIdByRunmeRefId: { markup_intro: 'intro' },
+        baselineCellHashes: {},
+        baselineOutputHashes: {},
+      },
+    })
+
+    const loaded = await store.load('local://file/cached-ipynb')
+
+    expect(loaded.cells[0]?.refId).toBe('intro')
+    expect(
+      loaded.cells[0]?.metadata['runme.dev/legacyCellRefIds']
+    ).toBeUndefined()
+  })
+
   it('keeps browser-local ipynb shadows current and accepts raw ipynb updates', async () => {
     const store = createTestStore({})
     await store.folders.put({

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -4,6 +4,7 @@ import md5 from 'md5'
 import { Subject, debounceTime } from 'rxjs'
 import { v4 as uuidv4 } from 'uuid'
 
+import { migrateNotebookCellIds } from '../lib/cellIdentity'
 import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { appLogger } from '../lib/logging/runtime'
 import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookToMarkdown'
@@ -1190,6 +1191,7 @@ export class LocalNotebooks extends Dexie {
       )
     }
 
+    migrateNotebookCellIds(notebook)
     const serialized = serializeNotebook(notebook)
     const checksum = checksumForSerializedNotebook(serialized)
 
@@ -1244,9 +1246,16 @@ export class LocalNotebooks extends Dexie {
     }
 
     try {
-      return fromJsonString(parser_pb.NotebookSchema, record.doc, {
+      const notebook = fromJsonString(parser_pb.NotebookSchema, record.doc, {
         ignoreUnknownFields: true,
       })
+      migrateNotebookCellIds(
+        notebook,
+        detectNotebookFileFormat(record.name) === 'ipynb'
+          ? record.ipynbPreservation?.jupyterIdByRunmeRefId
+          : undefined
+      )
+      return notebook
     } catch (error) {
       console.error('Failed to parse notebook from local store', error)
       return create(parser_pb.NotebookSchema, { cells: [] })

--- a/docs-dev/design/20260611_notebook_comments.md
+++ b/docs-dev/design/20260611_notebook_comments.md
@@ -266,17 +266,22 @@ Store a Runme-specific JSON payload in the Drive comment `anchor` field:
 ```json
 {
   "runme": {
-    "version": 1,
+    "version": 2,
     "type": "cell",
-    "cellId": "code_85a39e07",
-    "cellIdKind": "runme-ref-id"
+    "cellId": "85a39e07"
   }
 }
 ```
 
-For imported `.ipynb`, preserve the Jupyter cell `id` and map it to Runme's
-stable cell identity. When a Drive comment anchors to an imported notebook cell,
-the anchor should use the same stable id Runme uses to render that cell.
+`Cell.refId` and IPYNB `cell.id` are the same canonical identity serialized
+under format-specific field names. Cell kind is not part of identity. New
+anchors store only the opaque canonical `cellId` and do not include
+`cellIdKind`.
+
+The reader continues accepting version 1 anchors with `cellIdKind`. It resolves
+legacy `code_<id>` and `markup_<id>` values through the notebook's migration
+aliases. Exact canonical matches win. An alias that maps to multiple cells is
+shown as ambiguous instead of being silently retargeted.
 
 If a cell is deleted, keep the Drive comment. The UI should render it as an
 orphaned thread if the anchor no longer resolves.
@@ -316,7 +321,6 @@ type NotebookCommentThread = {
 type CommentAnchor = {
   type: 'cell'
   cellId: string
-  cellIdKind: 'runme-ref-id' | 'ipynb-cell-id'
 }
 
 type NotebookCommentReply = {

--- a/docs/17-ipynb-notebooks.md
+++ b/docs/17-ipynb-notebooks.md
@@ -54,6 +54,27 @@ shared document. The OPFS shadow belongs to the current browser profile and is
 supporting preservation data, not a second user-visible notebook or Markdown
 sidecar.
 
+## Cell identity
+
+Runme uses one canonical cell identifier in both notebook formats:
+
+- Runme JSON stores it as `Cell.refId`.
+- IPYNB stores the same value as `cell.id`.
+
+The IPYNB codec does not duplicate that identity in the per-cell Runme metadata
+envelope.
+
+Cell IDs are opaque. Their value does not encode whether a cell is code or
+markup, and changing a cell's kind does not change its identity. Canonical IDs
+use Jupyter's cell-ID constraints: 1–64 ASCII letters, digits, hyphens, or
+underscores, unique within the notebook.
+
+When Runme opens legacy content with a missing, invalid, or duplicate ID, it
+repairs the ID deterministically. Older Runme releases derived IDs such as
+`code_<id>` and `markup_<id>` from IPYNB cells. Runme recognizes those values
+as migration aliases for existing Drive comment anchors, but new files and
+comments use only the canonical ID.
+
 ## Sharing through Google Colab
 
 Google Colab can open an IPYNB file stored in Google Drive:
@@ -105,6 +126,7 @@ avoid relying on files or credentials that exist only in one runtime.
 - The extension determines the saved format.
 - The Runme protocol remains the internal data model.
 - Load and save convert between IPYNB and the Runme protocol.
+- `Cell.refId` and IPYNB `cell.id` contain the same canonical value.
 - OPFS preserves Jupyter-only fields that the Runme model cannot represent.
 - Only Drive-backed IPYNB notebooks expose a Google Colab link.
 - Drive permissions determine who can open the copied Colab link.


### PR DESCRIPTION
## Summary

- make Runme `Cell.refId` and IPYNB `cell.id` the same canonical identity
- stop deriving new or decoded cell IDs from cell kind
- deterministically migrate missing, invalid, duplicate, and legacy kind-prefixed IDs while preserving legacy Drive comment anchors
- write version 2 comment anchors with only the canonical cell ID and surface ambiguous legacy anchors in the comments UI
- document the identity contract and teach AppKernel agents to treat `refId` as opaque
- run the Jupyter CUJ against the companion direct-kernel bridge in runmedev/runme#1280

## Migration behavior

- IPYNB decode repairs IDs to Jupyter's 1–64 character `[A-Za-z0-9_-]` constraints and notebook uniqueness.
- Older cached `code_<id>` / `markup_<id>` identities migrate through the preservation map or legacy internal IPYNB ID metadata, which is then removed.
- Native JSON legacy IDs are migrated deterministically; non-prefix aliases are retained only when required to resolve existing comment anchors.
- Exact canonical anchor matches win. Multiple legacy alias candidates are reported as ambiguous rather than silently retargeted.
- IPYNB encode validates canonical identities, writes `cell.refId` directly as `cell.id`, and does not duplicate it in the per-cell Runme envelope.

Design source: https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1DydxMrOOdRpUogY9m4m0OkYp61C1vbEI%2Fview

## Verification

- `runme run build test`
- `pnpm -C app exec vitest run` — 81 files, 757 tests
- rebased onto `f699454` (the Jupyter/CUJ fixes from #318) before the final verification run
- focused identity/codec/comments/storage/editor suite — 9 files, 183 tests
- isolated Jupyter browser CUJ against runmedev/runme#1280 — 18/18 assertions
- `git diff --check`

CI dependency note: Web uses the direct `/v1/jupyter/kernels` API implemented by runmedev/runme#1280, but the app workflow was still building Runme `main`, which only exposes the legacy proxy API. The workflow now checks out that companion pull ref and includes an explicit instruction to return to `main` after #1280 merges.

## Review

Self-review findings addressed before publication:

- removed remaining kind-derived ID generation for editor and Markdown-import cells
- replaced nondeterministic missing-ID fallback with deterministic migration
- recovered canonical IDs from legacy cached IPYNB metadata when preservation state is absent
- removed redundant ID metadata and unused migration-state plumbing
- preserved unchanged IPYNB outputs across cached legacy identity migration
