### PR TITLE
Use exact cell IDs for comment anchors

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2003,9 +2003,7 @@ function NotebookTabContent({
     () =>
       cellDatas.flatMap((cellData) => {
         const cell = cellData.snapshot
-        return cell?.refId
-          ? [{ refId: cell.refId, metadata: cell.metadata }]
-          : []
+        return cell?.refId ? [{ refId: cell.refId }] : []
       }),
     [cellDatas]
   )

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -259,17 +259,18 @@ describe('NotebookCommentsPanel', () => {
     expect(onSelectCell).not.toHaveBeenCalled()
   })
 
-  it('surfaces ambiguous legacy comment anchors without selecting a cell', () => {
+  it('shows missing comment targets as deleted cells without selecting them', () => {
     const onSelectCell = vi.fn()
-    const ambiguous = thread('ambiguous comment', 'legacy-cell', {
-      id: 'comment-ambiguous',
+    const orphaned = thread('orphaned comment', 'markup_intro', {
+      id: 'comment-orphaned',
     })
-    ambiguous.ambiguous = true
+    orphaned.orphaned = true
 
-    renderPanel({ threads: [ambiguous], onSelectCell })
+    renderPanel({ threads: [orphaned], onSelectCell })
 
-    expect(screen.getByText('Ambiguous cell')).toBeTruthy()
+    expect(screen.getByText('Deleted cell')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Cell' })).toBeNull()
+    fireEvent.click(screen.getByText('orphaned comment').closest('article')!)
     expect(onSelectCell).not.toHaveBeenCalled()
   })
 })
@@ -282,7 +283,6 @@ function thread(
   return {
     cellId,
     orphaned: false,
-    ambiguous: false,
     comment: {
       id: overrides.id,
       content,

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -9,7 +9,6 @@ type CommentsPanelItem = {
   key: string
   cellId: string | null
   orphaned: boolean
-  ambiguous: boolean
   threads: CellCommentThread[]
   draftCellId?: string
 }
@@ -73,8 +72,7 @@ export function NotebookCommentsPanel({
       return null
     }
     const activeItem = panelItems.find(
-      (item) =>
-        item.cellId === activeCellId && !item.orphaned && !item.ambiguous
+      (item) => item.cellId === activeCellId && !item.orphaned
     )
     return activeItem?.key ?? null
   }, [activeCellId, panelItems])
@@ -103,8 +101,7 @@ export function NotebookCommentsPanel({
     }
     const targetCommentId = findReplyTargetCommentId(
       sortedThreads.filter(
-        (thread) =>
-          thread.cellId === draftCellId && !thread.orphaned && !thread.ambiguous
+        (thread) => thread.cellId === draftCellId && !thread.orphaned
       )
     )
     const submit = targetCommentId
@@ -121,7 +118,7 @@ export function NotebookCommentsPanel({
     const targetCommentId = findReplyTargetCommentId(item.threads)
     const submit = targetCommentId
       ? onReply(targetCommentId, content)
-      : item.cellId && !item.orphaned && !item.ambiguous
+      : item.cellId && !item.orphaned
         ? onCreateComment(item.cellId, content)
         : Promise.resolve()
     void submit.then(() => {
@@ -236,16 +233,10 @@ export function NotebookCommentsPanel({
               const isActiveThread =
                 activeThreadKey === item.key ||
                 Boolean(
-                  activeCellId &&
-                    activeCellId === item.cellId &&
-                    !item.orphaned &&
-                    !item.ambiguous
+                  activeCellId && activeCellId === item.cellId && !item.orphaned
                 )
               const isActiveCell = Boolean(
-                activeCellId &&
-                  item.cellId === activeCellId &&
-                  !item.orphaned &&
-                  !item.ambiguous
+                activeCellId && item.cellId === activeCellId && !item.orphaned
               )
               const canEditThread = isActiveThread && !item.draftCellId
               const replyDraft = replyDrafts[item.key] ?? ''
@@ -265,7 +256,7 @@ export function NotebookCommentsPanel({
                   }`}
                   onClick={() => {
                     setActiveThreadKey(item.key)
-                    if (item.cellId && !item.orphaned && !item.ambiguous) {
+                    if (item.cellId && !item.orphaned) {
                       onSelectCell(item.cellId)
                     }
                   }}
@@ -278,7 +269,7 @@ export function NotebookCommentsPanel({
                     }
                     event.preventDefault()
                     setActiveThreadKey(item.key)
-                    if (item.cellId && !item.orphaned && !item.ambiguous) {
+                    if (item.cellId && !item.orphaned) {
                       onSelectCell(item.cellId)
                     }
                   }}
@@ -293,7 +284,7 @@ export function NotebookCommentsPanel({
                       cellLabels={cellLabels}
                       isActiveCell={isActiveCell}
                       onSelectCell={() => {
-                        if (item.cellId && !item.orphaned && !item.ambiguous) {
+                        if (item.cellId && !item.orphaned) {
                           setActiveThreadKey(item.key)
                           onSelectCell(item.cellId)
                         }
@@ -469,7 +460,7 @@ function ThreadLocation({
   isActiveCell: boolean
   onSelectCell: () => void
 }) {
-  if (item.cellId && !item.orphaned && !item.ambiguous) {
+  if (item.cellId && !item.orphaned) {
     return (
       <button
         type="button"
@@ -485,13 +476,6 @@ function ThreadLocation({
       >
         {cellLabels.get(item.cellId) ?? 'Cell'}
       </button>
-    )
-  }
-  if (item.cellId && item.ambiguous) {
-    return (
-      <div className="text-xs font-medium text-nb-text-faint">
-        Ambiguous cell
-      </div>
     )
   }
   if (item.cellId && item.orphaned) {
@@ -614,7 +598,7 @@ function sortCommentPanelItems(
   const itemsByCell = new Map<string, CommentsPanelItem>()
 
   sortedThreads.forEach((thread) => {
-    if (thread.cellId && !thread.orphaned && !thread.ambiguous) {
+    if (thread.cellId && !thread.orphaned) {
       const key = getCellThreadKey(thread.cellId)
       let item = itemsByCell.get(key)
       if (!item) {
@@ -623,7 +607,6 @@ function sortCommentPanelItems(
           key,
           cellId: thread.cellId,
           orphaned: false,
-          ambiguous: false,
           threads: [],
         }
         itemsByCell.set(key, item)
@@ -638,7 +621,6 @@ function sortCommentPanelItems(
       key: `thread:${getThreadKey(thread)}`,
       cellId: thread.cellId,
       orphaned: thread.orphaned,
-      ambiguous: thread.ambiguous,
       threads: [thread],
     })
   })
@@ -660,12 +642,11 @@ function sortCommentPanelItems(
     key: draftKey,
     cellId: draftCellId,
     orphaned: false,
-    ambiguous: false,
     threads: [],
     draftCellId,
   }
   const insertionIndex = items.findIndex((item) => {
-    if (!item.cellId || item.orphaned || item.ambiguous) {
+    if (!item.cellId || item.orphaned) {
       return true
     }
     return cellIndex(cellLabels, item.cellId) > draftIndex
@@ -682,16 +663,13 @@ function sortCommentPanelItems(
 }
 
 function threadGroup(thread: CellCommentThread): number {
-  if (thread.cellId && !thread.orphaned && !thread.ambiguous) {
+  if (thread.cellId && !thread.orphaned) {
     return 0
   }
-  if (thread.ambiguous) {
+  if (thread.orphaned) {
     return 1
   }
-  if (thread.orphaned) {
-    return 2
-  }
-  return 3
+  return 2
 }
 
 function cellIndex(cellLabels: Map<string, string>, cellId: string): number {

--- a/app/src/lib/cellIdentity.test.ts
+++ b/app/src/lib/cellIdentity.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 
 import { parser_pb } from '../runme/client'
 import {
-  LEGACY_CELL_REF_IDS_METADATA_KEY,
   assertCanonicalNotebookCellIds,
   migrateNotebookCellIds,
 } from './cellIdentity'
@@ -25,12 +24,6 @@ describe('cell identity', () => {
       'invalid-id-2',
       'cell-3',
     ])
-    expect(notebook.cells[0]?.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY]).toBe(
-      '["invalid id"]'
-    )
-    expect(notebook.cells[1]?.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY]).toBe(
-      '["invalid id"]'
-    )
     expect(migrateNotebookCellIds(notebook).changed).toBe(false)
   })
 
@@ -42,9 +35,6 @@ describe('cell identity', () => {
     migrateNotebookCellIds(notebook, { markup_intro: 'intro' })
 
     expect(notebook.cells[0]?.refId).toBe('intro')
-    expect(
-      notebook.cells[0]?.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY]
-    ).toBeUndefined()
   })
 
   it('promotes a legacy metadata id to the canonical refId', () => {

--- a/app/src/lib/cellIdentity.ts
+++ b/app/src/lib/cellIdentity.ts
@@ -1,6 +1,5 @@
 import type { parser_pb } from '../runme/client'
 
-export const LEGACY_CELL_REF_IDS_METADATA_KEY = 'runme.dev/legacyCellRefIds'
 export const LEGACY_IPYNB_CELL_ID_METADATA_KEY = 'runme.dev/ipynbCellId'
 
 const CELL_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
@@ -28,26 +27,6 @@ export function uniqueCanonicalCellId(
   }
   used.add(candidate)
   return candidate
-}
-
-export function legacyCellRefIds(
-  metadata: Record<string, string> | undefined
-): string[] {
-  const value = metadata?.[LEGACY_CELL_REF_IDS_METADATA_KEY]
-  if (!value) {
-    return []
-  }
-  try {
-    const parsed = JSON.parse(value)
-    return Array.isArray(parsed)
-      ? parsed.filter(
-          (candidate): candidate is string =>
-            typeof candidate === 'string' && candidate.length > 0
-        )
-      : []
-  } catch {
-    return []
-  }
 }
 
 /**
@@ -89,18 +68,6 @@ export function migrateNotebookCellIds(
 
     changed = true
     cell.refId = canonical
-    if (original && original !== canonical) {
-      // Kind-prefixed IPYNB identities are recoverable from the canonical ID
-      // and should not become permanent per-cell metadata. Other legacy IDs
-      // need an explicit alias so Drive comments can continue to resolve.
-      if (preferred === original) {
-        const aliases = new Set([...legacyCellRefIds(cell.metadata), original])
-        aliases.delete(canonical)
-        cell.metadata[LEGACY_CELL_REF_IDS_METADATA_KEY] = JSON.stringify([
-          ...aliases,
-        ])
-      }
-    }
   })
 
   return { changed }

--- a/app/src/lib/notebookComments.test.ts
+++ b/app/src/lib/notebookComments.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-import { LEGACY_CELL_REF_IDS_METADATA_KEY } from './cellIdentity'
 import {
   createCellCommentAnchor,
   groupCommentsByCell,
@@ -31,7 +30,6 @@ describe('notebook comment anchors', () => {
       type: 'cell',
       cellId: 'cell-legacy',
       version: 1,
-      cellIdKind: 'runme-ref-id',
     })
   })
 
@@ -65,30 +63,33 @@ describe('notebook comment anchors', () => {
   })
 
   it('groups only unresolved cell comments', () => {
-    const grouped = groupCommentsByCell([
-      {
-        id: 'comment-1',
-        anchor: createCellCommentAnchor('cell-1'),
-        content: 'open',
-      },
-      {
-        id: 'comment-2',
-        anchor: createCellCommentAnchor('cell-1'),
-        resolved: true,
-        content: 'resolved',
-      },
-      {
-        id: 'comment-3',
-        content: 'unanchored',
-      },
-    ])
+    const grouped = groupCommentsByCell(
+      [
+        {
+          id: 'comment-1',
+          anchor: createCellCommentAnchor('cell-1'),
+          content: 'open',
+        },
+        {
+          id: 'comment-2',
+          anchor: createCellCommentAnchor('cell-1'),
+          resolved: true,
+          content: 'resolved',
+        },
+        {
+          id: 'comment-3',
+          content: 'unanchored',
+        },
+      ],
+      [{ refId: 'cell-1' }]
+    )
 
     expect(grouped.get('cell-1')?.map((comment) => comment.id)).toEqual([
       'comment-1',
     ])
   })
 
-  it('resolves legacy kind-prefixed anchors to canonical cell ids', () => {
+  it('treats legacy anchor cell ids as opaque and orphans missing ids', () => {
     const comments = [
       {
         id: 'legacy-comment',
@@ -104,19 +105,16 @@ describe('notebook comment anchors', () => {
       },
     ]
 
-    expect(
-      groupCommentsByCell(comments, [{ refId: 'intro' }]).get('intro')
-    ).toHaveLength(1)
+    expect(groupCommentsByCell(comments, [{ refId: 'intro' }]).size).toBe(0)
     expect(
       toCellCommentThreads(comments, [{ refId: 'intro' }])[0]
     ).toMatchObject({
-      cellId: 'intro',
-      orphaned: false,
-      ambiguous: false,
+      cellId: 'markup_intro',
+      orphaned: true,
     })
   })
 
-  it('prefers exact canonical ids over legacy alias interpretations', () => {
+  it('resolves an exact cell id even when it has a historical prefix', () => {
     const comments = [
       {
         id: 'exact-comment',
@@ -129,31 +127,38 @@ describe('notebook comment anchors', () => {
     expect(toCellCommentThreads(comments, cells)[0]).toMatchObject({
       cellId: 'markup_intro',
       orphaned: false,
-      ambiguous: false,
     })
   })
 
-  it('surfaces ambiguous legacy aliases instead of grouping them', () => {
+  it('does not reinterpret missing v2 canonical ids as legacy aliases', () => {
     const comments = [
       {
-        id: 'ambiguous-comment',
-        anchor: createCellCommentAnchor('legacy id'),
-        content: 'ambiguous',
+        id: 'missing-v2-comment',
+        anchor: createCellCommentAnchor('markup_intro'),
+        content: 'missing canonical target',
       },
     ]
-    const metadata = {
-      [LEGACY_CELL_REF_IDS_METADATA_KEY]: JSON.stringify(['legacy id']),
-    }
-    const cells = [
-      { refId: 'first', metadata },
-      { refId: 'second', metadata },
-    ]
+    const cells = [{ refId: 'intro' }]
 
     expect(groupCommentsByCell(comments, cells).size).toBe(0)
     expect(toCellCommentThreads(comments, cells)[0]).toMatchObject({
-      cellId: 'legacy id',
-      orphaned: false,
-      ambiguous: true,
+      cellId: 'markup_intro',
+      orphaned: true,
     })
+  })
+
+  it('marks cell comments as orphaned when the notebook has no cells', () => {
+    const [thread] = toCellCommentThreads(
+      [
+        {
+          id: 'comment-with-no-target',
+          anchor: createCellCommentAnchor('cell-1'),
+          content: 'missing target',
+        },
+      ],
+      []
+    )
+
+    expect(thread).toMatchObject({ cellId: 'cell-1', orphaned: true })
   })
 })

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -1,5 +1,4 @@
 import type { DriveComment } from '../storage/drive'
-import { legacyCellRefIds } from './cellIdentity'
 
 const RUNME_COMMENT_ANCHOR_VERSION = 2
 
@@ -7,12 +6,10 @@ export type CellCommentAnchor = {
   type: 'cell'
   cellId: string
   version: 1 | 2
-  cellIdKind?: 'runme-ref-id' | 'ipynb-cell-id'
 }
 
 export type CommentCellIdentity = {
   refId: string
-  metadata?: Record<string, string>
 }
 
 type RunmeCommentAnchorPayload = {
@@ -21,7 +18,6 @@ type RunmeCommentAnchorPayload = {
     type?: string
     kind?: string
     cellId?: string
-    cellIdKind?: string
   }
 }
 
@@ -29,13 +25,11 @@ export type CellCommentThread = {
   comment: DriveComment
   cellId: string | null
   orphaned: boolean
-  ambiguous: boolean
 }
 
 type CellAnchorResolution = {
   cellId: string
   orphaned: boolean
-  ambiguous: boolean
 }
 
 export function createCellCommentAnchor(cellId: string): string {
@@ -71,19 +65,6 @@ export function parseCellCommentAnchor(
       return null
     }
 
-    if (version === 1) {
-      const cellIdKind = parsed.runme.cellIdKind ?? 'runme-ref-id'
-      if (cellIdKind !== 'runme-ref-id' && cellIdKind !== 'ipynb-cell-id') {
-        return null
-      }
-      return {
-        type: 'cell',
-        cellId: parsed.runme.cellId,
-        version,
-        cellIdKind,
-      }
-    }
-
     return {
       type: 'cell',
       cellId: parsed.runme.cellId,
@@ -96,7 +77,7 @@ export function parseCellCommentAnchor(
 
 export function groupCommentsByCell(
   comments: DriveComment[],
-  cells: Iterable<CommentCellIdentity> = []
+  cells: Iterable<CommentCellIdentity>
 ): Map<string, DriveComment[]> {
   const identities = [...cells]
   const byCell = new Map<string, DriveComment[]>()
@@ -109,7 +90,7 @@ export function groupCommentsByCell(
       return
     }
     const resolution = resolveCellAnchor(anchor.cellId, identities)
-    if (resolution.orphaned || resolution.ambiguous) {
+    if (resolution.orphaned) {
       return
     }
     const existing = byCell.get(resolution.cellId) ?? []
@@ -121,7 +102,7 @@ export function groupCommentsByCell(
 
 export function toCellCommentThreads(
   comments: DriveComment[],
-  cells: Iterable<CommentCellIdentity> = []
+  cells: Iterable<CommentCellIdentity>
 ): CellCommentThread[] {
   const identities = [...cells]
   return comments
@@ -133,7 +114,6 @@ export function toCellCommentThreads(
           comment,
           cellId: null,
           orphaned: false,
-          ambiguous: false,
         }
       }
       const resolution = resolveCellAnchor(anchor.cellId, identities)
@@ -141,7 +121,6 @@ export function toCellCommentThreads(
         comment,
         cellId: resolution.cellId,
         orphaned: resolution.orphaned,
-        ambiguous: resolution.ambiguous,
       }
     })
 }
@@ -150,36 +129,9 @@ function resolveCellAnchor(
   anchoredCellId: string,
   cells: CommentCellIdentity[]
 ): CellAnchorResolution {
-  if (cells.length === 0) {
-    return { cellId: anchoredCellId, orphaned: false, ambiguous: false }
-  }
-
   const exact = cells.find((cell) => cell.refId === anchoredCellId)
   if (exact) {
-    return { cellId: exact.refId, orphaned: false, ambiguous: false }
+    return { cellId: exact.refId, orphaned: false }
   }
-
-  const candidates = new Set<string>()
-  for (const cell of cells) {
-    const aliases = [
-      `code_${cell.refId}`,
-      `markup_${cell.refId}`,
-      ...legacyCellRefIds(cell.metadata),
-    ]
-    if (aliases.includes(anchoredCellId)) {
-      candidates.add(cell.refId)
-    }
-  }
-
-  if (candidates.size === 1) {
-    return {
-      cellId: [...candidates][0]!,
-      orphaned: false,
-      ambiguous: false,
-    }
-  }
-  if (candidates.size > 1) {
-    return { cellId: anchoredCellId, orphaned: false, ambiguous: true }
-  }
-  return { cellId: anchoredCellId, orphaned: true, ambiguous: false }
+  return { cellId: anchoredCellId, orphaned: true }
 }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1054,9 +1054,6 @@ describe('LocalNotebooks ipynb conversion', () => {
     const loaded = await store.load('local://file/cached-ipynb')
 
     expect(loaded.cells[0]?.refId).toBe('intro')
-    expect(
-      loaded.cells[0]?.metadata['runme.dev/legacyCellRefIds']
-    ).toBeUndefined()
   })
 
   it('keeps browser-local ipynb shadows current and accepts raw ipynb updates', async () => {

--- a/docs-dev/design/20260611_notebook_comments.md
+++ b/docs-dev/design/20260611_notebook_comments.md
@@ -278,13 +278,16 @@ under format-specific field names. Cell kind is not part of identity. New
 anchors store only the opaque canonical `cellId` and do not include
 `cellIdKind`.
 
-The reader continues accepting version 1 anchors with `cellIdKind`. It resolves
-legacy `code_<id>` and `markup_<id>` values through the notebook's migration
-aliases. Exact canonical matches win. An alias that maps to multiple cells is
-shown as ambiguous instead of being silently retargeted.
+The reader continues accepting the version 1 anchor shape, but treats its
+`cellId` as an opaque identifier and ignores `cellIdKind`. Both anchor versions
+resolve by exact `Cell.refId` equality only. Runme does not strip or synthesize
+`code_` or `markup_` prefixes and does not consult legacy alias metadata.
 
-If a cell is deleted, keep the Drive comment. The UI should render it as an
-orphaned thread if the anchor no longer resolves.
+If no cell has the exact anchored ID, keep the Drive comment and render it as
+an orphaned ("Deleted cell") thread. This includes comments whose old anchor is
+`markup_intro` when the current notebook contains only `intro`. This simple,
+consistent behavior may orphan a small number of existing comments, which is
+an accepted compatibility tradeoff.
 
 If a cell is moved, the thread follows the cell id.
 


### PR DESCRIPTION
## Summary

- resolve Drive comment anchors only by exact `Cell.refId` equality
- treat version 1 anchor IDs as opaque values and ignore `cellIdKind`
- remove kind-prefix alias synthesis, legacy comment-alias metadata, and the `ambiguous` UI/model state
- show every missing exact target through the existing orphaned **Deleted cell** state
- document the accepted tradeoff that a small number of existing comments may become orphaned

## Identity migration

Deterministic codec migration for invalid, duplicate, and cached kind-prefixed notebook cell IDs remains. It establishes the canonical `Cell.refId`/IPYNB `cell.id`; it no longer creates aliases for retargeting comments. For example, an anchor for `markup_intro` resolves only if the notebook has a cell whose canonical ID is exactly `markup_intro`.

## Verification

- `runme run build test`
- `pnpm -C app exec vitest run` (81 files, 758 tests)
- focused comment, panel, identity, and local-storage tests (64 tests)
- `git diff --check`

## Compatibility

Older version 1 anchor envelopes are still parsed so their comments remain visible. When their literal `cellId` is absent, they appear as orphaned rather than being guessed or silently retargeted.