### PR TITLE
Move rendered selection comments to the context menu

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -2455,4 +2455,70 @@ describe('Action component', () => {
     })
     expect(screen.queryByRole('button', { name: 'Add Comment' })).toBeNull()
   })
+
+  it('starts a rendered-selection comment from the markdown context menu', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-selection-context-comment',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'Read **the [migration guide](https://example.com)** today.',
+    })
+    const stub = new StubCellData(cell)
+    const onStartComment = vi.fn()
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        commentsAvailable
+        onStartComment={onStartComment}
+      />
+    )
+
+    const selectedSpan = screen.getByText('migration guide')
+    const range = document.createRange()
+    range.setStart(selectedSpan.firstChild!, 0)
+    range.setEnd(selectedSpan.firstChild!, 'migration guide'.length)
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      value: () => ({
+        bottom: 20,
+        height: 10,
+        left: 10,
+        right: 90,
+        top: 10,
+        width: 80,
+        x: 10,
+        y: 10,
+        toJSON: () => ({}),
+      }),
+    })
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+      clientX: 40,
+      clientY: 20,
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Comment on selected text' })
+    )
+
+    expect(onStartComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'cell-text',
+        cellId: 'cell-md-selection-context-comment',
+        selectors: [
+          { type: 'TextPositionSelector', start: 9, end: 24 },
+          expect.objectContaining({
+            type: 'TextQuoteSelector',
+            exact: 'migration guide',
+          }),
+        ],
+      })
+    )
+    selection.removeAllRanges()
+  })
 })

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -2521,4 +2521,63 @@ describe('Action component', () => {
     )
     selection.removeAllRanges()
   })
+
+  it('keeps the cell comment button independent of a selection menu', () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-independent-comment',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'Select this text.',
+    })
+    const stub = new StubCellData(cell)
+    const onStartComment = vi.fn()
+
+    render(
+      <Action
+        cellData={stub as unknown as CellData}
+        isFirst={false}
+        commentsAvailable
+        onStartComment={onStartComment}
+      />
+    )
+
+    const text = screen.getByText('Select this text.').firstChild!
+    const range = document.createRange()
+    range.setStart(text, 0)
+    range.setEnd(text, 6)
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      value: () => ({
+        bottom: 20,
+        height: 10,
+        left: 10,
+        right: 70,
+        top: 10,
+        width: 60,
+        x: 10,
+        y: 10,
+        toJSON: () => ({}),
+      }),
+    })
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+      clientX: 40,
+      clientY: 20,
+    })
+    expect(
+      screen.getByRole('button', { name: 'Comment on selected text' })
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add comment' }))
+
+    expect(onStartComment).toHaveBeenCalledWith({
+      type: 'cell',
+      cellId: 'cell-md-independent-comment',
+    })
+    selection.removeAllRanges()
+  })
 })

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -113,7 +113,10 @@ import {
   toCellCommentThreads,
   type CommentDraftTarget,
 } from '../../lib/notebookComments'
-import { buildRenderedMarkdownProjection } from '../../lib/markdown/renderedMarkdownProjection'
+import {
+  buildRenderedMarkdownProjection,
+  type RenderedMarkdownSelectionDraft,
+} from '../../lib/markdown/renderedMarkdownProjection'
 import DriveLinkStatusTab from '../DriveLinkStatusTab'
 import DriveSyncStatusTab from '../DriveSyncStatusTab'
 import RunnerStatusTab from '../RunnerStatusTab'
@@ -657,6 +660,7 @@ export function Action({
   const [contextMenu, setContextMenu] = useState<{
     x: number
     y: number
+    captureRenderedSelection?: () => RenderedMarkdownSelectionDraft | null
   } | null>(null)
   const [shareTarget, setShareTarget] = useState<{
     docUri: string
@@ -785,6 +789,21 @@ export function Action({
       event.preventDefault()
       event.stopPropagation()
       setContextMenu({ x: event.clientX, y: event.clientY })
+    },
+    []
+  )
+
+  const handleRenderedSelectionContextMenu = useCallback(
+    (request: {
+      x: number
+      y: number
+      captureSelection: () => RenderedMarkdownSelectionDraft | null
+    }) => {
+      setContextMenu({
+        x: request.x,
+        y: request.y,
+        captureRenderedSelection: request.captureSelection,
+      })
     },
     []
   )
@@ -976,9 +995,22 @@ export function Action({
       setContextMenu(null)
       return
     }
-    onStartComment({ type: 'cell', cellId: cell.refId })
+    if (contextMenu?.captureRenderedSelection) {
+      const target = contextMenu.captureRenderedSelection()
+      if (!target) {
+        setContextMenu(null)
+        showToast({
+          message: 'The text selection changed. Select it again to comment.',
+          tone: 'error',
+        })
+        return
+      }
+      onStartComment(target)
+    } else {
+      onStartComment({ type: 'cell', cellId: cell.refId })
+    }
     setContextMenu(null)
-  }, [cell?.refId, onStartComment])
+  }, [cell?.refId, contextMenu, onStartComment])
 
   const sequenceLabel = useMemo(() => {
     if (!cell) {
@@ -1417,7 +1449,9 @@ export function Action({
               onFocusRoleChange={handleMarkdownFocusRoleChange}
               onLinkClick={handleMarkdownLinkClick}
               commentsAvailable={commentsAvailable}
-              onStartRenderedComment={onStartComment}
+              onRenderedSelectionContextMenu={
+                handleRenderedSelectionContextMenu
+              }
             />
             <CellCommentButton
               count={commentCount}
@@ -1485,7 +1519,9 @@ export function Action({
                 handleStartComment()
               }}
             >
-              Add Comment
+              {contextMenu?.captureRenderedSelection
+                ? 'Comment on selected text'
+                : 'Add Comment'}
             </button>
             <button
               type="button"

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -995,22 +995,31 @@ export function Action({
       setContextMenu(null)
       return
     }
-    if (contextMenu?.captureRenderedSelection) {
-      const target = contextMenu.captureRenderedSelection()
-      if (!target) {
-        setContextMenu(null)
-        showToast({
-          message: 'The text selection changed. Select it again to comment.',
-          tone: 'error',
-        })
-        return
-      }
-      onStartComment(target)
-    } else {
-      onStartComment({ type: 'cell', cellId: cell.refId })
-    }
+    onStartComment({ type: 'cell', cellId: cell.refId })
     setContextMenu(null)
-  }, [cell?.refId, contextMenu, onStartComment])
+  }, [cell?.refId, onStartComment])
+
+  const handleContextMenuComment = useCallback(() => {
+    if (!contextMenu?.captureRenderedSelection) {
+      handleStartComment()
+      return
+    }
+    if (!onStartComment) {
+      setContextMenu(null)
+      return
+    }
+    const target = contextMenu.captureRenderedSelection()
+    if (!target) {
+      setContextMenu(null)
+      showToast({
+        message: 'The text selection changed. Select it again to comment.',
+        tone: 'error',
+      })
+      return
+    }
+    onStartComment(target)
+    setContextMenu(null)
+  }, [contextMenu, handleStartComment, onStartComment])
 
   const sequenceLabel = useMemo(() => {
     if (!cell) {
@@ -1516,7 +1525,7 @@ export function Action({
               disabled={!commentsAvailable}
               onClick={(event) => {
                 event.stopPropagation()
-                handleStartComment()
+                handleContextMenuComment()
               }}
             >
               {contextMenu?.captureRenderedSelection

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -271,6 +271,38 @@ describe("MarkdownCell", () => {
     );
   });
 
+  it("enters edit mode when double-clicking selected rendered text", async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-selected-edit",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "hello world",
+    });
+    const stub = new StubCellData(cell);
+
+    renderMarkdownCell(stub as unknown as CellData);
+
+    const rendered = screen.getByTestId("markdown-rendered");
+    const text = screen.getByText("hello world").firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 5);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.doubleClick(rendered);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("markdown-editor")).toBeTruthy();
+    selection.removeAllRanges();
+  });
+
   it("opens read-only markdown source without allowing changes", async () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "md-read-only",
@@ -501,7 +533,7 @@ describe("MarkdownCell", () => {
     expect(screen.queryByTestId("markdown-editor")).toBeNull();
   });
 
-  it("annotates rendered text and creates a target from a browser selection", () => {
+  it("defers rendered selector capture until the context-menu action", () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "md-comment-selection",
       kind: parser_pb.CellKind.MARKUP,
@@ -510,11 +542,11 @@ describe("MarkdownCell", () => {
       metadata: {},
       value: "Read **the [migration guide](https://example.com)** today.",
     });
-    const onStartRenderedComment = vi.fn();
+    const onRenderedSelectionContextMenu = vi.fn();
 
     renderMarkdownCell(new StubCellData(cell) as unknown as CellData, {
       commentsAvailable: true,
-      onStartRenderedComment,
+      onRenderedSelectionContextMenu,
     });
 
     const rendered = screen.getByTestId("markdown-rendered");
@@ -547,12 +579,14 @@ describe("MarkdownCell", () => {
     const selection = window.getSelection()!;
     selection.removeAllRanges();
     selection.addRange(range);
-    fireEvent.pointerUp(rendered);
+    fireEvent.contextMenu(rendered, { clientX: 40, clientY: 20 });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Comment on selected text" }),
-    );
-    expect(onStartRenderedComment).toHaveBeenCalledWith(
+    expect(onRenderedSelectionContextMenu).toHaveBeenCalledOnce();
+    const request = onRenderedSelectionContextMenu.mock.calls[0][0];
+    expect(request).toMatchObject({ x: 40, y: 20 });
+
+    selection.removeAllRanges();
+    expect(request.captureSelection()).toEqual(
       expect.objectContaining({
         type: "cell-text",
         cellId: "md-comment-selection",

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -27,6 +27,7 @@ import {
   useState,
   useSyncExternalStore,
   type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
 } from 'react'
 import ReactMarkdown from 'react-markdown'
 import type { Components } from 'react-markdown'
@@ -37,7 +38,7 @@ import { parser_pb } from '../../runme/client'
 import type { CellData } from '../../lib/notebookData'
 import type { CellFocusRole } from '../../lib/notebookActiveCellState'
 import {
-  captureRenderedMarkdownSelection,
+  captureRenderedMarkdownRange,
   createRenderedMarkdownProjectionPlugin,
   RENDERED_MARKDOWN_PROJECTION_NAME,
   RENDERED_MARKDOWN_PROJECTION_VERSION,
@@ -182,8 +183,12 @@ interface MarkdownCellProps {
   readOnly?: boolean
   /** Whether the current Drive-backed notebook can accept comments. */
   commentsAvailable?: boolean
-  /** Start a comment draft for a rendered Markdown text selection. */
-  onStartRenderedComment?: (target: RenderedMarkdownSelectionDraft) => void
+  /** Open the cell context menu with a lazily captured rendered selection. */
+  onRenderedSelectionContextMenu?: (request: {
+    x: number
+    y: number
+    captureSelection: () => RenderedMarkdownSelectionDraft | null
+  }) => void
 }
 
 /**
@@ -210,7 +215,7 @@ const MarkdownCell = memo(
     onLinkClick,
     readOnly = false,
     commentsAvailable = false,
-    onStartRenderedComment,
+    onRenderedSelectionContextMenu,
   }: MarkdownCellProps) => {
     // Subscribe to cell data changes using useSyncExternalStore for tearing-safe reads
     const cell = useSyncExternalStore(
@@ -239,11 +244,6 @@ const MarkdownCell = memo(
     const previousShouldOwnFocusRef = useRef(false)
     const [editorFocusIntent, setEditorFocusIntent] = useState(false)
     const [renderedFocusIntent, setRenderedFocusIntent] = useState(false)
-    const [selectionAction, setSelectionAction] = useState<{
-      target: RenderedMarkdownSelectionDraft
-      left: number
-      top: number
-    } | null>(null)
 
     // Get the current cell value
     const value = cell?.value ?? ''
@@ -316,10 +316,6 @@ const MarkdownCell = memo(
      * Handle switching to edit mode when user double-clicks rendered content.
      */
     const handleDoubleClick = useCallback(() => {
-      const selection = document.getSelection()
-      if (selection && !selection.isCollapsed) {
-        return
-      }
       if (!canOpenSource) {
         return
       }
@@ -328,40 +324,53 @@ const MarkdownCell = memo(
       onFocusRoleChange?.('editor')
     }, [canOpenSource, onFocusRoleChange])
 
-    const captureSelection = useCallback(() => {
-      const root = renderedRef.current
-      const projection = projectionRef.current
-      const selection = document.getSelection()
-      if (
-        !root ||
-        !projection ||
-        !selection ||
-        !cell?.refId ||
-        !commentsAvailable ||
-        !onStartRenderedComment
-      ) {
-        setSelectionAction(null)
-        return
-      }
-      const target = captureRenderedMarkdownSelection({
-        root,
-        selection,
-        cellId: cell.refId,
-        source: value,
-        projection,
-      })
-      if (!target) {
-        setSelectionAction(null)
-        return
-      }
-      const rangeRect = selection.getRangeAt(0).getBoundingClientRect()
-      const rootRect = root.getBoundingClientRect()
-      setSelectionAction({
-        target,
-        left: Math.max(8, rangeRect.left - rootRect.left),
-        top: Math.max(8, rangeRect.bottom - rootRect.top + 6),
-      })
-    }, [cell?.refId, commentsAvailable, onStartRenderedComment, value])
+    const handleRenderedContextMenu = useCallback(
+      (event: ReactMouseEvent<HTMLDivElement>) => {
+        const root = renderedRef.current
+        const projection = projectionRef.current
+        const selection = document.getSelection()
+        if (
+          !root ||
+          !projection ||
+          !selection ||
+          !cell?.refId ||
+          !commentsAvailable ||
+          !onRenderedSelectionContextMenu ||
+          selection.rangeCount !== 1 ||
+          selection.isCollapsed
+        ) {
+          return
+        }
+        const range = selection.getRangeAt(0)
+        if (
+          !root.contains(range.startContainer) ||
+          !root.contains(range.endContainer)
+        ) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+        const rangeSnapshot = range.cloneRange()
+        const hasPointerPosition = event.clientX !== 0 || event.clientY !== 0
+        const rangeRect = hasPointerPosition
+          ? null
+          : range.getBoundingClientRect()
+        onRenderedSelectionContextMenu({
+          x: hasPointerPosition ? event.clientX : (rangeRect?.left ?? 0),
+          y: hasPointerPosition ? event.clientY : (rangeRect?.bottom ?? 0),
+          captureSelection: () =>
+            captureRenderedMarkdownRange({
+              root,
+              range: rangeSnapshot,
+              cellId: cell.refId,
+              source: value,
+              projection,
+            }),
+        })
+      },
+      [cell?.refId, commentsAvailable, onRenderedSelectionContextMenu, value]
+    )
 
     /**
      * Handle keyboard activation on the rendered container for accessibility.
@@ -528,30 +537,9 @@ const MarkdownCell = memo(
             data-runme-projection={`${RENDERED_MARKDOWN_PROJECTION_NAME}@${RENDERED_MARKDOWN_PROJECTION_VERSION}`}
             data-cell-focus-role="rendered"
             onFocus={() => onFocusRoleChange?.('rendered')}
-            onPointerUp={captureSelection}
-            onKeyUp={captureSelection}
+            onContextMenu={handleRenderedContextMenu}
           >
             {renderedMarkdown}
-            {selectionAction && (
-              <button
-                type="button"
-                className="absolute z-20 rounded-nb-sm bg-nb-accent px-2 py-1 text-xs font-medium text-white shadow-nb-lg"
-                style={{
-                  left: selectionAction.left,
-                  top: selectionAction.top,
-                }}
-                aria-label="Comment on selected text"
-                data-testid="rendered-selection-comment"
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onStartRenderedComment?.(selectionAction.target)
-                  setSelectionAction(null)
-                }}
-              >
-                Comment
-              </button>
-            )}
           </div>
         ) : (
           // Editor view - Escape, run, or focusing another cell renders it
@@ -618,7 +606,8 @@ const MarkdownCell = memo(
       prevProps.onLinkClick === nextProps.onLinkClick &&
       prevProps.readOnly === nextProps.readOnly &&
       prevProps.commentsAvailable === nextProps.commentsAvailable &&
-      prevProps.onStartRenderedComment === nextProps.onStartRenderedComment
+      prevProps.onRenderedSelectionContextMenu ===
+        nextProps.onRenderedSelectionContextMenu
     )
   }
 )

--- a/app/src/lib/markdown/renderedMarkdownProjection.ts
+++ b/app/src/lib/markdown/renderedMarkdownProjection.ts
@@ -462,7 +462,23 @@ export function captureRenderedMarkdownSelection(args: {
   if (selection.rangeCount !== 1 || selection.isCollapsed) {
     return null
   }
-  const range = selection.getRangeAt(0)
+  return captureRenderedMarkdownRange({
+    root,
+    range: selection.getRangeAt(0),
+    cellId,
+    source,
+    projection,
+  })
+}
+
+export function captureRenderedMarkdownRange(args: {
+  root: HTMLElement
+  range: Range
+  cellId: string
+  source: string
+  projection: RenderedMarkdownProjection
+}): RenderedMarkdownSelectionDraft | null {
+  const { root, range, cellId, source, projection } = args
   if (
     !root.contains(range.startContainer) ||
     !root.contains(range.endContainer)


### PR DESCRIPTION
## Summary

- move rendered-Markdown selection commenting from an automatic floating button into the existing cell context menu
- snapshot only the DOM Range when the context menu opens and defer projection/selector conversion until the user chooses **Comment on selected text**
- restore double-click editing when rendered text is selected
- preserve whole-cell **Add Comment** behavior when there is no rendered selection

## Root cause

The rendered-selection feature added an unconditional guard that refused to enter edit mode whenever the browser Selection was non-empty. A browser double-click normally creates a word selection before the `dblclick` handler runs, so rendered Markdown could no longer return to edit mode. The automatic popup also performed full selector capture on every selection.

## Impact

Selecting text has no application-side projection cost and no popup is inserted into the document. Right-clicking a valid selection opens the existing context menu; full W3C selector construction happens only after the user explicitly selects **Comment on selected text**.

Follow-up to #320.

## Verification

- `runme run build test`
- `pnpm -C app exec vitest run` — 83 files, 776 tests passed
- focused Actions, MarkdownCell, and rendered-projection tests — 84 tests passed
- `git diff --check`
