### PR TITLE
Add direct Drive discovery and mount tools

### DIFF
--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -713,6 +713,58 @@ describe('WebMcpToolRegistrationHost', () => {
     )
   })
 
+  it('preserves the Drive authorization error when interaction is unavailable', async () => {
+    searchDriveFilesMock.mockRejectedValueOnce(
+      new Error('Google Drive authorization is required.')
+    )
+    const registerTool = vi.fn()
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    })
+
+    render(<WebMcpToolRegistrationHost />)
+    const searchDriveItems = registerTool.mock.calls
+      .map((call) => call[0])
+      .find((tool) => tool.name === 'searchDriveItems')
+
+    await expect(
+      searchDriveItems.execute({ name: 'notebooks', itemType: 'folder' })
+    ).rejects.toThrow('Google Drive authorization is required.')
+  })
+
+  it('keeps idempotency guidance when Drive authorization is incomplete', async () => {
+    createDriveNotebookMock.mockRejectedValueOnce(
+      new Error('Google Drive authorization is required.')
+    )
+    startGoogleDriveOAuthMock.mockResolvedValueOnce({
+      status: 'pending',
+      authFlow: 'implicit',
+      mode: 'popup',
+    })
+    const registerTool = vi.fn()
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    })
+
+    render(<WebMcpToolRegistrationHost />)
+    const createDriveNotebook = registerTool.mock.calls
+      .map((call) => call[0])
+      .find((tool) => tool.name === 'createDriveNotebook')
+
+    await expect(
+      createDriveNotebook.execute(
+        {
+          folderIdOrUri: 'root',
+          fileName: 'demo.ipynb',
+          idempotencyKey: 'create-demo-notebook',
+        },
+        { requestUserInteraction: async (callback) => callback() }
+      )
+    ).rejects.toThrow('retry createDriveNotebook with the same idempotencyKey')
+  })
+
   it('marks the AppConsole cell failed when the operation settles unsuccessfully', async () => {
     startOperationMock.mockImplementationOnce(async (input) => {
       input.onAccepted?.('exec-2')

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.test.tsx
@@ -8,6 +8,8 @@ const {
   getOperationMock,
   cancelOperationMock,
   createDriveNotebookMock,
+  searchDriveFilesMock,
+  mountDriveFolderMock,
   startGoogleDriveOAuthMock,
   appConsoleDataMock,
   appLoggerMock,
@@ -17,6 +19,8 @@ const {
   getOperationMock: vi.fn(),
   cancelOperationMock: vi.fn(),
   createDriveNotebookMock: vi.fn(),
+  searchDriveFilesMock: vi.fn(),
+  mountDriveFolderMock: vi.fn(),
   startGoogleDriveOAuthMock: vi.fn(),
   appConsoleDataMock: {
     hydrate: vi.fn(),
@@ -53,6 +57,8 @@ vi.mock('../../lib/appConsole/appConsoleController', () => ({
 
 vi.mock('../../lib/driveTransfer', () => ({
   createDriveNotebook: createDriveNotebookMock,
+  searchDriveFiles: searchDriveFilesMock,
+  mountDriveFolder: mountDriveFolderMock,
 }))
 
 vi.mock('../../lib/logging/runtime', () => ({
@@ -120,6 +126,25 @@ describe('WebMcpToolRegistrationHost', () => {
       remoteUri: 'https://drive.google.com/file/d/drive-file-1/view',
       localUri: 'local://file/drive-file-1',
     })
+    searchDriveFilesMock.mockReset()
+    searchDriveFilesMock.mockResolvedValue({
+      files: [
+        {
+          id: 'drive-folder-1',
+          name: 'notebooks',
+          mimeType: 'application/vnd.google-apps.folder',
+          uri: 'https://drive.google.com/drive/folders/drive-folder-1',
+        },
+      ],
+    })
+    mountDriveFolderMock.mockReset()
+    mountDriveFolderMock.mockResolvedValue({
+      folderId: 'drive-folder-1',
+      name: 'notebooks',
+      remoteUri: 'https://drive.google.com/drive/folders/drive-folder-1',
+      localUri: 'local://folder/drive-folder-1',
+      alreadyMounted: false,
+    })
     startGoogleDriveOAuthMock.mockReset()
     startGoogleDriveOAuthMock.mockResolvedValue({
       status: 'authorized',
@@ -173,7 +198,7 @@ describe('WebMcpToolRegistrationHost', () => {
 
     render(<WebMcpToolRegistrationHost />)
 
-    expect(registerTool).toHaveBeenCalledTimes(9)
+    expect(registerTool).toHaveBeenCalledTimes(12)
   })
 
   it('prefers the current document.modelContext API', () => {
@@ -190,7 +215,7 @@ describe('WebMcpToolRegistrationHost', () => {
 
     render(<WebMcpToolRegistrationHost />)
 
-    expect(documentRegisterTool).toHaveBeenCalledTimes(9)
+    expect(documentRegisterTool).toHaveBeenCalledTimes(12)
     expect(navigatorRegisterTool).not.toHaveBeenCalled()
   })
 
@@ -251,7 +276,7 @@ describe('WebMcpToolRegistrationHost', () => {
 
     const rendered = render(<WebMcpToolRegistrationHost />)
 
-    expect(registerTool).toHaveBeenCalledTimes(9)
+    expect(registerTool).toHaveBeenCalledTimes(12)
     expect(
       registered.some(({ tool }) => tool.name === 'listNotebookComments')
     ).toBe(false)
@@ -464,6 +489,64 @@ describe('WebMcpToolRegistrationHost', () => {
     expect(JSON.parse(String(dismissTour?.tool.execute({})))).toEqual({
       dismissed: true,
     })
+
+    const searchDriveItems = registered.find(
+      ({ tool }) => tool.name === 'searchDriveItems'
+    )
+    expect(searchDriveItems?.tool.title).toBe('Search Google Drive Items')
+    expect(searchDriveItems?.tool.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: true,
+    })
+    expect(searchDriveItems?.tool.inputSchema).toMatchObject({
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        itemType: { enum: ['any', 'file', 'folder'] },
+        pageSize: { minimum: 1, maximum: 100 },
+      },
+    })
+    await expect(
+      searchDriveItems?.tool.execute({
+        name: 'notebooks',
+        itemType: 'folder',
+        exactName: true,
+      })
+    ).resolves.toContain('"name":"notebooks"')
+    expect(searchDriveFilesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: expect.stringContaining("name = 'notebooks'"),
+        includeItemsFromAllDrives: true,
+        supportsAllDrives: true,
+      })
+    )
+
+    const listDriveFolder = registered.find(
+      ({ tool }) => tool.name === 'listDriveFolder'
+    )
+    expect(listDriveFolder?.tool.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: true,
+    })
+    await expect(
+      listDriveFolder?.tool.execute({ folderIdOrUri: 'drive-folder-1' })
+    ).resolves.toContain(
+      '"folderUri":"https://drive.google.com/drive/folders/drive-folder-1"'
+    )
+
+    const mountDriveFolder = registered.find(
+      ({ tool }) => tool.name === 'mountDriveFolder'
+    )
+    expect(mountDriveFolder?.tool.annotations).toEqual({
+      readOnlyHint: false,
+      untrustedContentHint: true,
+    })
+    await expect(
+      mountDriveFolder?.tool.execute({ folderIdOrUri: 'drive-folder-1' })
+    ).resolves.toContain('"localUri":"local://folder/drive-folder-1"')
+    expect(mountDriveFolderMock).toHaveBeenCalledWith(
+      'https://drive.google.com/drive/folders/drive-folder-1'
+    )
 
     const createDriveNotebook = registered.find(
       ({ tool }) => tool.name === 'createDriveNotebook'

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -60,6 +60,23 @@ import {
   CREATE_DRIVE_NOTEBOOK_TOOL_TITLE,
   executeCreateDriveNotebook,
 } from '../../lib/runtime/createDriveNotebookTool'
+import {
+  buildListDriveFolderInputSchema,
+  buildMountDriveFolderInputSchema,
+  buildSearchDriveItemsInputSchema,
+  executeListDriveFolder,
+  executeMountDriveFolder,
+  executeSearchDriveItems,
+  LIST_DRIVE_FOLDER_TOOL_DESCRIPTION,
+  LIST_DRIVE_FOLDER_TOOL_NAME,
+  LIST_DRIVE_FOLDER_TOOL_TITLE,
+  MOUNT_DRIVE_FOLDER_TOOL_DESCRIPTION,
+  MOUNT_DRIVE_FOLDER_TOOL_NAME,
+  MOUNT_DRIVE_FOLDER_TOOL_TITLE,
+  SEARCH_DRIVE_ITEMS_TOOL_DESCRIPTION,
+  SEARCH_DRIVE_ITEMS_TOOL_NAME,
+  SEARCH_DRIVE_ITEMS_TOOL_TITLE,
+} from '../../lib/runtime/driveWorkspaceTools'
 import { appState } from '../../lib/runtime/AppState'
 
 type ToolExecuteOptionsLike = {
@@ -126,13 +143,15 @@ function isDriveAuthorizationRequired(error: unknown): boolean {
   )
 }
 
-async function executeCreateDriveNotebookWithAuthorization(
+async function executeDriveToolWithAuthorization(
+  toolName: string,
+  execute: (input: Record<string, unknown>) => Promise<string>,
   input: Record<string, unknown>,
   options: ToolExecuteOptionsLike
 ): Promise<string> {
   try {
     // Preserve the no-UI path for cached tokens and service-account sessions.
-    return await executeCreateDriveNotebook(input)
+    return await execute(input)
   } catch (error) {
     if (
       !isDriveAuthorizationRequired(error) ||
@@ -147,14 +166,14 @@ async function executeCreateDriveNotebookWithAuthorization(
       })
       if (authorization.status !== 'authorized') {
         throw new Error(
-          'Google Drive authorization opened in a new tab. Complete authorization, then retry createDriveNotebook with the same idempotencyKey.'
+          `Google Drive authorization opened in a new tab. Complete authorization, then retry ${toolName}.`
         )
       }
-      return executeCreateDriveNotebook(input)
+      return execute(input)
     })
 
     if (typeof result !== 'string') {
-      throw new Error('createDriveNotebook returned an invalid result')
+      throw new Error(`${toolName} returned an invalid result`)
     }
     return result
   }
@@ -458,6 +477,72 @@ export default function WebMcpToolRegistrationHost() {
       )
       registerTool(
         {
+          name: SEARCH_DRIVE_ITEMS_TOOL_NAME,
+          title: SEARCH_DRIVE_ITEMS_TOOL_TITLE,
+          description: SEARCH_DRIVE_ITEMS_TOOL_DESCRIPTION,
+          inputSchema: buildSearchDriveItemsInputSchema(),
+          annotations: {
+            readOnlyHint: true,
+            untrustedContentHint: true,
+          },
+          execute: (input, options) =>
+            executeDriveToolWithAuthorization(
+              SEARCH_DRIVE_ITEMS_TOOL_NAME,
+              executeSearchDriveItems,
+              input,
+              options
+            ),
+        },
+        {
+          signal: registrationController.signal,
+        }
+      )
+      registerTool(
+        {
+          name: LIST_DRIVE_FOLDER_TOOL_NAME,
+          title: LIST_DRIVE_FOLDER_TOOL_TITLE,
+          description: LIST_DRIVE_FOLDER_TOOL_DESCRIPTION,
+          inputSchema: buildListDriveFolderInputSchema(),
+          annotations: {
+            readOnlyHint: true,
+            untrustedContentHint: true,
+          },
+          execute: (input, options) =>
+            executeDriveToolWithAuthorization(
+              LIST_DRIVE_FOLDER_TOOL_NAME,
+              executeListDriveFolder,
+              input,
+              options
+            ),
+        },
+        {
+          signal: registrationController.signal,
+        }
+      )
+      registerTool(
+        {
+          name: MOUNT_DRIVE_FOLDER_TOOL_NAME,
+          title: MOUNT_DRIVE_FOLDER_TOOL_TITLE,
+          description: MOUNT_DRIVE_FOLDER_TOOL_DESCRIPTION,
+          inputSchema: buildMountDriveFolderInputSchema(),
+          annotations: {
+            readOnlyHint: false,
+            untrustedContentHint: true,
+          },
+          execute: (input, options) =>
+            executeDriveToolWithAuthorization(
+              MOUNT_DRIVE_FOLDER_TOOL_NAME,
+              executeMountDriveFolder,
+              input,
+              options
+            ),
+        },
+        {
+          signal: registrationController.signal,
+        }
+      )
+      registerTool(
+        {
           name: CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
           title: CREATE_DRIVE_NOTEBOOK_TOOL_TITLE,
           description: CREATE_DRIVE_NOTEBOOK_TOOL_DESCRIPTION,
@@ -467,7 +552,12 @@ export default function WebMcpToolRegistrationHost() {
             untrustedContentHint: false,
           },
           execute: (input, options) =>
-            executeCreateDriveNotebookWithAuthorization(input, options),
+            executeDriveToolWithAuthorization(
+              CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
+              executeCreateDriveNotebook,
+              input,
+              options
+            ),
         },
         {
           signal: registrationController.signal,
@@ -490,6 +580,9 @@ export default function WebMcpToolRegistrationHost() {
                 GET_DOCUMENTATION_TOOL_NAME,
                 SHOW_TOUR_STEP_TOOL_NAME,
                 DISMISS_TOUR_TOOL_NAME,
+                SEARCH_DRIVE_ITEMS_TOOL_NAME,
+                LIST_DRIVE_FOLDER_TOOL_NAME,
+                MOUNT_DRIVE_FOLDER_TOOL_NAME,
                 CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
               ],
             },
@@ -532,6 +625,9 @@ export default function WebMcpToolRegistrationHost() {
             GET_DOCUMENTATION_TOOL_NAME,
             SHOW_TOUR_STEP_TOOL_NAME,
             DISMISS_TOUR_TOOL_NAME,
+            SEARCH_DRIVE_ITEMS_TOOL_NAME,
+            LIST_DRIVE_FOLDER_TOOL_NAME,
+            MOUNT_DRIVE_FOLDER_TOOL_NAME,
             CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
           ],
         },

--- a/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
+++ b/app/src/components/WebMcp/WebMcpToolRegistrationHost.tsx
@@ -147,7 +147,8 @@ async function executeDriveToolWithAuthorization(
   toolName: string,
   execute: (input: Record<string, unknown>) => Promise<string>,
   input: Record<string, unknown>,
-  options: ToolExecuteOptionsLike
+  options?: ToolExecuteOptionsLike,
+  retryInstruction = toolName
 ): Promise<string> {
   try {
     // Preserve the no-UI path for cached tokens and service-account sessions.
@@ -155,7 +156,7 @@ async function executeDriveToolWithAuthorization(
   } catch (error) {
     if (
       !isDriveAuthorizationRequired(error) ||
-      typeof options.requestUserInteraction !== 'function'
+      typeof options?.requestUserInteraction !== 'function'
     ) {
       throw error
     }
@@ -166,7 +167,7 @@ async function executeDriveToolWithAuthorization(
       })
       if (authorization.status !== 'authorized') {
         throw new Error(
-          `Google Drive authorization opened in a new tab. Complete authorization, then retry ${toolName}.`
+          `Google Drive authorization opened in a new tab. Complete authorization, then retry ${retryInstruction}.`
         )
       }
       return execute(input)
@@ -556,7 +557,8 @@ export default function WebMcpToolRegistrationHost() {
               CREATE_DRIVE_NOTEBOOK_TOOL_NAME,
               executeCreateDriveNotebook,
               input,
-              options
+              options,
+              'createDriveNotebook with the same idempotencyKey'
             ),
         },
         {

--- a/app/src/lib/driveTransfer.test.ts
+++ b/app/src/lib/driveTransfer.test.ts
@@ -121,6 +121,13 @@ describe('driveTransfer', () => {
 
   it('mirrors and mounts an accessible Drive folder', async () => {
     const remoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const getRemoteMetadata = vi.fn().mockResolvedValue({
+      name: 'notebooks',
+      type: NotebookStoreItemType.Folder,
+    })
+    appState.setDriveNotebookStore({
+      getMetadata: getRemoteMetadata,
+    } as any)
     const updateFolder = vi.fn().mockResolvedValue('local://folder/folder123')
     const getMetadata = vi.fn().mockResolvedValue({ name: 'notebooks' })
     appState.setLocalNotebooks({ updateFolder, getMetadata } as any)
@@ -137,7 +144,8 @@ describe('driveTransfer', () => {
 
     const result = await mountDriveFolder('folder123')
 
-    expect(updateFolder).toHaveBeenCalledWith(remoteUri)
+    expect(getRemoteMetadata).toHaveBeenCalledWith(remoteUri)
+    expect(updateFolder).toHaveBeenCalledWith(remoteUri, 'notebooks')
     expect(addItem).toHaveBeenCalledWith('local://folder/folder123')
     expect(result).toEqual({
       folderId: 'folder123',
@@ -151,6 +159,12 @@ describe('driveTransfer', () => {
   it('reports an already-mounted Drive folder without duplicating workspace state', async () => {
     const remoteUri = 'https://drive.google.com/drive/folders/folder123'
     const localUri = 'local://folder/folder123'
+    appState.setDriveNotebookStore({
+      getMetadata: vi.fn().mockResolvedValue({
+        name: 'notebooks',
+        type: NotebookStoreItemType.Folder,
+      }),
+    } as any)
     appState.setLocalNotebooks({
       updateFolder: vi.fn().mockResolvedValue(localUri),
       getMetadata: vi.fn().mockResolvedValue({ name: 'notebooks' }),
@@ -171,6 +185,12 @@ describe('driveTransfer', () => {
   it('normalizes a remote workspace entry to its local Drive mirror', async () => {
     const remoteUri = 'https://drive.google.com/drive/folders/folder123'
     const localUri = 'local://folder/folder123'
+    appState.setDriveNotebookStore({
+      getMetadata: vi.fn().mockResolvedValue({
+        name: 'notebooks',
+        type: NotebookStoreItemType.Folder,
+      }),
+    } as any)
     appState.setLocalNotebooks({
       updateFolder: vi.fn().mockResolvedValue(localUri),
       getMetadata: vi.fn().mockResolvedValue({ name: 'notebooks' }),
@@ -188,6 +208,26 @@ describe('driveTransfer', () => {
     expect(result.alreadyMounted).toBe(true)
     expect(removeItem).toHaveBeenCalledWith(remoteUri)
     expect(addItem).toHaveBeenCalledWith(localUri)
+  })
+
+  it('rejects a raw Drive file id before creating local folder state', async () => {
+    const remoteUri = 'https://drive.google.com/drive/folders/file123'
+    const getRemoteMetadata = vi.fn().mockResolvedValue({
+      name: 'notes.json',
+      type: NotebookStoreItemType.File,
+    })
+    appState.setDriveNotebookStore({
+      getMetadata: getRemoteMetadata,
+    } as any)
+    const updateFolder = vi.fn()
+    appState.setLocalNotebooks({ updateFolder } as any)
+
+    await expect(mountDriveFolder('file123')).rejects.toThrow(
+      'drive.mountFolder requires a Google Drive folder URI or folder id'
+    )
+
+    expect(getRemoteMetadata).toHaveBeenCalledWith(remoteUri)
+    expect(updateFolder).not.toHaveBeenCalled()
   })
 
   it('copies a notebook file to another drive folder', async () => {

--- a/app/src/lib/driveTransfer.test.ts
+++ b/app/src/lib/driveTransfer.test.ts
@@ -1,33 +1,35 @@
-import { create } from "@bufbuild/protobuf";
-import md5 from "md5";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { create } from '@bufbuild/protobuf'
+import md5 from 'md5'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { parser_pb } from "../runme/client";
+import { parser_pb } from '../runme/client'
 import {
   DriveCreateNotCommittedError,
   DriveFileCreatedError,
-} from "../storage/drive";
-import { NotebookStoreItemType } from "../storage/notebook";
+} from '../storage/drive'
+import { NotebookStoreItemType } from '../storage/notebook'
 import {
   copyDriveNotebookFile,
   createDriveFile,
   createDriveNotebook,
   listDriveFolderItems,
+  mountDriveFolder,
   saveNotebookAsDriveCopy,
   searchDriveFiles,
   updateDriveFileBytes,
-} from "./driveTransfer";
-import { encodeRunmeNotebook } from "./notebookFormat";
-import { appState } from "./runtime/AppState";
+} from './driveTransfer'
+import { encodeRunmeNotebook } from './notebookFormat'
+import { appState } from './runtime/AppState'
 
 afterEach(() => {
-  vi.useRealTimers();
-  vi.unstubAllGlobals();
-  vi.restoreAllMocks();
-  appState.setDriveNotebookStore(null);
-  appState.setLocalNotebooks(null);
-  appState.setOpenNotebookHandler(null);
-});
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  appState.setDriveNotebookStore(null)
+  appState.setLocalNotebooks(null)
+  appState.setOpenNotebookHandler(null)
+  appState.setWorkspaceHandlers(null)
+})
 
 describe('driveTransfer', () => {
   it('creates a drive file and returns parsed id', async () => {
@@ -115,6 +117,77 @@ describe('driveTransfer', () => {
     ).rejects.toThrow(
       'drive.search requires a Google Drive files.list request object'
     )
+  })
+
+  it('mirrors and mounts an accessible Drive folder', async () => {
+    const remoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const updateFolder = vi.fn().mockResolvedValue('local://folder/folder123')
+    const getMetadata = vi.fn().mockResolvedValue({ name: 'notebooks' })
+    appState.setLocalNotebooks({ updateFolder, getMetadata } as any)
+
+    let workspaceItems: string[] = []
+    const addItem = vi.fn((uri: string) => {
+      workspaceItems = [...workspaceItems, uri]
+    })
+    appState.setWorkspaceHandlers({
+      getItems: () => workspaceItems,
+      addItem,
+      removeItem: vi.fn(),
+    })
+
+    const result = await mountDriveFolder('folder123')
+
+    expect(updateFolder).toHaveBeenCalledWith(remoteUri)
+    expect(addItem).toHaveBeenCalledWith('local://folder/folder123')
+    expect(result).toEqual({
+      folderId: 'folder123',
+      name: 'notebooks',
+      remoteUri,
+      localUri: 'local://folder/folder123',
+      alreadyMounted: false,
+    })
+  })
+
+  it('reports an already-mounted Drive folder without duplicating workspace state', async () => {
+    const remoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const localUri = 'local://folder/folder123'
+    appState.setLocalNotebooks({
+      updateFolder: vi.fn().mockResolvedValue(localUri),
+      getMetadata: vi.fn().mockResolvedValue({ name: 'notebooks' }),
+    } as any)
+    const addItem = vi.fn()
+    appState.setWorkspaceHandlers({
+      getItems: () => [localUri],
+      addItem,
+      removeItem: vi.fn(),
+    })
+
+    const result = await mountDriveFolder(remoteUri)
+
+    expect(result.alreadyMounted).toBe(true)
+    expect(addItem).toHaveBeenCalledWith(localUri)
+  })
+
+  it('normalizes a remote workspace entry to its local Drive mirror', async () => {
+    const remoteUri = 'https://drive.google.com/drive/folders/folder123'
+    const localUri = 'local://folder/folder123'
+    appState.setLocalNotebooks({
+      updateFolder: vi.fn().mockResolvedValue(localUri),
+      getMetadata: vi.fn().mockResolvedValue({ name: 'notebooks' }),
+    } as any)
+    const addItem = vi.fn()
+    const removeItem = vi.fn()
+    appState.setWorkspaceHandlers({
+      getItems: () => [remoteUri],
+      addItem,
+      removeItem,
+    })
+
+    const result = await mountDriveFolder(remoteUri)
+
+    expect(result.alreadyMounted).toBe(true)
+    expect(removeItem).toHaveBeenCalledWith(remoteUri)
+    expect(addItem).toHaveBeenCalledWith(localUri)
   })
 
   it('copies a notebook file to another drive folder', async () => {
@@ -281,7 +354,9 @@ describe('driveTransfer', () => {
     const initializeUploadedDriveNotebook = vi.fn().mockResolvedValue(true)
     appState.setLocalNotebooks({
       addFile: vi.fn().mockResolvedValue('local://file/committed'),
-      attachDriveFileToFolder: vi.fn().mockResolvedValue('local://folder/drive'),
+      attachDriveFileToFolder: vi
+        .fn()
+        .mockResolvedValue('local://folder/drive'),
       initializeUploadedDriveNotebook,
     } as any)
     appState.setOpenNotebookHandler(vi.fn().mockResolvedValue(undefined))
@@ -426,17 +501,19 @@ describe('driveTransfer', () => {
     })
     let uploadedContent = ''
     const generateFileId = vi.fn()
-    const createContent = vi.fn().mockImplementation(
-      async (_folder, _name, content, _mimeType, options) => {
-        uploadedContent = content
-        expect(options.fileId).toBeUndefined()
-        return {
-          uri: 'https://drive.google.com/file/d/shared123/view',
-          name: 'shared.json',
-          parents: ['https://drive.google.com/drive/folders/folder123'],
+    const createContent = vi
+      .fn()
+      .mockImplementation(
+        async (_folder, _name, content, _mimeType, options) => {
+          uploadedContent = content
+          expect(options.fileId).toBeUndefined()
+          return {
+            uri: 'https://drive.google.com/file/d/shared123/view',
+            name: 'shared.json',
+            parents: ['https://drive.google.com/drive/folders/folder123'],
+          }
         }
-      }
-    )
+      )
     appState.setDriveNotebookStore({
       canUsePreGeneratedFileId: vi.fn().mockResolvedValue(false),
       generateFileId,
@@ -453,7 +530,9 @@ describe('driveTransfer', () => {
     } as any)
     appState.setLocalNotebooks({
       addFile: vi.fn().mockResolvedValue('local://file/shared'),
-      attachDriveFileToFolder: vi.fn().mockResolvedValue('local://folder/shared'),
+      attachDriveFileToFolder: vi
+        .fn()
+        .mockResolvedValue('local://folder/shared'),
       initializeUploadedDriveNotebook: vi.fn().mockResolvedValue(true),
     } as any)
     appState.setOpenNotebookHandler(vi.fn().mockResolvedValue(undefined))

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -178,6 +178,75 @@ export async function searchDriveFiles(
   }
 }
 
+export type MountDriveFolderResult = {
+  folderId: string
+  name: string
+  remoteUri: string
+  localUri: string
+  alreadyMounted: boolean
+}
+
+/**
+ * Validate, mirror, and mount a Google Drive folder in the workspace explorer.
+ * Mirroring before registration means callers only receive success after the
+ * authenticated Drive request has proved that the folder is accessible.
+ */
+export async function mountDriveFolder(
+  folder: string
+): Promise<MountDriveFolderResult> {
+  const remoteUri = canonicalDriveFolderRef(folder, 'drive.mountFolder')
+  const { id: folderId } = parseDriveItem(remoteUri)
+  const localStore = ensureLocalStore()
+
+  appLogger.info('Mounting Google Drive folder', {
+    attrs: {
+      scope: 'drive.transfer',
+      folderId,
+    },
+  })
+
+  try {
+    const localUri = await localStore.updateFolder(remoteUri)
+    const metadata = await localStore.getMetadata(localUri)
+    const workspaceItems = appState.getWorkspaceItems()
+    const alreadyMounted =
+      workspaceItems.includes(localUri) || workspaceItems.includes(remoteUri)
+    if (workspaceItems.includes(remoteUri) && remoteUri !== localUri) {
+      // Older flows could register the remote URL before its local mirror was
+      // available. Replace that transient representation with the stable URI.
+      appState.removeWorkspaceItem(remoteUri)
+    }
+    appState.addWorkspaceItem(localUri)
+    const name = metadata?.name?.trim() || folderId
+
+    appLogger.info('Mounted Google Drive folder', {
+      attrs: {
+        scope: 'drive.transfer',
+        folderId,
+        localUri,
+        alreadyMounted,
+      },
+    })
+
+    return {
+      folderId,
+      name,
+      remoteUri,
+      localUri,
+      alreadyMounted,
+    }
+  } catch (error) {
+    appLogger.error('Failed to mount Google Drive folder', {
+      attrs: {
+        scope: 'drive.transfer',
+        folderId,
+        error: String(error),
+      },
+    })
+    throw error
+  }
+}
+
 export async function updateDriveFileBytes(
   idOrUri: string,
   bytes: Uint8Array | ArrayBuffer | ArrayLike<number>,
@@ -315,7 +384,8 @@ function readDriveCreateAttempt(key: string): {
       typeof parsed.fileName !== 'string' ||
       typeof parsed.expectedChecksum !== 'string' ||
       typeof parsed.createdAtMs !== 'number' ||
-      (parsed.remoteUri !== undefined && typeof parsed.remoteUri !== 'string') ||
+      (parsed.remoteUri !== undefined &&
+        typeof parsed.remoteUri !== 'string') ||
       (parsed.creationRevisionId !== undefined &&
         typeof parsed.creationRevisionId !== 'string')
     ) {

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -196,7 +196,6 @@ export async function mountDriveFolder(
 ): Promise<MountDriveFolderResult> {
   const remoteUri = canonicalDriveFolderRef(folder, 'drive.mountFolder')
   const { id: folderId } = parseDriveItem(remoteUri)
-  const localStore = ensureLocalStore()
 
   appLogger.info('Mounting Google Drive folder', {
     attrs: {
@@ -206,7 +205,20 @@ export async function mountDriveFolder(
   })
 
   try {
-    const localUri = await localStore.updateFolder(remoteUri)
+    // Raw Drive IDs do not encode whether they identify a file or a folder.
+    // Verify the provider metadata before creating any local mirror state.
+    const remoteMetadata = await ensureDriveStore().getMetadata(remoteUri)
+    if (remoteMetadata?.type !== NotebookStoreItemType.Folder) {
+      throw new Error(
+        'drive.mountFolder requires a Google Drive folder URI or folder id'
+      )
+    }
+
+    const localStore = ensureLocalStore()
+    const localUri = await localStore.updateFolder(
+      remoteUri,
+      remoteMetadata.name
+    )
     const metadata = await localStore.getMetadata(localUri)
     const workspaceItems = appState.getWorkspaceItems()
     const alreadyMounted =

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -30,6 +30,7 @@ This Runme instance is served from ${runmeOrigin}.
 - Claim the selected tab and use its page-provided WebMCP tools for notebook reads, edits, and execution.
 - Use the \`ExecuteCode\` WebMCP tool to run AppKernel JavaScript. Print values explicitly with \`console.log(...)\`.
 - Read notebooks with \`notebooks.get({ uri: notebookUri })\` and access cells through \`doc.notebook.cells\`. There is no \`notebooks.read\` method. Call \`await notebooks.help()\` before generating notebook code when the API is uncertain.
+- When the user identifies a Google Drive folder by name, call the direct read-only \`searchDriveItems\` tool with \`itemType: "folder"\`. If exactly one intended result remains, pass its ID or URI to \`mountDriveFolder\`; do not guess among duplicate names. Use \`listDriveFolder\` to inspect a known candidate without mounting it.
 - When the user explicitly requests a new notebook in Google Drive, call the direct \`createDriveNotebook\` WebMCP tool. It creates the Drive file and its Runme mirror as one retry-safe operation without a local staging notebook.
 - Use the \`comments\` library inside \`ExecuteCode\` for Drive comments and anchors. Runme does not expose a comment-specific WebMCP tool.
 - Use the \`ui\` library inside \`ExecuteCode\` to create rendered Markdown selections and open Runme's selection context menu. Do not invent CSS selectors or dispatch arbitrary DOM events.

--- a/app/src/lib/runtime/driveWorkspaceTools.test.ts
+++ b/app/src/lib/runtime/driveWorkspaceTools.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildListDriveFolderInputSchema,
+  buildMountDriveFolderInputSchema,
+  buildSearchDriveItemsInputSchema,
+  executeListDriveFolder,
+  executeMountDriveFolder,
+  executeSearchDriveItems,
+} from './driveWorkspaceTools'
+
+const { mountDriveFolderMock, searchDriveFilesMock } = vi.hoisted(() => ({
+  mountDriveFolderMock: vi.fn(),
+  searchDriveFilesMock: vi.fn(),
+}))
+
+vi.mock('../driveTransfer', () => ({
+  mountDriveFolder: mountDriveFolderMock,
+  searchDriveFiles: searchDriveFilesMock,
+}))
+
+describe('driveWorkspaceTools', () => {
+  beforeEach(() => {
+    mountDriveFolderMock.mockReset()
+    searchDriveFilesMock.mockReset()
+    searchDriveFilesMock.mockResolvedValue({ files: [] })
+  })
+
+  it('publishes bounded, strict input schemas', () => {
+    expect(buildSearchDriveItemsInputSchema()).toMatchObject({
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        itemType: { enum: ['any', 'file', 'folder'] },
+        pageSize: { minimum: 1, maximum: 100 },
+      },
+    })
+    expect(buildListDriveFolderInputSchema()).toMatchObject({
+      additionalProperties: false,
+      required: ['folderIdOrUri'],
+      properties: {
+        pageSize: { minimum: 1, maximum: 100 },
+      },
+    })
+    expect(buildMountDriveFolderInputSchema()).toMatchObject({
+      additionalProperties: false,
+      required: ['folderIdOrUri'],
+    })
+  })
+
+  it('searches exact folder names across My Drive and shared drives', async () => {
+    await executeSearchDriveItems({
+      name: 'notebooks',
+      itemType: 'folder',
+      exactName: true,
+      pageSize: 10,
+    })
+
+    expect(searchDriveFilesMock).toHaveBeenCalledWith({
+      q: "name = 'notebooks' and trashed = false and mimeType = 'application/vnd.google-apps.folder'",
+      spaces: 'drive',
+      orderBy: 'modifiedTime desc,name',
+      pageSize: 10,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+      fields:
+        'nextPageToken,incompleteSearch,files(id,name,mimeType,parents,driveId,createdTime,modifiedTime,webViewLink)',
+    })
+  })
+
+  it('escapes query text and scopes searches to a parent folder', async () => {
+    await executeSearchDriveItems({
+      name: "team's \\ notebooks",
+      parentFolderIdOrUri: 'https://drive.google.com/drive/folders/parent-123',
+      pageToken: 'next-page',
+    })
+
+    expect(searchDriveFilesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "name contains 'team\\'s \\\\ notebooks' and trashed = false and 'parent-123' in parents",
+        pageSize: 25,
+        pageToken: 'next-page',
+      })
+    )
+  })
+
+  it('rejects empty search names', async () => {
+    await expect(executeSearchDriveItems({ name: ' ' })).rejects.toThrow(
+      'searchDriveItems requires a non-empty name'
+    )
+  })
+
+  it('rejects invalid query and pagination controls at execution time', async () => {
+    await expect(
+      executeSearchDriveItems({ name: 'notebooks', itemType: 'directory' })
+    ).rejects.toThrow('itemType must be any, file, or folder')
+    await expect(
+      executeSearchDriveItems({ name: 'notebooks', exactName: 'yes' })
+    ).rejects.toThrow('exactName must be a boolean')
+    await expect(
+      executeSearchDriveItems({ name: 'notebooks', pageSize: 101 })
+    ).rejects.toThrow('pageSize must be an integer between 1 and 100')
+    await expect(
+      executeSearchDriveItems({ name: 'notebooks', pageToken: 42 })
+    ).rejects.toThrow('pageToken must be a string')
+  })
+
+  it('lists one bounded page from a canonical folder', async () => {
+    searchDriveFilesMock.mockResolvedValue({
+      files: [{ id: 'child-1', name: 'Child' }],
+      nextPageToken: 'next-page',
+    })
+
+    const result = JSON.parse(
+      await executeListDriveFolder({
+        folderIdOrUri: 'folder-123',
+        pageSize: 5,
+      })
+    )
+
+    expect(searchDriveFilesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "'folder-123' in parents and trashed = false",
+        orderBy: 'name',
+        pageSize: 5,
+      })
+    )
+    expect(result).toMatchObject({
+      folderUri: 'https://drive.google.com/drive/folders/folder-123',
+      nextPageToken: 'next-page',
+    })
+  })
+
+  it('mounts only canonical folder references', async () => {
+    mountDriveFolderMock.mockResolvedValue({
+      folderId: 'folder-123',
+      name: 'notebooks',
+      remoteUri: 'https://drive.google.com/drive/folders/folder-123',
+      localUri: 'local://folder/folder-123',
+      alreadyMounted: false,
+    })
+
+    const result = JSON.parse(
+      await executeMountDriveFolder({ folderIdOrUri: 'folder-123' })
+    )
+
+    expect(mountDriveFolderMock).toHaveBeenCalledWith(
+      'https://drive.google.com/drive/folders/folder-123'
+    )
+    expect(result.name).toBe('notebooks')
+  })
+
+  it('rejects file URLs where a folder is required', async () => {
+    await expect(
+      executeMountDriveFolder({
+        folderIdOrUri: 'https://drive.google.com/file/d/file-123/view',
+      })
+    ).rejects.toThrow(
+      'mountDriveFolder requires a Google Drive folder ID or URI'
+    )
+  })
+})

--- a/app/src/lib/runtime/driveWorkspaceTools.ts
+++ b/app/src/lib/runtime/driveWorkspaceTools.ts
@@ -1,0 +1,246 @@
+import { driveFolderUrl, parseDriveItem } from '../../storage/drive'
+import { NotebookStoreItemType } from '../../storage/notebook'
+import { mountDriveFolder, searchDriveFiles } from '../driveTransfer'
+
+type JsonRecord = Record<string, unknown>
+
+const DRIVE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
+const DEFAULT_PAGE_SIZE = 25
+const MAX_PAGE_SIZE = 100
+const DRIVE_RESULT_FIELDS =
+  'nextPageToken,incompleteSearch,files(id,name,mimeType,parents,driveId,createdTime,modifiedTime,webViewLink)'
+
+export const SEARCH_DRIVE_ITEMS_TOOL_NAME = 'searchDriveItems'
+export const SEARCH_DRIVE_ITEMS_TOOL_TITLE = 'Search Google Drive Items'
+export const SEARCH_DRIVE_ITEMS_TOOL_DESCRIPTION =
+  'Search accessible Google Drive files and folders by name. Use this before mounting when the user gives a folder name instead of an ID or URL. Prefer itemType "folder" and exactName true for a quoted folder name. Do not mount when multiple candidates remain; return them so the user or agent can disambiguate.'
+
+export const LIST_DRIVE_FOLDER_TOOL_NAME = 'listDriveFolder'
+export const LIST_DRIVE_FOLDER_TOOL_TITLE = 'List Google Drive Folder'
+export const LIST_DRIVE_FOLDER_TOOL_DESCRIPTION =
+  'List one bounded page of children in an accessible Google Drive folder. Use this to inspect a known folder or disambiguate search results without mounting it.'
+
+export const MOUNT_DRIVE_FOLDER_TOOL_NAME = 'mountDriveFolder'
+export const MOUNT_DRIVE_FOLDER_TOOL_TITLE = 'Mount Google Drive Folder'
+export const MOUNT_DRIVE_FOLDER_TOOL_DESCRIPTION =
+  'Validate, mirror, and add a specific Google Drive folder to the Runme workspace explorer. Pass only a folder ID or folder URL selected from user input or an unambiguous search result. The operation is idempotent for an already-mounted folder.'
+
+/** Escape user text before embedding it in the Google Drive query grammar. */
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/** Convert a raw folder ID or folder URL into its canonical URI and ID. */
+function parseFolderReference(folder: unknown, operation: string) {
+  if (typeof folder !== 'string' || !folder.trim()) {
+    throw new Error(`${operation} requires a Google Drive folder ID or URI`)
+  }
+  const candidate = folder.includes('://')
+    ? folder.trim()
+    : driveFolderUrl(folder.trim())
+  const item = parseDriveItem(candidate)
+  if (item.type !== NotebookStoreItemType.Folder) {
+    throw new Error(`${operation} requires a Google Drive folder ID or URI`)
+  }
+  return {
+    id: item.id,
+    uri: driveFolderUrl(item.id),
+  }
+}
+
+/** Normalize the bounded page controls shared by direct Drive read tools. */
+function pageControls(input: JsonRecord) {
+  const requestedPageSize = input.pageSize
+  if (
+    requestedPageSize !== undefined &&
+    (typeof requestedPageSize !== 'number' ||
+      !Number.isInteger(requestedPageSize) ||
+      requestedPageSize < 1 ||
+      requestedPageSize > MAX_PAGE_SIZE)
+  ) {
+    throw new Error(
+      `Drive pageSize must be an integer between 1 and ${MAX_PAGE_SIZE}`
+    )
+  }
+  const pageSize =
+    requestedPageSize === undefined
+      ? DEFAULT_PAGE_SIZE
+      : (requestedPageSize as number)
+  if (input.pageToken !== undefined && typeof input.pageToken !== 'string') {
+    throw new Error('Drive pageToken must be a string')
+  }
+  const pageToken =
+    typeof input.pageToken === 'string' && input.pageToken
+      ? input.pageToken
+      : undefined
+  return { pageSize, pageToken }
+}
+
+/** Describe name-based Drive discovery without exposing raw query injection. */
+export function buildSearchDriveItemsInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      name: {
+        type: 'string',
+        minLength: 1,
+        description: 'File or folder name to search for.',
+      },
+      itemType: {
+        type: 'string',
+        enum: ['any', 'file', 'folder'],
+        default: 'any',
+        description: 'Restrict matches to files, folders, or either.',
+      },
+      exactName: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Match the complete name instead of searching for a contained phrase.',
+      },
+      parentFolderIdOrUri: {
+        type: 'string',
+        minLength: 1,
+        description:
+          'Optional parent folder ID or URI used to scope the search.',
+      },
+      pageSize: {
+        type: 'integer',
+        minimum: 1,
+        maximum: MAX_PAGE_SIZE,
+        default: DEFAULT_PAGE_SIZE,
+      },
+      pageToken: {
+        type: 'string',
+        minLength: 1,
+        description: 'Opaque token returned by the previous page.',
+      },
+    },
+    required: ['name'],
+  }
+}
+
+/** Describe bounded folder traversal for a known Drive folder. */
+export function buildListDriveFolderInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      folderIdOrUri: {
+        type: 'string',
+        minLength: 1,
+        description: 'Google Drive folder ID or folder URI.',
+      },
+      pageSize: {
+        type: 'integer',
+        minimum: 1,
+        maximum: MAX_PAGE_SIZE,
+        default: DEFAULT_PAGE_SIZE,
+      },
+      pageToken: {
+        type: 'string',
+        minLength: 1,
+        description: 'Opaque token returned by the previous page.',
+      },
+    },
+    required: ['folderIdOrUri'],
+  }
+}
+
+/** Describe the explicit state-changing step after Drive discovery. */
+export function buildMountDriveFolderInputSchema(): JsonRecord {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      folderIdOrUri: {
+        type: 'string',
+        minLength: 1,
+        description:
+          'Google Drive folder ID or folder URI from the user or an unambiguous search result.',
+      },
+    },
+    required: ['folderIdOrUri'],
+  }
+}
+
+/** Execute a safe name-based Drive files.list request. */
+export async function executeSearchDriveItems(
+  input: JsonRecord
+): Promise<string> {
+  const name = typeof input.name === 'string' ? input.name.trim() : ''
+  if (!name) {
+    throw new Error('searchDriveItems requires a non-empty name')
+  }
+  if (
+    input.itemType !== undefined &&
+    input.itemType !== 'any' &&
+    input.itemType !== 'file' &&
+    input.itemType !== 'folder'
+  ) {
+    throw new Error('searchDriveItems itemType must be any, file, or folder')
+  }
+  if (input.exactName !== undefined && typeof input.exactName !== 'boolean') {
+    throw new Error('searchDriveItems exactName must be a boolean')
+  }
+
+  const escapedName = escapeDriveQueryValue(name)
+  const predicates = [
+    input.exactName === true
+      ? `name = '${escapedName}'`
+      : `name contains '${escapedName}'`,
+    'trashed = false',
+  ]
+  if (input.itemType === 'folder') {
+    predicates.push(`mimeType = '${DRIVE_FOLDER_MIME_TYPE}'`)
+  } else if (input.itemType === 'file') {
+    predicates.push(`mimeType != '${DRIVE_FOLDER_MIME_TYPE}'`)
+  }
+  if (input.parentFolderIdOrUri !== undefined) {
+    const parent = parseFolderReference(
+      input.parentFolderIdOrUri,
+      'searchDriveItems parentFolderIdOrUri'
+    )
+    predicates.push(`'${escapeDriveQueryValue(parent.id)}' in parents`)
+  }
+  const { pageSize, pageToken } = pageControls(input)
+  const result = await searchDriveFiles({
+    q: predicates.join(' and '),
+    spaces: 'drive',
+    orderBy: 'modifiedTime desc,name',
+    pageSize,
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+    fields: DRIVE_RESULT_FIELDS,
+    ...(pageToken ? { pageToken } : {}),
+  })
+  return JSON.stringify(result)
+}
+
+/** Execute one bounded parent-scoped Drive listing page. */
+export async function executeListDriveFolder(
+  input: JsonRecord
+): Promise<string> {
+  const folder = parseFolderReference(input.folderIdOrUri, 'listDriveFolder')
+  const { pageSize, pageToken } = pageControls(input)
+  const result = await searchDriveFiles({
+    q: `'${escapeDriveQueryValue(folder.id)}' in parents and trashed = false`,
+    spaces: 'drive',
+    orderBy: 'name',
+    pageSize,
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+    fields: DRIVE_RESULT_FIELDS,
+    ...(pageToken ? { pageToken } : {}),
+  })
+  return JSON.stringify({ folderUri: folder.uri, ...result })
+}
+
+/** Execute the explicit, idempotent mount after a folder has been resolved. */
+export async function executeMountDriveFolder(
+  input: JsonRecord
+): Promise<string> {
+  const folder = parseFolderReference(input.folderIdOrUri, 'mountDriveFolder')
+  return JSON.stringify(await mountDriveFolder(folder.uri))
+}

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -288,10 +288,45 @@ available, Save As leaves the local source unchanged and is the wrong primitive
 when Drive is the authoritative destination. Reserve Save As for intentional
 copies or migrations of existing notebooks.
 
+## Discover and mount a Drive folder
+
+When the user identifies a Drive folder by name instead of an ID or URL, use
+the direct read-only `searchDriveItems` WebMCP tool:
+
+```json
+{
+  "name": "notebooks",
+  "itemType": "folder",
+  "exactName": true,
+  "pageSize": 25
+}
+```
+
+Search includes accessible My Drive and Shared drive content. Names are not
+unique in Google Drive. If the result contains multiple plausible folders,
+return the candidates for disambiguation or inspect a known candidate with
+the read-only `listDriveFolder` tool. Do not choose a duplicate by result
+position.
+
+After resolving one folder, mount that specific ID or URI:
+
+```json
+{
+  "folderIdOrUri": "<resolved folder ID or URI>"
+}
+```
+
+The `mountDriveFolder` tool validates Drive access, mirrors the folder into
+Runme's local index, and adds the mirror to the workspace explorer before it
+returns. Repeating the call for the same folder is safe; the response reports
+`alreadyMounted: true` when the local mirror was already in the workspace.
+
 ## Drive-backed notebook lookup
 
 When a user identifies a Drive-backed notebook by name or metadata rather than
-by URL, use Runme's AppKernel Drive API instead of searching the rendered page:
+by URL, prefer the direct `searchDriveItems` tool for simple name searches.
+Use Runme's AppKernel Drive API when the lookup needs the complete Google Drive
+query grammar or must compose search with other notebook operations:
 
 ```js
 const result = await drive.search({


### PR DESCRIPTION
## Summary
- add direct WebMCP tools to search Drive items, page through folder children, and mount a resolved folder
- validate and mirror folders before workspace registration, including duplicate-entry normalization
- document the discover, disambiguate, then mount workflow for AI agents

## Design
[Direct WebMCP Google Drive Discovery and Mounting](https://docs.google.com/document/d/1MYmjBXYDftFcwrp4tZ6snoHvSIT74kf-00JTzG-dABA/edit)

## Verification
- runme run build test
- focused app tests: 48 passed
- documentation manifest check passed as part of the build