### PR TITLE
Clarify WebMCP notebook read API

### DIFF
--- a/app/src/lib/runtime/aiAgentInstructions.test.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.test.ts
@@ -61,6 +61,10 @@ describe('readInstructionsForAIAgents', () => {
     expect(instructions).toContain('documentation.get(name)')
     expect(instructions).toContain('await app.getSessionID()')
     expect(instructions).toContain('local://')
+    expect(instructions).toContain('notebooks.get({ uri: notebookUri })')
+    expect(instructions).toContain('doc.notebook.cells')
+    expect(instructions).toContain('There is no `notebooks.read` method')
+    expect(instructions).toContain('await notebooks.help()')
     expect(instructions).toContain('opaque canonical identifier')
     expect(instructions).toContain('IPYNB `cell.id`')
     expect(instructions).toContain(

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -29,6 +29,7 @@ This Runme instance is served from ${runmeOrigin}.
 - Reuse a Runme tab whose URL begins with ${runmeOrigin}. A session URL has the form \`${sessionUrl}\`.
 - Claim the selected tab and use its page-provided WebMCP tools for notebook reads, edits, and execution.
 - Use the \`ExecuteCode\` WebMCP tool to run AppKernel JavaScript. Print values explicitly with \`console.log(...)\`.
+- Read notebooks with \`notebooks.get({ uri: notebookUri })\` and access cells through \`doc.notebook.cells\`. There is no \`notebooks.read\` method. Call \`await notebooks.help()\` before generating notebook code when the API is uncertain.
 - Use the \`comments\` library inside \`ExecuteCode\` for Drive comments and anchors. Runme does not expose a comment-specific WebMCP tool.
 - Use the \`ui\` library inside \`ExecuteCode\` to create rendered Markdown selections and open Runme's selection context menu. Do not invent CSS selectors or dispatch arbitrary DOM events.
 - Do not edit or execute notebook cells through DOM clicks, keyboard automation, or Computer Use. If WebMCP is unavailable, stop and tell the user what must be done manually.

--- a/app/src/lib/runtime/executeCodeTool.test.ts
+++ b/app/src/lib/runtime/executeCodeTool.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  EXECUTE_CODE_TOOL_DESCRIPTION,
+  buildExecuteCodeInputSchema,
+} from './executeCodeTool'
+
+describe('ExecuteCode tool contract', () => {
+  it('keeps the live notebook read API next to code generation', () => {
+    expect(EXECUTE_CODE_TOOL_DESCRIPTION).toContain('notebooks.get({ uri })')
+    expect(EXECUTE_CODE_TOOL_DESCRIPTION).toContain('doc.notebook.cells')
+    expect(EXECUTE_CODE_TOOL_DESCRIPTION).toContain(
+      'notebooks.read is not an API'
+    )
+    expect(EXECUTE_CODE_TOOL_DESCRIPTION).toContain('notebooks.help()')
+
+    const schema = buildExecuteCodeInputSchema() as {
+      properties: { code: { description?: string } }
+    }
+    expect(schema.properties.code.description).toContain(
+      'notebooks.get({ uri })'
+    )
+    expect(schema.properties.code.description).toContain('doc.notebook.cells')
+    expect(schema.properties.code.description).toContain(
+      'Do not call notebooks.read'
+    )
+  })
+})

--- a/app/src/lib/runtime/executeCodeTool.ts
+++ b/app/src/lib/runtime/executeCodeTool.ts
@@ -5,7 +5,7 @@ type JsonRecord = Record<string, unknown>
 export const EXECUTE_CODE_TOOL_NAME = 'ExecuteCode'
 export const EXECUTE_CODE_TOOL_TITLE = 'Runme Execute Code'
 export const EXECUTE_CODE_TOOL_DESCRIPTION =
-  'Start JavaScript in the Runme AppKernel sandbox and return a JSON operation snapshot. Fast work completes inline. Long work continues by default after timeoutMs and can be polled with GetExecuteCodeOperation. Every accepted request returns a Runme-assigned operationId.'
+  'Start JavaScript in the Runme AppKernel sandbox and return a JSON operation snapshot. Read notebooks with notebooks.get({ uri }) and access cells through doc.notebook.cells; notebooks.read is not an API. Call await notebooks.help() when uncertain. Fast work completes inline. Long work continues by default after timeoutMs and can be polled with GetExecuteCodeOperation. Every accepted request returns a Runme-assigned operationId.'
 
 export const GET_EXECUTE_CODE_OPERATION_TOOL_NAME = 'GetExecuteCodeOperation'
 export const GET_EXECUTE_CODE_OPERATION_TOOL_TITLE =
@@ -27,6 +27,8 @@ export function buildExecuteCodeInputSchema(): JsonRecord {
     properties: {
       code: {
         type: 'string',
+        description:
+          'AppKernel JavaScript. For notebook reads, use await notebooks.get({ uri }) and doc.notebook.cells. Do not call notebooks.read; it does not exist. Use await notebooks.help() to inspect the live API.',
       },
       timeoutMs: {
         type: 'integer',


### PR DESCRIPTION
## What changed

- Put the canonical `notebooks.get({ uri })` read path and `doc.notebook.cells` response shape near the top of the runtime-generated AI instructions.
- Repeat that contract in the `ExecuteCode` tool description and `code` input schema, where it is visible closest to code generation.
- Explicitly state that `notebooks.read` is not part of the live API and direct uncertain callers to `notebooks.help()`.
- Add regression coverage for both instruction surfaces.

## Root cause

A WebMCP client correctly bound a notebook with `notebooks.get`, but later generated a mutation using the nonexistent `notebooks.read({ target })` method and assumed a legacy-looking `doc.cells` response. The runtime returned `TypeError: notebooks.read is not a function`. The canonical API was documented, but its highest-signal read contract was too easy to lose among the broader notebook automation guidance and was absent from the `ExecuteCode` schema itself.

This change keeps the correct method and result shape adjacent to every `ExecuteCode` call without adding a second notebook-read API.

## Validation

- `pnpm run build`
- `pnpm run test:run`
- `pnpm -C app exec vitest run src/lib/runtime/aiAgentInstructions.test.ts src/lib/runtime/executeCodeTool.test.ts`
- `pnpm exec prettier --check app/src/lib/runtime/aiAgentInstructions.ts app/src/lib/runtime/aiAgentInstructions.test.ts app/src/lib/runtime/executeCodeTool.ts app/src/lib/runtime/executeCodeTool.test.ts`
