### PR TITLE
Secure shared notebook link imports

### DIFF
--- a/app/src/components/DriveLinkCoordinatorHost.test.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.test.tsx
@@ -18,13 +18,17 @@ const mocks = vi.hoisted(() => ({
   setCurrentDoc: vi.fn(),
   showDocument: vi.fn(),
   store: {
-    addFile: vi.fn(),
+    importTrustedDriveSnapshot: vi.fn(),
     updateFolder: vi.fn(),
   },
 }));
 
 vi.mock("../contexts/GoogleAuthContext", () => ({
   useGoogleAuth: () => ({
+    driveAccount: "viewer@acme.example",
+    driveCredentialStatus: {
+      effectivePrincipal: "viewer@acme.example",
+    },
     ensureAccessToken: mocks.ensureAccessToken,
   }),
 }));
@@ -93,7 +97,7 @@ describe("DriveLinkCoordinatorHost", () => {
     mocks.removeItem.mockReset();
     mocks.setCurrentDoc.mockReset();
     mocks.showDocument.mockReset();
-    mocks.store.addFile.mockReset();
+    mocks.store.importTrustedDriveSnapshot.mockReset();
     mocks.store.updateFolder.mockReset();
   });
 
@@ -111,7 +115,8 @@ describe("DriveLinkCoordinatorHost", () => {
     await waitFor(() => {
       expect(mocks.consumeUrlIntentFromLocation).toHaveBeenCalledTimes(2);
     });
-    const callsAfterFirstUrl = mocks.consumeUrlIntentFromLocation.mock.calls.length;
+    const callsAfterFirstUrl =
+      mocks.consumeUrlIntentFromLocation.mock.calls.length;
 
     rendered.rerender(
       <MemoryRouter initialEntries={[firstUrl]}>
@@ -120,9 +125,9 @@ describe("DriveLinkCoordinatorHost", () => {
     );
 
     await waitFor(() => {
-      expect(mocks.consumeUrlIntentFromLocation.mock.calls.length).toBeGreaterThan(
-        callsAfterFirstUrl,
-      );
+      expect(
+        mocks.consumeUrlIntentFromLocation.mock.calls.length,
+      ).toBeGreaterThan(callsAfterFirstUrl);
     });
   });
 });

--- a/app/src/components/DriveLinkCoordinatorHost.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 
 import { useGoogleAuth } from "../contexts/GoogleAuthContext";
@@ -8,10 +8,17 @@ import { useCurrentDoc } from "../contexts/CurrentDocContext";
 import { useNotebookContext } from "../contexts/NotebookContext";
 import { useWorkspaceDocumentContext } from "../contexts/WorkspaceDocumentContext";
 import { driveLinkCoordinator } from "../lib/driveLinkCoordinator";
+import { fetchSharedNotebookPreflight } from "../storage/drive";
 
 export function DriveLinkCoordinatorHost() {
   const location = useLocation();
-  const { ensureAccessToken } = useGoogleAuth();
+  const { driveAccount, driveCredentialStatus, ensureAccessToken } =
+    useGoogleAuth();
+  const drivePrincipalRef = useRef<string | null>(
+    driveCredentialStatus.effectivePrincipal ?? driveAccount,
+  );
+  drivePrincipalRef.current =
+    driveCredentialStatus.effectivePrincipal ?? driveAccount;
   const { store } = useNotebookStore();
   const { addItem, getItems, removeItem } = useWorkspace();
   const { setCurrentDoc } = useCurrentDoc();
@@ -26,10 +33,15 @@ export function DriveLinkCoordinatorHost() {
 
     driveLinkCoordinator.configure({
       ensureAccessToken,
+      getEffectivePrincipal: () => drivePrincipalRef.current,
+      fetchPreflight: (remoteUri: string) =>
+        fetchSharedNotebookPreflight(remoteUri, () =>
+          ensureAccessToken({ interactive: false }),
+        ),
       updateFolder: (remoteUri: string, name?: string) =>
         store.updateFolder(remoteUri, name),
-      addFile: (remoteUri: string, name?: string) =>
-        store.addFile(remoteUri, name),
+      importFile: (remoteUri, name, options) =>
+        store.importTrustedDriveSnapshot(remoteUri, name, options),
       addWorkspaceItem: addItem,
       removeWorkspaceItem: removeItem,
       getWorkspaceItems: getItems,
@@ -61,6 +73,8 @@ export function DriveLinkCoordinatorHost() {
     };
   }, [
     addItem,
+    driveAccount,
+    driveCredentialStatus.effectivePrincipal,
     ensureAccessToken,
     getItems,
     openNotebook,

--- a/app/src/components/DriveLinkStatusTab.test.tsx
+++ b/app/src/components/DriveLinkStatusTab.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import DriveLinkStatusTab from './DriveLinkStatusTab'
+
+const mocks = vi.hoisted(() => ({
+  cancelIntent: vi.fn(),
+  trustAndOpen: vi.fn(async () => undefined),
+}))
+
+vi.mock('../lib/driveLinkCoordinator', () => ({
+  driveLinkCoordinator: {
+    cancelIntent: mocks.cancelIntent,
+    trustAndOpen: mocks.trustAndOpen,
+  },
+  useDriveLinkCoordinatorSnapshot: () => ({
+    authBlocked: false,
+    lastErrorMessage: null,
+    intents: [
+      {
+        id: 'intent-1',
+        remoteUri: 'https://drive.google.com/file/d/file-1/view',
+        action: 'open_shared_file',
+        source: 'url',
+        status: 'awaiting_review',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        retryCount: 1,
+        preflight: {
+          fileId: 'file-1',
+          uri: 'https://drive.google.com/file/d/file-1/view',
+          name: 'external-design.ipynb',
+          mimeType: 'application/x-ipynb+json',
+          parents: [{ name: 'Partner Folder' }],
+          owners: [
+            {
+              displayName: 'External Owner',
+              emailAddress: 'owner@external.example',
+            },
+          ],
+          canDownload: true,
+        },
+        trustDecision: {
+          trusted: false,
+          reason: 'Owner is external.',
+        },
+      },
+    ],
+  }),
+}))
+
+describe('DriveLinkStatusTab', () => {
+  it('shows metadata and requires an explicit action for an untrusted file', () => {
+    render(<DriveLinkStatusTab onLogin={vi.fn()} onRetry={vi.fn()} />)
+
+    expect(screen.getByText('Review Shared Notebook')).toBeTruthy()
+    expect(screen.getByText('external-design.ipynb')).toBeTruthy()
+    expect(
+      screen.getByText('External Owner (owner@external.example)')
+    ).toBeTruthy()
+    expect(screen.getByText('Partner Folder')).toBeTruthy()
+    expect(
+      screen.getByText(/Notebook content will not be downloaded or rendered/i)
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('drive-link-trust-open'))
+    expect(mocks.trustAndOpen).toHaveBeenCalledWith('intent-1')
+
+    fireEvent.click(screen.getByTestId('drive-link-cancel'))
+    expect(mocks.cancelIntent).toHaveBeenCalledWith('intent-1')
+  })
+})

--- a/app/src/components/DriveLinkStatusTab.tsx
+++ b/app/src/components/DriveLinkStatusTab.tsx
@@ -1,6 +1,19 @@
 import { Button, ScrollArea, Text } from "@radix-ui/themes";
 
-import { useDriveLinkCoordinatorSnapshot } from "../lib/driveLinkCoordinator";
+import {
+  driveLinkCoordinator,
+  useDriveLinkCoordinatorSnapshot,
+} from "../lib/driveLinkCoordinator";
+
+function identityLabel(identity: {
+  displayName?: string;
+  emailAddress?: string;
+}): string {
+  if (identity.displayName && identity.emailAddress) {
+    return `${identity.displayName} (${identity.emailAddress})`;
+  }
+  return identity.emailAddress ?? identity.displayName ?? "Unknown owner";
+}
 
 export function DriveLinkStatusTab({
   onLogin,
@@ -10,6 +23,9 @@ export function DriveLinkStatusTab({
   onRetry: () => void | Promise<void>;
 }) {
   const snapshot = useDriveLinkCoordinatorSnapshot();
+  const awaitingReview = snapshot.intents.filter(
+    (intent) => intent.status === "awaiting_review",
+  );
 
   return (
     <ScrollArea
@@ -21,10 +37,14 @@ export function DriveLinkStatusTab({
       <div className="mx-auto flex h-full max-w-3xl flex-col gap-6 text-sm">
         <div className="space-y-2">
           <Text size="5" weight="bold" as="p" className="text-nb-text">
-            Loading Shared Notebook
+            {awaitingReview.length > 0
+              ? "Review Shared Notebook"
+              : "Loading Shared Notebook"}
           </Text>
           <Text size="2" as="p" className="text-nb-text-muted">
-            The app is resolving one or more shared Google Drive links.
+            {awaitingReview.length > 0
+              ? "Runme has only read Google Drive metadata. Notebook content will not be downloaded or rendered until you trust it."
+              : "The app is resolving one or more shared Google Drive links."}
           </Text>
         </div>
 
@@ -35,13 +55,19 @@ export function DriveLinkStatusTab({
           <Text
             size="2"
             as="p"
-            className={snapshot.authBlocked ? "mt-2 text-nb-error" : "mt-2 text-nb-text-muted"}
+            className={
+              snapshot.authBlocked
+                ? "mt-2 text-nb-error"
+                : "mt-2 text-nb-text-muted"
+            }
           >
             {snapshot.authBlocked
               ? "Google Drive authorization is required before shared links can be loaded. Click Login to Drive to continue."
-              : snapshot.intents.length === 0 && snapshot.lastErrorMessage
-                ? "No pending shared links. See the latest status message below."
-              : "Shared links are queued for processing."}
+              : awaitingReview.length > 0
+                ? "One or more notebooks are from an owner Runme could not automatically trust. Review the source before opening."
+                : snapshot.intents.length === 0 && snapshot.lastErrorMessage
+                  ? "No pending shared links. See the latest status message below."
+                  : "Shared links are queued for processing."}
           </Text>
           {snapshot.lastErrorMessage && (
             <pre
@@ -79,15 +105,84 @@ export function DriveLinkStatusTab({
                   <div className="text-xs font-semibold uppercase tracking-wide text-nb-text-faint">
                     {intent.status}
                   </div>
-                  <div className="mt-1 break-all text-sm text-nb-text">
-                    {intent.remoteUri}
-                  </div>
+                  {intent.preflight ? (
+                    <div className="mt-2 space-y-1 text-sm text-nb-text">
+                      <div>
+                        <span className="font-semibold">Name:</span>{" "}
+                        {intent.preflight.name}
+                      </div>
+                      <div>
+                        <span className="font-semibold">Owner:</span>{" "}
+                        {intent.preflight.owners.length > 0
+                          ? intent.preflight.owners
+                              .map(identityLabel)
+                              .join(", ")
+                          : "Google Drive did not provide owner information"}
+                      </div>
+                      <div>
+                        <span className="font-semibold">Location:</span>{" "}
+                        {intent.preflight.parents.length > 0
+                          ? intent.preflight.parents
+                              .map((parent) => parent.name)
+                              .join(", ")
+                          : "No parent folder reported"}
+                      </div>
+                      {intent.preflight.lastModifyingUser && (
+                        <div>
+                          <span className="font-semibold">
+                            Last modified by:
+                          </span>{" "}
+                          {identityLabel(intent.preflight.lastModifyingUser)}
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="mt-1 break-all text-sm text-nb-text">
+                      {intent.remoteUri}
+                    </div>
+                  )}
                   <div className="mt-1 text-xs text-nb-text-muted">
                     action={intent.action} retries={intent.retryCount}
                   </div>
                   {intent.lastErrorMessage && (
                     <div className="mt-2 text-xs text-nb-error">
                       {intent.lastErrorMessage}
+                    </div>
+                  )}
+                  {intent.status === "awaiting_review" && (
+                    <div className="mt-3 space-y-3">
+                      <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-950">
+                        Opening a notebook can display active content and may
+                        expose data available to this browser session. Only
+                        continue if you recognize and trust its source.
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          data-testid="drive-link-trust-open"
+                          onClick={() =>
+                            void driveLinkCoordinator.trustAndOpen(intent.id)
+                          }
+                        >
+                          Trust This Document And Open
+                        </Button>
+                        <Button
+                          variant="soft"
+                          data-testid="drive-link-cancel"
+                          onClick={() =>
+                            driveLinkCoordinator.cancelIntent(intent.id)
+                          }
+                        >
+                          Cancel
+                        </Button>
+                        <a
+                          className="inline-flex items-center text-xs text-blue-700 underline"
+                          href={intent.remoteUri}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Open In Google Drive
+                        </a>
+                      </div>
                     </div>
                   )}
                 </li>

--- a/app/src/lib/driveLinkCoordinator.test.ts
+++ b/app/src/lib/driveLinkCoordinator.test.ts
@@ -1,12 +1,62 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { NotebookStoreItemType } from "../storage/notebook";
 import {
   isDriveAuthError,
   isDriveMissingOrAccessDeniedError,
 } from "./driveLinkCoordinator";
 
 const STORAGE_KEY = "runme/drive-link-intents";
+
+function createPreflight(ownerEmail = "owner@acme.example") {
+  const remoteUri = "https://drive.google.com/file/d/file123/view";
+  return {
+    item: {
+      uri: remoteUri,
+      name: "design.ipynb",
+      mimeType: "application/x-ipynb+json",
+    },
+    parents: [
+      {
+        uri: "https://drive.google.com/drive/folders/parent123",
+        name: "Shared Notebooks",
+        type: NotebookStoreItemType.Folder,
+      },
+    ],
+    preflight: {
+      fileId: "file123",
+      uri: remoteUri,
+      name: "design.ipynb",
+      mimeType: "application/x-ipynb+json",
+      parents: [],
+      owners: [
+        {
+          emailAddress: ownerEmail,
+          permissionId: `owner-${ownerEmail}`,
+        },
+      ],
+      canDownload: true,
+      version: "7",
+      headRevisionId: "revision-1",
+      md5Checksum: "checksum-1",
+    },
+  };
+}
+
+function createCoordinatorDeps(ownerEmail = "owner@acme.example") {
+  return {
+    ensureAccessToken: vi.fn(async () => "token"),
+    getEffectivePrincipal: vi.fn(() => "viewer@acme.example"),
+    fetchPreflight: vi.fn(async () => createPreflight(ownerEmail)),
+    updateFolder: vi.fn(async () => "local://folder/parent123"),
+    importFile: vi.fn(async () => "local://file/file123"),
+    addWorkspaceItem: vi.fn(),
+    removeWorkspaceItem: vi.fn(),
+    getWorkspaceItems: vi.fn(() => [] as string[]),
+    openNotebook: vi.fn(async () => undefined),
+  };
+}
 
 function createStoredIntent(overrides: Partial<Record<string, unknown>> = {}) {
   return {
@@ -120,8 +170,10 @@ describe("driveLinkCoordinator intent storage", () => {
       ensureAccessToken: vi.fn(async () => {
         throw new Error("Google Drive authorization is required.");
       }),
+      getEffectivePrincipal: vi.fn(() => null),
+      fetchPreflight: vi.fn(),
       updateFolder: vi.fn(),
-      addFile: vi.fn(),
+      importFile: vi.fn(),
       addWorkspaceItem: vi.fn(),
       removeWorkspaceItem: vi.fn(),
       getWorkspaceItems: vi.fn(() => []),
@@ -142,5 +194,111 @@ describe("driveLinkCoordinator intent storage", () => {
       }),
     ]);
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("automatically opens a notebook owned by the same Workspace domain", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+    const deps = createCoordinatorDeps();
+    driveLinkCoordinator.configure(deps);
+
+    await driveLinkCoordinator.enqueue(remoteUri, "manual");
+
+    expect(deps.fetchPreflight).toHaveBeenCalledWith(remoteUri);
+    expect(deps.importFile).toHaveBeenCalledWith(
+      remoteUri,
+      "design.ipynb",
+      expect.objectContaining({
+        expected: {
+          checksum: "checksum-1",
+          revisionId: "revision-1",
+          version: "7",
+        },
+      }),
+    );
+    expect(deps.openNotebook).toHaveBeenCalledWith("local://file/file123");
+    expect(driveLinkCoordinator.getSnapshot().intents).toEqual([]);
+
+    const { loadSharedNotebookTrustRecords } = await import(
+      "./sharedNotebookTrust"
+    );
+    expect(loadSharedNotebookTrustRecords()).toEqual([
+      expect.objectContaining({
+        fileId: "file123",
+        effectivePrincipal: "viewer@acme.example",
+        basis: "same_domain",
+      }),
+    ]);
+  });
+
+  it("does not download an external notebook before review", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+    const deps = createCoordinatorDeps("attacker@external.example");
+    driveLinkCoordinator.configure(deps);
+
+    await driveLinkCoordinator.enqueue(remoteUri, "manual");
+
+    expect(deps.importFile).not.toHaveBeenCalled();
+    expect(deps.openNotebook).not.toHaveBeenCalled();
+    expect(driveLinkCoordinator.getSnapshot().intents).toEqual([
+      expect.objectContaining({
+        remoteUri,
+        status: "awaiting_review",
+        preflight: expect.objectContaining({ name: "design.ipynb" }),
+        trustDecision: expect.objectContaining({ trusted: false }),
+      }),
+    ]);
+  });
+
+  it("persists explicit document trust before opening a reviewed notebook", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+    const deps = createCoordinatorDeps("partner@external.example");
+    driveLinkCoordinator.configure(deps);
+
+    await driveLinkCoordinator.enqueue(remoteUri, "manual");
+    const intent = driveLinkCoordinator.getSnapshot().intents[0];
+    expect(intent?.status).toBe("awaiting_review");
+
+    await driveLinkCoordinator.trustAndOpen(intent.id);
+
+    expect(deps.importFile).toHaveBeenCalledTimes(1);
+    expect(deps.openNotebook).toHaveBeenCalledTimes(1);
+    expect(driveLinkCoordinator.getSnapshot().intents).toEqual([]);
+    const { loadSharedNotebookTrustRecords } = await import(
+      "./sharedNotebookTrust"
+    );
+    expect(loadSharedNotebookTrustRecords()).toEqual([
+      expect.objectContaining({
+        fileId: "file123",
+        basis: "explicit_document",
+      }),
+    ]);
+  });
+
+  it("re-evaluates a metadata-only review when authorization identifies the principal", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+    let principal: string | null = null;
+    const deps = {
+      ...createCoordinatorDeps(),
+      getEffectivePrincipal: vi.fn(() => principal),
+    };
+    driveLinkCoordinator.configure(deps);
+
+    await driveLinkCoordinator.enqueue(remoteUri, "manual");
+    expect(driveLinkCoordinator.getSnapshot().intents[0]?.status).toBe(
+      "awaiting_review",
+    );
+    expect(deps.importFile).not.toHaveBeenCalled();
+
+    principal = "viewer@acme.example";
+    driveLinkCoordinator.configure(deps);
+    await driveLinkCoordinator.processPending();
+
+    expect(deps.importFile).toHaveBeenCalledTimes(1);
+    expect(deps.openNotebook).toHaveBeenCalledTimes(1);
+    expect(driveLinkCoordinator.getSnapshot().intents).toEqual([]);
   });
 });

--- a/app/src/lib/driveLinkCoordinator.ts
+++ b/app/src/lib/driveLinkCoordinator.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 
+import { type SharedNotebookPreflight, parseDriveItem } from "../storage/drive";
+import { NotebookStoreItemType } from "../storage/notebook";
 import { appLogger } from "./logging/runtime";
 import {
-  fetchDriveItemWithParents,
-  parseDriveItem,
-} from "../storage/drive";
-import { NotebookStoreItemType } from "../storage/notebook";
+  type SharedNotebookTrustDecision,
+  evaluateSharedNotebookTrust,
+  rememberSharedNotebookTrust,
+} from "./sharedNotebookTrust";
 
 const STORAGE_KEY = "runme/drive-link-intents";
 const STATUS_TAB_URI = "status://drive-link";
@@ -13,12 +15,12 @@ const STATUS_TAB_URI = "status://drive-link";
 export type DriveLinkIntentStatus =
   | "pending"
   | "processing"
+  | "fetching_metadata"
+  | "awaiting_review"
   | "waiting_for_auth"
   | "failed";
 
-export type DriveLinkIntentAction =
-  | "open_shared_file"
-  | "mount_shared_folder";
+export type DriveLinkIntentAction = "open_shared_file" | "mount_shared_folder";
 
 export interface DriveLinkIntent {
   id: string;
@@ -30,6 +32,8 @@ export interface DriveLinkIntent {
   updatedAt: string;
   retryCount: number;
   lastErrorMessage?: string;
+  preflight?: SharedNotebookPreflight;
+  trustDecision?: SharedNotebookTrustDecision;
 }
 
 export interface DriveLinkCoordinatorSnapshot {
@@ -40,8 +44,29 @@ export interface DriveLinkCoordinatorSnapshot {
 
 type DriveLinkCoordinatorDeps = {
   ensureAccessToken: (options?: { interactive?: boolean }) => Promise<string>;
+  getEffectivePrincipal: () => string | null;
+  fetchPreflight: (remoteUri: string) => Promise<{
+    item: {
+      uri: string;
+      name: string;
+      mimeType?: string;
+    };
+    parents: Array<{
+      uri: string;
+      name: string;
+      type: NotebookStoreItemType;
+    }>;
+    preflight: SharedNotebookPreflight;
+  }>;
   updateFolder: (remoteUri: string, name?: string) => Promise<string>;
-  addFile: (remoteUri: string, name?: string) => Promise<string>;
+  importFile: (
+    remoteUri: string,
+    name: string,
+    options: {
+      mimeType?: string;
+      expected?: { checksum?: string; revisionId?: string; version?: string };
+    },
+  ) => Promise<string>;
   addWorkspaceItem: (localUri: string) => void;
   removeWorkspaceItem: (uri: string) => void;
   getWorkspaceItems: () => string[];
@@ -65,10 +90,7 @@ function nowIso(): string {
 }
 
 function isLocalUri(uri: string): boolean {
-  return (
-    uri.startsWith("local://") ||
-    uri.startsWith("fs://")
-  );
+  return uri.startsWith("local://") || uri.startsWith("fs://");
 }
 
 export function isDriveAuthError(error: unknown): boolean {
@@ -155,7 +177,11 @@ function loadIntents(): DriveLinkIntent[] {
         ...intent,
         // "processing" can be left behind in sessionStorage after reload/crash.
         // Treat it as pending so the coordinator can resume it.
-        status: intent.status === "processing" ? "pending" : intent.status,
+        status:
+          intent.status === "processing" ||
+          intent.status === "fetching_metadata"
+            ? "pending"
+            : intent.status,
       }));
   } catch {
     return [];
@@ -191,8 +217,31 @@ class DriveLinkCoordinatorRuntime {
 
   private processing = false;
 
+  private configuredPrincipal: string | null = null;
+
   configure(deps: DriveLinkCoordinatorDeps | null): void {
     this.deps = deps;
+    const nextPrincipal = deps?.getEffectivePrincipal()?.trim().toLowerCase() ?? null;
+    const principalChanged = nextPrincipal !== this.configuredPrincipal;
+    this.configuredPrincipal = nextPrincipal;
+
+    if (nextPrincipal && principalChanged) {
+      let changed = false;
+      this.intents = this.intents.map((intent) => {
+        if (intent.status !== "awaiting_review") {
+          return intent;
+        }
+        changed = true;
+        return {
+          ...intent,
+          status: "pending",
+          updatedAt: nowIso(),
+        };
+      });
+      if (changed) {
+        this.persistAndEmit();
+      }
+    }
   }
 
   getStatusTabUri(): string {
@@ -212,9 +261,8 @@ class DriveLinkCoordinatorRuntime {
       (intent) => intent.status === "waiting_for_auth",
     );
     const intentErrorMessage =
-      [...this.intents]
-        .reverse()
-        .find((intent) => intent.lastErrorMessage)?.lastErrorMessage ?? null;
+      [...this.intents].reverse().find((intent) => intent.lastErrorMessage)
+        ?.lastErrorMessage ?? null;
     return {
       intents: this.intents.map((intent) => ({ ...intent })),
       authBlocked,
@@ -232,8 +280,7 @@ class DriveLinkCoordinatorRuntime {
   ): Promise<void> {
     const action = this.resolveAction(remoteUri);
     const existing = this.intents.find(
-      (intent) =>
-        intent.remoteUri === remoteUri && intent.action === action,
+      (intent) => intent.remoteUri === remoteUri && intent.action === action,
     );
     if (existing) {
       return;
@@ -288,12 +335,15 @@ class DriveLinkCoordinatorRuntime {
     if (this.processing) {
       this.lastMessage =
         "Shared links are already being processed. Please wait for the current attempt to finish.";
-      appLogger.info("Retry requested while shared links are still processing", {
-        attrs: {
-          scope: "storage.drive.share",
-          code: "DRIVE_SHARED_LINK_RETRY_IGNORED_PROCESSING",
+      appLogger.info(
+        "Retry requested while shared links are still processing",
+        {
+          attrs: {
+            scope: "storage.drive.share",
+            code: "DRIVE_SHARED_LINK_RETRY_IGNORED_PROCESSING",
+          },
         },
-      });
+      );
       this.persistAndEmit();
       return;
     }
@@ -317,6 +367,38 @@ class DriveLinkCoordinatorRuntime {
     }));
     this.persistAndEmit();
     await this.processPending();
+  }
+
+  async trustAndOpen(intentId: string): Promise<void> {
+    const intent = this.intents.find((item) => item.id === intentId);
+    const principal = this.deps?.getEffectivePrincipal();
+    if (!intent?.preflight || intent.status !== "awaiting_review") {
+      return;
+    }
+    if (!principal) {
+      this.updateIntent(intentId, {
+        lastErrorMessage:
+          "Runme could not identify the active Google Drive account. Reconnect Drive and try again.",
+      });
+      return;
+    }
+
+    rememberSharedNotebookTrust(
+      intent.preflight,
+      principal,
+      "explicit_document",
+    );
+    this.updateIntent(intentId, {
+      status: "pending",
+      lastErrorMessage: undefined,
+    });
+    await this.processPending();
+  }
+
+  cancelIntent(intentId: string): void {
+    this.intents = this.intents.filter((intent) => intent.id !== intentId);
+    this.lastMessage = null;
+    this.persistAndEmit();
   }
 
   async loginToDriveAndProcess(): Promise<void> {
@@ -396,10 +478,39 @@ class DriveLinkCoordinatorRuntime {
         }
         deps.removeWorkspaceItem(intent.remoteUri);
       } else {
-        const { item, parents } = await fetchDriveItemWithParents(
+        this.updateIntent(intentId, { status: "fetching_metadata" });
+        const { item, parents, preflight } = await deps.fetchPreflight(
           intent.remoteUri,
-          deps.ensureAccessToken,
         );
+        const trustDecision = evaluateSharedNotebookTrust({
+          preflight,
+          effectivePrincipal: deps.getEffectivePrincipal(),
+        });
+        this.updateIntent(intentId, { preflight, trustDecision });
+
+        if (!preflight.canDownload) {
+          throw new Error(
+            "Google Drive does not allow this file to be downloaded.",
+          );
+        }
+        if (
+          !preflight.version &&
+          !preflight.headRevisionId &&
+          !preflight.md5Checksum
+        ) {
+          throw new Error(
+            "Google Drive did not provide a content version, so Runme cannot safely import this notebook.",
+          );
+        }
+        if (!trustDecision.trusted) {
+          this.lastMessage = null;
+          this.updateIntent(intentId, {
+            status: "awaiting_review",
+            lastErrorMessage: undefined,
+          });
+          return;
+        }
+
         const parentFolder = parents.find(
           (parent) => parent.type === NotebookStoreItemType.Folder,
         );
@@ -413,9 +524,24 @@ class DriveLinkCoordinatorRuntime {
           }
         }
 
-        const localFileUri = await deps.addFile(item.uri, item.name);
+        const localFileUri = await deps.importFile(item.uri, item.name, {
+          mimeType: item.mimeType,
+          expected: {
+            checksum: preflight.md5Checksum,
+            revisionId: preflight.headRevisionId,
+            version: preflight.version,
+          },
+        });
         deps.removeWorkspaceItem(intent.remoteUri);
         await deps.openNotebook(localFileUri);
+
+        if (trustDecision.basis && trustDecision.effectivePrincipal) {
+          rememberSharedNotebookTrust(
+            preflight,
+            trustDecision.effectivePrincipal,
+            trustDecision.basis,
+          );
+        }
       }
 
       this.lastMessage = null;
@@ -459,7 +585,12 @@ class DriveLinkCoordinatorRuntime {
 
   private updateIntent(
     intentId: string,
-    updates: Partial<Omit<DriveLinkIntent, "id" | "remoteUri" | "action" | "source" | "createdAt">>,
+    updates: Partial<
+      Omit<
+        DriveLinkIntent,
+        "id" | "remoteUri" | "action" | "source" | "createdAt"
+      >
+    >,
   ): void {
     this.intents = this.intents.map((intent) =>
       intent.id === intentId

--- a/app/src/lib/sharedNotebookTrust.test.ts
+++ b/app/src/lib/sharedNotebookTrust.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { SharedNotebookPreflight } from '../storage/drive'
+import {
+  evaluateSharedNotebookTrust,
+  loadSharedNotebookTrustRecords,
+  rememberSharedNotebookTrust,
+  sharedNotebookSubjectFingerprint,
+} from './sharedNotebookTrust'
+
+function preflight(
+  overrides: Partial<SharedNotebookPreflight> = {}
+): SharedNotebookPreflight {
+  return {
+    fileId: 'file-1',
+    uri: 'https://drive.google.com/file/d/file-1/view',
+    name: 'design.ipynb',
+    mimeType: 'application/x-ipynb+json',
+    parents: [],
+    owners: [
+      {
+        emailAddress: 'owner@acme.example',
+        permissionId: 'owner-permission',
+      },
+    ],
+    canDownload: true,
+    ...overrides,
+  }
+}
+
+describe('evaluateSharedNotebookTrust', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('trusts a Workspace-owned file in the same domain', () => {
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: preflight(),
+        effectivePrincipal: 'viewer@acme.example',
+        records: [],
+        trustedDriveIds: [],
+      })
+    ).toMatchObject({
+      trusted: true,
+      basis: 'same_domain',
+      principalDomain: 'acme.example',
+      ownerDomains: ['acme.example'],
+    })
+  })
+
+  it('does not treat consumer Gmail addresses as an organization', () => {
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: preflight({
+          owners: [{ emailAddress: 'owner@gmail.com' }],
+        }),
+        effectivePrincipal: 'viewer@gmail.com',
+        records: [],
+        trustedDriveIds: [],
+      }).trusted
+    ).toBe(false)
+  })
+
+  it('does not treat third-party consumer email domains as organizations', () => {
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: preflight({
+          owners: [{ emailAddress: 'owner@outlook.com' }],
+        }),
+        effectivePrincipal: 'viewer@outlook.com',
+        records: [],
+        trustedDriveIds: [],
+      }).trusted
+    ).toBe(false)
+  })
+
+  it('requires review for an external owner', () => {
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: preflight({
+          owners: [{ emailAddress: 'owner@partner.example' }],
+        }),
+        effectivePrincipal: 'viewer@acme.example',
+        records: [],
+        trustedDriveIds: [],
+      })
+    ).toMatchObject({ trusted: false })
+  })
+
+  it('trusts an explicitly allowlisted Shared Drive', () => {
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: preflight({ driveId: 'drive-1', owners: [] }),
+        effectivePrincipal: 'viewer@acme.example',
+        records: [],
+        trustedDriveIds: ['drive-1'],
+      })
+    ).toMatchObject({ trusted: true, basis: 'trusted_drive' })
+  })
+
+  it('persists explicit document trust and invalidates it on ownership change', () => {
+    const original = preflight()
+    rememberSharedNotebookTrust(
+      original,
+      'viewer@acme.example',
+      'explicit_document'
+    )
+
+    expect(loadSharedNotebookTrustRecords()).toHaveLength(1)
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: original,
+        effectivePrincipal: 'viewer@acme.example',
+        trustedDriveIds: [],
+      })
+    ).toMatchObject({ trusted: true, basis: 'explicit_document' })
+
+    const changedOwner = preflight({
+      owners: [
+        {
+          emailAddress: 'replacement@partner.example',
+          permissionId: 'replacement-permission',
+        },
+      ],
+    })
+    expect(sharedNotebookSubjectFingerprint(changedOwner)).not.toBe(
+      sharedNotebookSubjectFingerprint(original)
+    )
+    expect(
+      evaluateSharedNotebookTrust({
+        preflight: changedOwner,
+        effectivePrincipal: 'viewer@acme.example',
+        trustedDriveIds: [],
+      }).trusted
+    ).toBe(false)
+  })
+})

--- a/app/src/lib/sharedNotebookTrust.ts
+++ b/app/src/lib/sharedNotebookTrust.ts
@@ -1,0 +1,293 @@
+import type { SharedNotebookPreflight } from '../storage/drive'
+
+const TRUST_STORAGE_KEY = 'runme/shared-notebook-trust/v1'
+const TRUSTED_DRIVES_STORAGE_KEY = 'runme/shared-notebook-trusted-drives/v1'
+
+const CONSUMER_EMAIL_DOMAINS = new Set([
+  'aol.com',
+  'gmail.com',
+  'googlemail.com',
+  'hotmail.com',
+  'icloud.com',
+  'live.com',
+  'msn.com',
+  'outlook.com',
+  'proton.me',
+  'protonmail.com',
+  'yahoo.com',
+])
+
+export type SharedNotebookTrustBasis =
+  | 'explicit_document'
+  | 'owned_by_me'
+  | 'same_domain'
+  | 'trusted_drive'
+
+export interface SharedNotebookTrustRecord {
+  provider: 'google-drive'
+  effectivePrincipal: string
+  fileId: string
+  basis: SharedNotebookTrustBasis
+  subjectFingerprint: string
+  trustedAt: string
+}
+
+export interface SharedNotebookTrustDecision {
+  trusted: boolean
+  basis?: SharedNotebookTrustBasis
+  reason: string
+  effectivePrincipal: string | null
+  principalDomain: string | null
+  ownerDomains: string[]
+  subjectFingerprint: string
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function normalizeGooglePrincipal(
+  principal: string | null | undefined
+): string | null {
+  const normalized = principal?.trim().toLowerCase() ?? ''
+  return normalized || null
+}
+
+export function emailDomain(email: string | null | undefined): string | null {
+  const normalized = normalizeGooglePrincipal(email)
+  if (!normalized) {
+    return null
+  }
+  const separator = normalized.lastIndexOf('@')
+  if (separator <= 0 || separator === normalized.length - 1) {
+    return null
+  }
+  return normalized.slice(separator + 1)
+}
+
+export function isWorkspaceDomain(domain: string | null): domain is string {
+  return Boolean(domain && !CONSUMER_EMAIL_DOMAINS.has(domain))
+}
+
+function uniqueOwnerDomains(preflight: SharedNotebookPreflight): string[] {
+  return Array.from(
+    new Set(
+      preflight.owners
+        .map((owner) => emailDomain(owner.emailAddress))
+        .filter((domain): domain is string => Boolean(domain))
+    )
+  ).sort()
+}
+
+export function sharedNotebookSubjectFingerprint(
+  preflight: SharedNotebookPreflight
+): string {
+  if (preflight.driveId) {
+    return `drive:${preflight.driveId}`
+  }
+  const ownerIds = preflight.owners
+    .map((owner) => owner.permissionId?.trim())
+    .filter((permissionId): permissionId is string => Boolean(permissionId))
+    .sort()
+  if (ownerIds.length > 0) {
+    return `owners:${ownerIds.join(',')}`
+  }
+  const ownerEmails = preflight.owners
+    .map((owner) => normalizeGooglePrincipal(owner.emailAddress))
+    .filter((email): email is string => Boolean(email))
+    .sort()
+  if (ownerEmails.length > 0) {
+    return `owner-emails:${ownerEmails.join(',')}`
+  }
+  return `file:${preflight.fileId}`
+}
+
+export function loadSharedNotebookTrustRecords(): SharedNotebookTrustRecord[] {
+  const storage = getStorage()
+  if (!storage) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(storage.getItem(TRUST_STORAGE_KEY) ?? '[]')
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+    return parsed.filter(
+      (record): record is SharedNotebookTrustRecord =>
+        record?.provider === 'google-drive' &&
+        typeof record.effectivePrincipal === 'string' &&
+        typeof record.fileId === 'string' &&
+        typeof record.basis === 'string' &&
+        typeof record.subjectFingerprint === 'string' &&
+        typeof record.trustedAt === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+export function saveSharedNotebookTrustRecord(
+  record: SharedNotebookTrustRecord
+): void {
+  const storage = getStorage()
+  if (!storage) {
+    return
+  }
+  const records = loadSharedNotebookTrustRecords().filter(
+    (candidate) =>
+      !(
+        candidate.effectivePrincipal === record.effectivePrincipal &&
+        candidate.fileId === record.fileId
+      )
+  )
+  storage.setItem(TRUST_STORAGE_KEY, JSON.stringify([...records, record]))
+}
+
+export function rememberSharedNotebookTrust(
+  preflight: SharedNotebookPreflight,
+  effectivePrincipal: string,
+  basis: SharedNotebookTrustBasis
+): SharedNotebookTrustRecord {
+  const normalizedPrincipal = normalizeGooglePrincipal(effectivePrincipal)
+  if (!normalizedPrincipal) {
+    throw new Error('A Google Drive principal is required to trust a notebook.')
+  }
+  const record: SharedNotebookTrustRecord = {
+    provider: 'google-drive',
+    effectivePrincipal: normalizedPrincipal,
+    fileId: preflight.fileId,
+    basis,
+    subjectFingerprint: sharedNotebookSubjectFingerprint(preflight),
+    trustedAt: new Date().toISOString(),
+  }
+  saveSharedNotebookTrustRecord(record)
+  return record
+}
+
+export function loadTrustedSharedDriveIds(): string[] {
+  const storage = getStorage()
+  if (!storage) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(
+      storage.getItem(TRUSTED_DRIVES_STORAGE_KEY) ?? '[]'
+    )
+    return Array.isArray(parsed)
+      ? parsed.filter((value): value is string => typeof value === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+export function evaluateSharedNotebookTrust({
+  preflight,
+  effectivePrincipal,
+  records = loadSharedNotebookTrustRecords(),
+  trustedDriveIds = loadTrustedSharedDriveIds(),
+}: {
+  preflight: SharedNotebookPreflight
+  effectivePrincipal: string | null | undefined
+  records?: SharedNotebookTrustRecord[]
+  trustedDriveIds?: string[]
+}): SharedNotebookTrustDecision {
+  const principal = normalizeGooglePrincipal(effectivePrincipal)
+  const principalDomain = emailDomain(principal)
+  const ownerDomains = uniqueOwnerDomains(preflight)
+  const subjectFingerprint = sharedNotebookSubjectFingerprint(preflight)
+
+  if (!principal) {
+    return {
+      trusted: false,
+      reason: 'Runme could not identify the effective Google Drive account.',
+      effectivePrincipal: null,
+      principalDomain: null,
+      ownerDomains,
+      subjectFingerprint,
+    }
+  }
+
+  const stored = records.find(
+    (record) =>
+      record.effectivePrincipal === principal &&
+      record.fileId === preflight.fileId &&
+      record.subjectFingerprint === subjectFingerprint
+  )
+  if (stored) {
+    return {
+      trusted: true,
+      basis: stored.basis,
+      reason: 'This Google Drive document was previously trusted.',
+      effectivePrincipal: principal,
+      principalDomain,
+      ownerDomains,
+      subjectFingerprint,
+    }
+  }
+
+  if (preflight.ownedByMe) {
+    return {
+      trusted: true,
+      basis: 'owned_by_me',
+      reason: 'Google Drive reports that the current account owns this file.',
+      effectivePrincipal: principal,
+      principalDomain,
+      ownerDomains,
+      subjectFingerprint,
+    }
+  }
+
+  if (
+    preflight.driveId &&
+    trustedDriveIds.some((driveId) => driveId === preflight.driveId)
+  ) {
+    return {
+      trusted: true,
+      basis: 'trusted_drive',
+      reason: 'This file belongs to an explicitly trusted Shared Drive.',
+      effectivePrincipal: principal,
+      principalDomain,
+      ownerDomains,
+      subjectFingerprint,
+    }
+  }
+
+  if (
+    isWorkspaceDomain(principalDomain) &&
+    ownerDomains.some((domain) => domain === principalDomain)
+  ) {
+    return {
+      trusted: true,
+      basis: 'same_domain',
+      reason: `The file owner and current Drive account belong to ${principalDomain}.`,
+      effectivePrincipal: principal,
+      principalDomain,
+      ownerDomains,
+      subjectFingerprint,
+    }
+  }
+
+  return {
+    trusted: false,
+    reason: preflight.driveId
+      ? 'This Shared Drive is not trusted by the current policy.'
+      : 'The file owner is outside the current Google Workspace domain or could not be verified.',
+    effectivePrincipal: principal,
+    principalDomain,
+    ownerDomains,
+    subjectFingerprint,
+  }
+}
+
+export {
+  TRUST_STORAGE_KEY as SHARED_NOTEBOOK_TRUST_STORAGE_KEY,
+  TRUSTED_DRIVES_STORAGE_KEY as TRUSTED_SHARED_DRIVES_STORAGE_KEY,
+}

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -18,7 +18,7 @@ const GAPI_SCRIPT_SRC = 'https://apis.google.com/js/api.js'
 
 // VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file content version.
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
-const VERSION_FIELDS = 'md5Checksum,headRevisionId,appProperties'
+const VERSION_FIELDS = 'md5Checksum,headRevisionId,version,appProperties'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
@@ -1682,11 +1682,51 @@ type DriveFileMetadata = {
   name?: string
   mimeType?: string
   parents?: string[]
+  driveId?: string
+  ownedByMe?: boolean
+  modifiedTime?: string
+  version?: string
+  headRevisionId?: string
+  md5Checksum?: string
+  size?: string
+  owners?: DriveIdentity[]
+  sharingUser?: DriveIdentity
+  lastModifyingUser?: DriveIdentity
+  capabilities?: {
+    canDownload?: boolean
+  }
+}
+
+export interface DriveIdentity {
+  displayName?: string
+  emailAddress?: string
+  permissionId?: string
+  me?: boolean
+}
+
+export interface SharedNotebookPreflight {
+  fileId: string
+  uri: string
+  name: string
+  mimeType: string
+  parents: NotebookStoreItem[]
+  driveId?: string
+  ownedByMe?: boolean
+  modifiedTime?: string
+  version?: string
+  headRevisionId?: string
+  md5Checksum?: string
+  sizeBytes?: number
+  owners: DriveIdentity[]
+  sharingUser?: DriveIdentity
+  lastModifyingUser?: DriveIdentity
+  canDownload: boolean
 }
 
 export interface DriveVersionMetadata {
   md5Checksum?: string
   headRevisionId?: string
+  version?: string
   appProperties?: Record<string, string>
 }
 
@@ -3282,10 +3322,14 @@ export class DriveNotebookStore {
   }
 }
 
-export async function fetchDriveItemWithParents(
+export async function fetchSharedNotebookPreflight(
   uri: string,
   ensureAccessToken: () => Promise<string>
-): Promise<{ item: NotebookStoreItem; parents: NotebookStoreItem[] }> {
+): Promise<{
+  item: NotebookStoreItem
+  parents: NotebookStoreItem[]
+  preflight: SharedNotebookPreflight
+}> {
   const { id, type } = parseDriveItem(uri)
   if (
     type !== NotebookStoreItemType.File &&
@@ -3299,7 +3343,13 @@ export async function fetchDriveItemWithParents(
   const metadataResponse = await client.get({
     fileId: id,
     supportsAllDrives: true,
-    fields: 'id,name,mimeType,parents',
+    fields:
+      'id,name,mimeType,parents,driveId,ownedByMe,modifiedTime,version,' +
+      'headRevisionId,md5Checksum,size,' +
+      'owners(displayName,emailAddress,permissionId,me),' +
+      'sharingUser(displayName,emailAddress,permissionId,me),' +
+      'lastModifyingUser(displayName,emailAddress,permissionId,me),' +
+      'capabilities(canDownload)',
   })
 
   const meta = (metadataResponse.result ?? {}) as DriveFileMetadata
@@ -3358,5 +3408,40 @@ export async function fetchDriveItemWithParents(
     }
   }
 
+  const parsedSize = meta.size ? Number(meta.size) : undefined
+  const preflight: SharedNotebookPreflight = {
+    fileId: meta.id,
+    uri: item.uri,
+    name: item.name,
+    mimeType: meta.mimeType ?? '',
+    parents,
+    owners: Array.isArray(meta.owners) ? meta.owners : [],
+    canDownload: meta.capabilities?.canDownload !== false,
+    ...(meta.driveId ? { driveId: meta.driveId } : {}),
+    ...(typeof meta.ownedByMe === 'boolean'
+      ? { ownedByMe: meta.ownedByMe }
+      : {}),
+    ...(meta.modifiedTime ? { modifiedTime: meta.modifiedTime } : {}),
+    ...(meta.version ? { version: String(meta.version) } : {}),
+    ...(meta.headRevisionId ? { headRevisionId: meta.headRevisionId } : {}),
+    ...(meta.md5Checksum ? { md5Checksum: meta.md5Checksum } : {}),
+    ...(Number.isFinite(parsedSize) ? { sizeBytes: parsedSize } : {}),
+    ...(meta.sharingUser ? { sharingUser: meta.sharingUser } : {}),
+    ...(meta.lastModifyingUser
+      ? { lastModifyingUser: meta.lastModifyingUser }
+      : {}),
+  }
+
+  return { item, parents, preflight }
+}
+
+export async function fetchDriveItemWithParents(
+  uri: string,
+  ensureAccessToken: () => Promise<string>
+): Promise<{ item: NotebookStoreItem; parents: NotebookStoreItem[] }> {
+  const { item, parents } = await fetchSharedNotebookPreflight(
+    uri,
+    ensureAccessToken
+  )
   return { item, parents }
 }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -20,6 +20,7 @@ import {
 } from './excalidraw'
 import { MemoryIpynbShadowStorage } from './ipynbShadows'
 import LocalNotebooks, {
+  DriveSnapshotChangedError,
   type LocalFileRecord,
   type LocalFolderRecord,
   NotebookConflictChangedError,
@@ -153,6 +154,85 @@ function notebookJson(value: string): string {
   )
 }
 
+describe('LocalNotebooks trusted Drive snapshot import', () => {
+  it('initializes a new mirror only after the downloaded version stays stable', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/trusted123/view'
+    const version = {
+      md5Checksum: 'checksum-1',
+      headRevisionId: 'revision-1',
+      version: '7',
+    }
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => version),
+      loadContent: vi.fn(async () => notebookJson('trusted snapshot')),
+    }
+    const store = createTestStore(driveStore)
+
+    const localUri = await store.importTrustedDriveSnapshot(
+      remoteUri,
+      'trusted.json',
+      {
+        expected: {
+          checksum: 'checksum-1',
+          revisionId: 'revision-1',
+          version: '7',
+        },
+      }
+    )
+
+    const record = await store.files.get(localUri)
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(1)
+    expect(driveStore.getVersionMetadata).toHaveBeenCalledTimes(2)
+    expect(record).toMatchObject({
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'checksum-1',
+      lastUpstreamVersion: {
+        checksum: 'checksum-1',
+        revisionId: 'revision-1',
+      },
+    })
+    expect(record?.doc).toContain('trusted snapshot')
+  })
+
+  it('rejects a changed Drive snapshot without initializing candidate bytes', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/changing123/view'
+    const driveStore = {
+      getVersionMetadata: vi
+        .fn()
+        .mockResolvedValueOnce({
+          md5Checksum: 'checksum-1',
+          headRevisionId: 'revision-1',
+          version: '7',
+        })
+        .mockResolvedValueOnce({
+          md5Checksum: 'checksum-2',
+          headRevisionId: 'revision-2',
+          version: '8',
+        }),
+      loadContent: vi.fn(async () => notebookJson('changed snapshot')),
+    }
+    const store = createTestStore(driveStore)
+
+    await expect(
+      store.importTrustedDriveSnapshot(remoteUri, 'changing.json', {
+        expected: {
+          checksum: 'checksum-1',
+          revisionId: 'revision-1',
+          version: '7',
+        },
+      })
+    ).rejects.toBeInstanceOf(DriveSnapshotChangedError)
+
+    const [record] = await store.files.toArray()
+    expect(record).toMatchObject({
+      remoteId: remoteUri,
+      doc: '',
+      lastSynced: '',
+      lastRemoteChecksum: '',
+    })
+  })
+})
+
 describe('LocalNotebooks pending Drive create', () => {
   it('creates one local mirror across concurrent addFile calls', async () => {
     const store = createTestStore({})
@@ -165,9 +245,9 @@ describe('LocalNotebooks pending Drive create', () => {
 
     expect(second).toBe(first)
     const records = await store.files.toArray()
-    expect(records.filter((record) => record.remoteId === remoteUri)).toHaveLength(
-      1
-    )
+    expect(
+      records.filter((record) => record.remoteId === remoteUri)
+    ).toHaveLength(1)
   })
 
   it('initializes an uploaded Drive ipynb as a synced mirror', async () => {
@@ -468,11 +548,15 @@ describe('LocalNotebooks pending Drive create', () => {
       'local://file/moved'
     )
 
-    await expect(store.folders.get('local://folder/old')).resolves.toMatchObject({
+    await expect(
+      store.folders.get('local://folder/old')
+    ).resolves.toMatchObject({
       children: [],
       provisionalChildren: [],
     })
-    await expect(store.folders.get('local://folder/new')).resolves.toMatchObject({
+    await expect(
+      store.folders.get('local://folder/new')
+    ).resolves.toMatchObject({
       children: ['local://file/moved'],
     })
   })

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -184,6 +184,37 @@ export class NotebookConflictChangedError extends Error {
   }
 }
 
+export class DriveSnapshotChangedError extends Error {
+  constructor(readonly remoteUri: string) {
+    super(`Google Drive changed while importing ${remoteUri}. Please retry.`)
+    this.name = 'DriveSnapshotChangedError'
+  }
+}
+
+function driveVersionMatches(
+  actual: DriveVersionMetadata | null,
+  expected: { checksum?: string; revisionId?: string; version?: string }
+): boolean {
+  return (
+    (expected.checksum === undefined ||
+      actual?.md5Checksum === expected.checksum) &&
+    (expected.revisionId === undefined ||
+      actual?.headRevisionId === expected.revisionId) &&
+    (expected.version === undefined || actual?.version === expected.version)
+  )
+}
+
+function sameDriveVersion(
+  before: DriveVersionMetadata | null,
+  after: DriveVersionMetadata | null
+): boolean {
+  return (
+    before?.md5Checksum === after?.md5Checksum &&
+    before?.headRevisionId === after?.headRevisionId &&
+    before?.version === after?.version
+  )
+}
+
 /**
  * LocalFolderRecord represents a folder in the mirrored hierarchy.
  *
@@ -374,6 +405,60 @@ export class LocalNotebooks extends Dexie {
       this.fileMirrorLockKey(remoteUri),
       () => this.addFileInner(remoteUri, name, options)
     )
+  }
+
+  /**
+   * Import one stable Drive snapshot without exposing candidate bytes to the
+   * notebook UI. This is the shared-link boundary: metadata is checked before
+   * and after the download, and only a consistent snapshot initializes the
+   * local mirror that openNotebook can render.
+   */
+  async importTrustedDriveSnapshot(
+    remoteUri: string,
+    name: string,
+    options: {
+      mimeType?: string
+      expected?: { checksum?: string; revisionId?: string; version?: string }
+    } = {}
+  ): Promise<string> {
+    const localUri = await this.addFile(remoteUri, name, {
+      mimeType: options.mimeType,
+    })
+    const record = await this.files.get(localUri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${localUri}`)
+    }
+
+    // Existing mirrors have already crossed a user- or policy-authorized
+    // import boundary. Preserve possible local edits and let normal sync and
+    // conflict handling own subsequent refreshes.
+    if (!isUninitializedDriveMirror(record)) {
+      return localUri
+    }
+
+    const expected = options.expected ?? {}
+    const before = await this.driveStore.getVersionMetadata(remoteUri)
+    if (!driveVersionMatches(before, expected)) {
+      throw new DriveSnapshotChangedError(remoteUri)
+    }
+
+    const content = await this.driveStore.loadContent(remoteUri)
+    const after = await this.driveStore.getVersionMetadata(remoteUri)
+    if (
+      !sameDriveVersion(before, after) ||
+      !driveVersionMatches(after, expected)
+    ) {
+      throw new DriveSnapshotChangedError(remoteUri)
+    }
+
+    const decoded = decodeNotebookFile(content, name)
+    await this.initializeUploadedDriveNotebook(
+      localUri,
+      decoded.notebook,
+      content,
+      driveMetadataToUpstreamVersion(after)
+    )
+    return localUri
   }
 
   private fileMirrorLockKey(remoteUri: string): string {

--- a/app/test/browser/test-scenario-open-shared-drive-link.ts
+++ b/app/test/browser/test-scenario-open-shared-drive-link.ts
@@ -10,7 +10,9 @@ const SHARED_FOLDER_URL = "https://drive.google.com/drive/folders/shared-folder-
 const SHARED_FILE_MARKDOWN = `[shared-drive-notebook](${FRONTEND_URL}/?doc=${encodeURIComponent(SHARED_FILE_URL)})`;
 const GOOGLE_CLIENT_STORAGE_KEY = "googleClientConfig";
 const GOOGLE_AUTH_STORAGE_KEY = "runme/google-auth/token";
+const GOOGLE_DRIVE_ACCOUNT_STORAGE_KEY = "runme/google-auth/drive-account";
 const GOOGLE_DRIVE_RUNTIME_STORAGE_KEY = "runme/google-drive/runtime";
+const SHARED_NOTEBOOK_TRUST_STORAGE_KEY = "runme/shared-notebook-trust/v1";
 const CURRENT_DOC_STORAGE_KEY = "runme/currentDoc";
 const WORKSPACE_STORAGE_KEY = "runme/workspace";
 
@@ -384,6 +386,8 @@ const seedRuntime = run(
     localStorage.setItem('${GOOGLE_DRIVE_RUNTIME_STORAGE_KEY}', JSON.stringify({ baseUrl: '${FAKE_DRIVE_URL}' }));
     localStorage.setItem('${GOOGLE_CLIENT_STORAGE_KEY}', JSON.stringify({}));
     localStorage.removeItem('${GOOGLE_AUTH_STORAGE_KEY}');
+    localStorage.setItem('${GOOGLE_DRIVE_ACCOUNT_STORAGE_KEY}', 'viewer@acme.example');
+    localStorage.removeItem('${SHARED_NOTEBOOK_TRUST_STORAGE_KEY}');
     sessionStorage.removeItem('${CURRENT_DOC_STORAGE_KEY}');
     localStorage.setItem('${WORKSPACE_STORAGE_KEY}', JSON.stringify({ items: [] }));
     return 'ok';
@@ -482,6 +486,15 @@ if (/shared-drive-notebook\.json/i.test(documentsText)) {
   pass("Opened the shared notebook tab");
 } else {
   fail("Shared notebook tab was not opened");
+}
+
+const trustRecordRaw = run(
+  `agent-browser eval "localStorage.getItem('${SHARED_NOTEBOOK_TRUST_STORAGE_KEY}') || ''"`,
+).stdout;
+if (trustRecordRaw.includes("shared-file-123") && trustRecordRaw.includes("same_domain")) {
+  pass("Persisted same-domain trust for the shared notebook");
+} else {
+  fail("Did not persist same-domain trust for the shared notebook");
 }
 takeScreenshot(FILE_LOADED_SCREENSHOT);
 

--- a/docs-dev/design/20260822_shared_notebook_link_trust.md
+++ b/docs-dev/design/20260822_shared_notebook_link_trust.md
@@ -1,0 +1,661 @@
+# 2026-08-22: Shared notebook link trust
+
+## Status
+
+P0 implemented. URL-driven notebook opens now pass through a metadata-only
+trust decision and a version-checked import. Renderer and execution hardening
+remain follow-up work.
+
+## Decision
+
+Runme will not download, parse, initialize a local mirror, or render a notebook
+solely because a user navigated to a `?doc=<Google Drive URL>` link.
+
+Runme will first fetch a bounded set of Google Drive metadata from Google's API
+and evaluate local policy. The P0 policy automatically trusts files that Drive
+reports as owned by the current account, files whose owner email domain exactly
+matches the current non-consumer Workspace domain, previously approved
+documents, and files in a locally allowlisted Shared Drive. All other files
+stop at a review screen. The user must explicitly choose **Trust this document
+and open** before Runme fetches notebook bytes.
+
+Trust is bound to the effective Google principal, Drive file ID, and an
+ownership/Shared Drive fingerprint. It survives ordinary revisions. Drive
+`version`, `headRevisionId`, and `md5Checksum` are transaction-integrity
+signals: Runme checks them before and after download so it never opens different
+bytes from the metadata snapshot that passed policy.
+
+Same-domain ownership is a pragmatic trust policy, not a malware verdict. It
+reduces friction for internal sharing but accepts the risk of a malicious or
+compromised account in the same organization. Known public consumer email
+domains are never treated as organizations. A future administrator policy
+should replace email suffix inference with verified Workspace organization
+identity.
+
+## Why this is P0
+
+A shared Runme URL is an untrusted document delivery mechanism. Today the URL
+path can progress from a Drive metadata request to a local mirror and an open
+notebook without a trust decision:
+
+1. `DriveLinkCoordinatorHost` consumes `?doc=`.
+2. `driveLinkCoordinator.processIntent` calls `fetchDriveItemWithParents`.
+3. The coordinator calls `LocalNotebooks.addFile` and then `openNotebook`.
+4. `LocalNotebooks.load` synchronizes an uninitialized mirror from Drive.
+5. React mounts the notebook and its stored rich content.
+
+Opening is not passive:
+
+- Markdown images use attacker-controlled `src` URLs and load automatically.
+- Authored HTML cells mount an `iframe srcDoc` automatically. Their empty
+  sandbox blocks script, but does not block all network subresources.
+- Stored `text/html` outputs mount an `iframe` with `sandbox="allow-scripts"`.
+  Script cannot read the parent origin because `allow-same-origin` is absent,
+  but it can execute immediately, render deceptive UI, consume resources, and
+  attempt outbound requests from its opaque origin.
+- Stored image and SVG outputs are decoded automatically and can consume CPU or
+  memory.
+- A notebook can socially engineer a user into executing code against a local,
+  Jupyter, or cloud runner. Execution can expose files, environment variables,
+  cloud credentials, and any other capability held by that runner.
+
+The current browser security boundaries reduce the impact of a malicious
+notebook but do not make automatic opening safe. A future renderer regression
+or sandbox bypass would also have a high-value target: Runme currently holds a
+broad Google Drive OAuth token in origin storage.
+
+## Security invariant
+
+No attacker-controlled notebook byte or attacker-controlled remote asset may
+reach a parser, renderer, media decoder, executable runtime, or browser network
+sink before the user or trust policy accepts the document. The accepted Drive
+metadata snapshot must remain unchanged throughout download and local mirror
+initialization.
+
+The metadata review path may process untrusted strings, but it must render them
+as text and must not dereference URLs returned in metadata.
+
+## Precedents
+
+### Jupyter
+
+Jupyter defines the core invariant directly: code must not execute merely
+because a user opened a notebook they did not write. Its model sanitizes
+untrusted HTML, never executes untrusted JavaScript, never trusts HTML or
+JavaScript in Markdown, and trusts outputs produced by the current user.
+Jupyter signs notebook contents with a per-user secret and checks that
+signature when the notebook is reopened. A user can explicitly trust an
+otherwise untrusted notebook.
+
+JupyterLab blocks interactive outputs until the notebook is trusted, exposes
+trust state with a shield, and always sanitizes Markdown. Its trust decision is
+about active stored output, not permission to read file metadata.
+
+Runme should adopt Jupyter's central question—“did the current user produce or
+approve this exact content?”—but put the first decision before content download
+because Runme already has enough provider metadata to present a useful review.
+
+Sources:
+
+- [Jupyter Server: Security in notebook documents](https://jupyter-server.readthedocs.io/en/latest/operators/security.html#security-in-notebook-documents)
+- [JupyterLab: Notebook trust](https://jupyterlab.readthedocs.io/en/stable/user/notebook.html#trust)
+
+### Google Colab
+
+Colab's public documentation distinguishes reading a notebook from granting it
+power. It warns users to trust notebook authors before execution. Mounting
+Google Drive normally requires a manual grant because notebook code then gains
+access to the user's Drive. Colab only reuses that grant after multiple checks;
+the documented example says a notebook edited by another user does not qualify
+for automatic remount. Colab also restricts automatic scheduled execution when
+it cannot establish that the notebook was edited only by the user.
+
+Runme should likewise separate three decisions:
+
+1. inspect provider metadata;
+2. display stored notebook content;
+3. execute code or grant external capabilities.
+
+Sources:
+
+- [Colab FAQ: Drive mounting and edited notebooks](https://research.google.com/colaboratory/faq.html#drive-mount)
+- [Colab local runtimes: Security considerations](https://research.google.com/colaboratory/local-runtimes.html#security-considerations)
+
+## Threat model
+
+### Protected assets
+
+- Google Drive access and refresh tokens stored by Runme.
+- Notebook data already mirrored in IndexedDB or OPFS.
+- Local files, environment variables, and credentials exposed to a runner.
+- Cloud credentials and APIs available through service-account or user
+  impersonation.
+- The user's identity, network location, and browser resources.
+- User trust in the `web.runme.dev` origin.
+
+### Attacker capabilities
+
+The attacker can create or modify a Drive notebook, save arbitrary cells and
+outputs, share it with the victim, and send a Runme URL containing the Drive
+file ID. The attacker may be external, in the same Workspace organization, or
+a collaborator on a user-owned file. The attacker may race a file update while
+the victim reviews it.
+
+The attacker cannot initially read the victim's Runme origin, Drive token, or
+runner state. The design must preserve that boundary even if the document
+contains HTML, JavaScript output, SVG, large media, malformed JSON, misleading
+filenames, or nested Drive shortcuts.
+
+### Primary abuse cases
+
+| Abuse case | Current trigger | Potential impact | P0 control |
+| --- | --- | --- | --- |
+| Tracking beacon | Markdown image or HTML subresource mounts | IP/user-agent disclosure and link-open confirmation | Do not render before approval |
+| Stored script | `text/html` output mounts with `allow-scripts` | Phishing UI, outbound requests, resource abuse, exploitation of renderer defects | Do not render before approval; later add output CSP |
+| Credential phishing | Notebook or output imitates Runme/Google login | User enters credentials into attacker UI | Metadata interstitial; visible trust state; iframe UI hardening |
+| Runner code execution | User runs an attacker cell | Local/cloud data theft or destruction | Separate first-execution capability confirmation |
+| Parser/decoder denial of service | Oversized or pathological notebook/output | Browser crash or storage exhaustion | Size/cell/output budgets and worker parsing |
+| Time-of-check/time-of-use race | Attacker changes file after review | Different bytes open than the user approved | Bind approval to Drive version and recheck after fetch |
+| Trust confusion through Drive shortcut | Benign-looking shortcut targets another file | Wrong owner/location evidence | Resolve and review the ultimate target |
+| Cross-account trust reuse | Browser changes Google principal | One account inherits another account's approval | Principal-scoped trust records |
+
+### Out of scope for P0
+
+- Proving that a known author is uncompromised.
+- Malware scanning or semantic review of notebook code.
+- Making arbitrary runner execution safe.
+- A complete enterprise reputation service.
+- Rendering an untrusted notebook in a reduced-function preview.
+
+## Trust model
+
+### Trust is document-scoped, principal-scoped, and local
+
+A trust record has this shape:
+
+```ts
+type NotebookTrustRecord = {
+  provider: 'google-drive'
+  effectivePrincipal: string
+  fileId: string
+  basis: 'explicit_document' | 'owned_by_me' | 'same_domain' | 'trusted_drive'
+  subjectFingerprint: string
+  trustedAt: string
+}
+```
+
+P0 uses the normalized effective Drive account email because every current auth
+mode exposes it. Service-account and impersonated sessions use the effective
+Drive principal, not merely the human who authorized the session. Replace this
+with a stable verified principal ID when the auth layer exposes one consistently.
+
+Store records in Runme's origin-local database. Do not write trust into the
+notebook or Drive `appProperties`: a document author must not be able to assert
+their own trust.
+
+Explicit approval is document-scoped and survives revisions. It is invalidated
+when the ownership/Shared Drive fingerprint changes. Version changes do not
+re-prompt; they are guarded by the import transaction's pre/post checks.
+
+### Automatic trust in P0
+
+These cases bypass the review screen:
+
+- A matching trust record exists for the effective principal, file ID, and
+  current ownership/drive fingerprint.
+- Drive reports `ownedByMe=true`.
+- At least one owner email has the same exact non-consumer domain as the
+  effective Drive principal.
+- `driveId` appears in the local trusted-Shared-Drive policy.
+
+`lastModifyingUser.me`, `isAppAuthorized`, prior viewing, editor permissions,
+and Shared Drive membership without an allowlist do not establish trust.
+
+### Same-domain tradeoff
+
+P0 accepts same-domain ownership as an automatic signal to support the core
+internal-sharing workflow. The comparison is normalized, exact, and disabled
+for known public consumer providers such as Gmail, Outlook, Yahoo, iCloud, and
+Proton.
+
+This is weaker than verified organization membership. Drive owner email can be
+absent; Shared Drive files have no individual owner; same-organization accounts
+can be malicious or compromised; and collaborators can change a user-owned
+file. The review UI and trust basis must not describe same-domain content as
+safe. A later backend can verify both principals against Workspace identity and
+apply an auditable administrator policy.
+
+Source: [Google OpenID Connect claims](https://developers.google.com/identity/openid-connect/reference#id_token)
+
+## Google Drive metadata preflight
+
+### Request
+
+After non-interactive Drive authentication succeeds, call `files.get` with
+`supportsAllDrives=true` and an explicit field mask:
+
+```text
+id,name,mimeType,size,createdTime,modifiedTime,version,
+md5Checksum,headRevisionId,driveId,parents,ownedByMe,shared,
+isAppAuthorized,shortcutDetails(targetId,targetMimeType,targetResourceKey),
+owners(displayName,emailAddress,me,permissionId),
+sharingUser(displayName,emailAddress,me,permissionId),
+lastModifyingUser(displayName,emailAddress,me,permissionId),
+capabilities(canDownload),resourceKey
+```
+
+If the item is a shortcut, resolve `shortcutDetails.targetId` and repeat the
+preflight for the target. Apply a small depth/cycle limit and make the target,
+not the shortcut, the trust subject.
+
+For `driveId`, fetch only the shared-drive name and membership/policy data
+needed by the UI. For `parents`, fetch bounded parent names. Do not attempt an
+unbounded hierarchy walk. “Location unavailable” is valid.
+
+### Safe fields to display
+
+| Signal | UI use | Trust weight | Caveat |
+| --- | --- | --- | --- |
+| `name` | Primary title | Context only | Untrusted text; can impersonate a known notebook |
+| `mimeType`, `size` | Type/size warning | Validation | Reject unsupported type and oversize files |
+| `owners[]` | Owner identity | Medium context | Absent for shared drives; email may be hidden |
+| `sharingUser` | “Shared with you by” | Medium context | Sharer is not necessarily owner or author |
+| `lastModifyingUser` | Latest editor warning | Medium context | Does not attest all persisted content |
+| `ownedByMe` | “You own this file” | Positive context | Collaborators may still have edited it |
+| `driveId` + drive name | Shared-drive provenance | Policy input | Shared drive is organization-owned; name is untrusted text |
+| `parents` + parent names | Best-effort location | Context only | Parent access/path can be incomplete |
+| `version` | Approval binding | Strong freshness | Changes for server-side metadata changes too |
+| `headRevisionId`, `md5Checksum` | Content/version binding | Strong freshness | Only available for applicable binary content |
+| `capabilities.canDownload` | Eligibility | Enforcement | Says nothing about safety |
+| `isAppAuthorized` | Diagnostics | Weak context | App access is not authorship or safety |
+
+Google documents that `owners` is absent for shared-drive items, user email can
+be hidden, `version` increases for every server-side change, and shared-drive
+ownership belongs to an organization.
+
+Sources:
+
+- [Drive File resource](https://developers.google.com/workspace/drive/api/reference/rest/v3/files)
+- [Drive User resource](https://developers.google.com/workspace/drive/api/reference/rest/v3/User)
+- [Drive files and folders: ownership](https://developers.google.com/workspace/drive/api/guides/about-files#ownership)
+- [Drive shared drives overview](https://developers.google.com/workspace/drive/api/guides/about-shareddrives)
+
+### Metadata-path restrictions
+
+- Treat every returned string as plain text. React interpolation is acceptable;
+  `innerHTML` is not.
+- Do not load `thumbnailLink`, `iconLink`, `photoLink`, descriptions containing
+  markup, or any URL supplied by the file.
+- Compute the external Drive URL from the validated file ID and fixed
+  `https://drive.google.com/file/d/<id>/view` template.
+- Send credentials only to the configured Google API origin. The existing
+  `resourceFetch` same-origin check is the model.
+- Bound response size, parent lookups, retries, and total preflight time.
+- Do not put filenames, owner emails, full Drive URLs, or file IDs in analytics.
+
+## User experience
+
+### Review screen
+
+The existing `status://drive-link` document becomes a review document. It does
+not mount a notebook component.
+
+```text
+Review shared notebook
+
+Opening a notebook can load active content and code. Only continue if you
+recognize the source and expect this file.
+
+Name              quarterly-analysis.ipynb
+Owner             Alice Example (alice@example.com)
+Shared by         Bob Example (bob@partner.example)
+Last modified by  Carol Example (carol@example.com)
+Location          Finance Shared Drive / Forecasts
+Modified          2026-08-21 15:42 PDT
+Type / size        Jupyter notebook / 2.4 MiB
+
+[Cancel] [Open in Google Drive] [Trust this document and open]
+```
+
+Rules:
+
+- **Cancel** is the default focused action.
+- The trust action states its persistent document scope. Avoid generic
+  **Continue** or **Open**.
+- External owner, unknown owner, shared-drive owner absence, unsupported MIME,
+  unusually large size, and a different last editor receive explicit text.
+- Do not use green “safe” styling. Provider identity is evidence, not a malware
+  verdict.
+- Authentication happens as a separate step. Logging in to Drive does not
+  approve the notebook.
+- Multiple queued links are reviewed separately.
+- If metadata changes while the screen is open, refresh the screen and require
+  a new click.
+
+### Persistent trust state
+
+P1 should show the trust basis in the notebook tab:
+
+- **You trusted this document**: explicit document approval.
+- **Owned by you**: Drive reports `ownedByMe`.
+- **Organization owner**: same-domain policy accepted the file.
+- **Trusted Shared Drive**: local or administrator policy accepted `driveId`.
+
+Do not use **Trusted author** in P0. Runme has not authenticated authorship of
+all notebook bytes or outputs.
+
+### Execution is a separate capability decision
+
+Trusting display does not imply permission to run code. The first execution of
+a shared notebook should show the selected runner and the capabilities it can
+reach. High-risk grants such as Drive mounting, service-account use, local
+filesystem access, or a local runtime require their own confirmation. This
+matches Colab's manual Drive-mount boundary.
+
+This execution confirmation is P1 unless Runme currently auto-executes any
+cell. Automatic execution from link navigation is forbidden in P0.
+
+## State machine
+
+```mermaid
+flowchart TD
+    A[Shared link received] --> B{Validated Drive URL?}
+    B -- no --> X[Reject]
+    B -- yes --> C{Drive auth available?}
+    C -- no --> D[Show login requirement]
+    D --> C
+    C -- yes --> E[Fetch metadata only]
+    E --> F{Document trusted?}
+    F -- yes --> J[Version-checked download]
+    F -- no --> G[Show review document]
+    G -- cancel --> Y[Discard intent]
+    G -- approve --> H[Persist document trust]
+    H --> E
+    J --> K[Keep bytes outside notebook UI]
+    K --> L[Refetch content version]
+    L --> M{Version unchanged?}
+    M -- no --> E
+    M -- yes --> N[Initialize local mirror]
+    N --> O[Open notebook]
+```
+
+The content must remain unreachable by notebook renderers until state `O`.
+
+## Implemented P0
+
+### New modules
+
+```ts
+type DriveVersionIdentity = {
+  checksum?: string
+  revisionId?: string
+  version?: string
+}
+
+interface SharedNotebookPreflight {
+  uri: string
+  fileId: string
+  name: string
+  mimeType: string
+  sizeBytes?: number
+  modifiedTime?: string
+  version?: string
+  headRevisionId?: string
+  md5Checksum?: string
+  owners: DriveIdentity[]
+  sharingUser?: DriveIdentity
+  lastModifyingUser?: DriveIdentity
+  ownedByMe?: boolean
+  driveId?: string
+  parents: NotebookStoreItem[]
+  canDownload: boolean
+}
+
+declare function evaluateSharedNotebookTrust(input: {
+  preflight: SharedNotebookPreflight
+  effectivePrincipal: string | null
+}): SharedNotebookTrustDecision
+```
+
+Implemented in:
+
+- `app/src/lib/sharedNotebookTrust.ts`: policy and local trust records.
+- `app/src/storage/drive.ts`: bounded metadata preflight.
+- `app/src/storage/local.ts`: version-checked import and mirror initialization.
+- `app/src/components/DriveLinkStatusTab.tsx`: inert review UI.
+
+### Coordinator changes
+
+Extend `DriveLinkIntentStatus` with `fetching_metadata` and `awaiting_review`.
+Attach a serializable preflight snapshot to the intent, excluding access tokens.
+
+Change `processIntent`:
+
+1. authenticate non-interactively;
+2. fetch metadata only;
+3. reject folders from the notebook-review flow and keep folder mounting as a
+   separate explicit action;
+4. evaluate document trust for the current effective principal;
+5. stop in `awaiting_review` unless policy trusts the document;
+6. call the version-checked import method only after approval.
+
+The coordinator must not call `addFile`, `updateFolder`, `openNotebook`,
+`loadContent`, `DriveNotebookStore.load`, or `LocalNotebooks.load` while the
+intent is untrusted.
+
+### Version-checked import
+
+Approval records document trust, then re-enters the metadata policy check. The
+import operation owns the byte transition:
+
+```ts
+importTrustedDriveSnapshot(
+  remoteUri: string,
+  name: string,
+  options: { mimeType?: string; expected: DriveVersionIdentity },
+): Promise<string>
+```
+
+The operation:
+
+1. creates only an uninitialized local metadata record;
+2. refetches the current content version and compares it with preflight;
+3. downloads bytes without exposing them to notebook UI state;
+4. refetches Drive content-version metadata;
+5. aborts if `version`, `headRevisionId`, or `md5Checksum` changed;
+6. decodes and initializes the local mirror;
+7. returns a local URI that is safe to pass to `openNotebook`.
+
+At least one Drive version signal is required. If Drive does not provide a
+content hash, use the pre/post `version` or `headRevisionId` check. Never
+silently open bytes from a different metadata snapshot.
+
+### Folder links
+
+The existing coordinator recursively mirrors a shared folder. That can import
+many unreviewed notebooks and assets. P0 must not recursively mount a folder
+from `?doc=`. Show folder metadata and require **Mount folder**. Files discovered
+inside the folder remain unopened; each first open goes through notebook
+review. An admin-trusted shared-drive policy may relax this later.
+
+## Defense in depth after P0
+
+The review gate reduces exposure but does not replace renderer hardening.
+Jupyter's model still sanitizes Markdown even for trusted notebooks.
+
+### Markdown and remote assets
+
+- Keep raw HTML disabled.
+- Validate URL schemes.
+- Add `referrerPolicy="no-referrer"` to external resources.
+- Prefer an explicit **Load external images** action or a same-origin media
+  proxy with size and MIME checks.
+- Never interpolate notebook URLs into privileged fetches.
+
+### Authored HTML cells
+
+Keep `sandbox=""` and inject a restrictive CSP into `srcDoc`, initially:
+
+```text
+default-src 'none'; img-src data: blob:; media-src data: blob:;
+style-src 'unsafe-inline'; font-src data:; form-action 'none'; base-uri 'none'
+```
+
+This preserves static HTML/SVG while blocking external subresources.
+
+### Stored HTML outputs
+
+Do not mount stored `text/html` output until the version is trusted. When
+scripted output is enabled, use an isolated output origin plus a restrictive
+CSP and a narrow, validated message protocol. `sandbox="allow-scripts"` without
+`allow-same-origin` is a useful boundary, but it is not a network policy.
+
+### Resource limits
+
+Set limits for:
+
+- raw notebook bytes;
+- number and size of cells;
+- aggregate decoded output bytes;
+- SVG/image dimensions and decode time;
+- HTML output frame count;
+- linked-resource count and automatic fetches.
+
+Parsing should happen off the main thread. Fail closed with a user-readable
+error and an option to inspect the file in Drive.
+
+## Observability and privacy
+
+Record only coarse events:
+
+- preflight started/succeeded/failed;
+- review shown;
+- cancelled/approved;
+- automatically matched document policy;
+- version changed during approval;
+- import blocked by type/size/parser policy.
+
+Do not log notebook names, Drive URLs, file IDs, owner/sharer emails, parent
+names, or content hashes to analytics. Application logs should use a local
+correlation ID. Security telemetry can use a keyed, rotating pseudonym only if
+there is a documented retention and access policy.
+
+## Testing
+
+### Unit tests
+
+- A URL-sourced file reaches `awaiting_review` without invoking `addFile`,
+  `loadContent`, `openNotebook`, or any renderer.
+- Cancel removes the intent and never downloads content.
+- Approval is scoped to principal + file ID + ownership/drive fingerprint.
+- Changing principal invalidates the match.
+- Same-domain Workspace ownership opens automatically; known consumer email
+  domains do not.
+- A changed Drive content version aborts the import without initializing bytes.
+- Missing owner/email and shared-drive owner absence fail closed without UI
+  crashes.
+- Shortcut metadata is resolved to the ultimate file.
+- Filenames and identity strings containing markup render as text.
+- Folder links do not recursively mirror files before explicit mount.
+
+### Browser tests
+
+- A malicious Markdown image server receives no request before approval.
+- Script in persisted HTML output does not run before approval.
+- An HTML cell cannot fetch an external image after output CSP hardening.
+- A file changed between review and download never opens.
+- Oversized/malformed notebooks do not block the main thread or exhaust local
+  storage.
+- Back/forward, focus, `pageshow`, and multi-tab events do not duplicate an
+  approval or bypass review.
+- A previously cached local mirror does not bypass the version gate.
+- Direct manual open, rendered Markdown links, App Console helpers, and WebMCP
+  all call the same trust policy when the source is remote.
+
+### Security regression fixture
+
+Add a generated notebook fixture containing:
+
+- Markdown remote image and link schemes;
+- authored HTML with script, form, iframe, external CSS, image, video, and
+  audio;
+- stored HTML output with script and network beacons;
+- inline and external SVG;
+- large base64 outputs;
+- cells that request powerful runners.
+
+The test server records every request. The pre-approval request count to
+attacker-controlled origins must remain zero.
+
+## Rollout
+
+1. **P0:** ship metadata preflight, review UI, principal/document trust records,
+   version-checked import, and regression tests. Enable by default with no
+   legacy bypass.
+3. **P1:** add persistent trust indicators, first-execution capability review,
+   renderer CSP, external-asset gating, and resource budgets.
+4. **P2:** add verified Workspace/admin policies for organization IDs and
+   allowlisted shared drives. Keep auditability and user-visible policy source.
+
+Monitor approval rate, cancellation rate, preflight failures, version races,
+and blocked imports. Do not measure identity or filenames.
+
+## Alternatives rejected
+
+### Require review for every new revision
+
+Rejected for P0. It creates repeated prompts during normal collaboration and
+confuses document trust with transaction integrity. Runme persists document
+trust and separately verifies that downloaded bytes match the policy-evaluated
+metadata snapshot.
+
+### Download first, but do not render
+
+Rejected for P0. It unnecessarily exposes parsers, storage, and sync paths to
+untrusted bytes and complicates proof that no renderer observes the content.
+
+### Open read-only
+
+Rejected as a security control. Read-only prevents notebook mutation; it does
+not stop stored HTML, images, media, or output from rendering.
+
+### Rely only on iframe sandboxing
+
+Rejected. Sandboxing protects the parent origin but does not provide complete
+network, resource, phishing, or runner-execution protection.
+
+### Trust the Drive ACL
+
+Rejected. Authorization answers whether the current principal may read the
+file. It does not attest who authored the bytes or whether they are safe.
+
+## Open questions
+
+- What maximum notebook and decoded-output sizes preserve existing real-world
+  notebooks?
+- Should explicit approval survive browser data clearing or synchronize across
+  devices? P0 says no.
+- Which verified organization identifier can Runme obtain in every auth mode,
+  including service accounts and impersonation?
+- Should administrator policy replace email-domain inference with verified
+  Workspace organization IDs? P0 says yes when that identity is available.
+- Should folder mounting require per-file review or only review on first open?
+  P0 chooses review on first open and no recursive content download.
+- Which output features require scripts strongly enough to justify a dedicated
+  output origin?
+
+## Acceptance criteria
+
+- Navigating to an unknown Drive notebook URL causes zero notebook-content and
+  attacker-origin requests before an explicit trust decision.
+- The review screen shows safely rendered provider metadata, including owner or
+  shared-drive provenance when available.
+- Same-domain ownership automatically trusts a notebook only for an exact,
+  non-consumer domain match.
+- Approval persists for the document but opens only bytes from the metadata
+  snapshot that passed policy.
+- A principal switch, ownership/drive fingerprint change, shortcut target
+  change, or missing trust record returns to review.
+- Every remote-open entry point uses the same policy gate.
+- Tests demonstrate that Markdown, HTML, SVG, media, and stored outputs cannot
+  become active before approval.

--- a/testing/fake-drive-server.go
+++ b/testing/fake-drive-server.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log"
@@ -29,11 +33,26 @@ type driveFile struct {
 	Name          string            `json:"name"`
 	MimeType      string            `json:"mimeType"`
 	Parents       []string          `json:"parents,omitempty"`
+	DriveID       string            `json:"driveId,omitempty"`
+	OwnedByMe     bool              `json:"ownedByMe"`
+	Owners        []driveUser       `json:"owners,omitempty"`
+	Capabilities  driveCapabilities `json:"capabilities"`
 	AppProperties map[string]string `json:"appProperties,omitempty"`
 	Content       string            `json:"-"`
-	Version       int               `json:"version"`
+	Version       int               `json:"version,string"`
 	HeadRev       string            `json:"headRevisionId"`
 	MD5Checksum   string            `json:"md5Checksum,omitempty"`
+}
+
+type driveUser struct {
+	DisplayName  string `json:"displayName,omitempty"`
+	EmailAddress string `json:"emailAddress,omitempty"`
+	PermissionID string `json:"permissionId,omitempty"`
+	Me           bool   `json:"me,omitempty"`
+}
+
+type driveCapabilities struct {
+	CanDownload bool `json:"canDownload"`
 }
 
 type driveStore struct {
@@ -49,21 +68,26 @@ func newDriveStore() *driveStore {
 	}
 
 	store.files[seedFolderID] = &driveFile{
-		ID:       seedFolderID,
-		Name:     "Shared Drive Folder",
-		MimeType: driveFolderMime,
-		Version:  1,
-		HeadRev:  "rev-1",
+		ID:           seedFolderID,
+		Name:         "Shared Drive Folder",
+		MimeType:     driveFolderMime,
+		OwnedByMe:    false,
+		Capabilities: driveCapabilities{CanDownload: true},
+		Version:      1,
+		HeadRev:      "rev-1",
 	}
 
 	store.files[seedFileID] = &driveFile{
-		ID:       seedFileID,
-		Name:     seedFileName,
-		MimeType: notebookJSONMime,
-		Parents:  []string{seedFolderID},
-		Content:  `{"cells":[{"refId":"cell_shared_drive","kind":"CODE","languageId":"bash","value":"echo \"shared drive\"","metadata":{"runner":"default"},"outputs":[]}],"metadata":{}}`,
-		Version:  1,
-		HeadRev:  "rev-1",
+		ID:           seedFileID,
+		Name:         seedFileName,
+		MimeType:     notebookJSONMime,
+		Parents:      []string{seedFolderID},
+		OwnedByMe:    false,
+		Owners:       []driveUser{{DisplayName: "Acme Notebook Owner", EmailAddress: "owner@acme.example", PermissionID: "owner-acme-1"}},
+		Capabilities: driveCapabilities{CanDownload: true},
+		Content:      `{"cells":[{"refId":"cell_shared_drive","kind":"CODE","languageId":"bash","value":"echo \"shared drive\"","metadata":{"runner":"default"},"outputs":[]}],"metadata":{}}`,
+		Version:      1,
+		HeadRev:      "rev-1",
 	}
 	store.refreshChecksum(seedFileID)
 
@@ -110,6 +134,9 @@ func (s *driveStore) create(resource map[string]any) (*driveFile, bool) {
 		MimeType:      stringValue(resource["mimeType"], notebookJSONMime),
 		Parents:       stringSlice(resource["parents"]),
 		AppProperties: stringMap(resource["appProperties"]),
+		OwnedByMe:     true,
+		Owners:        []driveUser{{DisplayName: "Fake Drive User", EmailAddress: "viewer@acme.example", PermissionID: "viewer-acme-1", Me: true}},
+		Capabilities:  driveCapabilities{CanDownload: true},
 		Version:       1,
 		HeadRev:       "rev-1",
 	}
@@ -202,6 +229,7 @@ func cloneFile(file *driveFile) *driveFile {
 		return nil
 	}
 	parents := append([]string(nil), file.Parents...)
+	owners := append([]driveUser(nil), file.Owners...)
 	appProperties := make(map[string]string, len(file.AppProperties))
 	for key, value := range file.AppProperties {
 		appProperties[key] = value
@@ -211,6 +239,10 @@ func cloneFile(file *driveFile) *driveFile {
 		Name:          file.Name,
 		MimeType:      file.MimeType,
 		Parents:       parents,
+		DriveID:       file.DriveID,
+		OwnedByMe:     file.OwnedByMe,
+		Owners:        owners,
+		Capabilities:  file.Capabilities,
 		AppProperties: appProperties,
 		Content:       file.Content,
 		Version:       file.Version,
@@ -275,6 +307,48 @@ func filterStrings(values []string, keep func(string) bool) []string {
 
 func newDriveHandler(store *driveStore) http.Handler {
 	mux := http.NewServeMux()
+	serviceAccountKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(fmt.Sprintf("generate fake service-account key: %v", err))
+	}
+	serviceAccountKeyBytes, err := x509.MarshalPKCS8PrivateKey(serviceAccountKey)
+	if err != nil {
+		panic(fmt.Sprintf("marshal fake service-account key: %v", err))
+	}
+	serviceAccountPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: serviceAccountKeyBytes,
+	}))
+	mux.HandleFunc("/app-config.json", func(w http.ResponseWriter, r *http.Request) {
+		if allowCORS(w, r) {
+			return
+		}
+		writeJSON(w, map[string]any{
+			"googleDrive": map[string]any{
+				"baseUrl":  "http://127.0.0.1:9090",
+				"authFlow": "service_account",
+				"serviceAccount": map[string]any{
+					"clientEmail": "viewer@acme.example",
+					"privateKey":  serviceAccountPEM,
+					"tokenUri":    "http://127.0.0.1:9090/token",
+				},
+			},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if allowCORS(w, r) {
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"access_token": "fake-drive-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
 	mux.HandleFunc("/drive/v3/files/generateIds", func(w http.ResponseWriter, r *http.Request) {
 		if allowCORS(w, r) {
 			return


### PR DESCRIPTION
## Summary
- preflight shared Drive notebook links using bounded metadata before downloading content
- automatically trust owned and same-domain notebooks while requiring explicit approval for external sources
- bind persisted trust to the effective principal and Drive ownership identity, with version checks around import
- add the shared-notebook trust design notebook and browser/unit coverage

## Verification
- runme run build test
- 74 focused Vitest tests
- local browser verification on localhost:5173