### PR TITLE
Update WebMCP registration to current spec

### DIFF
--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -229,7 +229,10 @@ describe('WebMcpToolRegistrationHost', () => {
           readOnlyHint: boolean
           untrustedContentHint: boolean
         }
-        execute: (input: Record<string, unknown>) => Promise<string> | string
+        execute: (
+          input: Record<string, unknown>,
+          options?: { signal?: AbortSignal }
+        ) => Promise<string> | string
       }
       signal?: AbortSignal
     }> = []
@@ -507,6 +510,52 @@ describe('WebMcpToolRegistrationHost', () => {
     expect(registered.every(({ signal }) => signal?.aborted === true)).toBe(
       true
     )
+  })
+
+  it('cancels an accepted ExecuteCode operation when WebMCP aborts', async () => {
+    let resolveStart:
+      | ((operation: { operationId: string; status: string }) => void)
+      | undefined
+    startOperationMock.mockImplementationOnce(
+      (input) =>
+        new Promise((resolve) => {
+          resolveStart = resolve
+          input.onAccepted?.('exec-aborted')
+        })
+    )
+    cancelOperationMock.mockImplementationOnce(async () => {
+      const operation = {
+        operationId: 'exec-aborted',
+        status: 'cancelled',
+      }
+      resolveStart?.(operation)
+      return operation
+    })
+    const registerTool = vi.fn()
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    })
+
+    render(<WebMcpToolRegistrationHost />)
+    const executeCode = registerTool.mock.calls
+      .map((call) => call[0])
+      .find((tool) => tool.name === 'ExecuteCode')
+    const controller = new AbortController()
+    const execution = executeCode.execute(
+      { code: 'await new Promise(() => {})' },
+      { signal: controller.signal }
+    )
+
+    await waitFor(() => expect(startOperationMock).toHaveBeenCalledTimes(1))
+    controller.abort(new DOMException('Cancelled', 'AbortError'))
+
+    await waitFor(() => {
+      expect(cancelOperationMock).toHaveBeenCalledWith({
+        operationId: 'exec-aborted',
+      })
+    })
+    await expect(execution).resolves.toContain('"status":"cancelled"')
   })
 
   it('does not create an AppConsole cell when ExecuteCode is rejected before acceptance', async () => {

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, waitFor } from '@testing-library/react'
 
 const {
   executeMock,
@@ -141,15 +141,17 @@ describe('WebMcpToolRegistrationHost', () => {
     appLoggerMock.debug.mockReset()
     appLoggerMock.info.mockReset()
     appLoggerMock.error.mockReset()
+    delete (document as Document & { modelContext?: unknown }).modelContext
     delete (navigator as Navigator & { modelContext?: unknown }).modelContext
   })
 
   afterEach(() => {
     cleanup()
+    delete (document as Document & { modelContext?: unknown }).modelContext
     delete (navigator as Navigator & { modelContext?: unknown }).modelContext
   })
 
-  it('skips registration when navigator.modelContext is unavailable', () => {
+  it('skips registration when modelContext is unavailable', () => {
     render(<WebMcpToolRegistrationHost />)
 
     expect(appLoggerMock.debug).toHaveBeenCalledWith(
@@ -160,6 +162,60 @@ describe('WebMcpToolRegistrationHost', () => {
         }),
       })
     )
+  })
+
+  it('falls back to the legacy navigator.modelContext API', () => {
+    const registerTool = vi.fn()
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    })
+
+    render(<WebMcpToolRegistrationHost />)
+
+    expect(registerTool).toHaveBeenCalledTimes(9)
+  })
+
+  it('prefers the current document.modelContext API', () => {
+    const documentRegisterTool = vi.fn()
+    const navigatorRegisterTool = vi.fn()
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool: documentRegisterTool },
+    })
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      value: { registerTool: navigatorRegisterTool },
+    })
+
+    render(<WebMcpToolRegistrationHost />)
+
+    expect(documentRegisterTool).toHaveBeenCalledTimes(9)
+    expect(navigatorRegisterTool).not.toHaveBeenCalled()
+  })
+
+  it('reports asynchronous registration failures', async () => {
+    const registerTool = vi
+      .fn()
+      .mockRejectedValueOnce(new DOMException('not allowed', 'NotAllowedError'))
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    })
+
+    render(<WebMcpToolRegistrationHost />)
+
+    await waitFor(() => {
+      expect(appLoggerMock.error).toHaveBeenCalledWith(
+        'Failed to register WebMCP tools',
+        expect.objectContaining({
+          attrs: expect.objectContaining({
+            scope: 'webmcp',
+            error: 'NotAllowedError: not allowed',
+          }),
+        })
+      )
+    })
   })
 
   it('registers WebMCP tools and unregisters them on cleanup', async () => {
@@ -183,7 +239,7 @@ describe('WebMcpToolRegistrationHost', () => {
         signal: options?.signal,
       })
     })
-    Object.defineProperty(navigator, 'modelContext', {
+    Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: {
         registerTool,
@@ -409,9 +465,7 @@ describe('WebMcpToolRegistrationHost', () => {
     const createDriveNotebook = registered.find(
       ({ tool }) => tool.name === 'createDriveNotebook'
     )
-    expect(createDriveNotebook?.tool.title).toBe(
-      'Create Google Drive Notebook'
-    )
+    expect(createDriveNotebook?.tool.title).toBe('Create Google Drive Notebook')
     expect(createDriveNotebook?.tool.annotations).toEqual({
       readOnlyHint: false,
       untrustedContentHint: false,
@@ -434,14 +488,10 @@ describe('WebMcpToolRegistrationHost', () => {
         cells: [{ kind: 'markup', value: '# Demo' }],
       })
     ).resolves.toContain('"fileId":"drive-file-1"')
-    expect(createDriveNotebookMock).toHaveBeenCalledWith(
-      'root',
-      'demo.ipynb',
-      {
-        idempotencyKey: 'create-demo-notebook',
-        cells: [{ kind: 'markup', value: '# Demo' }],
-      }
-    )
+    expect(createDriveNotebookMock).toHaveBeenCalledWith('root', 'demo.ipynb', {
+      idempotencyKey: 'create-demo-notebook',
+      cells: [{ kind: 'markup', value: '# Demo' }],
+    })
 
     expect(
       registered.some(({ tool }) => tool.name === 'startTourWorkflow')
@@ -461,7 +511,7 @@ describe('WebMcpToolRegistrationHost', () => {
 
   it('does not create an AppConsole cell when ExecuteCode is rejected before acceptance', async () => {
     startOperationMock.mockRejectedValueOnce(new Error('boom'))
-    Object.defineProperty(navigator, 'modelContext', {
+    Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: {
         registerTool: vi.fn(),
@@ -470,7 +520,7 @@ describe('WebMcpToolRegistrationHost', () => {
 
     render(<WebMcpToolRegistrationHost />)
     const registerTool = (
-      navigator as Navigator & {
+      document as Document & {
         modelContext?: { registerTool: ReturnType<typeof vi.fn> }
       }
     ).modelContext?.registerTool
@@ -500,7 +550,7 @@ describe('WebMcpToolRegistrationHost', () => {
         localUri: 'local://file/drive-file-1',
       })
     const registerTool = vi.fn()
-    Object.defineProperty(navigator, 'modelContext', {
+    Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: { registerTool },
     })
@@ -555,7 +605,7 @@ describe('WebMcpToolRegistrationHost', () => {
       input.onSettled?.(operation)
       return operation
     })
-    Object.defineProperty(navigator, 'modelContext', {
+    Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: {
         registerTool: vi.fn(),
@@ -564,7 +614,7 @@ describe('WebMcpToolRegistrationHost', () => {
 
     render(<WebMcpToolRegistrationHost />)
     const registerTool = (
-      navigator as Navigator & {
+      document as Document & {
         modelContext?: { registerTool: ReturnType<typeof vi.fn> }
       }
     ).modelContext?.registerTool

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -87,7 +87,7 @@ type ModelContextLike = {
       ) => Promise<string> | string
     },
     options?: { signal?: AbortSignal }
-  ) => Promise<void> | void
+  ) => Promise<undefined> | undefined
 }
 
 function getModelContext(): ModelContextLike | null {
@@ -177,7 +177,7 @@ export default function WebMcpToolRegistrationHost() {
     }
 
     const registrationController = new AbortController()
-    const registrationPromises: Promise<void>[] = []
+    const registrationPromises: Promise<undefined>[] = []
 
     const registerTool: ModelContextLike['registerTool'] = (tool, options) => {
       const result = modelContext.registerTool(tool, options)

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -197,17 +197,60 @@ export default function WebMcpToolRegistrationHost() {
             readOnlyHint: false,
             untrustedContentHint: true,
           },
-          execute: async (input) => {
+          execute: async (input, options) => {
             const code =
               typeof input?.code === 'string'
                 ? input.code
                 : String(input?.code ?? '')
-            await appConsoleData.hydrate()
+            const signal = options?.signal
+            if (signal?.aborted) {
+              throw (
+                signal.reason ??
+                new DOMException('ExecuteCode was cancelled.', 'AbortError')
+              )
+            }
             const executionState: {
               current: ReturnType<typeof appConsoleData.startExternalExecution>
             } = { current: null }
+            let acceptedOperationId: string | null = null
+            let cancellationPromise: Promise<unknown> | null = null
+
+            // WebMCP cancellation can arrive before the registry assigns an
+            // operation ID. Once accepted, schedule cancellation after the
+            // registry has installed its live control handle.
+            const cancelAcceptedOperation = () => {
+              if (!acceptedOperationId || cancellationPromise) {
+                return
+              }
+              const operationId = acceptedOperationId
+              cancellationPromise = codeOperationRegistry
+                .cancel({ operationId })
+                .catch((error) => {
+                  appLogger.error(
+                    'Failed to cancel WebMCP ExecuteCode operation',
+                    {
+                      attrs: {
+                        scope: 'webmcp.execute_code',
+                        operationId,
+                        error: String(error),
+                      },
+                    }
+                  )
+                })
+            }
+            const handleAbort = () => {
+              queueMicrotask(cancelAcceptedOperation)
+            }
+            signal?.addEventListener('abort', handleAbort, { once: true })
 
             try {
+              await appConsoleData.hydrate()
+              if (signal?.aborted) {
+                throw (
+                  signal.reason ??
+                  new DOMException('ExecuteCode was cancelled.', 'AbortError')
+                )
+              }
               const result = await codeOperationRegistry.start({
                 code,
                 ...(typeof input?.timeoutMs === 'number'
@@ -223,9 +266,13 @@ export default function WebMcpToolRegistrationHost() {
                 ...(typeof input?.idempotencyKey === 'string'
                   ? { idempotencyKey: input.idempotencyKey }
                   : {}),
-                onAccepted: () => {
+                onAccepted: (operationId) => {
+                  acceptedOperationId = operationId
                   executionState.current =
                     appConsoleData.startExternalExecution(code)
+                  if (signal?.aborted) {
+                    queueMicrotask(cancelAcceptedOperation)
+                  }
                 },
                 hooks: {
                   onStdout: (chunk) => {
@@ -260,6 +307,11 @@ export default function WebMcpToolRegistrationHost() {
                   })
                 },
               })
+              if (signal?.aborted) {
+                acceptedOperationId ??= result.operationId
+                cancelAcceptedOperation()
+                await cancellationPromise
+              }
               return JSON.stringify(result)
             } catch (error) {
               const execution = executionState.current
@@ -270,6 +322,8 @@ export default function WebMcpToolRegistrationHost() {
                 })
               }
               throw error
+            } finally {
+              signal?.removeEventListener('abort', handleAbort)
             }
           },
         },

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -62,7 +62,9 @@ import {
 } from '../../lib/runtime/createDriveNotebookTool'
 import { appState } from '../../lib/runtime/AppState'
 
-type ModelContextClientLike = {
+type ToolExecuteOptionsLike = {
+  signal?: AbortSignal
+  // Legacy host extension. This is not part of the current WebMCP specification.
   requestUserInteraction?: (
     callback: () => Promise<unknown> | unknown
   ) => Promise<unknown>
@@ -81,26 +83,40 @@ type ModelContextLike = {
       }
       execute: (
         input: Record<string, unknown>,
-        client: ModelContextClientLike
+        options: ToolExecuteOptionsLike
       ) => Promise<string> | string
     },
     options?: { signal?: AbortSignal }
-  ) => void
+  ) => Promise<void> | void
 }
 
 function getModelContext(): ModelContextLike | null {
-  if (typeof navigator === 'undefined') {
-    return null
+  const documentModelContext =
+    typeof document === 'undefined'
+      ? undefined
+      : (
+          document as Document & {
+            modelContext?: Partial<ModelContextLike>
+          }
+        ).modelContext
+  if (typeof documentModelContext?.registerTool === 'function') {
+    return documentModelContext as ModelContextLike
   }
-  const modelContext = (
-    navigator as Navigator & {
-      modelContext?: Partial<ModelContextLike>
-    }
-  ).modelContext
-  if (!modelContext || typeof modelContext.registerTool !== 'function') {
-    return null
+
+  // Compatibility fallback for implementations of the earlier WebMCP draft.
+  const navigatorModelContext =
+    typeof navigator === 'undefined'
+      ? undefined
+      : (
+          navigator as Navigator & {
+            modelContext?: Partial<ModelContextLike>
+          }
+        ).modelContext
+  if (typeof navigatorModelContext?.registerTool === 'function') {
+    return navigatorModelContext as ModelContextLike
   }
-  return modelContext as ModelContextLike
+
+  return null
 }
 
 function isDriveAuthorizationRequired(error: unknown): boolean {
@@ -112,7 +128,7 @@ function isDriveAuthorizationRequired(error: unknown): boolean {
 
 async function executeCreateDriveNotebookWithAuthorization(
   input: Record<string, unknown>,
-  client: ModelContextClientLike
+  options: ToolExecuteOptionsLike
 ): Promise<string> {
   try {
     // Preserve the no-UI path for cached tokens and service-account sessions.
@@ -120,12 +136,12 @@ async function executeCreateDriveNotebookWithAuthorization(
   } catch (error) {
     if (
       !isDriveAuthorizationRequired(error) ||
-      typeof client.requestUserInteraction !== 'function'
+      typeof options.requestUserInteraction !== 'function'
     ) {
       throw error
     }
 
-    const result = await client.requestUserInteraction(async () => {
+    const result = await options.requestUserInteraction(async () => {
       const authorization = await appState.startGoogleDriveOAuth({
         mode: 'popup',
       })
@@ -161,9 +177,17 @@ export default function WebMcpToolRegistrationHost() {
     }
 
     const registrationController = new AbortController()
+    const registrationPromises: Promise<void>[] = []
+
+    const registerTool: ModelContextLike['registerTool'] = (tool, options) => {
+      const result = modelContext.registerTool(tool, options)
+      const registration = Promise.resolve(result)
+      registrationPromises.push(registration)
+      return registration
+    }
 
     try {
-      modelContext.registerTool(
+      registerTool(
         {
           name: EXECUTE_CODE_TOOL_NAME,
           title: EXECUTE_CODE_TOOL_TITLE,
@@ -253,7 +277,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: GET_EXECUTE_CODE_OPERATION_TOOL_NAME,
           title: GET_EXECUTE_CODE_OPERATION_TOOL_TITLE,
@@ -274,7 +298,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: CANCEL_EXECUTE_CODE_OPERATION_TOOL_NAME,
           title: CANCEL_EXECUTE_CODE_OPERATION_TOOL_TITLE,
@@ -295,7 +319,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
           title: READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_TITLE,
@@ -311,7 +335,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: LIST_DOCUMENTATION_TOOL_NAME,
           title: LIST_DOCUMENTATION_TOOL_TITLE,
@@ -327,7 +351,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: GET_DOCUMENTATION_TOOL_NAME,
           title: GET_DOCUMENTATION_TOOL_TITLE,
@@ -346,7 +370,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: SHOW_TOUR_STEP_TOOL_NAME,
           title: SHOW_TOUR_STEP_TOOL_TITLE,
@@ -362,7 +386,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: DISMISS_TOUR_TOOL_NAME,
           title: DISMISS_TOUR_TOOL_TITLE,
@@ -378,7 +402,7 @@ export default function WebMcpToolRegistrationHost() {
           signal: registrationController.signal,
         }
       )
-      modelContext.registerTool(
+      registerTool(
         {
           name: CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
           title: CREATE_DRIVE_NOTEBOOK_TOOL_TITLE,
@@ -388,32 +412,50 @@ export default function WebMcpToolRegistrationHost() {
             readOnlyHint: false,
             untrustedContentHint: false,
           },
-          execute: (input, client) =>
-            executeCreateDriveNotebookWithAuthorization(input, client),
+          execute: (input, options) =>
+            executeCreateDriveNotebookWithAuthorization(input, options),
         },
         {
           signal: registrationController.signal,
         }
       )
-      appLogger.info('WebMCP tools registered', {
-        attrs: {
-          scope: 'webmcp',
-          toolNames: [
-            EXECUTE_CODE_TOOL_NAME,
-            GET_EXECUTE_CODE_OPERATION_TOOL_NAME,
-            CANCEL_EXECUTE_CODE_OPERATION_TOOL_NAME,
-            READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
-            LIST_DOCUMENTATION_TOOL_NAME,
-            GET_DOCUMENTATION_TOOL_NAME,
-            SHOW_TOUR_STEP_TOOL_NAME,
-            DISMISS_TOUR_TOOL_NAME,
-            CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
-          ],
-        },
-      })
+      void Promise.all(registrationPromises)
+        .then(() => {
+          if (registrationController.signal.aborted) {
+            return
+          }
+          appLogger.info('WebMCP tools registered', {
+            attrs: {
+              scope: 'webmcp',
+              toolNames: [
+                EXECUTE_CODE_TOOL_NAME,
+                GET_EXECUTE_CODE_OPERATION_TOOL_NAME,
+                CANCEL_EXECUTE_CODE_OPERATION_TOOL_NAME,
+                READ_INSTRUCTIONS_FOR_AI_AGENTS_TOOL_NAME,
+                LIST_DOCUMENTATION_TOOL_NAME,
+                GET_DOCUMENTATION_TOOL_NAME,
+                SHOW_TOUR_STEP_TOOL_NAME,
+                DISMISS_TOUR_TOOL_NAME,
+                CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
+              ],
+            },
+          })
+        })
+        .catch((error) => {
+          if (registrationController.signal.aborted) {
+            return
+          }
+          registrationController.abort(error)
+          appLogger.error('Failed to register WebMCP tools', {
+            attrs: {
+              scope: 'webmcp',
+              error: String(error),
+            },
+          })
+        })
     } catch (error) {
       registrationController.abort()
-      appLogger.error('Failed to register WebMCP tool', {
+      appLogger.error('Failed to register WebMCP tools', {
         attrs: {
           scope: 'webmcp',
           error: String(error),

--- a/docs-dev/design/20260510_webmcp.md
+++ b/docs-dev/design/20260510_webmcp.md
@@ -2,12 +2,12 @@
 
 ## Status
 
-Draft proposal.
+Implemented. Updated August 21, 2026 for the current WebMCP API.
 
 ## Summary
 
 Add WebMCP support to the web app by registering one browser tool through
-`navigator.modelContext.registerTool(...)` when the API is available.
+`document.modelContext.registerTool(...)` when the API is available.
 
 The tool will reuse the existing AppKernel code-mode path:
 
@@ -56,11 +56,12 @@ opening the AI panel.
 ## Why WebMCP Fits This Architecture
 
 The WebMCP spec is a browser API for exposing site-defined tools to browser
-agents. The current draft published on April 23, 2026 defines:
+agents. The current draft defines:
 
-- `navigator.modelContext` on `Navigator`
+- `document.modelContext` on `Document`
 - `modelContext.registerTool(tool, options?)`
 - imperative tool registration with a JSON-schema-like `inputSchema`
+- promise-based registration
 - `AbortSignal`-driven unregistration
 
 That maps cleanly onto Runme's existing browser-local tool execution model. We
@@ -83,17 +84,17 @@ Proposed WebMCP registration object:
 
 ```ts
 const tool = {
-  name: "ExecuteCode",
-  title: "Runme Execute Code",
+  name: 'ExecuteCode',
+  title: 'Runme Execute Code',
   description:
-    "Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr string.",
+    'Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr string.',
   inputSchema: {
-    type: "object",
+    type: 'object',
     additionalProperties: false,
     properties: {
-      code: { type: "string" },
+      code: { type: 'string' },
     },
-    required: ["code"],
+    required: ['code'],
   },
   annotations: {
     readOnlyHint: false,
@@ -102,11 +103,11 @@ const tool = {
   async execute(input: { code: string }) {
     const result = await codeModeExecutor.execute({
       code: input.code,
-      source: "webmcp",
-    });
-    return result.output;
+      source: 'webmcp',
+    })
+    return result.output
   },
-};
+}
 ```
 
 Notes:
@@ -124,16 +125,17 @@ Register only when all of these are true:
 
 ```ts
 const isWebMcpAvailable =
-  typeof navigator !== "undefined" &&
-  typeof navigator.modelContext !== "undefined" &&
-  typeof navigator.modelContext?.registerTool === "function";
+  typeof document !== 'undefined' &&
+  typeof document.modelContext?.registerTool === 'function'
 ```
 
-`navigator.modelContext` presence is the right first gate. Checking
+`document.modelContext` presence is the standards-based first gate. Checking
 `registerTool` as a function keeps the detection resilient to partial or
-experimental browser implementations.
+experimental browser implementations. Runme also checks
+`navigator.modelContext` as a compatibility fallback for implementations of
+the earlier draft.
 
-The spec marks `navigator.modelContext` as a secure-context API. In practice,
+The spec marks `document.modelContext` as a secure-context API. In practice,
 that means this should only work where the browser exposes it, typically under
 HTTPS or localhost-style development contexts.
 
@@ -153,11 +155,14 @@ Use `AbortController` so cleanup automatically unregisters the tool:
 
 ```ts
 const controller = new AbortController();
-navigator.modelContext.registerTool(tool, { signal: controller.signal });
+await document.modelContext.registerTool(tool, { signal: controller.signal });
 return () => controller.abort();
 ```
 
-This follows the spec and keeps dev/HMR behavior manageable.
+This follows the spec and keeps dev/HMR behavior manageable. Registration
+promises must be observed so asynchronous schema, duplicate-name, and
+permissions-policy failures are logged instead of becoming unhandled promise
+rejections.
 
 ### Execution ownership
 
@@ -169,12 +174,12 @@ example:
 
 ```ts
 type UseCodeModeExecutorOptions = {
-  mode?: "browser" | "sandbox";
-};
+  mode?: 'browser' | 'sandbox'
+}
 
 function useCodeModeExecutor(
-  options?: UseCodeModeExecutorOptions,
-): CodeModeExecutor;
+  options?: UseCodeModeExecutorOptions
+): CodeModeExecutor
 ```
 
 This hook should own:
@@ -201,21 +206,21 @@ WebMCP do not drift.
 Example:
 
 ```ts
-export const EXECUTE_CODE_TOOL_NAME = "ExecuteCode";
+export const EXECUTE_CODE_TOOL_NAME = 'ExecuteCode'
 
 export function buildExecuteCodeInputSchema() {
   return {
-    type: "object",
+    type: 'object',
     additionalProperties: false,
     properties: {
-      code: { type: "string" },
+      code: { type: 'string' },
     },
-    required: ["code"],
-  };
+    required: ['code'],
+  }
 }
 
 export function getExecuteCodeDescription(): string {
-  return "Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr string.";
+  return 'Execute JavaScript in the Runme AppKernel sandbox and return one merged stdout/stderr string.'
 }
 ```
 
@@ -231,13 +236,13 @@ We do not need to refactor the proto-based Codex bridge in this change.
 Extend `CodeModeSource` in `codeModeExecutor.ts` from:
 
 ```ts
-type CodeModeSource = "chatkit" | "codex";
+type CodeModeSource = 'chatkit' | 'codex'
 ```
 
 to:
 
 ```ts
-type CodeModeSource = "chatkit" | "codex" | "webmcp";
+type CodeModeSource = 'chatkit' | 'codex' | 'webmcp'
 ```
 
 This is not required for functionality, but it makes logs and future metrics
@@ -292,7 +297,7 @@ to notebook state.
 
 ```mermaid
 flowchart TD
-    A["Browser loads Runme page"] --> B{"navigator.modelContext available?"}
+    A["Browser loads Runme page"] --> B{"document.modelContext available?"}
     B -- "no" --> C["No-op; feature remains disabled"]
     B -- "yes" --> D["WebMcpToolRegistrationHost registers ExecuteCode"]
     D --> E["Browser agent discovers tool"]
@@ -365,15 +370,19 @@ using a distinct `source: "webmcp"` value.
 
 ### Unit
 
-- `isWebMcpAvailable` returns false when `navigator.modelContext` is missing
+- availability detection returns false when neither current nor legacy
+  `modelContext` is present
 - registrar calls `registerTool(...)` once when available
+- asynchronous registration failures are observed and logged
 - cleanup aborts the registration signal
 - registered callback invokes `CodeModeExecutor.execute(...)`
 - registered callback returns the merged output string
 
 ### Integration
 
-- fake `navigator.modelContext` in jsdom and verify root registration
+- fake `document.modelContext` in jsdom and verify root registration
+- verify `navigator.modelContext` remains a compatibility fallback
+- verify `document.modelContext` wins when both APIs exist
 - verify the registered tool can call notebook helpers through the existing
   AppKernel sandbox bridge
 - verify the app does nothing in browsers without WebMCP support
@@ -414,11 +423,11 @@ sandbox code-mode executor.
 
 We will:
 
-- register one `ExecuteCode` tool through `navigator.modelContext`
+- register tools through `document.modelContext`
 - reuse `createCodeModeExecutor(...)`
 - extract the executor setup from `ChatKitPanel` into a shared hook
 - mount a root-level registration host in `App.tsx`
-- no-op when `navigator.modelContext` is not defined
+- no-op when neither current nor legacy `modelContext` is defined
 
 We will not:
 
@@ -428,7 +437,9 @@ We will not:
 
 ## References
 
-- WebMCP draft, April 23, 2026: https://webmachinelearning.github.io/webmcp/
+- WebMCP Community Group draft: https://webmachinelearning.github.io/webmcp/
+- Chrome WebMCP imperative API:
+  https://developer.chrome.com/docs/ai/webmcp/imperative-api
 - `app/src/lib/runtime/codeModeExecutor.ts`
 - `app/src/lib/runtime/notebookToolHandlers.ts`
 - `app/src/lib/runtime/responsesDirectChatKitAdapter.ts`


### PR DESCRIPTION
## Summary

- register tools through the current `document.modelContext` WebMCP API
- retain `navigator.modelContext` as a compatibility fallback for earlier implementations
- observe asynchronous `registerTool` failures and update the design documentation

## Verification

- `pnpm -C app exec vitest run src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx`
- `runme run build test`
- opened `http://localhost:5173` in the ChatGPT in-app browser
- verified all nine Runme WebMCP tools were registered
- successfully invoked the read-only `listDocumentation` tool through WebMCP