### PR TITLE
Fix UTF-8 decoding for Drive media

### DIFF
--- a/app/src/storage/drive.gapi.test.ts
+++ b/app/src/storage/drive.gapi.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="vitest" />
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { clearGoogleDriveRuntime } from '../lib/googleDriveRuntime'
+import { DriveNotebookStore } from './drive'
+
+const originalGapi = window.gapi
+
+afterEach(() => {
+  clearGoogleDriveRuntime()
+  vi.restoreAllMocks()
+  window.gapi = originalGapi
+})
+
+describe('GAPI Drive media downloads', () => {
+  it('decodes UTF-8 file and revision content without emoji mojibake', async () => {
+    const mojibake = '{"text":"ðð½"}'
+    const filesGet = vi.fn().mockResolvedValue({ body: mojibake })
+    const revisionsGet = vi.fn().mockResolvedValue({ body: mojibake })
+
+    window.gapi = {
+      load: (_name, options) => options.callback(),
+      client: {
+        load: vi.fn().mockResolvedValue(undefined),
+        setToken: vi.fn(),
+        getToken: () => ({ access_token: 'access-token' }),
+        drive: {
+          files: {
+            create: vi.fn(),
+            update: vi.fn(),
+            get: filesGet,
+            list: vi.fn(),
+          },
+          drives: { get: vi.fn() },
+          revisions: { get: revisionsGet, list: vi.fn() },
+        },
+        request: vi.fn(),
+      },
+    }
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response('{"text":"👍🏽"}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/x-ipynb+json' },
+        })
+    )
+
+    const store = new DriveNotebookStore(async () => 'access-token')
+
+    await expect(
+      store.loadContent('https://drive.google.com/file/d/file123/view')
+    ).resolves.toBe('{"text":"👍🏽"}')
+    await expect(
+      store.loadRevisionContent(
+        'https://drive.google.com/file/d/file123/view',
+        'revision456'
+      )
+    ).resolves.toBe('{"text":"👍🏽"}')
+    expect(filesGet).not.toHaveBeenCalled()
+    expect(revisionsGet).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.googleapis.com/drive/v3/files/file123?supportsAllDrives=true&alt=media',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer access-token',
+        }),
+      })
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.googleapis.com/drive/v3/files/file123/revisions/revision456?supportsAllDrives=true&alt=media',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer access-token',
+        }),
+      })
+    )
+  })
+})

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -273,6 +273,19 @@ class GapiDriveFilesClient implements DriveFilesClient {
     return { result: JSON.parse(text) }
   }
 
+  private getUtf8Media(
+    path: string,
+    request: Record<string, unknown>
+  ): Promise<{ body?: string; result?: unknown }> {
+    const params = { ...request }
+    delete params.fileId
+    delete params.revisionId
+
+    // GAPI decodes media response bytes as Latin-1. Fetch's Response.text()
+    // decodes them as UTF-8, preserving emoji and other non-ASCII text.
+    return this.request('GET', path, { params, expectText: true })
+  }
+
   // setContent uploads content to a Google Drive file using a media upload.
   // https://content.googleapis.com/upload/drive/v3/files/19uA730OLadqxfEUgUHN35YAQDAt2Pcax?uploadType=media&alt=json
   // It looks like gapi unlike node clients don't have helper methods for media uploads
@@ -394,6 +407,13 @@ class GapiDriveFilesClient implements DriveFilesClient {
   get(
     request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }> {
+    if (request.alt === 'media') {
+      const fileId = String(request.fileId ?? '')
+      return this.getUtf8Media(
+        `/drive/v3/files/${encodeURIComponent(fileId)}`,
+        request
+      )
+    }
     return this.files.get(request as any) as Promise<{
       body?: string
       result?: unknown
@@ -419,6 +439,14 @@ class GapiDriveFilesClient implements DriveFilesClient {
   getRevision(
     request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }> {
+    if (request.alt === 'media') {
+      const fileId = String(request.fileId ?? '')
+      const revisionId = String(request.revisionId ?? '')
+      return this.getUtf8Media(
+        `/drive/v3/files/${encodeURIComponent(fileId)}/revisions/${encodeURIComponent(revisionId)}`,
+        request
+      )
+    }
     return this.revisions.get(request as any) as Promise<{
       body?: string
       result?: unknown


### PR DESCRIPTION
## Summary

- decode Google Drive media responses through the Fetch UTF-8 text path instead of GAPI's Latin-1 response body
- apply the same behavior to current files and historical revisions
- add a regression test covering the combined emoji `👍🏽` and the observed mojibake

## Root cause

GAPI's `alt=media` response body converts UTF-8 bytes to a Latin-1-style string before the notebook parser sees them. Fetching the same authenticated media response and reading it with `Response.text()` preserves the original UTF-8.

## Validation

- `pnpm -C app exec vitest run` — 84 test files, 778 tests passed
- `pnpm -C app exec vitest run src/storage/drive.gapi.test.ts`
- `runme run build test`

## Reproduction notebook

[20260816_test_comments.ipynb](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1X7A3L3tiID2dN1xmcRsilzv4HDnHhVOT%2Fview)
