### PR TITLE
Fix comment range navigation and highlights

### DIFF
--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2177,6 +2177,20 @@ function NotebookTabContent({
       focusCommentCell(target.cellId)
       const range = target.range
       setActiveCommentRange(range ? { cellId: target.cellId, ...range } : null)
+
+      const scrollCellIntoView = () => {
+        const element = findCellElement(target.cellId)
+        if (!element) {
+          return false
+        }
+        element.scrollIntoView({
+          block: 'center',
+          inline: 'nearest',
+          behavior: 'smooth',
+        })
+        return true
+      }
+
       const scrollToTarget = () => {
         const element = findCellElement(target.cellId)
         if (!element) {
@@ -2194,20 +2208,30 @@ function NotebookTabContent({
           }
           return false
         }
-        element.scrollIntoView({
-          block: 'center',
-          inline: 'nearest',
-          behavior: 'smooth',
-        })
-        return true
+        return scrollCellIntoView()
       }
 
-      if (!scrollToTarget() && typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(scrollToTarget)
+      if (scrollToTarget()) {
+        return
+      }
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => {
+          if (!scrollToTarget()) {
+            scrollCellIntoView()
+          }
+        })
+      } else {
+        scrollCellIntoView()
       }
     },
     [findCellElement, focusCommentCell]
   )
+
+  useEffect(() => {
+    if (!commentsPanelOpen) {
+      setActiveCommentRange(null)
+    }
+  }, [commentsPanelOpen])
 
   const embedImageFiles = useCallback(
     async (files: File[]) => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -112,11 +112,14 @@ import {
   groupCommentsByCell,
   toCellCommentThreads,
   type CommentDraftTarget,
+  type CommentNavigationTarget,
 } from '../../lib/notebookComments'
 import {
   buildRenderedMarkdownProjection,
+  scrollRenderedMarkdownRangeIntoView,
   type RenderedMarkdownSelectionDraft,
 } from '../../lib/markdown/renderedMarkdownProjection'
+import type { RenderedMarkdownCommentRange } from '../../lib/markdown/renderedMarkdownCommentHighlights'
 import DriveLinkStatusTab from '../DriveLinkStatusTab'
 import DriveSyncStatusTab from '../DriveSyncStatusTab'
 import RunnerStatusTab from '../RunnerStatusTab'
@@ -590,6 +593,7 @@ export function Action({
   readOnly = false,
   commentsAvailable = false,
   commentCount = 0,
+  commentRanges = [],
   onStartComment,
   isDeepLinkTarget = false,
 }: {
@@ -604,6 +608,7 @@ export function Action({
   readOnly?: boolean
   commentsAvailable?: boolean
   commentCount?: number
+  commentRanges?: readonly RenderedMarkdownCommentRange[]
   onStartComment?: (target: CommentDraftTarget) => void
   isDeepLinkTarget?: boolean
 }) {
@@ -1458,6 +1463,7 @@ export function Action({
               onFocusRoleChange={handleMarkdownFocusRoleChange}
               onLinkClick={handleMarkdownLinkClick}
               commentsAvailable={commentsAvailable}
+              commentRanges={commentRanges}
               onRenderedSelectionContextMenu={
                 handleRenderedSelectionContextMenu
               }
@@ -2059,6 +2065,11 @@ function NotebookTabContent({
   const [draftTarget, setDraftTarget] = useState<CommentDraftTarget | null>(
     null
   )
+  const [activeCommentRange, setActiveCommentRange] = useState<{
+    cellId: string
+    start: number
+    end: number
+  } | null>(null)
   const [draftContent, setDraftContent] = useState('')
   const commentsSyncInFlightRef = useRef<Promise<void> | null>(null)
   const commentsSyncRerunRequestedRef = useRef(false)
@@ -2095,6 +2106,45 @@ function NotebookTabContent({
     () => toCellCommentThreads(comments, commentCellIdentities),
     [commentCellIdentities, comments]
   )
+  const commentRangesByCell = useMemo(() => {
+    const ranges = new Map<string, RenderedMarkdownCommentRange[]>()
+    const addRange = (cellId: string, start: number, end: number) => {
+      const values = ranges.get(cellId) ?? []
+      const active =
+        activeCommentRange?.cellId === cellId &&
+        activeCommentRange.start === start &&
+        activeCommentRange.end === end
+      const existing = values.find(
+        (value) => value.start === start && value.end === end
+      )
+      if (existing) {
+        existing.active ||= active
+      } else {
+        values.push({
+          start,
+          end,
+          active,
+        })
+        ranges.set(cellId, values)
+      }
+    }
+    commentThreads.forEach((thread) => {
+      if (
+        thread.comment.resolved ||
+        !thread.cellId ||
+        (thread.location?.status !== 'exact' &&
+          thread.location?.status !== 'moved')
+      ) {
+        return
+      }
+      addRange(thread.cellId, thread.location.start, thread.location.end)
+    })
+    if (draftTarget?.type === 'cell-text') {
+      const { start, end } = draftTarget.selectors[0]
+      addRange(draftTarget.cellId, start, end)
+    }
+    return ranges
+  }, [activeCommentRange, commentThreads, draftTarget])
 
   const findCellElement = useCallback((cellId: string) => {
     const elements =
@@ -2108,7 +2158,7 @@ function NotebookTabContent({
     )
   }, [])
 
-  const selectCommentCell = useCallback(
+  const focusCommentCell = useCallback(
     (cellId: string) => {
       const element = findCellElement(cellId)
       const focusRole = element?.id.startsWith('markdown-action-')
@@ -2118,9 +2168,45 @@ function NotebookTabContent({
       if (nextState) {
         onCellFocus(docUri, nextState)
       }
-      element?.scrollIntoView({ block: 'center', behavior: 'smooth' })
     },
     [docUri, findCellElement, onCellFocus]
+  )
+
+  const selectCommentTarget = useCallback(
+    (target: CommentNavigationTarget) => {
+      focusCommentCell(target.cellId)
+      const range = target.range
+      setActiveCommentRange(range ? { cellId: target.cellId, ...range } : null)
+      const scrollToTarget = () => {
+        const element = findCellElement(target.cellId)
+        if (!element) {
+          return false
+        }
+        if (range) {
+          const root = element.querySelector<HTMLElement>(
+            '[data-runme-surface="rendered-markdown"]'
+          )
+          if (
+            root &&
+            scrollRenderedMarkdownRangeIntoView(root, range.start, range.end)
+          ) {
+            return true
+          }
+          return false
+        }
+        element.scrollIntoView({
+          block: 'center',
+          inline: 'nearest',
+          behavior: 'smooth',
+        })
+        return true
+      }
+
+      if (!scrollToTarget() && typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(scrollToTarget)
+      }
+    },
+    [findCellElement, focusCommentCell]
   )
 
   const embedImageFiles = useCallback(
@@ -2408,6 +2494,7 @@ function NotebookTabContent({
     let cancelled = false
     setDraftTarget(null)
     setDraftContent('')
+    setActiveCommentRange(null)
     setCommentsErrorMessage(undefined)
 
     void (async () => {
@@ -2491,6 +2578,11 @@ function NotebookTabContent({
       }
       setDraftTarget(draft.target)
       setDraftContent(draft.content)
+      setActiveCommentRange(
+        draft.target.type === 'cell-text'
+          ? { cellId: draft.target.cellId, ...draft.target.selectors[0] }
+          : null
+      )
       openCommentsPanel()
     })
     return () => {
@@ -2513,7 +2605,12 @@ function NotebookTabContent({
       openCommentsPanel()
       setDraftTarget(target)
       setDraftContent('')
-      selectCommentCell(target.cellId)
+      focusCommentCell(target.cellId)
+      setActiveCommentRange(
+        target.type === 'cell-text'
+          ? { cellId: target.cellId, ...target.selectors[0] }
+          : null
+      )
       if (commentsRemoteUri) {
         void appState.localComments
           ?.saveDraft({
@@ -2529,7 +2626,7 @@ function NotebookTabContent({
           })
       }
     },
-    [commentsRemoteUri, docUri, openCommentsPanel, selectCommentCell]
+    [commentsRemoteUri, docUri, focusCommentCell, openCommentsPanel]
   )
 
   const handleDraftContentChange = useCallback(
@@ -2561,6 +2658,7 @@ function NotebookTabContent({
   const handleCancelCommentDraft = useCallback(() => {
     setDraftTarget(null)
     setDraftContent('')
+    setActiveCommentRange(null)
     void appState.localComments?.deleteDraft(docUri).catch((error) => {
       setCommentsSyncErrorMessage(
         `Could not discard the saved comment draft: ${String(error)}`
@@ -3032,6 +3130,7 @@ function NotebookTabContent({
                     readOnly={readOnly}
                     commentsAvailable={Boolean(commentsRemoteUri)}
                     commentCount={commentsByCell.get(refId)?.length ?? 0}
+                    commentRanges={commentRangesByCell.get(refId) ?? []}
                     onStartComment={startCommentDraft}
                   />
                 )
@@ -3084,8 +3183,11 @@ function NotebookTabContent({
           onReopen={handleReopenComment}
           onRefresh={refreshComments}
           onRetryFailed={handleRetryFailedComments}
-          onHide={() => setCommentsPanelOpen(false)}
-          onSelectCell={selectCommentCell}
+          onHide={() => {
+            setActiveCommentRange(null)
+            setCommentsPanelOpen(false)
+          }}
+          onSelectTarget={selectCommentTarget}
         />
       )}
     </div>

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -600,4 +600,68 @@ describe("MarkdownCell", () => {
       }),
     );
   });
+
+  it("keeps resolved comment ranges highlighted after selection collapses", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-comment-highlight",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "Read **the [migration guide](https://example.com)** today.",
+    });
+
+    renderMarkdownCell(new StubCellData(cell) as unknown as CellData, {
+      commentRanges: [{ start: 9, end: 24, active: true }],
+    });
+
+    const rendered = screen.getByTestId("markdown-rendered");
+    expect(rendered.dataset.runmeCommentRangeCount).toBe("1");
+    expect(screen.getByText("migration guide").dataset).toMatchObject({
+      runmeCommentHighlight: "active",
+    });
+    expect(
+      screen.getByText("1 commented text range in this cell."),
+    ).toBeTruthy();
+
+    window.getSelection()?.removeAllRanges();
+    expect(screen.getByText("migration guide").dataset).toMatchObject({
+      runmeCommentHighlight: "active",
+    });
+  });
+
+  it("registers comment ranges that arrive after the rendered cell mounts", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-comment-highlight-sync",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      outputs: [],
+      metadata: {},
+      value: "Read **the [migration guide](https://example.com)** today.",
+    });
+    const stub = new StubCellData(cell);
+    const baseProps = {
+      cellData: stub as unknown as CellData,
+      selectedLanguage: "markdown",
+      languageSelectId: "lang-md-comment-highlight-sync",
+      languageOptions: [{ label: "Markdown", value: "markdown" }],
+      onLanguageChange: () => {},
+    };
+    const { rerender } = render(<MarkdownCell {...baseProps} />);
+
+    expect(screen.getByText("migration guide").dataset).not.toHaveProperty(
+      "runmeCommentHighlight",
+    );
+
+    rerender(
+      <MarkdownCell
+        {...baseProps}
+        commentRanges={[{ start: 9, end: 24, active: true }]}
+      />,
+    );
+
+    expect(screen.getByText("migration guide").dataset).toMatchObject({
+      runmeCommentHighlight: "active",
+    });
+  });
 });

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -22,6 +22,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -45,6 +46,10 @@ import {
   type RenderedMarkdownProjection,
   type RenderedMarkdownSelectionDraft,
 } from '../../lib/markdown/renderedMarkdownProjection'
+import {
+  registerRenderedMarkdownCommentHighlights,
+  type RenderedMarkdownCommentRange,
+} from '../../lib/markdown/renderedMarkdownCommentHighlights'
 import Editor from './Editor'
 import { fontSettings } from './CellConsole'
 
@@ -183,12 +188,33 @@ interface MarkdownCellProps {
   readOnly?: boolean
   /** Whether the current Drive-backed notebook can accept comments. */
   commentsAvailable?: boolean
+  /** Resolved open-comment ranges to keep visible in rendered Markdown. */
+  commentRanges?: readonly RenderedMarkdownCommentRange[]
   /** Open the cell context menu with a lazily captured rendered selection. */
   onRenderedSelectionContextMenu?: (request: {
     x: number
     y: number
     captureSelection: () => RenderedMarkdownSelectionDraft | null
   }) => void
+}
+
+function sameCommentRanges(
+  left: readonly RenderedMarkdownCommentRange[] | undefined,
+  right: readonly RenderedMarkdownCommentRange[] | undefined
+): boolean {
+  const leftRanges = left ?? []
+  const rightRanges = right ?? []
+  return (
+    leftRanges.length === rightRanges.length &&
+    leftRanges.every((range, index) => {
+      const other = rightRanges[index]
+      return (
+        range.start === other?.start &&
+        range.end === other?.end &&
+        Boolean(range.active) === Boolean(other?.active)
+      )
+    })
+  )
 }
 
 /**
@@ -215,6 +241,7 @@ const MarkdownCell = memo(
     onLinkClick,
     readOnly = false,
     commentsAvailable = false,
+    commentRanges = [],
     onRenderedSelectionContextMenu,
   }: MarkdownCellProps) => {
     // Subscribe to cell data changes using useSyncExternalStore for tearing-safe reads
@@ -241,6 +268,7 @@ const MarkdownCell = memo(
     })
     const renderedRef = useRef<HTMLDivElement | null>(null)
     const projectionRef = useRef<RenderedMarkdownProjection | null>(null)
+    const commentHighlightOwnerRef = useRef<object>({})
     const previousShouldOwnFocusRef = useRef(false)
     const [editorFocusIntent, setEditorFocusIntent] = useState(false)
     const [renderedFocusIntent, setRenderedFocusIntent] = useState(false)
@@ -277,7 +305,7 @@ const MarkdownCell = memo(
       if (!renderedFocusIntent || !rendered) {
         return
       }
-      renderedRef.current?.focus()
+      renderedRef.current?.focus({ preventScroll: true })
       setRenderedFocusIntent(false)
     }, [rendered, renderedFocusIntent])
 
@@ -295,14 +323,14 @@ const MarkdownCell = memo(
         return
       }
       setRendered(true)
-      renderedRef.current?.focus()
+      renderedRef.current?.focus({ preventScroll: true })
     }, [activeFocusRole, canOpenSource, readOnly, shouldOwnFocus, value])
 
     useEffect(() => {
       if (!shouldOwnFocus || activeFocusRole !== 'rendered' || !rendered) {
         return
       }
-      renderedRef.current?.focus()
+      renderedRef.current?.focus({ preventScroll: true })
     }, [activeFocusRole, rendered, shouldOwnFocus])
 
     useEffect(() => {
@@ -503,6 +531,18 @@ const MarkdownCell = memo(
       )
     }, [projectionPlugin, readOnly, renderedMarkdownComponents, value])
 
+    useLayoutEffect(() => {
+      const root = renderedRef.current
+      if (!rendered || !root || commentRanges.length === 0) {
+        return
+      }
+      return registerRenderedMarkdownCommentHighlights(
+        commentHighlightOwnerRef.current,
+        root,
+        commentRanges
+      )
+    }, [commentRanges, rendered, value])
+
     if (!cell) {
       return null
     }
@@ -535,10 +575,25 @@ const MarkdownCell = memo(
             data-runme-cell-id={cell.refId}
             data-runme-surface="rendered-markdown"
             data-runme-projection={`${RENDERED_MARKDOWN_PROJECTION_NAME}@${RENDERED_MARKDOWN_PROJECTION_VERSION}`}
+            data-runme-comment-range-count={commentRanges.length || undefined}
             data-cell-focus-role="rendered"
+            aria-describedby={
+              commentRanges.length > 0
+                ? `markdown-comment-ranges-${cell.refId}`
+                : undefined
+            }
             onFocus={() => onFocusRoleChange?.('rendered')}
             onContextMenu={handleRenderedContextMenu}
           >
+            {commentRanges.length > 0 && (
+              <span
+                id={`markdown-comment-ranges-${cell.refId}`}
+                className="sr-only"
+              >
+                {commentRanges.length} commented text{' '}
+                {commentRanges.length === 1 ? 'range' : 'ranges'} in this cell.
+              </span>
+            )}
             {renderedMarkdown}
           </div>
         ) : (
@@ -606,6 +661,7 @@ const MarkdownCell = memo(
       prevProps.onLinkClick === nextProps.onLinkClick &&
       prevProps.readOnly === nextProps.readOnly &&
       prevProps.commentsAvailable === nextProps.commentsAvailable &&
+      sameCommentRanges(prevProps.commentRanges, nextProps.commentRanges) &&
       prevProps.onRenderedSelectionContextMenu ===
         nextProps.onRenderedSelectionContextMenu
     )

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -38,7 +38,7 @@ function renderPanel(overrides = {}) {
     onRefresh: noop,
     onRetryFailed: noop,
     onHide: noop,
-    onSelectCell: noop,
+    onSelectTarget: noop,
     ...overrides,
   }
 
@@ -265,21 +265,21 @@ describe('NotebookCommentsPanel', () => {
   })
 
   it('selects the owning cell when a comment thread is clicked', () => {
-    const onSelectCell = vi.fn()
+    const onSelectTarget = vi.fn()
 
     renderPanel({
       threads: [thread('cell one thread', 'cell-1', { id: 'comment-1' })],
       cellLabels: new Map([['cell-1', 'Cell 1']]),
-      onSelectCell,
+      onSelectTarget,
     })
 
     fireEvent.click(screen.getByText('cell one thread').closest('article')!)
 
-    expect(onSelectCell).toHaveBeenCalledWith('cell-1')
+    expect(onSelectTarget).toHaveBeenCalledWith({ cellId: 'cell-1' })
   })
 
   it('does not treat textarea space key presses as thread selection', () => {
-    const onSelectCell = vi.fn()
+    const onSelectTarget = vi.fn()
     const threads: CellCommentThread[] = [
       thread('active thread', 'cell-1', { id: 'comment-1' }),
     ]
@@ -288,28 +288,28 @@ describe('NotebookCommentsPanel', () => {
       threads,
       activeCellId: 'cell-1',
       cellLabels: new Map([['cell-1', 'Cell 1']]),
-      onSelectCell,
+      onSelectTarget,
     })
 
     const textarea = screen.getByPlaceholderText('Reply or add others with @')
     fireEvent.keyDown(textarea, { key: ' ' })
 
-    expect(onSelectCell).not.toHaveBeenCalled()
+    expect(onSelectTarget).not.toHaveBeenCalled()
   })
 
   it('shows missing comment targets as deleted cells without selecting them', () => {
-    const onSelectCell = vi.fn()
+    const onSelectTarget = vi.fn()
     const orphaned = thread('orphaned comment', 'markup_intro', {
       id: 'comment-orphaned',
     })
     orphaned.orphaned = true
 
-    renderPanel({ threads: [orphaned], onSelectCell })
+    renderPanel({ threads: [orphaned], onSelectTarget })
 
     expect(screen.getByText('Deleted cell')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Cell' })).toBeNull()
     fireEvent.click(screen.getByText('orphaned comment').closest('article')!)
-    expect(onSelectCell).not.toHaveBeenCalled()
+    expect(onSelectTarget).not.toHaveBeenCalled()
   })
 
   it('shows a rendered selection draft as its own quoted thread', () => {
@@ -345,6 +345,7 @@ describe('NotebookCommentsPanel', () => {
   })
 
   it('keeps only the selected range thread active within one cell', async () => {
+    const onSelectTarget = vi.fn()
     renderPanel({
       threads: [
         rangeThread('first range', 'comment-range-1', 5, 8),
@@ -352,11 +353,17 @@ describe('NotebookCommentsPanel', () => {
       ],
       activeCellId: 'cell-1',
       cellLabels: new Map([['cell-1', 'Cell 1']]),
+      onSelectTarget,
     })
 
     const first = screen.getByText('first range').closest('article')!
     const second = screen.getByText('second range').closest('article')!
     fireEvent.click(second)
+
+    expect(onSelectTarget).toHaveBeenCalledWith({
+      cellId: 'cell-1',
+      range: { start: 12, end: 18 },
+    })
 
     await waitFor(() => {
       expect(first.getAttribute('aria-current')).toBeNull()

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type {
   CellCommentThread,
   CommentDraftTarget,
+  CommentNavigationTarget,
 } from '../lib/notebookComments'
 
 type CommentsStatus = 'loading' | 'available' | 'unavailable' | 'error'
@@ -37,7 +38,7 @@ export function NotebookCommentsPanel({
   onRefresh,
   onRetryFailed,
   onHide,
-  onSelectCell,
+  onSelectTarget,
 }: {
   status: CommentsStatus
   errorMessage?: string
@@ -62,7 +63,7 @@ export function NotebookCommentsPanel({
   onRefresh: () => void
   onRetryFailed: () => void
   onHide: () => void
-  onSelectCell: (cellId: string) => void
+  onSelectTarget: (target: CommentNavigationTarget) => void
 }) {
   const [filter, setFilter] = useState<CommentsFilter>('open')
   const [draft, setDraft] = useState(draftContent)
@@ -345,8 +346,9 @@ export function NotebookCommentsPanel({
                   }`}
                   onClick={() => {
                     setActiveThreadKey(item.key)
-                    if (item.cellId && !item.orphaned) {
-                      onSelectCell(item.cellId)
+                    const target = navigationTargetForItem(item)
+                    if (target) {
+                      onSelectTarget(target)
                     }
                   }}
                   onKeyDown={(event) => {
@@ -358,8 +360,9 @@ export function NotebookCommentsPanel({
                     }
                     event.preventDefault()
                     setActiveThreadKey(item.key)
-                    if (item.cellId && !item.orphaned) {
-                      onSelectCell(item.cellId)
+                    const target = navigationTargetForItem(item)
+                    if (target) {
+                      onSelectTarget(target)
                     }
                   }}
                 >
@@ -373,9 +376,10 @@ export function NotebookCommentsPanel({
                       cellLabels={cellLabels}
                       isActiveCell={isActiveCell}
                       onSelectCell={() => {
-                        if (item.cellId && !item.orphaned) {
+                        const target = navigationTargetForItem(item)
+                        if (target) {
                           setActiveThreadKey(item.key)
-                          onSelectCell(item.cellId)
+                          onSelectTarget(target)
                         }
                       }}
                     />
@@ -841,6 +845,37 @@ function getThreadKey(thread: CellCommentThread): string {
       thread.comment.content ?? '',
     ].join(':')
   )
+}
+
+function navigationTargetForItem(
+  item: CommentsPanelItem
+): CommentNavigationTarget | null {
+  if (!item.cellId || item.orphaned) {
+    return null
+  }
+  if (item.draftTarget?.type === 'cell-text') {
+    const { start, end } = item.draftTarget.selectors[0]
+    return { cellId: item.cellId, range: { start, end } }
+  }
+  const rangeThread = item.threads.find(
+    (thread) =>
+      thread.anchor?.type === 'cell-text' &&
+      (thread.location?.status === 'exact' ||
+        thread.location?.status === 'moved')
+  )
+  if (
+    rangeThread?.location?.status === 'exact' ||
+    rangeThread?.location?.status === 'moved'
+  ) {
+    return {
+      cellId: item.cellId,
+      range: {
+        start: rangeThread.location.start,
+        end: rangeThread.location.end,
+      },
+    }
+  }
+  return { cellId: item.cellId }
 }
 
 function findReplyTargetCommentId(threads: CellCommentThread[]): string | null {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -46,6 +46,8 @@
   --nb-success: #16a34a;
   --nb-error: #dc2626;
   --nb-warning: #d97706;
+  --nb-comment-highlight: rgba(250, 204, 21, 0.34);
+  --nb-comment-highlight-active: rgba(245, 158, 11, 0.52);
 
   /* ── Radius ───────────────────────────────────────────────────── */
   --nb-r-xs: 4px;
@@ -66,6 +68,26 @@
   --vscode-terminal-background: #ffffff;
   --vscode-terminal-foreground: #0f172a;
   --vscode-terminal-border: #b0bac5;
+}
+
+::highlight(runme-comment-range) {
+  background-color: var(--nb-comment-highlight);
+}
+
+::highlight(runme-comment-range-active) {
+  background-color: var(--nb-comment-highlight-active);
+  text-decoration: underline 2px var(--nb-warning);
+  text-underline-offset: 2px;
+}
+
+[data-runme-comment-highlight="true"] {
+  background-color: var(--nb-comment-highlight);
+}
+
+[data-runme-comment-highlight="active"] {
+  background-color: var(--nb-comment-highlight-active);
+  text-decoration: underline 2px var(--nb-warning);
+  text-underline-offset: 2px;
 }
 
 /* ═══════════════════════════════════════════════════════════════════

--- a/app/src/lib/markdown/renderedMarkdownCommentHighlights.ts
+++ b/app/src/lib/markdown/renderedMarkdownCommentHighlights.ts
@@ -1,0 +1,136 @@
+import { renderedMarkdownDomRange } from './renderedMarkdownProjection'
+
+export const COMMENT_HIGHLIGHT_NAME = 'runme-comment-range'
+export const ACTIVE_COMMENT_HIGHLIGHT_NAME = 'runme-comment-range-active'
+
+export type RenderedMarkdownCommentRange = {
+  start: number
+  end: number
+  active?: boolean
+}
+
+type HighlightRegistry = {
+  set: (name: string, highlight: unknown) => void
+  delete: (name: string) => void
+}
+
+type HighlightConstructor = new (...ranges: Range[]) => unknown
+
+const owners = new Map<
+  object,
+  { regular: Range[]; active: Range[]; root: HTMLElement }
+>()
+
+function highlightApi(): {
+  registry: HighlightRegistry
+  Highlight: HighlightConstructor
+} | null {
+  const registry =
+    typeof CSS === 'undefined'
+      ? undefined
+      : (CSS as typeof CSS & { highlights?: HighlightRegistry }).highlights
+  const Highlight = (
+    globalThis as typeof globalThis & { Highlight?: HighlightConstructor }
+  ).Highlight
+  return registry && Highlight ? { registry, Highlight } : null
+}
+
+function rebuildHighlights() {
+  const api = highlightApi()
+  if (!api) {
+    return false
+  }
+  const regular = Array.from(owners.values()).flatMap((entry) => entry.regular)
+  const active = Array.from(owners.values()).flatMap((entry) => entry.active)
+  if (regular.length > 0) {
+    api.registry.set(COMMENT_HIGHLIGHT_NAME, new api.Highlight(...regular))
+  } else {
+    api.registry.delete(COMMENT_HIGHLIGHT_NAME)
+  }
+  if (active.length > 0) {
+    api.registry.set(
+      ACTIVE_COMMENT_HIGHLIGHT_NAME,
+      new api.Highlight(...active)
+    )
+  } else {
+    api.registry.delete(ACTIVE_COMMENT_HIGHLIGHT_NAME)
+  }
+  return true
+}
+
+function clearFallback(root: HTMLElement) {
+  root
+    .querySelectorAll<HTMLElement>('[data-runme-comment-highlight]')
+    .forEach((span) => delete span.dataset.runmeCommentHighlight)
+}
+
+function applyFallback(
+  root: HTMLElement,
+  ranges: readonly RenderedMarkdownCommentRange[]
+) {
+  clearFallback(root)
+  root
+    .querySelectorAll<HTMLElement>('[data-runme-projection-start]')
+    .forEach((span) => {
+      const spanStart = Number(span.dataset.runmeProjectionStart)
+      const spanEnd = Number(span.dataset.runmeProjectionEnd)
+      const overlapping = ranges.filter(
+        (range) => spanEnd > range.start && spanStart < range.end
+      )
+      if (overlapping.length === 0) {
+        return
+      }
+      span.dataset.runmeCommentHighlight = overlapping.some(
+        (range) => range.active
+      )
+        ? 'active'
+        : 'true'
+    })
+}
+
+/**
+ * Register the exact rendered ranges for one mounted Markdown cell. Modern
+ * browsers use the CSS Custom Highlight API; the data-attribute fallback keeps
+ * comments visible in browsers that do not expose that API.
+ */
+export function registerRenderedMarkdownCommentHighlights(
+  owner: object,
+  root: HTMLElement,
+  ranges: readonly RenderedMarkdownCommentRange[]
+): () => void {
+  const regular: Range[] = []
+  const active: Range[] = []
+  ranges.forEach((range) => {
+    const domRange = renderedMarkdownDomRange(root, range.start, range.end)
+    if (!domRange) {
+      return
+    }
+    ;(range.active ? active : regular).push(domRange)
+  })
+  owners.set(owner, { regular, active, root })
+  const nativeHighlights = rebuildHighlights()
+  if (nativeHighlights) {
+    clearFallback(root)
+  } else {
+    applyFallback(root, ranges)
+  }
+  const view = root.ownerDocument.defaultView
+  const frame = view?.requestAnimationFrame(() => {
+    if (nativeHighlights) {
+      rebuildHighlights()
+    } else {
+      // React Markdown can replace its projected text spans once more after
+      // the parent layout effect. Reapply the fallback to the settled DOM.
+      applyFallback(root, ranges)
+    }
+  })
+
+  return () => {
+    if (frame !== undefined) {
+      view?.cancelAnimationFrame(frame)
+    }
+    clearFallback(root)
+    owners.delete(owner)
+    rebuildHighlights()
+  }
+}

--- a/app/src/lib/markdown/renderedMarkdownProjection.test.ts
+++ b/app/src/lib/markdown/renderedMarkdownProjection.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   buildRenderedMarkdownProjection,
   captureRenderedMarkdownSelection,
+  renderedMarkdownDomRange,
+  scrollRenderedMarkdownRangeIntoView,
   sliceByCodePoint,
   sourceRangesForProjectionRange,
   utf16OffsetToCodePointOffset,
@@ -83,6 +85,43 @@ describe('rendered Markdown projection', () => {
         { start: 12, end: 27 },
       ],
     })
+  })
+
+  it('maps projection offsets back to an exact DOM range', () => {
+    const root = document.createElement('div')
+    root.innerHTML = [
+      '<span data-runme-projection-start="0" data-runme-projection-end="7">before </span>',
+      '<strong><span data-runme-projection-start="7" data-runme-projection-end="14">A😀B end</span></strong>',
+    ].join('')
+
+    const range = renderedMarkdownDomRange(root, 8, 11)
+
+    expect(range?.toString()).toBe('😀B ')
+    expect(range?.startContainer.parentElement?.dataset).toMatchObject({
+      runmeProjectionStart: '7',
+    })
+    expect(renderedMarkdownDomRange(root, 11, 8)).toBeNull()
+  })
+
+  it('scrolls the exact projection span rather than the whole cell', () => {
+    const root = document.createElement('div')
+    root.innerHTML = [
+      '<span data-runme-projection-start="0" data-runme-projection-end="7">before </span>',
+      '<span data-runme-projection-start="7" data-runme-projection-end="13">target</span>',
+    ].join('')
+    const spans = root.querySelectorAll('span')
+    spans[0]!.scrollIntoView = vi.fn()
+    spans[1]!.scrollIntoView = vi.fn()
+    root.scrollIntoView = vi.fn()
+
+    expect(scrollRenderedMarkdownRangeIntoView(root, 7, 13)).toBe(true)
+    expect(spans[1]!.scrollIntoView).toHaveBeenCalledWith({
+      block: 'center',
+      inline: 'nearest',
+      behavior: 'auto',
+    })
+    expect(spans[0]!.scrollIntoView).not.toHaveBeenCalled()
+    expect(root.scrollIntoView).not.toHaveBeenCalled()
   })
 
   it('uses Unicode code points for selector positions', () => {

--- a/app/src/lib/markdown/renderedMarkdownProjection.test.ts
+++ b/app/src/lib/markdown/renderedMarkdownProjection.test.ts
@@ -124,6 +124,70 @@ describe('rendered Markdown projection', () => {
     expect(root.scrollIntoView).not.toHaveBeenCalled()
   })
 
+  it('centers the exact range inside a scrollable notebook viewport', () => {
+    const viewport = document.createElement('div')
+    viewport.style.overflowY = 'auto'
+    const root = document.createElement('div')
+    root.innerHTML =
+      '<span data-runme-projection-start="0" data-runme-projection-end="18">before exact target</span>'
+    viewport.append(root)
+    document.body.append(viewport)
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1200 },
+    })
+    Object.defineProperty(viewport, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        bottom: 300,
+        height: 200,
+        left: 0,
+        right: 400,
+        top: 100,
+        width: 400,
+        x: 0,
+        y: 100,
+        toJSON: () => ({}),
+      }),
+    })
+    viewport.scrollBy = vi.fn()
+    root.querySelector<HTMLElement>('span')!.scrollIntoView = vi.fn()
+    const createRange = vi.spyOn(document, 'createRange')
+    const nativeCreateRange = createRange.getMockImplementation()
+    createRange.mockImplementation(() => {
+      const range = nativeCreateRange
+        ? nativeCreateRange()
+        : Document.prototype.createRange.call(document)
+      Object.defineProperty(range, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({
+          bottom: 720,
+          height: 20,
+          left: 40,
+          right: 120,
+          top: 700,
+          width: 80,
+          x: 40,
+          y: 700,
+          toJSON: () => ({}),
+        }),
+      })
+      return range
+    })
+
+    expect(scrollRenderedMarkdownRangeIntoView(root, 7, 12)).toBe(true)
+    expect(viewport.scrollBy).toHaveBeenCalledWith({
+      behavior: 'auto',
+      left: 0,
+      top: 510,
+    })
+    expect(
+      root.querySelector<HTMLElement>('span')!.scrollIntoView
+    ).not.toHaveBeenCalled()
+
+    createRange.mockRestore()
+  })
+
   it('uses Unicode code points for selector positions', () => {
     const value = 'A😀B'
 

--- a/app/src/lib/markdown/renderedMarkdownProjection.ts
+++ b/app/src/lib/markdown/renderedMarkdownProjection.ts
@@ -302,6 +302,100 @@ function mappedText(span: HTMLElement): Text | null {
   return walker.nextNode() as Text | null
 }
 
+function codePointOffsetToUtf16Offset(
+  value: string,
+  codePointOffset: number
+): number | null {
+  if (!Number.isInteger(codePointOffset) || codePointOffset < 0) {
+    return null
+  }
+  const prefix = codePoints(value).slice(0, codePointOffset).join('')
+  return codePoints(prefix).length === codePointOffset ? prefix.length : null
+}
+
+function domBoundaryForProjectionOffset(
+  root: HTMLElement,
+  offset: number,
+  direction: 'start' | 'end'
+): { node: Text; offset: number } | null {
+  const spans = Array.from(
+    root.querySelectorAll<HTMLElement>('[data-runme-projection-start]')
+  )
+  const span = spans.find((candidate) => {
+    const start = Number(candidate.dataset.runmeProjectionStart)
+    const end = Number(candidate.dataset.runmeProjectionEnd)
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      return false
+    }
+    return direction === 'start'
+      ? start <= offset && offset < end
+      : start < offset && offset <= end
+  })
+  if (!span) {
+    return null
+  }
+  const node = mappedText(span)
+  const projectionStart = Number(span.dataset.runmeProjectionStart)
+  if (!node || !Number.isInteger(projectionStart)) {
+    return null
+  }
+  const utf16Offset = codePointOffsetToUtf16Offset(
+    node.data,
+    offset - projectionStart
+  )
+  return utf16Offset === null ? null : { node, offset: utf16Offset }
+}
+
+/**
+ * Resolve projection offsets back to the precise DOM range rendered by the
+ * projection plugin. This is the inverse of captureRenderedMarkdownRange and
+ * is used for comment highlighting and navigation.
+ */
+export function renderedMarkdownDomRange(
+  root: HTMLElement,
+  start: number,
+  end: number
+): Range | null {
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start >= end) {
+    return null
+  }
+  const startBoundary = domBoundaryForProjectionOffset(root, start, 'start')
+  const endBoundary = domBoundaryForProjectionOffset(root, end, 'end')
+  if (!startBoundary || !endBoundary) {
+    return null
+  }
+  const range = root.ownerDocument.createRange()
+  try {
+    range.setStart(startBoundary.node, startBoundary.offset)
+    range.setEnd(endBoundary.node, endBoundary.offset)
+  } catch {
+    return null
+  }
+  return range.collapsed ? null : range
+}
+
+export function scrollRenderedMarkdownRangeIntoView(
+  root: HTMLElement,
+  start: number,
+  end: number,
+  behavior: ScrollBehavior = 'auto'
+): boolean {
+  const range = renderedMarkdownDomRange(root, start, end)
+  const projectionSpan =
+    range?.startContainer.parentElement?.closest<HTMLElement>(
+      '[data-runme-projection-start]'
+    ) ?? null
+  if (!projectionSpan) {
+    return false
+  }
+  projectionSpan.scrollIntoView({
+    block: 'center',
+    inline: 'nearest',
+    behavior,
+  })
+  return true
+}
+
 function boundarySpan(
   container: Node,
   offset: number,

--- a/app/src/lib/markdown/renderedMarkdownProjection.ts
+++ b/app/src/lib/markdown/renderedMarkdownProjection.ts
@@ -374,6 +374,47 @@ export function renderedMarkdownDomRange(
   return range.collapsed ? null : range
 }
 
+function nearestScrollableAncestor(
+  element: HTMLElement,
+  axis: 'horizontal' | 'vertical'
+): HTMLElement | null {
+  const view = element.ownerDocument.defaultView
+  for (
+    let parent = element.parentElement;
+    parent;
+    parent = parent.parentElement
+  ) {
+    const style = view?.getComputedStyle(parent)
+    const overflow =
+      axis === 'vertical'
+        ? `${style?.overflowY ?? ''} ${style?.overflow ?? ''}`
+        : `${style?.overflowX ?? ''} ${style?.overflow ?? ''}`
+    const canScroll = /(?:auto|overlay|scroll)/.test(overflow)
+    const hasOverflow =
+      axis === 'vertical'
+        ? parent.scrollHeight > parent.clientHeight
+        : parent.scrollWidth > parent.clientWidth
+    if (canScroll && hasOverflow) {
+      return parent
+    }
+  }
+  return null
+}
+
+function scrollElementBy(
+  element: HTMLElement,
+  left: number,
+  top: number,
+  behavior: ScrollBehavior
+) {
+  if (typeof element.scrollBy === 'function') {
+    element.scrollBy({ left, top, behavior })
+    return
+  }
+  element.scrollLeft += left
+  element.scrollTop += top
+}
+
 export function scrollRenderedMarkdownRangeIntoView(
   root: HTMLElement,
   start: number,
@@ -388,6 +429,33 @@ export function scrollRenderedMarkdownRangeIntoView(
   if (!projectionSpan) {
     return false
   }
+
+  const verticalScroller = nearestScrollableAncestor(root, 'vertical')
+  if (verticalScroller && typeof range?.getBoundingClientRect === 'function') {
+    const rangeRect = range.getBoundingClientRect()
+    const scrollerRect = verticalScroller.getBoundingClientRect()
+    const top =
+      rangeRect.top -
+      scrollerRect.top -
+      (verticalScroller.clientHeight - rangeRect.height) / 2
+    scrollElementBy(verticalScroller, 0, top, behavior)
+
+    const horizontalScroller = nearestScrollableAncestor(root, 'horizontal')
+    if (horizontalScroller) {
+      const horizontalRect = horizontalScroller.getBoundingClientRect()
+      const left =
+        rangeRect.left < horizontalRect.left
+          ? rangeRect.left - horizontalRect.left
+          : rangeRect.right > horizontalRect.right
+            ? rangeRect.right - horizontalRect.right
+            : 0
+      if (left !== 0) {
+        scrollElementBy(horizontalScroller, left, 0, behavior)
+      }
+    }
+    return true
+  }
+
   projectionSpan.scrollIntoView({
     block: 'center',
     inline: 'nearest',

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -45,6 +45,11 @@ export type CommentDraftTarget =
   | { type: 'cell'; cellId: string }
   | RenderedMarkdownSelectionDraft
 
+export type CommentNavigationTarget = {
+  cellId: string
+  range?: TextRange
+}
+
 export type CommentCellIdentity = {
   refId: string
   value?: string


### PR DESCRIPTION
## Summary

- Navigate range-comment threads to the exact rendered Markdown text instead of only the owning cell.
- Preserve notebook scroll position when opening a rendered-text comment draft.
- Keep unresolved comment ranges visibly highlighted, with stronger active styling and an accessible range count.
- Map Unicode projection offsets back to precise DOM ranges while retaining cell-level fallback for outdated anchors.
- Center the exact DOM range inside the notebook viewport, retain a whole-cell fallback when mapping is unavailable, and clear active styling whenever the comments panel closes.

## Validation

- `pnpm -C app exec vitest run src/lib/markdown/renderedMarkdownProjection.test.ts src/components/Actions/MarkdownCell.test.tsx src/components/NotebookCommentsPanel.test.tsx src/components/Actions/Actions.test.tsx` — 107 tests passed.
- `pnpm -C app exec vitest run` — 847 tests passed across 88 files.
- `runme run build test` — passed.
- Local Drive-backed CUJ: selecting the thread moved its exact range from 6306.5–6325.5 px outside an 806 px viewport to 704.5–723.5 px; opening a draft kept `scrollTop` at 5602; after the native selection collapsed, the persistent highlight remained visible.

Validation notebook: [20260820_0601_comments_ux_fix_validation.ipynb](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1dMlZOI4VIHLUNN0jRzXCx7_HQGZH72Cc%2Fview)
