### PR TITLE
Fix impersonated Drive failures and Shared drive picker

### DIFF
--- a/app/src/auth/googleServiceAccountImpersonation.test.ts
+++ b/app/src/auth/googleServiceAccountImpersonation.test.ts
@@ -5,6 +5,7 @@ import {
   mintImpersonatedServiceAccountCredentials,
   normalizeServiceAccountEmail,
   resolveAuthorizationLeaseSeconds,
+  validateImpersonatedGoogleDriveAccessToken,
 } from './googleServiceAccountImpersonation'
 
 function makeUnsignedJwt(payload: Record<string, unknown>): string {
@@ -260,6 +261,43 @@ describe('Google service-account impersonation', () => {
       'https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com?project=554943104515'
     )
     expect(result.errors[0]?.message).toContain('wait a few minutes')
+  })
+
+  it('explains how to enable a disabled Drive API before installing the token', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            status: 'PERMISSION_DENIED',
+            message:
+              'Google Drive API has not been used in project 123456 before or it is disabled.',
+            details: [
+              {
+                reason: 'SERVICE_DISABLED',
+                metadata: {
+                  consumer: 'projects/123456',
+                  service: 'drive.googleapis.com',
+                },
+              },
+            ],
+          },
+        }),
+        { status: 403, statusText: 'Forbidden' }
+      )
+    )
+
+    await expect(
+      validateImpersonatedGoogleDriveAccessToken(
+        'do-not-print-this-token',
+        'runme@runme-lewi-dev.iam.gserviceaccount.com'
+      )
+    ).rejects.toThrow(
+      /Google Drive API is not enabled for service-account project 123456.*https:\/\/console\.cloud\.google\.com\/apis\/library\/drive\.googleapis\.com\?project=123456/
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.googleapis.com/drive/v3/about?fields=user(permissionId)',
+      { headers: { Authorization: 'Bearer do-not-print-this-token' } }
+    )
   })
 
   it('explains the organization policy needed above one hour', async () => {

--- a/app/src/auth/googleServiceAccountImpersonation.ts
+++ b/app/src/auth/googleServiceAccountImpersonation.ts
@@ -11,6 +11,8 @@ export const GOOGLE_SERVICE_ACCOUNT_IMPERSONATION_SCOPES = [
 const IAM_CREDENTIALS_BASE_URL =
   'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts'
 const GOOGLE_USERINFO_URL = 'https://openidconnect.googleapis.com/v1/userinfo'
+const GOOGLE_DRIVE_ABOUT_URL =
+  'https://www.googleapis.com/drive/v3/about?fields=user(permissionId)'
 export const DEFAULT_IMPERSONATED_ACCESS_TOKEN_LIFETIME_SECONDS = 60 * 60
 const MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 43200
 const DEFAULT_AUTHORIZATION_LEASE_SECONDS = 24 * 60 * 60
@@ -79,6 +81,19 @@ export type ServiceAccountCredentialStatus = {
 export type ServiceAccountCredentialTargetError = {
   target: ServiceAccountCredentialTarget
   message: string
+}
+
+export function getServiceAccountCredentialStatusError(
+  status: ServiceAccountCredentialStatus
+): string | null {
+  if (status.status !== 'partial') {
+    return null
+  }
+  return (
+    status.errors
+      ?.map((error) => `${error.target}: ${error.message}`)
+      .join('; ') || 'Service-account authorization completed only partially.'
+  )
 }
 
 export type MintImpersonatedServiceAccountCredentialsRequest = {
@@ -202,6 +217,59 @@ function formatIamCredentialsError(
   }
 
   return `Google IAM ${method} failed (${status}): ${detail.message}`
+}
+
+function serviceAccountProjectId(serviceAccount: string): string | undefined {
+  return serviceAccount.match(/@([^.]+)\.iam\.gserviceaccount\.com$/)?.[1]
+}
+
+function formatDriveCredentialError(
+  status: number,
+  detail: ParsedGoogleApiError,
+  serviceAccount: string
+): string {
+  const service = detail.metadata?.service
+  const isDriveApiDisabled =
+    detail.reason === 'SERVICE_DISABLED' &&
+    (!service || service === 'drive.googleapis.com')
+  if (
+    isDriveApiDisabled ||
+    /Drive API.*(?:disabled|not been used)/i.test(detail.message)
+  ) {
+    const consumer = detail.metadata?.consumer?.replace(/^projects\//, '')
+    const project = consumer || serviceAccountProjectId(serviceAccount)
+    const projectDescription = project ? ` ${project}` : ''
+    const activationUrl = new URL(
+      'https://console.cloud.google.com/apis/library/drive.googleapis.com'
+    )
+    if (project) {
+      activationUrl.searchParams.set('project', project)
+    }
+    return `Google Drive credential validation failed (${status}): Google Drive API is not enabled for service-account project${projectDescription}. Enable it, wait a few minutes for the change to propagate, then reconnect Drive: ${activationUrl.toString()}`
+  }
+
+  return `Google Drive credential validation failed (${status}): ${detail.message}`
+}
+
+/**
+ * Verifies a newly minted service-account token against Drive before the app
+ * publishes it as a syncing credential. IAM can mint a token even when the
+ * Drive API is disabled for the service-account project.
+ */
+export async function validateImpersonatedGoogleDriveAccessToken(
+  accessToken: string,
+  serviceAccount: string
+): Promise<void> {
+  const response = await fetch(GOOGLE_DRIVE_ABOUT_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (response.ok) {
+    return
+  }
+  const detail = await readGoogleApiError(response)
+  throw new Error(
+    formatDriveCredentialError(response.status, detail, serviceAccount)
+  )
 }
 
 async function postIamCredentials<T>(

--- a/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.test.tsx
+++ b/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.test.tsx
@@ -318,4 +318,35 @@ describe('AuthenticationSettingsPanel', () => {
       )
     )
   })
+
+  it('shows an actionable Drive error when service-account authorization is partial', async () => {
+    mocks.getServiceAccountCredentials.mockResolvedValueOnce({
+      status: 'partial',
+      errors: [
+        {
+          target: 'drive',
+          message:
+            'Google Drive API is not enabled. Enable it at https://console.cloud.google.com/apis/library/drive.googleapis.com?project=runme-lewi-dev',
+        },
+      ],
+    })
+    render(<AuthenticationSettingsPanel />)
+
+    fireEvent.change(screen.getByLabelText('Shared login identity'), {
+      target: { value: 'service_account' },
+    })
+    fireEvent.change(
+      screen.getByLabelText('Shared Google service account identity'),
+      {
+        target: { value: 'runme-web-test@project.iam.gserviceaccount.com' },
+      }
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Connect or refresh' }))
+
+    expect(
+      (await screen.findByText(/Google Drive API is not enabled/)).textContent
+    ).toContain(
+      'https://console.cloud.google.com/apis/library/drive.googleapis.com?project=runme-lewi-dev'
+    )
+  })
 })

--- a/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.tsx
+++ b/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
   type AppLoginMode,
   type IdentitySharingMode,
 } from '../../auth/appLoginConfiguration'
+import { getServiceAccountCredentialStatusError } from '../../auth/googleServiceAccountImpersonation'
 import { oidcConfigManager } from '../../auth/oidcConfig'
 import {
   getBrowserAdapter,
@@ -329,12 +330,19 @@ export default function AuthenticationSettingsPanel() {
       selectedHumanAccount: string,
       targets: Array<'drive' | 'app'>
     ) => {
-      await getServiceAccountCredentials(selectedServiceAccount.trim(), {
-        humanAccount: selectedHumanAccount.trim() || undefined,
-        prompt: selectedHumanAccount.trim() ? '' : 'select_account',
-        targets,
-        authorizationLeaseSeconds: 24 * 60 * 60,
-      })
+      const status = await getServiceAccountCredentials(
+        selectedServiceAccount.trim(),
+        {
+          humanAccount: selectedHumanAccount.trim() || undefined,
+          prompt: selectedHumanAccount.trim() ? '' : 'select_account',
+          targets,
+          authorizationLeaseSeconds: 24 * 60 * 60,
+        }
+      )
+      const error = getServiceAccountCredentialStatusError(status)
+      if (error) {
+        throw new Error(error)
+      }
     },
     [getServiceAccountCredentials]
   )

--- a/app/src/components/SidePanel/SidePanel.test.tsx
+++ b/app/src/components/SidePanel/SidePanel.test.tsx
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ServiceAccountCredentialStatus } from '../../auth/googleServiceAccountImpersonation'
+
+const { showToastMock } = vi.hoisted(() => ({
+  showToastMock: vi.fn(),
+}))
 
 type PanelKey =
   | 'explorer'
@@ -41,13 +46,16 @@ const startGoogleDriveOAuthMock = vi.fn(async () => ({
 }))
 const logoutGoogleDriveMock = vi.fn(async () => {})
 const setDriveAccountMock = vi.fn()
-const getServiceAccountCredentialsMock = vi.fn(async () => ({
-  humanPrincipal: 'human@example.com',
-  serviceAccount: 'runme@example.iam.gserviceaccount.com',
-  authorizationLeaseExpiresAt: '2026-08-22T00:00:00.000Z',
-  drive: { scopes: [], expiresAt: '2026-08-21T02:00:00.000Z' },
-  app: { audience: 'runme', expiresAt: '2026-08-21T02:00:00.000Z' },
-}))
+const getServiceAccountCredentialsMock = vi.fn(
+  async (): Promise<ServiceAccountCredentialStatus> => ({
+    status: 'authorized',
+    humanPrincipal: 'human@example.com',
+    serviceAccount: 'runme@example.iam.gserviceaccount.com',
+    authorizationLeaseExpiresAt: '2026-08-22T00:00:00.000Z',
+    drive: { scopes: [], expiresAt: '2026-08-21T02:00:00.000Z' },
+    app: { audience: 'runme', expiresAt: '2026-08-21T02:00:00.000Z' },
+  })
+)
 const loginWithRedirectMock = vi.fn(async () => {})
 const logoutMock = vi.fn()
 const togglePanelMock = vi.fn()
@@ -136,6 +144,10 @@ vi.mock('../AuthenticationSettings/AuthenticationSettingsPanel', () => ({
   default: () => <div data-testid="authentication-settings-panel-mock" />,
 }))
 
+vi.mock('../../lib/toast', () => ({
+  showToast: showToastMock,
+}))
+
 import { SidePanelContent, SidePanelToolbar } from './SidePanel'
 
 describe('SidePanelToolbar drive status button', () => {
@@ -161,6 +173,7 @@ describe('SidePanelToolbar drive status button', () => {
     setCurrentDocMock.mockClear()
     showDocumentMock.mockClear()
     closeWorkspaceDocumentMock.mockClear()
+    showToastMock.mockClear()
   })
 
   it('renders the Drive status button above Login and refreshes credentials', async () => {
@@ -246,6 +259,43 @@ describe('SidePanelToolbar drive status button', () => {
 
     await waitFor(() =>
       expect(getServiceAccountCredentialsMock).toHaveBeenCalledTimes(1)
+    )
+    expect(loginWithRedirectMock).not.toHaveBeenCalled()
+  })
+
+  it('shows an actionable error when shared Login is only partially authorized', async () => {
+    window.localStorage.setItem(
+      'runme/app-login-configuration',
+      JSON.stringify({
+        identitySharing: 'shared',
+        mode: 'service_account',
+        humanAccount: 'jeremy@lewi.us',
+        serviceAccount: 'runme@example.iam.gserviceaccount.com',
+      })
+    )
+    getServiceAccountCredentialsMock.mockResolvedValueOnce({
+      status: 'partial',
+      humanPrincipal: 'jeremy@lewi.us',
+      serviceAccount: 'runme@example.iam.gserviceaccount.com',
+      authorizationLeaseExpiresAt: '2026-08-22T00:00:00.000Z',
+      app: { audience: 'runme', expiresAt: '2026-08-21T02:00:00.000Z' },
+      errors: [
+        {
+          target: 'drive',
+          message: 'Enable the Google Drive API, then reconnect Drive.',
+        },
+      ],
+    })
+    render(<SidePanelToolbar />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }))
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith({
+        message:
+          'drive: Enable the Google Drive API, then reconnect Drive.',
+        tone: 'error',
+      })
     )
     expect(loginWithRedirectMock).not.toHaveBeenCalled()
   })

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -56,6 +56,7 @@ import {
   readAppLoginConfiguration,
   resolveDriveLoginConfiguration,
 } from '../../auth/appLoginConfiguration'
+import { getServiceAccountCredentialStatusError } from '../../auth/googleServiceAccountImpersonation'
 import AuthenticationSettingsPanel from '../AuthenticationSettings/AuthenticationSettingsPanel'
 import { showToast } from '../../lib/toast'
 
@@ -293,14 +294,21 @@ export function SidePanelToolbar() {
       const usesSharedIdentity = configuration.identitySharing === 'shared'
       const driveConfiguration = resolveDriveLoginConfiguration(configuration)
       if (driveConfiguration.mode === 'service_account') {
-        await getServiceAccountCredentials(driveConfiguration.serviceAccount, {
-          ...(driveConfiguration.humanAccount
-            ? { humanAccount: driveConfiguration.humanAccount }
-            : {}),
-          prompt: driveConfiguration.humanAccount ? '' : 'select_account',
-          targets: usesSharedIdentity ? ['drive', 'app'] : ['drive'],
-          authorizationLeaseSeconds: 24 * 60 * 60,
-        })
+        const status = await getServiceAccountCredentials(
+          driveConfiguration.serviceAccount,
+          {
+            ...(driveConfiguration.humanAccount
+              ? { humanAccount: driveConfiguration.humanAccount }
+              : {}),
+            prompt: driveConfiguration.humanAccount ? '' : 'select_account',
+            targets: usesSharedIdentity ? ['drive', 'app'] : ['drive'],
+            authorizationLeaseSeconds: 24 * 60 * 60,
+          }
+        )
+        const error = getServiceAccountCredentialStatusError(status)
+        if (error) {
+          throw new Error(error)
+        }
       } else {
         await startGoogleDriveOAuth()
       }

--- a/app/src/components/SidePanel/SidePanel.tsx
+++ b/app/src/components/SidePanel/SidePanel.tsx
@@ -372,9 +372,11 @@ export function SidePanelToolbar() {
       return
     }
     const configuration = readAppLoginConfiguration()
-    const loginPromise =
-      configuration.mode === 'service_account'
-        ? getServiceAccountCredentials(configuration.serviceAccount, {
+    void (async () => {
+      if (configuration.mode === 'service_account') {
+        const status = await getServiceAccountCredentials(
+          configuration.serviceAccount,
+          {
             ...(configuration.humanAccount
               ? { humanAccount: configuration.humanAccount }
               : {}),
@@ -384,11 +386,18 @@ export function SidePanelToolbar() {
                 ? ['drive', 'app']
                 : ['app'],
             authorizationLeaseSeconds: 24 * 60 * 60,
-          })
-        : browserAdapter.loginWithRedirect({
-            loginHint: configuration.humanAccount || undefined,
-          })
-    void loginPromise.catch((error) => {
+          }
+        )
+        const error = getServiceAccountCredentialStatusError(status)
+        if (error) {
+          throw new Error(error)
+        }
+        return
+      }
+      await browserAdapter.loginWithRedirect({
+        loginHint: configuration.humanAccount || undefined,
+      })
+    })().catch((error) => {
       showToast({
         message: error instanceof Error ? error.message : String(error),
         tone: 'error',

--- a/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   getItems: vi.fn(),
   getDrivePickerConfig: vi.fn(),
   openPicker: vi.fn(),
+  pickerViews: [{ scope: "my-drive" }, { scope: "shared-drives" }],
   startGoogleDriveOAuth: vi.fn(),
   updateFolder: vi.fn(),
 }));
@@ -55,6 +56,10 @@ vi.mock("../../lib/onboarding", () => ({
   markOnboardingTaskComplete: vi.fn(),
 }));
 
+vi.mock("./googleDrivePickerViews", () => ({
+  getGoogleDrivePickerViews: vi.fn(async () => mocks.pickerViews),
+}));
+
 describe("GoogleDrivePickerButton", () => {
   beforeEach(() => {
     tourUiController.resetForTests();
@@ -91,6 +96,8 @@ describe("GoogleDrivePickerButton", () => {
           developerKey: "drive-developer-key",
           token: "cached-access-token",
           viewId: "FOLDERS",
+          disableDefaultView: true,
+          customViews: mocks.pickerViews,
         }),
       );
     });

--- a/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
@@ -11,13 +11,8 @@ const mocks = vi.hoisted(() => ({
   getItems: vi.fn(),
   getDrivePickerConfig: vi.fn(),
   openPicker: vi.fn(),
-  pickerViews: [{ scope: "my-drive" }, { scope: "shared-drives" }],
   startGoogleDriveOAuth: vi.fn(),
   updateFolder: vi.fn(),
-}));
-
-vi.mock("react-google-drive-picker", () => ({
-  default: () => [mocks.openPicker],
 }));
 
 vi.mock("../../contexts/GoogleAuthContext", async () => {
@@ -57,7 +52,7 @@ vi.mock("../../lib/onboarding", () => ({
 }));
 
 vi.mock("./googleDrivePickerViews", () => ({
-  getGoogleDrivePickerViews: vi.fn(async () => mocks.pickerViews),
+  openGoogleDrivePicker: mocks.openPicker,
 }));
 
 describe("GoogleDrivePickerButton", () => {
@@ -92,12 +87,10 @@ describe("GoogleDrivePickerButton", () => {
       expect(mocks.openPicker).toHaveBeenCalledWith(
         expect.objectContaining({
           appId: "drive-app-id",
-          clientId: "drive-client-id",
           developerKey: "drive-developer-key",
           token: "cached-access-token",
-          viewId: "FOLDERS",
-          disableDefaultView: true,
-          customViews: mocks.pickerViews,
+          kind: "folder",
+          callback: expect.any(Function),
         }),
       );
     });
@@ -129,7 +122,7 @@ describe("GoogleDrivePickerButton", () => {
     );
 
     const pickerConfig = mocks.openPicker.mock.calls[0]?.[0];
-    pickerConfig.callbackFunction({
+    pickerConfig.callback({
       action: "picked",
       docs: [
         {

--- a/app/src/components/Workspace/GoogleDrivePickerButton.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.tsx
@@ -9,8 +9,6 @@ import { markOnboardingTaskComplete } from "../../lib/onboarding";
 import { tourUiController } from "../../lib/tourUiController";
 import { getGoogleDrivePickerViews } from "./googleDrivePickerViews";
 
-type PickerAction = "picked" | "cancel";
-
 type PickerDocument = {
   id: string;
   name?: string;
@@ -20,7 +18,7 @@ type PickerDocument = {
 };
 
 type PickerCallbackData = {
-  action: PickerAction;
+  action: string;
   docs?: PickerDocument[];
 };
 

--- a/app/src/components/Workspace/GoogleDrivePickerButton.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.tsx
@@ -7,6 +7,7 @@ import { driveFolderUrl } from "../../storage/drive";
 import { googleClientManager } from "../../lib/googleClientManager";
 import { markOnboardingTaskComplete } from "../../lib/onboarding";
 import { tourUiController } from "../../lib/tourUiController";
+import { getGoogleDrivePickerViews } from "./googleDrivePickerViews";
 
 type PickerAction = "picked" | "cancel";
 
@@ -75,19 +76,26 @@ export function GoogleDrivePickerButton({
         return;
       }
 
+      let customViews;
+      try {
+        customViews = await getGoogleDrivePickerViews("folder");
+      } catch (error) {
+        console.error("Failed to load Google Drive picker views", error);
+        return;
+      }
+
       openPicker({
         token: accessToken,
         appId: pickerConfig.appId,
         clientId: pickerConfig.clientId,
         developerKey: pickerConfig.developerKey,
         viewId: "FOLDERS",
+        disableDefaultView: true,
+        customViews,
         customScopes: DRIVE_SCOPES,
         showUploadView: false,
         showUploadFolders: false,
-        supportDrives: true,
         multiselect: false,
-        setIncludeFolders: true,
-        setSelectFolderEnabled: true,
         callbackFunction: (data: PickerCallbackData) => {
           if (data.action !== "picked" || !data.docs?.length) {
             return;

--- a/app/src/components/Workspace/GoogleDrivePickerButton.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.tsx
@@ -1,26 +1,13 @@
 import { ReactNode, useCallback } from "react";
-import useDrivePicker from "react-google-drive-picker";
-import { useGoogleAuth, DRIVE_SCOPES } from "../../contexts/GoogleAuthContext";
+import { useGoogleAuth } from "../../contexts/GoogleAuthContext";
 import { useWorkspace } from "../../contexts/WorkspaceContext";
 import { useNotebookStore } from "../../contexts/NotebookStoreContext";
 import { driveFolderUrl } from "../../storage/drive";
 import { googleClientManager } from "../../lib/googleClientManager";
 import { markOnboardingTaskComplete } from "../../lib/onboarding";
 import { tourUiController } from "../../lib/tourUiController";
-import { getGoogleDrivePickerViews } from "./googleDrivePickerViews";
-
-type PickerDocument = {
-  id: string;
-  name?: string;
-  mimeType?: string;
-  url?: string;
-  [key: string]: unknown;
-};
-
-type PickerCallbackData = {
-  action: string;
-  docs?: PickerDocument[];
-};
+import { appLogger } from "../../lib/logging/runtime";
+import { openGoogleDrivePicker } from "./googleDrivePickerViews";
 
 interface GoogleDrivePickerButtonProps {
   label?: string;
@@ -35,7 +22,6 @@ export function GoogleDrivePickerButton({
   className,
   children,
 }: GoogleDrivePickerButtonProps) {
-  const [openPicker] = useDrivePicker();
   const { ensureAccessToken } = useGoogleAuth();
   const { addItem, getItems } = useWorkspace();
   const { store } = useNotebookStore();
@@ -74,81 +60,75 @@ export function GoogleDrivePickerButton({
         return;
       }
 
-      let customViews;
       try {
-        customViews = await getGoogleDrivePickerViews("folder");
-      } catch (error) {
-        console.error("Failed to load Google Drive picker views", error);
-        return;
-      }
-
-      openPicker({
-        token: accessToken,
-        appId: pickerConfig.appId,
-        clientId: pickerConfig.clientId,
-        developerKey: pickerConfig.developerKey,
-        viewId: "FOLDERS",
-        disableDefaultView: true,
-        customViews,
-        customScopes: DRIVE_SCOPES,
-        showUploadView: false,
-        showUploadFolders: false,
-        multiselect: false,
-        callbackFunction: (data: PickerCallbackData) => {
-          if (data.action !== "picked" || !data.docs?.length) {
-            return;
-          }
-
-          const [primaryDoc] = data.docs;
-          if (!primaryDoc) {
-            return;
-          }
-          void (async () => {
-            if (!primaryDoc.id) {
-              console.error("Selected document is missing an identifier.");
+        await openGoogleDrivePicker({
+          token: accessToken,
+          appId: pickerConfig.appId,
+          developerKey: pickerConfig.developerKey,
+          kind: "folder",
+          callback: (data) => {
+            if (data.action !== "picked" || !data.docs?.length) {
               return;
             }
 
-            if (
-              primaryDoc.mimeType &&
-              primaryDoc.mimeType !== "application/vnd.google-apps.folder"
-            ) {
-              console.error("Selected item is not a Google Drive folder.");
+            const [primaryDoc] = data.docs;
+            if (!primaryDoc) {
               return;
             }
-
-            if (!store) {
-              console.error(
-                "Notebook store is not available; cannot mirror folder.",
-              );
-              return;
-            }
-
-            const remoteUri = driveFolderUrl(primaryDoc.id);
-            try {
-              const localUri = await store.updateFolder(
-                remoteUri,
-                primaryDoc.name ?? primaryDoc.id,
-              );
-              const workspaceUris = getItems();
-              if (!workspaceUris.includes(localUri)) {
-                addItem(localUri);
+            void (async () => {
+              if (!primaryDoc.id) {
+                console.error("Selected document is missing an identifier.");
+                return;
               }
-              markOnboardingTaskComplete("add-drive-folder");
-              tourUiController.recordGoogleDriveFolderAdded();
-            } catch (error) {
-              console.error("Failed to mirror Drive folder", error);
-            }
-          })();
-        },
-      });
+
+              if (
+                primaryDoc.mimeType &&
+                primaryDoc.mimeType !== "application/vnd.google-apps.folder"
+              ) {
+                console.error("Selected item is not a Google Drive folder.");
+                return;
+              }
+
+              if (!store) {
+                console.error(
+                  "Notebook store is not available; cannot mirror folder.",
+                );
+                return;
+              }
+
+              const remoteUri = driveFolderUrl(primaryDoc.id);
+              try {
+                const localUri = await store.updateFolder(
+                  remoteUri,
+                  primaryDoc.name ?? primaryDoc.id,
+                );
+                const workspaceUris = getItems();
+                if (!workspaceUris.includes(localUri)) {
+                  addItem(localUri);
+                }
+                markOnboardingTaskComplete("add-drive-folder");
+                tourUiController.recordGoogleDriveFolderAdded();
+              } catch (error) {
+                console.error("Failed to mirror Drive folder", error);
+              }
+            })();
+          },
+        });
+      } catch (error) {
+        appLogger.error("Failed to open Google Drive picker", {
+          attrs: {
+            scope: "storage.drive.picker",
+            code: "DRIVE_PICKER_OPEN_FAILED",
+            error: String(error),
+          },
+        });
+      }
     })();
   }, [
     addItem,
     ensureAccessToken,
     getItems,
     getPickerConfig,
-    openPicker,
     store,
   ]);
 

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NotebookStoreItemType } from '../../storage/notebook'
+import { DriveCreateNotCommittedError } from '../../storage/drive'
 import { WorkspaceExplorer } from './WorkspaceExplorer'
 
 const mocks = vi.hoisted(() => ({
@@ -127,6 +128,7 @@ vi.mock('../../contexts/WorkspaceDocumentContext', () => ({
 }))
 
 vi.mock('../../storage/drive', () => ({
+  DriveCreateNotCommittedError: class extends Error {},
   fetchDriveItemWithParents: mocks.fetchDriveItemWithParents,
   isDriveItemUri: mocks.isDriveItemUri,
   parseDriveItem: mocks.parseDriveItem,
@@ -476,6 +478,39 @@ describe('WorkspaceExplorer current document handling', () => {
     await waitFor(() => {
       expect(mocks.treeEdit).toHaveBeenCalledWith('local://file/ipynb')
     })
+  })
+
+  it('shows Shared drive guidance when a service account cannot create a notebook', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      return null
+    })
+    const message =
+      "Google Drive cannot create this file because service accounts do not have storage quota. Choose a folder in a Shared drive. A folder shared from a user's My Drive is not a Shared drive."
+    mocks.store.create.mockRejectedValueOnce(
+      new DriveCreateNotCommittedError(message)
+    )
+
+    render(<WorkspaceExplorer />)
+
+    fireEvent.contextMenu(await screen.findByText('Drive Root'))
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'New Jupyter Notebook (.ipynb)',
+      })
+    )
+
+    expect(await screen.findByText(message)).toBeTruthy()
   })
 
   it('starts inline rename from a Drive-backed folder context menu', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -42,6 +42,7 @@ import {
 import type { StorageBrowser } from "../../storage/browser";
 import { isFileSystemAccessSupported } from "../../storage/fs";
 import {
+  DriveCreateNotCommittedError,
   fetchDriveItemWithParents,
   isDriveItemUri,
   parseDriveItem,
@@ -94,6 +95,12 @@ function createPlaceholderNode(uri: string, label: string): TreeNode {
     name: label,
     type: "placeholder",
   };
+}
+
+function driveCreateErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof DriveCreateNotCommittedError
+    ? error.message
+    : fallback;
 }
 
 function createFolderNode(
@@ -925,7 +932,10 @@ export function WorkspaceExplorer() {
       } catch (error) {
         console.error("Failed to create Excalidraw diagram", error);
         setErrorMessage(
-          "Unable to create an Excalidraw diagram. Please try again.",
+          driveCreateErrorMessage(
+            error,
+            "Unable to create an Excalidraw diagram. Please try again.",
+          ),
         );
         showToast({
           message: "Could not create Excalidraw diagram",
@@ -967,7 +977,12 @@ export function WorkspaceExplorer() {
         setErrorMessage(null);
       } catch (error) {
         console.error('Failed to create notebook', error)
-        setErrorMessage('Unable to create a new notebook. Please try again.')
+        setErrorMessage(
+          driveCreateErrorMessage(
+            error,
+            'Unable to create a new notebook. Please try again.'
+          )
+        )
       }
     },
     [fetchChildren, fsStore, store],
@@ -991,7 +1006,12 @@ export function WorkspaceExplorer() {
         showToast({ message: "Google Drive folder created", tone: "success" });
       } catch (error) {
         console.error("Failed to create Google Drive folder", error);
-        setErrorMessage("Unable to create Google Drive folder. Please try again.");
+        setErrorMessage(
+          driveCreateErrorMessage(
+            error,
+            "Unable to create Google Drive folder. Please try again.",
+          ),
+        );
         showToast({
           message: "Could not create Google Drive folder",
           tone: "error",

--- a/app/src/components/Workspace/googleDrivePickerViews.test.ts
+++ b/app/src/components/Workspace/googleDrivePickerViews.test.ts
@@ -1,9 +1,24 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createGoogleDrivePickerViews } from "./googleDrivePickerViews";
+import {
+  createGoogleDrivePickerViews,
+  getGoogleDrivePickerViews,
+  openGoogleDrivePicker,
+} from "./googleDrivePickerViews";
 
 describe("Google Drive picker views", () => {
+  afterEach(() => {
+    Object.defineProperty(window, "gapi", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "google", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
   it.each([
     ["folder", "FOLDERS", true],
     ["file", "DOCS", false],
@@ -48,4 +63,101 @@ describe("Google Drive picker views", () => {
       }
     },
   );
+
+  it("loads the Picker module before constructing custom views", async () => {
+    const picker = {
+      ViewId: { DOCS: "DOCS", FOLDERS: "FOLDERS" },
+      DocsView: class {
+        setEnableDrives = vi.fn(() => this);
+        setIncludeFolders = vi.fn(() => this);
+        setSelectFolderEnabled = vi.fn(() => this);
+      },
+    };
+    const load = vi.fn(
+      (
+        apiName: string,
+        options: {
+          callback: () => void;
+        },
+      ) => {
+        expect(apiName).toBe("picker");
+        Object.defineProperty(window, "google", {
+          configurable: true,
+          value: { picker },
+        });
+        options.callback();
+      },
+    );
+    Object.defineProperty(window, "gapi", {
+      configurable: true,
+      value: { load },
+    });
+
+    const views = await getGoogleDrivePickerViews("folder", 100);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(views).toHaveLength(2);
+  });
+
+  it("opens Picker directly with both My Drive and Shared drives views", async () => {
+    const addedViews: unknown[] = [];
+    const setVisible = vi.fn();
+    const setAppId = vi.fn();
+    const setOAuthToken = vi.fn();
+    const setDeveloperKey = vi.fn();
+    const setCallback = vi.fn();
+    const picker = {
+      ViewId: { DOCS: "DOCS", FOLDERS: "FOLDERS" },
+      DocsView: class {
+        setEnableDrives = vi.fn(() => this);
+        setIncludeFolders = vi.fn(() => this);
+        setSelectFolderEnabled = vi.fn(() => this);
+      },
+      PickerBuilder: class {
+        addView(view: unknown) {
+          addedViews.push(view);
+          return this;
+        }
+        build() {
+          return { setVisible };
+        }
+        setAppId(appId: string) {
+          setAppId(appId);
+          return this;
+        }
+        setCallback(callback: (data: unknown) => void) {
+          setCallback(callback);
+          return this;
+        }
+        setDeveloperKey(developerKey: string) {
+          setDeveloperKey(developerKey);
+          return this;
+        }
+        setOAuthToken(token: string) {
+          setOAuthToken(token);
+          return this;
+        }
+      },
+    };
+    Object.defineProperty(window, "google", {
+      configurable: true,
+      value: { picker },
+    });
+    const callback = vi.fn();
+
+    await openGoogleDrivePicker({
+      appId: "app-id",
+      callback,
+      developerKey: "developer-key",
+      kind: "folder",
+      token: "access-token",
+    });
+
+    expect(addedViews).toHaveLength(2);
+    expect(setAppId).toHaveBeenCalledWith("app-id");
+    expect(setOAuthToken).toHaveBeenCalledWith("access-token");
+    expect(setDeveloperKey).toHaveBeenCalledWith("developer-key");
+    expect(setCallback).toHaveBeenCalledWith(callback);
+    expect(setVisible).toHaveBeenCalledWith(true);
+  });
 });

--- a/app/src/components/Workspace/googleDrivePickerViews.test.ts
+++ b/app/src/components/Workspace/googleDrivePickerViews.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+import { createGoogleDrivePickerViews } from "./googleDrivePickerViews";
+
+describe("Google Drive picker views", () => {
+  it.each([
+    ["folder", "FOLDERS", true],
+    ["file", "DOCS", false],
+  ] as const)(
+    "adds separate My Drive and Shared drives views for %s selection",
+    (kind, expectedViewId, configuresFolders) => {
+      const createdViews: Array<{
+        viewId: unknown;
+        setEnableDrives: ReturnType<typeof vi.fn>;
+        setIncludeFolders: ReturnType<typeof vi.fn>;
+        setSelectFolderEnabled: ReturnType<typeof vi.fn>;
+      }> = [];
+      const picker = {
+        ViewId: { DOCS: "DOCS", FOLDERS: "FOLDERS" },
+        DocsView: class {
+          setEnableDrives = vi.fn(() => this);
+          setIncludeFolders = vi.fn(() => this);
+          setSelectFolderEnabled = vi.fn(() => this);
+
+          constructor(readonly viewId: unknown) {
+            createdViews.push(this);
+          }
+        },
+      };
+
+      const views = createGoogleDrivePickerViews(picker, kind);
+
+      expect(views).toHaveLength(2);
+      expect(createdViews.map((view) => view.viewId)).toEqual([
+        expectedViewId,
+        expectedViewId,
+      ]);
+      expect(createdViews[0].setEnableDrives).not.toHaveBeenCalled();
+      expect(createdViews[1].setEnableDrives).toHaveBeenCalledWith(true);
+      for (const view of createdViews) {
+        expect(view.setIncludeFolders).toHaveBeenCalledTimes(
+          configuresFolders ? 1 : 0,
+        );
+        expect(view.setSelectFolderEnabled).toHaveBeenCalledTimes(
+          configuresFolders ? 1 : 0,
+        );
+      }
+    },
+  );
+});

--- a/app/src/components/Workspace/googleDrivePickerViews.ts
+++ b/app/src/components/Workspace/googleDrivePickerViews.ts
@@ -6,8 +6,24 @@ type GoogleDrivePickerView = {
   setSelectFolderEnabled(enabled: boolean): GoogleDrivePickerView;
 };
 
+type GoogleDrivePicker = {
+  setVisible(visible: boolean): void;
+};
+
+type GoogleDrivePickerBuilder = {
+  addView(view: GoogleDrivePickerView): GoogleDrivePickerBuilder;
+  build(): GoogleDrivePicker;
+  setAppId(appId: string): GoogleDrivePickerBuilder;
+  setCallback(
+    callback: (data: GoogleDrivePickerCallbackData) => void,
+  ): GoogleDrivePickerBuilder;
+  setDeveloperKey(developerKey: string): GoogleDrivePickerBuilder;
+  setOAuthToken(token: string): GoogleDrivePickerBuilder;
+};
+
 type GoogleDrivePickerApi = {
   DocsView: new (viewId: unknown) => GoogleDrivePickerView;
+  PickerBuilder: new () => GoogleDrivePickerBuilder;
   ViewId: {
     DOCS: unknown;
     FOLDERS: unknown;
@@ -15,6 +31,17 @@ type GoogleDrivePickerApi = {
 };
 
 type GooglePickerWindow = Window & {
+  gapi?: {
+    load(
+      apiName: string,
+      options: {
+        callback: () => void;
+        onerror: () => void;
+        timeout: number;
+        ontimeout: () => void;
+      },
+    ): void;
+  };
   google?: {
     picker?: GoogleDrivePickerApi;
   };
@@ -22,6 +49,27 @@ type GooglePickerWindow = Window & {
 
 const GOOGLE_PICKER_LOAD_TIMEOUT_MS = 5_000;
 const GOOGLE_PICKER_POLL_INTERVAL_MS = 25;
+
+export type GoogleDrivePickerDocument = {
+  id: string;
+  name?: string;
+  mimeType?: string;
+  url?: string;
+  [key: string]: unknown;
+};
+
+export type GoogleDrivePickerCallbackData = {
+  action: string;
+  docs?: GoogleDrivePickerDocument[];
+};
+
+export type OpenGoogleDrivePickerOptions = {
+  appId: string;
+  callback: (data: GoogleDrivePickerCallbackData) => void;
+  developerKey: string;
+  kind: GoogleDrivePickerResourceKind;
+  token: string;
+};
 
 function getGoogleDrivePickerApi(): GoogleDrivePickerApi | undefined {
   return (window as GooglePickerWindow).google?.picker;
@@ -39,7 +87,7 @@ function configureView(
 }
 
 export function createGoogleDrivePickerViews(
-  picker: GoogleDrivePickerApi,
+  picker: Pick<GoogleDrivePickerApi, "DocsView" | "ViewId">,
   kind: GoogleDrivePickerResourceKind,
 ): GoogleDrivePickerView[] {
   const viewId =
@@ -50,20 +98,78 @@ export function createGoogleDrivePickerViews(
   return [myDriveView, sharedDriveView];
 }
 
+/**
+ * Loads the Picker module before constructing custom views. Loading api.js only
+ * exposes gapi; the google.picker constructors arrive asynchronously after
+ * gapi.load("picker") completes.
+ */
 export async function getGoogleDrivePickerViews(
   kind: GoogleDrivePickerResourceKind,
   timeoutMs = GOOGLE_PICKER_LOAD_TIMEOUT_MS,
 ): Promise<GoogleDrivePickerView[]> {
+  const existingPicker = getGoogleDrivePickerApi();
+  if (existingPicker) {
+    return createGoogleDrivePickerViews(existingPicker, kind);
+  }
+
   const deadline = Date.now() + timeoutMs;
+  let gapi: GooglePickerWindow["gapi"];
   do {
-    const picker = getGoogleDrivePickerApi();
-    if (picker) {
-      return createGoogleDrivePickerViews(picker, kind);
+    gapi = (window as GooglePickerWindow).gapi;
+    if (gapi?.load) {
+      break;
     }
     await new Promise((resolve) =>
       window.setTimeout(resolve, GOOGLE_PICKER_POLL_INTERVAL_MS),
     );
   } while (Date.now() < deadline);
 
-  throw new Error("Google Drive picker did not finish loading.");
+  if (!gapi?.load) {
+    throw new Error("Google API loader did not finish loading.");
+  }
+
+  const remainingMs = Math.max(1, deadline - Date.now());
+  const picker = await new Promise<GoogleDrivePickerApi>((resolve, reject) => {
+    const resolveLoadedPicker = () => {
+      const loadedPicker = getGoogleDrivePickerApi();
+      if (loadedPicker) {
+        resolve(loadedPicker);
+        return;
+      }
+      reject(new Error("Google Drive picker module loaded without its API."));
+    };
+    gapi.load("picker", {
+      callback: resolveLoadedPicker,
+      onerror: () => reject(new Error("Google Drive picker failed to load.")),
+      timeout: remainingMs,
+      ontimeout: () =>
+        reject(new Error("Google Drive picker did not finish loading.")),
+    });
+  });
+
+  return createGoogleDrivePickerViews(picker, kind);
+}
+
+/**
+ * Opens Picker directly after its API is ready. This avoids coupling custom
+ * view construction to a React hook's asynchronous internal load state.
+ */
+export async function openGoogleDrivePicker(
+  options: OpenGoogleDrivePickerOptions,
+): Promise<void> {
+  const views = await getGoogleDrivePickerViews(options.kind);
+  const pickerApi = getGoogleDrivePickerApi();
+  if (!pickerApi) {
+    throw new Error("Google Drive picker API is unavailable.");
+  }
+
+  const builder = new pickerApi.PickerBuilder()
+    .setAppId(options.appId)
+    .setOAuthToken(options.token)
+    .setDeveloperKey(options.developerKey)
+    .setCallback(options.callback);
+  for (const view of views) {
+    builder.addView(view);
+  }
+  builder.build().setVisible(true);
 }

--- a/app/src/components/Workspace/googleDrivePickerViews.ts
+++ b/app/src/components/Workspace/googleDrivePickerViews.ts
@@ -1,0 +1,69 @@
+export type GoogleDrivePickerResourceKind = "file" | "folder";
+
+type GoogleDrivePickerView = {
+  setEnableDrives(enabled: boolean): GoogleDrivePickerView;
+  setIncludeFolders(included: boolean): GoogleDrivePickerView;
+  setSelectFolderEnabled(enabled: boolean): GoogleDrivePickerView;
+};
+
+type GoogleDrivePickerApi = {
+  DocsView: new (viewId: unknown) => GoogleDrivePickerView;
+  ViewId: {
+    DOCS: unknown;
+    FOLDERS: unknown;
+  };
+};
+
+type GooglePickerWindow = Window & {
+  google?: {
+    picker?: GoogleDrivePickerApi;
+  };
+};
+
+const GOOGLE_PICKER_LOAD_TIMEOUT_MS = 5_000;
+const GOOGLE_PICKER_POLL_INTERVAL_MS = 25;
+
+function getGoogleDrivePickerApi(): GoogleDrivePickerApi | undefined {
+  return (window as GooglePickerWindow).google?.picker;
+}
+
+function configureView(
+  view: GoogleDrivePickerView,
+  kind: GoogleDrivePickerResourceKind,
+): GoogleDrivePickerView {
+  if (kind === "folder") {
+    view.setIncludeFolders(true);
+    view.setSelectFolderEnabled(true);
+  }
+  return view;
+}
+
+export function createGoogleDrivePickerViews(
+  picker: GoogleDrivePickerApi,
+  kind: GoogleDrivePickerResourceKind,
+): GoogleDrivePickerView[] {
+  const viewId =
+    kind === "folder" ? picker.ViewId.FOLDERS : picker.ViewId.DOCS;
+  const myDriveView = configureView(new picker.DocsView(viewId), kind);
+  const sharedDriveView = configureView(new picker.DocsView(viewId), kind);
+  sharedDriveView.setEnableDrives(true);
+  return [myDriveView, sharedDriveView];
+}
+
+export async function getGoogleDrivePickerViews(
+  kind: GoogleDrivePickerResourceKind,
+  timeoutMs = GOOGLE_PICKER_LOAD_TIMEOUT_MS,
+): Promise<GoogleDrivePickerView[]> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const picker = getGoogleDrivePickerApi();
+    if (picker) {
+      return createGoogleDrivePickerViews(picker, kind);
+    }
+    await new Promise((resolve) =>
+      window.setTimeout(resolve, GOOGLE_PICKER_POLL_INTERVAL_MS),
+    );
+  } while (Date.now() < deadline);
+
+  throw new Error("Google Drive picker did not finish loading.");
+}

--- a/app/src/components/Workspace/useDriveResourcePicker.ts
+++ b/app/src/components/Workspace/useDriveResourcePicker.ts
@@ -1,22 +1,9 @@
 import { useCallback } from 'react'
-import useDrivePicker from 'react-google-drive-picker'
 
-import { DRIVE_SCOPES } from '../../contexts/GoogleAuthContext'
 import { googleClientManager } from '../../lib/googleClientManager'
 import { appState } from '../../lib/runtime/AppState'
 import { driveFileUrl, driveFolderUrl } from '../../storage/drive'
-import { getGoogleDrivePickerViews } from './googleDrivePickerViews'
-
-type PickerDocument = {
-  id: string
-  name?: string
-  mimeType?: string
-}
-
-type PickerCallbackData = {
-  action: string
-  docs?: PickerDocument[]
-}
+import { openGoogleDrivePicker } from './googleDrivePickerViews'
 
 export type PickedDriveResource = {
   uri: string
@@ -25,8 +12,6 @@ export type PickedDriveResource = {
 }
 
 export function useDriveResourcePicker() {
-  const [openPicker] = useDrivePicker()
-
   const pick = useCallback(
     async (kind: 'file' | 'folder'): Promise<PickedDriveResource | null> => {
       const { clientId, developerKey, appId } =
@@ -41,21 +26,13 @@ export function useDriveResourcePicker() {
         throw new Error('Google Drive storage is not initialized.')
       }
       const token = await driveStore.getAccessToken({ interactive: true })
-      const customViews = await getGoogleDrivePickerViews(kind)
-      return new Promise((resolve) => {
-        openPicker({
+      return new Promise((resolve, reject) => {
+        void openGoogleDrivePicker({
           token,
           appId,
-          clientId,
           developerKey,
-          viewId: kind === 'folder' ? 'FOLDERS' : 'DOCS',
-          disableDefaultView: true,
-          customViews,
-          customScopes: DRIVE_SCOPES,
-          showUploadView: false,
-          showUploadFolders: false,
-          multiselect: false,
-          callbackFunction: (data: PickerCallbackData) => {
+          kind,
+          callback: (data) => {
             const selected = data.action === 'picked' ? data.docs?.[0] : null
             if (!selected?.id) {
               resolve(null)
@@ -70,10 +47,10 @@ export function useDriveResourcePicker() {
               mimeType: selected.mimeType,
             })
           },
-        })
+        }).catch(reject)
       })
     },
-    [openPicker]
+    []
   )
 
   return {

--- a/app/src/components/Workspace/useDriveResourcePicker.ts
+++ b/app/src/components/Workspace/useDriveResourcePicker.ts
@@ -5,6 +5,7 @@ import { DRIVE_SCOPES } from '../../contexts/GoogleAuthContext'
 import { googleClientManager } from '../../lib/googleClientManager'
 import { appState } from '../../lib/runtime/AppState'
 import { driveFileUrl, driveFolderUrl } from '../../storage/drive'
+import { getGoogleDrivePickerViews } from './googleDrivePickerViews'
 
 type PickerDocument = {
   id: string
@@ -40,6 +41,7 @@ export function useDriveResourcePicker() {
         throw new Error('Google Drive storage is not initialized.')
       }
       const token = await driveStore.getAccessToken({ interactive: true })
+      const customViews = await getGoogleDrivePickerViews(kind)
       return new Promise((resolve) => {
         openPicker({
           token,
@@ -47,13 +49,12 @@ export function useDriveResourcePicker() {
           clientId,
           developerKey,
           viewId: kind === 'folder' ? 'FOLDERS' : 'DOCS',
+          disableDefaultView: true,
+          customViews,
           customScopes: DRIVE_SCOPES,
           showUploadView: false,
           showUploadFolders: false,
-          supportDrives: true,
           multiselect: false,
-          setIncludeFolders: kind === 'folder',
-          setSelectFolderEnabled: kind === 'folder',
           callbackFunction: (data: PickerCallbackData) => {
             const selected = data.action === 'picked' ? data.docs?.[0] : null
             if (!selected?.id) {

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -305,7 +305,23 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       }
       throw new Error(`Unexpected request: ${url}`)
     })
+    mergeImpersonatedServiceAccountCredential({
+      serviceAccount: 'runme@runme-lewi-dev.iam.gserviceaccount.com',
+      humanPrincipal: 'jeremy@lewi.us',
+      authorizationLeaseExpiresAt: new Date(
+        Date.now() + 86_400_000
+      ).toISOString(),
+      drive: {
+        accessToken: 'previously-cached-drive-token',
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        scopes: DRIVE_SCOPES,
+      },
+    })
     const auth = await renderWithGoogleAuthProvider()
+
+    await expect(auth.ensureAccessToken({ interactive: false })).resolves.toBe(
+      'previously-cached-drive-token'
+    )
 
     let authorizationError: unknown
     await act(async () => {

--- a/app/src/contexts/GoogleAuthContext.test.tsx
+++ b/app/src/contexts/GoogleAuthContext.test.tsx
@@ -200,6 +200,12 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
       if (url.endsWith(':generateIdToken')) {
         return new Response(JSON.stringify({ token: idToken }), { status: 200 })
       }
+      if (url.includes('/drive/v3/about')) {
+        return new Response(
+          JSON.stringify({ user: { permissionId: 'service-account-id' } }),
+          { status: 200 }
+        )
+      }
       throw new Error(`Unexpected request: ${url}`)
     })
     const auth = await renderWithGoogleAuthProvider()
@@ -238,6 +244,96 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
     expect(getBrowserAdapter().simpleAuth?.idToken).toBe(idToken)
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
     expect(window.localStorage.getItem('oidc-auth')).toBeNull()
+  })
+
+  it('does not install an impersonated Drive token when the Drive API is disabled', async () => {
+    saveAppLoginConfiguration({
+      ...DEFAULT_APP_LOGIN_CONFIGURATION,
+      identitySharing: 'separate',
+      driveMode: 'service_account',
+      driveHumanAccount: 'jeremy@lewi.us',
+      driveServiceAccount: 'runme@runme-lewi-dev.iam.gserviceaccount.com',
+    })
+    let tokenCallback: ((response: { access_token?: string }) => void) | null =
+      null
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: vi.fn((options) => {
+            tokenCallback = options.callback
+            return {
+              callback: options.callback,
+              requestAccessToken: vi.fn(() => {
+                tokenCallback?.({ access_token: 'human-iam-token' })
+              }),
+            }
+          }),
+        },
+      },
+    }
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/userinfo')) {
+        return new Response(JSON.stringify({ email: 'jeremy@lewi.us' }), {
+          status: 200,
+        })
+      }
+      if (url.endsWith(':generateAccessToken')) {
+        return new Response(
+          JSON.stringify({
+            accessToken: 'unusable-drive-token',
+            expireTime: new Date(Date.now() + 3_600_000).toISOString(),
+          }),
+          { status: 200 }
+        )
+      }
+      if (url.includes('/drive/v3/about')) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: 'Google Drive API is disabled.',
+              details: [
+                {
+                  reason: 'SERVICE_DISABLED',
+                  metadata: { service: 'drive.googleapis.com' },
+                },
+              ],
+            },
+          }),
+          { status: 403, statusText: 'Forbidden' }
+        )
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const auth = await renderWithGoogleAuthProvider()
+
+    let authorizationError: unknown
+    await act(async () => {
+      try {
+        await auth.getServiceAccountCredentials(
+          'runme@runme-lewi-dev.iam.gserviceaccount.com',
+          {
+            humanAccount: 'jeremy@lewi.us',
+            mode: 'popup',
+            targets: ['drive'],
+          }
+        )
+      } catch (error) {
+        authorizationError = error
+      }
+    })
+    expect(authorizationError).toBeInstanceOf(Error)
+    expect((authorizationError as Error).message).toContain(
+      'Google Drive API is not enabled for service-account project runme-lewi-dev'
+    )
+    expect(
+      window.localStorage.getItem(
+        IMPERSONATED_SERVICE_ACCOUNT_CREDENTIAL_STORAGE_KEY
+      )
+    ).toBeNull()
+    await expect(
+      auth.ensureAccessToken({ interactive: false })
+    ).rejects.toThrow('Google Drive service-account authorization is required')
   })
 
   it('rejects a Google account that does not match the configured human', async () => {
@@ -384,6 +480,12 @@ describe('GoogleAuthProvider implicit redirect flow', () => {
             accessToken: 'service-account-drive-token',
             expireTime: new Date(Date.now() + 3_600_000).toISOString(),
           }),
+          { status: 200 }
+        )
+      }
+      if (url.includes('/drive/v3/about')) {
+        return new Response(
+          JSON.stringify({ user: { permissionId: 'service-account-id' } }),
           { status: 200 }
         )
       }

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -803,6 +803,30 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           )
         } catch (error) {
           hasDriveCredential = false
+          const cachedCredential =
+            readImpersonatedServiceAccountCredential()
+          const cachedIdentityMatches = Boolean(
+            cachedCredential &&
+              cachedCredential.serviceAccount.toLowerCase() ===
+                serviceAccount.trim().toLowerCase() &&
+              cachedCredential.humanPrincipal.toLowerCase() ===
+                humanPrincipal.toLowerCase()
+          )
+          // A failed preflight must invalidate the previous Drive target for
+          // the same identity. Otherwise the merge below can retain and later
+          // reinstall a credential that Drive has already rejected.
+          if (cachedIdentityMatches) {
+            clearImpersonatedServiceAccountCredential(['drive'])
+          }
+          if (
+            tokenInfoRef.current?.authFlow ===
+              'impersonated_service_account' &&
+            tokenInfoRef.current.effectivePrincipal?.toLowerCase() ===
+              serviceAccount.trim().toLowerCase()
+          ) {
+            setAccessToken('')
+            window.gapi?.client?.setToken(null)
+          }
           errors.push({
             target: 'drive',
             message: error instanceof Error ? error.message : String(error),

--- a/app/src/contexts/GoogleAuthContext.tsx
+++ b/app/src/contexts/GoogleAuthContext.tsx
@@ -15,6 +15,7 @@ import {
   getGoogleHumanPrincipal,
   mintImpersonatedServiceAccountCredentials,
   resolveAuthorizationLeaseSeconds,
+  validateImpersonatedGoogleDriveAccessToken,
   type GetServiceAccountCredentialsOptions,
   type ServiceAccountCredentialStatus,
   type ServiceAccountCredentialTarget,
@@ -787,15 +788,30 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
       const driveExpiresAtMs = credentials.driveAccessTokenExpiresAt
         ? Date.parse(credentials.driveAccessTokenExpiresAt)
         : Number.NaN
-      const hasDriveCredential = Boolean(
+      let hasDriveCredential = Boolean(
         credentials.driveAccessToken && Number.isFinite(driveExpiresAtMs)
       )
       const hasAppCredential = Boolean(
         credentials.appIdToken && credentials.appIdTokenExpiresAt
       )
+      const errors = [...credentials.errors]
+      if (hasDriveCredential) {
+        try {
+          await validateImpersonatedGoogleDriveAccessToken(
+            credentials.driveAccessToken!,
+            serviceAccount
+          )
+        } catch (error) {
+          hasDriveCredential = false
+          errors.push({
+            target: 'drive',
+            message: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
       if (!hasDriveCredential && !hasAppCredential) {
         throw new Error(
-          credentials.errors.map((error) => error.message).join('; ') ||
+          errors.map((error) => error.message).join('; ') ||
             'Google IAM did not mint any requested service-account credentials.'
         )
       }
@@ -844,10 +860,16 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
           credentials.appIdTokenExpiresAt!
         )
       }
-      setCredentialError(null)
+      setCredentialError(
+        errors.length > 0
+          ? errors
+              .map((error) => `${error.target}: ${error.message}`)
+              .join('; ')
+          : null
+      )
 
       return {
-        status: credentials.errors.length > 0 ? 'partial' : 'authorized',
+        status: errors.length > 0 ? 'partial' : 'authorized',
         humanPrincipal,
         serviceAccount: serviceAccount.trim(),
         authorizationLeaseExpiresAt,
@@ -867,9 +889,7 @@ export function GoogleAuthProvider({ children }: { children: ReactNode }) {
               },
             }
           : {}),
-        ...(credentials.errors.length > 0
-          ? { errors: credentials.errors }
-          : {}),
+        ...(errors.length > 0 ? { errors } : {}),
       }
     },
     [setAccessToken]

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -462,6 +462,59 @@ describe("DriveNotebookStore", () => {
     ).rejects.toBeInstanceOf(DriveCreateNotCommittedError);
   });
 
+  it.each([
+    ["notebook create", "create"],
+    ["arbitrary content create", "createContent"],
+    ["folder create", "createFolder"],
+  ] as const)(
+    "explains the Shared drive requirement after a service-account %s failure",
+    async (_description, method) => {
+      setGoogleDriveBaseUrl("https://drive.example.test");
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 403,
+              message: "Service Accounts do not have storage quota.",
+              errors: [
+                {
+                  reason: "storageQuotaExceeded",
+                  message: "Service Accounts do not have storage quota.",
+                },
+              ],
+            },
+          }),
+          {
+            status: 403,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+      const store = new DriveNotebookStore(async () => "access-token");
+      const parent = "https://drive.google.com/drive/folders/folder123";
+      const create =
+        method === "create"
+          ? store.create(parent, "notebook.ipynb")
+          : method === "createContent"
+            ? store.createContent(
+                parent,
+                "notebook.ipynb",
+                "{}",
+                "application/x-ipynb+json",
+              )
+            : store.createFolder(parent, "new-folder");
+
+      await expect(create).rejects.toThrow(
+        "service accounts do not have storage quota",
+      );
+      await expect(create).rejects.toThrow("Choose a folder in a Shared drive");
+      await expect(create).rejects.toThrow(
+        "A folder shared from a user's My Drive is not a Shared drive",
+      );
+    },
+  );
+
   it("reports the created file when its initial content upload fails", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -188,9 +188,13 @@ async function driveErrorFromResponse(
     )
   }
   if (response.status === 403) {
+    const responseText = await response.text().catch(() => '')
+    const serviceAccountMessage = serviceAccountStorageQuotaErrorMessage(
+      new DriveRequestError(responseText, response.status)
+    )
     return new LinkedResourceError(
       operation === 'download' ? 'DOWNLOAD_RESTRICTED' : 'ACCESS_DENIED',
-      `Google Drive denied ${operation} access`
+      serviceAccountMessage ?? `Google Drive denied ${operation} access`
     )
   }
   if (response.status === 404) {
@@ -357,6 +361,79 @@ function driveErrorStatus(error: unknown): number | undefined {
   }
   const status = candidate.status ?? candidate.result?.error?.code
   return typeof status === 'number' ? status : undefined
+}
+
+function driveErrorText(error: unknown): string {
+  const messages: string[] = []
+  if (error instanceof Error && error.message) {
+    messages.push(error.message)
+  }
+  if (error && typeof error === 'object') {
+    const candidate = error as {
+      body?: unknown
+      message?: unknown
+      result?: {
+        error?: {
+          message?: unknown
+          errors?: Array<{ message?: unknown; reason?: unknown }>
+        }
+      }
+    }
+    if (typeof candidate.message === 'string') {
+      messages.push(candidate.message)
+    }
+    if (typeof candidate.body === 'string') {
+      messages.push(candidate.body)
+    }
+    const resultError = candidate.result?.error
+    if (typeof resultError?.message === 'string') {
+      messages.push(resultError.message)
+    }
+    for (const detail of resultError?.errors ?? []) {
+      if (typeof detail.reason === 'string') {
+        messages.push(detail.reason)
+      }
+      if (typeof detail.message === 'string') {
+        messages.push(detail.message)
+      }
+    }
+  }
+  return messages.join(' ')
+}
+
+function serviceAccountStorageQuotaErrorMessage(
+  error: unknown
+): string | undefined {
+  const errorText = driveErrorText(error).toLowerCase()
+  const isStorageQuotaError =
+    errorText.includes('storagequotaexceeded') ||
+    errorText.includes('storage quota')
+  if (!isStorageQuotaError || !errorText.includes('service account')) {
+    return undefined
+  }
+  return (
+    'Google Drive cannot create this file because service accounts do not ' +
+    "have storage quota and cannot own files in a user's My Drive. Choose " +
+    'a folder in a Shared drive, add the service account as a Contributor ' +
+    '(or Content manager for move and delete operations), and try again. ' +
+    "A folder shared from a user's My Drive is not a Shared drive. " +
+    'Alternatively, authenticate as a human user.'
+  )
+}
+
+async function createDriveItem(
+  client: DriveFilesClient,
+  doc: DriveDoc
+): Promise<DriveDoc> {
+  try {
+    return await client.create(doc)
+  } catch (error) {
+    const message = serviceAccountStorageQuotaErrorMessage(error)
+    if (message) {
+      throw new DriveCreateNotCommittedError(message, error)
+    }
+    throw error
+  }
 }
 
 function isDefinitelyRejectedCreate(error: unknown): boolean {
@@ -1936,7 +2013,7 @@ export class DriveNotebookStore {
     }
 
     const client = await this.getFilesClient()
-    const folder = await client.create({
+    const folder = await createDriveItem(client, {
       name: `${notebookName}.assets`,
       mimeType: DRIVE_FOLDER_MIME_TYPE,
       parents: [parentId],
@@ -1989,7 +2066,7 @@ export class DriveNotebookStore {
     const client = await this.getFilesClient()
     const format = detectNotebookFileFormat(name)
     const mimeType = format === 'ipynb' ? IPYNB_MIME_TYPE : 'application/json'
-    let file = await client.create({
+    let file = await createDriveItem(client, {
       id: options.fileId,
       name,
       mimeType,
@@ -2089,6 +2166,11 @@ export class DriveNotebookStore {
     } catch (error) {
       if (error instanceof DriveFileCreatedError) {
         throw error
+      }
+      const serviceAccountMessage =
+        serviceAccountStorageQuotaErrorMessage(error)
+      if (serviceAccountMessage) {
+        throw new DriveCreateNotCommittedError(serviceAccountMessage, error)
       }
       if (options.fileId && driveErrorStatus(error) === 409) {
         const response = await client.get({
@@ -2258,7 +2340,7 @@ export class DriveNotebookStore {
       throw new Error('DriveNotebookStore.createFolder expects a folder URI')
     }
     const client = await this.getFilesClient()
-    let folder = await client.create({
+    let folder = await createDriveItem(client, {
       name,
       mimeType: DRIVE_FOLDER_MIME_TYPE,
       parents: [id],

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -254,6 +254,13 @@ const result = await drive.search({
 folder. Use `drive.search` when the caller needs Drive query expressions,
 pagination, ordering, shared-drive scoping, or additional file metadata.
 
+The Explorer's **Add Google Drive folder** picker presents separate views for
+folders in My Drive and folders in Shared drives. Google Picker's deprecated
+`Feature.SUPPORT_DRIVES` flag is not sufficient to expose Shared drives. The
+Shared drives view must be a `DocsView` configured with
+`setEnableDrives(true)`. Selecting a Shared drive or a folder within it mounts
+that location in the Explorer using the same Drive mirror as a My Drive folder.
+
 `drive.authorize()` starts a fresh Google Drive OAuth flow. It first clears any
 locally stored Drive OAuth handoff state from a previous redirect or new-tab
 attempt, then starts the flow configured by `googleDrive.authFlow` and

--- a/docs/14-authentication-and-app-configuration.md
+++ b/docs/14-authentication-and-app-configuration.md
@@ -116,6 +116,48 @@ OAuth token, then uses the IAM Service Account Credentials API to mint:
 - a Drive-scoped OAuth access token; and
 - an audience-bound OIDC ID token for the Runme Agent.
 
+Enable both APIs before connecting:
+
+- **IAM Service Account Credentials API** in the OAuth client or quota project;
+  and
+- **Google Drive API** (`drive.googleapis.com`) in the target service account's
+  Google Cloud project.
+
+Sharing a Drive folder with the service account does not enable the Drive API.
+IAM can still mint a correctly scoped access token while the Drive API is
+disabled, but every Drive operation then fails with `403 SERVICE_DISABLED`.
+Runme validates a newly minted Drive token before reporting Drive as syncing.
+If validation detects this configuration, Authentication Settings and the
+Drive status action show an error with a direct link to enable the API for the
+affected project. After enabling it, allow a few minutes for propagation and
+then use **Connect or refresh** to mint and validate a new credential.
+
+#### Service-account storage and Shared drives
+
+An impersonated service account is still the service-account principal; it is
+not a Google Workspace user acting through domain-wide delegation. Service
+accounts do not have Drive storage quota and cannot own files in a user's **My
+Drive**. Sharing a My Drive folder with the service account can permit reading,
+editing, or moving existing files, but it does not let the service account
+create files that it would need to own. Google reports this as
+`403 storageQuotaExceeded`, often with a message that service accounts do not
+have storage quota.
+
+To create notebooks with service-account credentials, select a folder in an
+actual **Shared drive**, where the organization owns the files. A folder shared
+from a user's My Drive is not a Shared drive. Add the service-account email as
+a Shared drive member with **Contributor** access to create files. Use **Content
+manager** or **Manager** when Runme also needs to move or delete items within
+the Shared drive. Workspace policies must allow the service account to be
+added, which can be governed as external membership.
+
+Runme sends the Shared drive parameters required by the Drive API. When Google
+returns the service-account `storageQuotaExceeded` response during creation,
+Runme explains the ownership limitation and directs the user to choose a Shared
+drive or authenticate as a human user. Normal user OAuth, or domain-wide
+delegation that truly impersonates a Workspace user, can create files in that
+user's My Drive because the human user owns the resulting files.
+
 Both tokens represent the same service-account email. The short-lived
 service-account credentials are persisted locally so they survive the OAuth
 redirect and reloads; the human OAuth token is not persisted. Switching to the


### PR DESCRIPTION
## Summary

- validate impersonated Google Drive credentials before installing them and surface a direct API-enablement error
- explain service-account My Drive ownership limits and translate `storageQuotaExceeded` into Shared drive guidance
- replace the deprecated Picker `SUPPORT_DRIVES` feature with explicit My Drive and Shared drives `DocsView` instances
- document both failure modes and add storage, auth, Picker, and UI regression coverage

## Verification

- `runme run build test`
- `pnpm -C app test --run src/components/Workspace/googleDrivePickerViews.test.ts src/components/Workspace/GoogleDrivePickerButton.test.tsx src/storage/drive.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx`
- `git diff --check`

## Manual reproduction

On `web.runme.dev`, the previous Add Google Drive folder dialog showed My Drive/shared-folder entries but no Shared drives view even though `supportDrives: true` was set. The wrapper mapped that option to Google Picker's deprecated builder feature and never called `DocsView.setEnableDrives(true)`.