### PR TITLE
Fix nested Drive mounts and fuzzy folder search

### DIFF
--- a/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
@@ -8,6 +8,7 @@ import { GoogleDrivePickerButton } from './GoogleDrivePickerButton'
 const mocks = vi.hoisted(() => ({
   addItem: vi.fn(),
   ensureAccessToken: vi.fn(),
+  getNotebookStore: vi.fn(),
   getItems: vi.fn(),
   listChildren: vi.fn(),
   listRoots: vi.fn(),
@@ -38,7 +39,7 @@ vi.mock('../../contexts/WorkspaceContext', () => ({
 
 vi.mock('../../contexts/NotebookStoreContext', () => ({
   useNotebookStore: () => ({
-    store: { updateFolder: mocks.updateFolder },
+    store: mocks.getNotebookStore(),
   }),
 }))
 
@@ -67,6 +68,10 @@ describe('GoogleDrivePickerButton', () => {
     mocks.addItem.mockReset()
     mocks.ensureAccessToken.mockReset()
     mocks.ensureAccessToken.mockResolvedValue('cached-access-token')
+    mocks.getNotebookStore.mockReset()
+    mocks.getNotebookStore.mockReturnValue({
+      updateFolder: mocks.updateFolder,
+    })
     mocks.getItems.mockReset()
     mocks.getItems.mockReturnValue([])
     mocks.listRoots.mockReset()
@@ -194,6 +199,40 @@ describe('GoogleDrivePickerButton', () => {
 
     expect((await screen.findByRole('alert')).textContent).toContain(
       'could not authorize Google Drive'
+    )
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: 'error' })
+    )
+  })
+
+  it('shows an authorization failure when no access token is returned', async () => {
+    mocks.ensureAccessToken.mockResolvedValue('')
+    render(<GoogleDrivePickerButton />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose Folder' }))
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'could not authorize Google Drive'
+    )
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: 'error' })
+    )
+  })
+
+  it('shows an error when storage becomes unavailable before mounting', async () => {
+    mocks.getNotebookStore.mockReturnValue(null)
+    render(<GoogleDrivePickerButton />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose Folder' }))
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Open notebooks' })
+    )
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Select this folder' })
+    )
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'storage is not ready'
     )
     expect(mocks.showToast).toHaveBeenCalledWith(
       expect.objectContaining({ tone: 'error' })

--- a/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   getItems: vi.fn(),
   listChildren: vi.fn(),
   listRoots: vi.fn(),
+  showToast: vi.fn(),
   startGoogleDriveOAuth: vi.fn(),
   updateFolder: vi.fn(),
 }))
@@ -45,6 +46,10 @@ vi.mock('../../lib/onboarding', () => ({
   markOnboardingTaskComplete: vi.fn(),
 }))
 
+vi.mock('../../lib/toast', () => ({
+  showToast: mocks.showToast,
+}))
+
 vi.mock('./googleDriveBrowser', async () => {
   const actual = await vi.importActual<typeof import('./googleDriveBrowser')>(
     './googleDriveBrowser'
@@ -71,6 +76,7 @@ describe('GoogleDrivePickerButton', () => {
     ])
     mocks.listChildren.mockReset()
     mocks.listChildren.mockResolvedValue([])
+    mocks.showToast.mockReset()
     mocks.startGoogleDriveOAuth.mockReset()
     mocks.updateFolder.mockReset()
   })
@@ -122,9 +128,35 @@ describe('GoogleDrivePickerButton', () => {
       )
     )
     expect(mocks.addItem).toHaveBeenCalledWith('local://folder/shared-drive')
+    expect(mocks.showToast).toHaveBeenCalledWith({
+      message: 'Added "notebooks" to Explorer',
+      tone: 'success',
+    })
     expect(tourUiController.getSnapshot().googleDriveFolderAddedCount).toBe(
       initialCount + 1
     )
+  })
+
+  it('reports an already-mounted folder instead of silently closing', async () => {
+    mocks.updateFolder.mockResolvedValue('local://folder/shared-drive')
+    mocks.getItems.mockReturnValue(['local://folder/shared-drive'])
+
+    render(<GoogleDrivePickerButton />)
+    fireEvent.click(screen.getByRole('button', { name: 'Choose Folder' }))
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Open notebooks' })
+    )
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Select this folder' })
+    )
+
+    await waitFor(() =>
+      expect(mocks.showToast).toHaveBeenCalledWith({
+        message: '"notebooks" is already in Explorer',
+        tone: 'success',
+      })
+    )
+    expect(mocks.addItem).not.toHaveBeenCalled()
   })
 
   it('preserves a resource key when mounting a protected folder', async () => {
@@ -163,6 +195,9 @@ describe('GoogleDrivePickerButton', () => {
     expect((await screen.findByRole('alert')).textContent).toContain(
       'could not authorize Google Drive'
     )
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: 'error' })
+    )
   })
 
   it('shows actionable mount failures', async () => {
@@ -179,6 +214,9 @@ describe('GoogleDrivePickerButton', () => {
 
     expect((await screen.findByRole('alert')).textContent).toContain(
       'effective Drive identity can read it'
+    )
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: 'error' })
     )
   })
 })

--- a/app/src/components/Workspace/GoogleDrivePickerButton.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.tsx
@@ -43,7 +43,10 @@ export function GoogleDrivePickerButton({
             code: 'DRIVE_FOLDER_STORE_UNAVAILABLE',
           },
         })
-        setMountError('Runme storage is not ready. Reload the page and retry.')
+        const message =
+          'Runme storage is not ready. Reload the page and retry.'
+        setMountError(message)
+        showToast({ message, tone: 'error' })
         return
       }
 
@@ -88,6 +91,8 @@ export function GoogleDrivePickerButton({
         const accessToken = await ensureAccessToken({ interactive: true })
         if (accessToken) {
           setPickerAccessToken(accessToken)
+        } else {
+          throw new Error('Google Drive authorization returned no access token')
         }
       } catch (error) {
         appLogger.error('Failed to authorize Google Drive browser', {

--- a/app/src/components/Workspace/GoogleDrivePickerButton.tsx
+++ b/app/src/components/Workspace/GoogleDrivePickerButton.tsx
@@ -5,6 +5,7 @@ import { useNotebookStore } from '../../contexts/NotebookStoreContext'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { appLogger } from '../../lib/logging/runtime'
 import { markOnboardingTaskComplete } from '../../lib/onboarding'
+import { showToast } from '../../lib/toast'
 import { tourUiController } from '../../lib/tourUiController'
 import { driveFolderUrl } from '../../storage/drive'
 import { GoogleDriveResourcePickerDialog } from './GoogleDriveResourcePickerDialog'
@@ -51,11 +52,18 @@ export function GoogleDrivePickerButton({
           driveFolderUrl(folderId, resourceKey),
           folderName
         )
-        if (!getItems().includes(localUri)) {
+        const alreadyMounted = getItems().includes(localUri)
+        if (!alreadyMounted) {
           addItem(localUri)
         }
         markOnboardingTaskComplete('add-drive-folder')
         tourUiController.recordGoogleDriveFolderAdded()
+        showToast({
+          message: alreadyMounted
+            ? `"${folderName}" is already in Explorer`
+            : `Added "${folderName}" to Explorer`,
+          tone: 'success',
+        })
       } catch (error) {
         appLogger.error('Failed to mirror Drive folder', {
           attrs: {
@@ -64,9 +72,10 @@ export function GoogleDrivePickerButton({
             error: String(error),
           },
         })
-        setMountError(
+        const message =
           'Runme could not add this folder. Verify that the effective Drive identity can read it, then retry.'
-        )
+        setMountError(message)
+        showToast({ message, tone: 'error' })
       }
     },
     [addItem, getItems, store]
@@ -88,9 +97,10 @@ export function GoogleDrivePickerButton({
             error: String(error),
           },
         })
-        setMountError(
+        const message =
           'Runme could not authorize Google Drive. Check the configured credential and retry.'
-        )
+        setMountError(message)
+        showToast({ message, tone: 'error' })
       }
     })()
   }, [ensureAccessToken])

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -227,6 +227,56 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(mocks.setCurrentDoc).not.toHaveBeenCalledWith(null)
   })
 
+  it('keeps an explicitly mounted nested folder visible as a root', async () => {
+    mocks.workspaceItems = [
+      'local://folder/local',
+      'local://folder/root',
+      'local://folder/nested',
+    ]
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/local') {
+        return {
+          uri,
+          name: 'Local Notebooks',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          parents: [],
+        }
+      }
+      if (uri === 'local://folder/root') {
+        return {
+          uri,
+          name: 'Mounted root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://folder/nested'],
+          parents: [],
+        }
+      }
+      if (uri === 'local://folder/nested') {
+        return {
+          uri,
+          name: 'Nested mount',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          parents: ['local://folder/root'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Mounted root')
+    await screen.findByText('Nested mount')
+    expect(screen.getAllByText('Nested mount')).toHaveLength(1)
+
+    act(() => {
+      mocks.treeProps.onToggle('local://folder/root')
+    })
+    await screen.findByText('Mounted folders are shown as roots')
+    expect(screen.getAllByText('Nested mount')).toHaveLength(1)
+  })
+
   it('shows a directly created Drive notebook in its mounted folder', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     let blockFolderLoad = false

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -19,7 +19,7 @@ import useResizeObserver from "use-resize-observer";
 
 import { GoogleDrivePickerButton } from "./GoogleDrivePickerButton";
 import {
-  filterNestedWorkspaceFolders,
+  filterMountedWorkspaceFolderChildren,
   type WorkspaceFolderCandidate,
 } from "./workspaceTree";
 import { useWorkspace } from "../../contexts/WorkspaceContext";
@@ -459,7 +459,6 @@ export function WorkspaceExplorer() {
             folderCandidates.push({
               uri,
               name,
-              parentUris: metadata?.parents ?? [],
             });
           } catch (error) {
             console.error("Failed to load fs workspace metadata", uri, error);
@@ -503,27 +502,10 @@ export function WorkspaceExplorer() {
           uri: localUri,
           name,
           remoteUri: metadata?.remoteUri,
-          parentUris: metadata?.parents ?? [],
         });
       }
 
-      const visibleFolders = await filterNestedWorkspaceFolders(
-        folderCandidates,
-        async (parentUri) => {
-          const targetStore = storeForUri(parentUri, store, fsStore);
-          if (!targetStore) {
-            return [];
-          }
-          try {
-            const metadata = await targetStore.getMetadata(parentUri);
-            return metadata?.parents ?? [];
-          } catch {
-            return [];
-          }
-        },
-      );
-
-      const folderNodes = visibleFolders.map((folder) =>
+      const folderNodes = folderCandidates.map((folder) =>
         createFolderNode(folder.uri, folder.name, {
           remoteUri: folder.remoteUri,
         }),
@@ -808,10 +790,21 @@ export function WorkspaceExplorer() {
           }
         }
 
+        const visibleChildNodes = filterMountedWorkspaceFolderChildren(
+          childNodes,
+          new Set(workspaceUris),
+        );
         const nodes =
-          childNodes.length > 0
-            ? childNodes
-            : [createPlaceholderNode(uri, "Folder is empty")];
+          visibleChildNodes.length > 0
+            ? visibleChildNodes
+            : [
+                createPlaceholderNode(
+                  uri,
+                  childNodes.length > 0
+                    ? "Mounted folders are shown as roots"
+                    : "Folder is empty",
+                ),
+              ];
 
         setTreeNodes((prev) =>
           (folderMutationVersionsRef.current.get(uri) ?? 0) === mutationVersion
@@ -848,7 +841,7 @@ export function WorkspaceExplorer() {
         );
       }
     },
-    [fsStore, store],
+    [fsStore, store, workspaceUris],
   );
 
   const handleFileOpen = useCallback(

--- a/app/src/components/Workspace/googleDriveBrowser.test.ts
+++ b/app/src/components/Workspace/googleDriveBrowser.test.ts
@@ -275,6 +275,102 @@ describe('googleDriveBrowser', () => {
     )
   })
 
+  it('finds and prioritizes a close typo match from a bounded prefix search', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            files: [
+              {
+                id: 'renamed-folder',
+                name: 'olympus-runbooks-jlewi',
+                mimeType: 'application/vnd.google-apps.folder',
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            files: [
+              {
+                id: 'typo-folder',
+                name: 'olympus-runboooks',
+                mimeType: 'application/vnd.google-apps.folder',
+              },
+              {
+                id: 'unrelated-folder',
+                name: 'olympus-archive',
+                mimeType: 'application/vnd.google-apps.folder',
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+
+    await expect(
+      searchGoogleDriveResources(
+        'token',
+        'olympus-runbooks',
+        'folder',
+        fetchImpl
+      )
+    ).resolves.toEqual([
+      {
+        id: 'typo-folder',
+        name: 'olympus-runboooks',
+        mimeType: 'application/vnd.google-apps.folder',
+        driveId: undefined,
+      },
+      {
+        id: 'renamed-folder',
+        name: 'olympus-runbooks-jlewi',
+        mimeType: 'application/vnd.google-apps.folder',
+        driveId: undefined,
+      },
+    ])
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    const exactUrl = new URL(fetchImpl.mock.calls[0]?.[0] as string)
+    const candidateUrl = new URL(fetchImpl.mock.calls[1]?.[0] as string)
+    expect(exactUrl.searchParams.get('q')).toContain(
+      "name contains 'olympus-runbooks'"
+    )
+    expect(candidateUrl.searchParams.get('q')).toContain(
+      "name contains 'olympus'"
+    )
+  })
+
+  it('does not issue a fuzzy fallback when Drive returns an exact name', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          files: [
+            {
+              id: 'exact-folder',
+              name: 'olympus-runbooks',
+              mimeType: 'application/vnd.google-apps.folder',
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    )
+
+    await searchGoogleDriveResources(
+      'token',
+      'olympus-runbooks',
+      'folder',
+      fetchImpl
+    )
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects incomplete all-Drive search results instead of presenting them as exhaustive', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(

--- a/app/src/components/Workspace/googleDriveBrowser.test.ts
+++ b/app/src/components/Workspace/googleDriveBrowser.test.ts
@@ -188,7 +188,7 @@ describe('googleDriveBrowser', () => {
   })
 
   it('searches all visible Drives and filters folder mode server-side', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
       new Response(
         JSON.stringify({
           files: [
@@ -230,7 +230,7 @@ describe('googleDriveBrowser', () => {
   })
 
   it('keeps folder shortcuts in folder search results while filtering file targets', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
       new Response(
         JSON.stringify({
           files: [
@@ -283,6 +283,11 @@ describe('googleDriveBrowser', () => {
           JSON.stringify({
             files: [
               {
+                id: 'close-folder',
+                name: 'olympus-runbook',
+                mimeType: 'application/vnd.google-apps.folder',
+              },
+              {
                 id: 'renamed-folder',
                 name: 'olympus-runbooks-jlewi',
                 mimeType: 'application/vnd.google-apps.folder',
@@ -320,6 +325,12 @@ describe('googleDriveBrowser', () => {
         fetchImpl
       )
     ).resolves.toEqual([
+      {
+        id: 'close-folder',
+        name: 'olympus-runbook',
+        mimeType: 'application/vnd.google-apps.folder',
+        driveId: undefined,
+      },
       {
         id: 'typo-folder',
         name: 'olympus-runboooks',

--- a/app/src/components/Workspace/googleDriveBrowser.ts
+++ b/app/src/components/Workspace/googleDriveBrowser.ts
@@ -35,6 +35,9 @@ type FileListResponse = {
   nextPageToken?: string
 }
 
+const FUZZY_SEARCH_MAX_PAGES = 3
+const FUZZY_SEARCH_MIN_QUERY_LENGTH = 6
+
 /**
  * Signals that Drive returned only a partial all-Drive result set. Callers
  * must not present collected matches as exhaustive and should ask the user to
@@ -115,6 +118,66 @@ function driveApiUrl(path: string): URL {
 /** Escapes backslashes and quotes before text is embedded in a Drive query. */
 function escapeDriveQueryLiteral(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/** Normalizes names before local relevance and edit-distance comparisons. */
+function normalizeSearchName(value: string): string {
+  return value.normalize('NFKC').trim().toLocaleLowerCase()
+}
+
+/**
+ * Returns a narrow Drive-supported prefix for collecting fuzzy candidates.
+ * Drive only supports prefix matching for `name contains`, so Runme asks for
+ * a stable leading token (or half of a single token) and ranks that bounded
+ * candidate set locally.
+ */
+function fuzzyCandidatePrefix(query: string): string | null {
+  if (query.length < FUZZY_SEARCH_MIN_QUERY_LENGTH) {
+    return null
+  }
+
+  const separator = query.search(/[\s._-]/)
+  const prefixLength =
+    separator >= 3 ? separator : Math.max(3, Math.floor(query.length / 2))
+  if (prefixLength >= query.length) {
+    return null
+  }
+  return query.slice(0, prefixLength)
+}
+
+/** Calculates Levenshtein edit distance with O(min(a, b)) memory. */
+function editDistance(left: string, right: string): number {
+  if (left === right) {
+    return 0
+  }
+  if (left.length > right.length) {
+    return editDistance(right, left)
+  }
+
+  let previous = Array.from({ length: left.length + 1 }, (_, index) => index)
+  for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+    const current = [rightIndex]
+    for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+      current[leftIndex] = Math.min(
+        (current[leftIndex - 1] ?? 0) + 1,
+        (previous[leftIndex] ?? 0) + 1,
+        (previous[leftIndex - 1] ?? 0) +
+          (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1)
+      )
+    }
+    previous = current
+  }
+  return previous[left.length] ?? right.length
+}
+
+function fuzzySearchDistanceLimit(queryLength: number): number {
+  if (queryLength < FUZZY_SEARCH_MIN_QUERY_LENGTH) {
+    return 0
+  }
+  if (queryLength < 10) {
+    return 1
+  }
+  return Math.min(3, Math.ceil(queryLength * 0.12))
 }
 
 /**
@@ -268,58 +331,103 @@ export async function searchGoogleDriveResources(
     return []
   }
 
-  const resources: GoogleDriveResource[] = []
-  let incompleteSearch = false
-  let pageToken: string | undefined
-  do {
-    const url = driveApiUrl('drive/v3/files')
-    const clauses = [
-      `name contains '${escapeDriveQueryLiteral(normalizedQuery)}'`,
-      'trashed = false',
-    ]
-    if (mode === 'folder') {
-      clauses.push(
-        `(mimeType = '${GOOGLE_DRIVE_FOLDER_MIME_TYPE}' or mimeType = '${GOOGLE_DRIVE_SHORTCUT_MIME_TYPE}')`
-      )
-    }
-    url.searchParams.set('q', clauses.join(' and '))
-    url.searchParams.set('pageSize', '100')
-    url.searchParams.set(
-      'fields',
-      'nextPageToken,incompleteSearch,files(id,name,mimeType,driveId,resourceKey,shortcutDetails(targetId,targetMimeType,targetResourceKey))'
-    )
-    url.searchParams.set('spaces', 'drive')
-    url.searchParams.set('corpora', 'allDrives')
-    url.searchParams.set('supportsAllDrives', 'true')
-    url.searchParams.set('includeItemsFromAllDrives', 'true')
-    url.searchParams.set('orderBy', 'folder,name_natural')
-    if (pageToken) {
-      url.searchParams.set('pageToken', pageToken)
-    }
-
-    const page = await getJson<FileListResponse>(
-      url,
-      accessToken,
-      `search Drive for ${normalizedQuery}`,
-      fetchImpl
-    )
-    for (const file of page.files ?? []) {
-      const resource = normalizeGoogleDriveResource(file)
-      if (resource) {
-        resources.push(resource)
+  const searchPrefix = async (
+    prefix: string,
+    maxPages = Number.POSITIVE_INFINITY
+  ): Promise<GoogleDriveResource[]> => {
+    const matches: GoogleDriveResource[] = []
+    let pageCount = 0
+    let pageToken: string | undefined
+    do {
+      const url = driveApiUrl('drive/v3/files')
+      const clauses = [
+        `name contains '${escapeDriveQueryLiteral(prefix)}'`,
+        'trashed = false',
+      ]
+      if (mode === 'folder') {
+        clauses.push(
+          `(mimeType = '${GOOGLE_DRIVE_FOLDER_MIME_TYPE}' or mimeType = '${GOOGLE_DRIVE_SHORTCUT_MIME_TYPE}')`
+        )
       }
-    }
-    incompleteSearch ||= page.incompleteSearch === true
-    pageToken = page.nextPageToken
-  } while (pageToken)
+      url.searchParams.set('q', clauses.join(' and '))
+      url.searchParams.set('pageSize', '100')
+      url.searchParams.set(
+        'fields',
+        'nextPageToken,incompleteSearch,files(id,name,mimeType,driveId,resourceKey,shortcutDetails(targetId,targetMimeType,targetResourceKey))'
+      )
+      url.searchParams.set('spaces', 'drive')
+      url.searchParams.set('corpora', 'allDrives')
+      url.searchParams.set('supportsAllDrives', 'true')
+      url.searchParams.set('includeItemsFromAllDrives', 'true')
+      url.searchParams.set('orderBy', 'folder,name_natural')
+      if (pageToken) {
+        url.searchParams.set('pageToken', pageToken)
+      }
 
-  if (incompleteSearch) {
-    throw new IncompleteGoogleDriveSearchError()
+      const page = await getJson<FileListResponse>(
+        url,
+        accessToken,
+        `search Drive for ${normalizedQuery}`,
+        fetchImpl
+      )
+      if (page.incompleteSearch === true) {
+        throw new IncompleteGoogleDriveSearchError()
+      }
+      for (const file of page.files ?? []) {
+        const resource = normalizeGoogleDriveResource(file)
+        if (resource) {
+          matches.push(resource)
+        }
+      }
+      pageToken = page.nextPageToken
+      pageCount += 1
+    } while (pageToken && pageCount < maxPages)
+
+    return mode === 'folder'
+      ? matches.filter(
+          (resource) => resource.mimeType === GOOGLE_DRIVE_FOLDER_MIME_TYPE
+        )
+      : matches
   }
 
-  return mode === 'folder'
-    ? resources.filter(
-        (resource) => resource.mimeType === GOOGLE_DRIVE_FOLDER_MIME_TYPE
-      )
-    : resources
+  const resources = await searchPrefix(normalizedQuery)
+  const comparableQuery = normalizeSearchName(normalizedQuery)
+  const distanceLimit = fuzzySearchDistanceLimit(comparableQuery.length)
+  if (
+    resources.some(
+      (resource) =>
+        editDistance(comparableQuery, normalizeSearchName(resource.name)) <=
+        distanceLimit
+    )
+  ) {
+    return resources
+  }
+
+  const candidatePrefix = fuzzyCandidatePrefix(normalizedQuery)
+  if (!candidatePrefix) {
+    return resources
+  }
+
+  const fuzzyMatches = (
+    await searchPrefix(candidatePrefix, FUZZY_SEARCH_MAX_PAGES)
+  ).filter(
+    (resource) =>
+      editDistance(comparableQuery, normalizeSearchName(resource.name)) <=
+      distanceLimit
+  )
+  const combined = new Map(
+    [...resources, ...fuzzyMatches].map((resource) => [resource.id, resource])
+  )
+
+  return [...combined.values()].sort((left, right) => {
+    const leftDistance = editDistance(
+      comparableQuery,
+      normalizeSearchName(left.name)
+    )
+    const rightDistance = editDistance(
+      comparableQuery,
+      normalizeSearchName(right.name)
+    )
+    return leftDistance - rightDistance || left.name.localeCompare(right.name)
+  })
 }

--- a/app/src/components/Workspace/googleDriveBrowser.ts
+++ b/app/src/components/Workspace/googleDriveBrowser.ts
@@ -396,8 +396,7 @@ export async function searchGoogleDriveResources(
   if (
     resources.some(
       (resource) =>
-        editDistance(comparableQuery, normalizeSearchName(resource.name)) <=
-        distanceLimit
+        normalizeSearchName(resource.name) === comparableQuery
     )
   ) {
     return resources

--- a/app/src/components/Workspace/workspaceTree.test.ts
+++ b/app/src/components/Workspace/workspaceTree.test.ts
@@ -1,68 +1,46 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  type WorkspaceFolderCandidate,
-  filterNestedWorkspaceFolders,
-} from "./workspaceTree";
+import { NotebookStoreItemType } from "../../storage/notebook";
+import { filterMountedWorkspaceFolderChildren } from "./workspaceTree";
 
-function candidate(
-  uri: string,
-  parentUris: string[] = [],
-): WorkspaceFolderCandidate {
-  return {
-    uri,
-    name: uri,
-    parentUris,
-  };
-}
-
-describe("filterNestedWorkspaceFolders", () => {
-  it("keeps only the mounted ancestor when nested folders are also mounted", async () => {
-    const folders = [
-      candidate("local://folder/root"),
-      candidate("local://folder/root/child", ["local://folder/root"]),
-      candidate("local://folder/root/child/grandchild", [
-        "local://folder/root/child",
-      ]),
-      candidate("local://folder/other"),
+describe("filterMountedWorkspaceFolderChildren", () => {
+  it("omits folders that are also explicit workspace roots", () => {
+    const children = [
+      {
+        uri: "local://folder/nested",
+        type: NotebookStoreItemType.Folder,
+      },
+      {
+        uri: "local://folder/ordinary",
+        type: NotebookStoreItemType.Folder,
+      },
+      {
+        uri: "local://file/notebook",
+        type: NotebookStoreItemType.File,
+      },
     ];
+    const mountedUris = new Set(["local://folder/nested"]);
 
-    const visible = await filterNestedWorkspaceFolders(folders, async () => []);
-
-    expect(visible.map((folder) => folder.uri)).toEqual([
-      "local://folder/root",
-      "local://folder/other",
-    ]);
+    expect(
+      filterMountedWorkspaceFolderChildren(children, mountedUris).map(
+        (child) => child.uri
+      )
+    ).toEqual(["local://folder/ordinary", "local://file/notebook"]);
   });
 
-  it("walks parent metadata to find non-immediate mounted ancestors", async () => {
-    const folders = [
-      candidate("local://folder/root"),
-      candidate("local://folder/root/child/grandchild", [
-        "local://folder/root/child",
-      ]),
-    ];
-    const parents = new Map([
-      ["local://folder/root/child", ["local://folder/root"]],
-    ]);
-
-    const visible = await filterNestedWorkspaceFolders(
-      folders,
-      async (uri) => parents.get(uri) ?? [],
-    );
-
-    expect(visible.map((folder) => folder.uri)).toEqual(["local://folder/root"]);
-  });
-
-  it("does not hide a workspace root that reports itself as its parent", async () => {
-    const folders = [
-      candidate("fs://workspace/demo/dir/", ["fs://workspace/demo/dir/"]),
+  it("does not hide a file whose URI is registered directly", () => {
+    const children = [
+      {
+        uri: "local://file/notebook",
+        type: NotebookStoreItemType.File,
+      },
     ];
 
-    const visible = await filterNestedWorkspaceFolders(folders, async () => []);
-
-    expect(visible.map((folder) => folder.uri)).toEqual([
-      "fs://workspace/demo/dir/",
-    ]);
+    expect(
+      filterMountedWorkspaceFolderChildren(
+        children,
+        new Set(["local://file/notebook"])
+      )
+    ).toEqual(children);
   });
 });

--- a/app/src/components/Workspace/workspaceTree.ts
+++ b/app/src/components/Workspace/workspaceTree.ts
@@ -1,62 +1,26 @@
+import { NotebookStoreItemType } from "../../storage/notebook";
+
 export interface WorkspaceFolderCandidate {
   uri: string;
   name: string;
   remoteUri?: string;
-  parentUris: string[];
 }
 
-type ParentLoader = (uri: string) => Promise<string[]>;
-
-async function hasMountedAncestor(
-  uri: string,
-  parentUris: string[],
-  mountedUris: Set<string>,
-  loadParents: ParentLoader,
-  seen: Set<string>,
-): Promise<boolean> {
-  for (const parentUri of parentUris) {
-    if (!parentUri || parentUri === uri || seen.has(parentUri)) {
-      continue;
-    }
-    if (mountedUris.has(parentUri)) {
-      return true;
-    }
-    seen.add(parentUri);
-
-    const nextParents = await loadParents(parentUri);
-    if (
-      await hasMountedAncestor(uri, nextParents, mountedUris, loadParents, seen)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
+export type WorkspaceTreeChild = {
+  uri: string;
+  type: NotebookStoreItemType | "placeholder";
+};
 
 /**
- * Keep the workspace tree a tree, not a DAG. react-arborist requires stable
- * unique ids for every rendered node; if a nested folder is rendered both as a
- * root and as a child, the virtualized row geometry can become inconsistent.
+ * Explicitly mounted folders remain visible as roots. Remove their duplicate
+ * child edge from an ancestor so react-arborist still receives unique ids and
+ * the workspace remains a tree rather than a DAG.
  */
-export async function filterNestedWorkspaceFolders(
-  candidates: WorkspaceFolderCandidate[],
-  loadParents: ParentLoader,
-): Promise<WorkspaceFolderCandidate[]> {
-  const mountedUris = new Set(candidates.map((candidate) => candidate.uri));
-  const visible: WorkspaceFolderCandidate[] = [];
-
-  for (const candidate of candidates) {
-    const nested = await hasMountedAncestor(
-      candidate.uri,
-      candidate.parentUris,
-      mountedUris,
-      loadParents,
-      new Set<string>(),
-    );
-    if (!nested) {
-      visible.push(candidate);
-    }
-  }
-
-  return visible;
+export function filterMountedWorkspaceFolderChildren<
+  T extends WorkspaceTreeChild,
+>(children: T[], mountedUris: ReadonlySet<string>): T[] {
+  return children.filter(
+    (child) =>
+      child.type !== NotebookStoreItemType.Folder || !mountedUris.has(child.uri)
+  );
 }


### PR DESCRIPTION
## Summary

- keep every explicitly mounted Drive folder visible as an Explorer root, including a folder nested beneath another mounted root
- remove the nested folder's duplicate child edge so the Explorer remains a tree with unique node IDs
- show explicit success, already-mounted, authorization-failure, and mount-failure notifications
- add typo-tolerant Drive search for cases such as `olympus-runbooks` versus `olympus-runboooks`

## Fuzzy search behavior

Google Drive `name contains` only supports prefix matching. Runme keeps that native query as the first pass. When it does not return an already-close name, Runme performs a bounded prefix query (at most three pages), filters candidates by edit distance, removes duplicates, and ranks close names ahead of longer prefix matches. The picker still requires the user to select a result; it never guesses or mounts automatically.

Google API behavior: https://developers.google.com/workspace/drive/api/guides/ref-search-terms

## Verification

- `pnpm -C app exec vitest run src/components/Workspace/WorkspaceExplorer.test.tsx src/components/Workspace/googleDriveBrowser.test.ts src/components/Workspace/GoogleDrivePickerButton.test.tsx src/components/Workspace/workspaceTree.test.ts` (31 tests)
- `runme run build test`
