### PR TITLE
Fix Drive-backed explorer rename authorization

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   showDocument: vi.fn(),
   addItem: vi.fn(),
   removeItem: vi.fn(),
+  ensureAccessToken: vi.fn(),
   store: {
     getMetadata: vi.fn(),
     create: vi.fn(),
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => ({
     createFolder: vi.fn(),
     move: vi.fn(),
     moveToTrash: vi.fn(),
+    rename: vi.fn(),
     sync: vi.fn(),
   },
   openNotebookUpstreamDiff: vi.fn(),
@@ -104,7 +106,7 @@ vi.mock('../../contexts/FilesystemStoreContext', () => ({
 
 vi.mock('../../contexts/GoogleAuthContext', () => ({
   useGoogleAuth: () => ({
-    ensureAccessToken: vi.fn(),
+    ensureAccessToken: mocks.ensureAccessToken,
   }),
 }))
 
@@ -161,6 +163,8 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.showDocument.mockReset()
     mocks.addItem.mockReset()
     mocks.removeItem.mockReset()
+    mocks.ensureAccessToken.mockReset()
+    mocks.ensureAccessToken.mockResolvedValue('access-token')
     mocks.workspaceItems = []
     mocks.store.getMetadata.mockReset()
     mocks.store.getMetadata.mockResolvedValue({
@@ -203,6 +207,14 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.store.moveToTrash.mockResolvedValue(undefined)
     mocks.store.move.mockReset()
     mocks.store.move.mockResolvedValue(undefined)
+    mocks.store.rename.mockReset()
+    mocks.store.rename.mockResolvedValue({
+      uri: 'local://file/renamed',
+      name: 'renamed.json',
+      type: NotebookStoreItemType.File,
+      children: [],
+      parents: [],
+    })
     mocks.store.sync.mockReset()
     mocks.openNotebookUpstreamDiff.mockReset()
     mocks.dragHandle.mockReset()
@@ -542,6 +554,102 @@ describe('WorkspaceExplorer current document handling', () => {
     await waitFor(() => {
       expect(mocks.treeEdit).toHaveBeenCalledWith('local://folder/drive')
     })
+  })
+
+  it('authorizes interactively before renaming a Drive-backed notebook', async () => {
+    mocks.currentDoc = 'local://file/current'
+    mocks.isDriveItemUri.mockReturnValue(true)
+
+    render(<WorkspaceExplorer />)
+
+    await waitFor(() => expect(mocks.treeProps).toBeTruthy())
+    await act(async () => {
+      await mocks.treeProps.onRename({
+        id: 'local://file/drive',
+        name: 'renamed.json',
+        node: {
+          data: {
+            uri: 'local://file/drive',
+            name: 'original.json',
+            type: NotebookStoreItemType.File,
+            remoteUri: 'https://drive.google.com/file/d/file123/view',
+          },
+          parent: null,
+          reset: vi.fn(),
+        },
+      })
+    })
+
+    expect(mocks.ensureAccessToken).toHaveBeenCalledWith({ interactive: true })
+    expect(mocks.store.rename).toHaveBeenCalledWith(
+      'local://file/drive',
+      'renamed.json'
+    )
+  })
+
+  it('surfaces Drive authorization errors instead of silently resetting rename', async () => {
+    const authorizationError =
+      'Google Drive service-account authorization is required.'
+    mocks.currentDoc = 'local://file/current'
+    mocks.isDriveItemUri.mockReturnValue(true)
+    mocks.ensureAccessToken.mockRejectedValueOnce(new Error(authorizationError))
+    const reset = vi.fn()
+
+    render(<WorkspaceExplorer />)
+
+    await waitFor(() => expect(mocks.treeProps).toBeTruthy())
+    await act(async () => {
+      await mocks.treeProps.onRename({
+        id: 'local://file/drive',
+        name: 'renamed.json',
+        node: {
+          data: {
+            uri: 'local://file/drive',
+            name: 'original.json',
+            type: NotebookStoreItemType.File,
+            remoteUri: 'https://drive.google.com/file/d/file123/view',
+          },
+          parent: null,
+          reset,
+        },
+      })
+    })
+
+    expect(mocks.store.rename).not.toHaveBeenCalled()
+    expect(reset).toHaveBeenCalled()
+    expect(
+      await screen.findByText(
+        `${authorizationError} Complete Google Drive authorization, then retry the rename.`
+      )
+    ).toBeTruthy()
+  })
+
+  it('renames a local notebook without requesting Drive authorization', async () => {
+    mocks.currentDoc = 'local://file/current'
+    render(<WorkspaceExplorer />)
+
+    await waitFor(() => expect(mocks.treeProps).toBeTruthy())
+    await act(async () => {
+      await mocks.treeProps.onRename({
+        id: 'local://file/local',
+        name: 'renamed.json',
+        node: {
+          data: {
+            uri: 'local://file/local',
+            name: 'original.json',
+            type: NotebookStoreItemType.File,
+          },
+          parent: null,
+          reset: vi.fn(),
+        },
+      })
+    })
+
+    expect(mocks.ensureAccessToken).not.toHaveBeenCalled()
+    expect(mocks.store.rename).toHaveBeenCalledWith(
+      'local://file/local',
+      'renamed.json'
+    )
   })
 
   it('creates an Excalidraw diagram through the local mirror before Drive sync', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -624,6 +624,39 @@ describe('WorkspaceExplorer current document handling', () => {
     ).toBeTruthy()
   })
 
+  it('validates a Drive rename before requesting authorization', async () => {
+    mocks.currentDoc = 'local://file/current'
+    mocks.isDriveItemUri.mockReturnValue(true)
+
+    render(<WorkspaceExplorer />)
+
+    await waitFor(() => expect(mocks.treeProps).toBeTruthy())
+    await act(async () => {
+      await mocks.treeProps.onRename({
+        id: 'local://file/drive',
+        name: 'renamed.ipynb',
+        node: {
+          data: {
+            uri: 'local://file/drive',
+            name: 'original.json',
+            type: NotebookStoreItemType.File,
+            remoteUri: 'https://drive.google.com/file/d/file123/view',
+          },
+          parent: null,
+          reset: vi.fn(),
+        },
+      })
+    })
+
+    expect(mocks.ensureAccessToken).not.toHaveBeenCalled()
+    expect(mocks.store.rename).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText(
+        'Changing notebook formats by rename is not supported. Use Save as instead.'
+      )
+    ).toBeTruthy()
+  })
+
   it('renames a local notebook without requesting Drive authorization', async () => {
     mocks.currentDoc = 'local://file/current'
     render(<WorkspaceExplorer />)

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -104,6 +104,12 @@ function driveCreateErrorMessage(error: unknown, fallback: string): string {
     : fallback;
 }
 
+/**
+ * Preserves actionable authorization and filename-validation errors while
+ * hiding unexpected storage failures behind a stable user-facing fallback.
+ * The recognized prefixes mirror upstream error contracts, so wording changes
+ * there must update this mapping and its tests together.
+ */
 function renameErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message.trim() : "";
   if (

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -103,6 +103,25 @@ function driveCreateErrorMessage(error: unknown, fallback: string): string {
     : fallback;
 }
 
+function renameErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message.trim() : "";
+  if (
+    message.startsWith("Google Drive authorization is required") ||
+    message.startsWith("Google Drive service-account authorization is required") ||
+    message.startsWith("Google service-account authorization opened in a new tab") ||
+    message.startsWith("Redirecting to Google OAuth for Drive authorization")
+  ) {
+    return `${message} Complete Google Drive authorization, then retry the rename.`;
+  }
+  if (
+    message.startsWith("Changing notebook formats by rename") ||
+    message.startsWith("Unsupported notebook file extension")
+  ) {
+    return message;
+  }
+  return "Unable to rename item. Please try again.";
+}
+
 function createFolderNode(
   uri: string,
   name: string,
@@ -1194,6 +1213,9 @@ function formatShortTimestamp(date: Date): string {
             : "untitled.json"
           : trimmed;
       try {
+        if (target.remoteUri && isDriveItemUri(target.remoteUri)) {
+          await ensureAccessToken({ interactive: true });
+        }
         await targetStore.rename(target.uri, nextName);
         const parentUri = node.parent?.data.uri;
         if (parentUri) {
@@ -1206,12 +1228,22 @@ function formatShortTimestamp(date: Date): string {
         setErrorMessage(null);
         setPendingEditId(null);
       } catch (error) {
-        console.error("Failed to rename workspace item", error);
-        setErrorMessage("Unable to rename item. Please try again.");
+        const message = renameErrorMessage(error);
+        appLogger.error("Failed to rename workspace item", {
+          attrs: {
+            scope: "storage.rename",
+            code: "EXPLORER_RENAME_FAILED",
+            uri: target.uri,
+            remoteUri: target.remoteUri,
+            error: String(error),
+          },
+        });
+        setErrorMessage(message);
+        showToast({ message, tone: "error" });
         node.reset();
       }
     },
-    [fetchChildren, fsStore, store],
+    [ensureAccessToken, fetchChildren, fsStore, store],
   );
 
   const handleMove = useCallback(

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -29,6 +29,7 @@ import { appLogger } from "../../lib/logging/runtime";
 import {
   type NotebookFileFormat,
   isNotebookFileName,
+  validateNotebookRenameFormat,
 } from '../../lib/notebookFormat'
 import {
   copyNotebookMarkdownLink,
@@ -1213,6 +1214,9 @@ function formatShortTimestamp(date: Date): string {
             : "untitled.json"
           : trimmed;
       try {
+        if (target.type === NotebookStoreItemType.File) {
+          validateNotebookRenameFormat(target.name, nextName);
+        }
         if (target.remoteUri && isDriveItemUri(target.remoteUri)) {
           await ensureAccessToken({ interactive: true });
         }

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -35,6 +35,30 @@ export function detectNotebookFileFormat(
   return null
 }
 
+export function validateNotebookRenameFormat(
+  currentName: string,
+  nextName: string
+): void {
+  const currentFormat = detectNotebookFileFormat(currentName)
+  const requestedFormat = detectNotebookFileFormat(nextName)
+  if (
+    currentFormat &&
+    requestedFormat &&
+    currentFormat !== requestedFormat
+  ) {
+    throw new Error(
+      'Changing notebook formats by rename is not supported. Use Save as instead.'
+    )
+  }
+  if (
+    currentFormat &&
+    !requestedFormat &&
+    /\.[^/]+$/.test(nextName.trim())
+  ) {
+    throw new Error(`Unsupported notebook file extension: ${nextName}`)
+  }
+}
+
 export function isNotebookFileName(fileName: string): boolean {
   return detectNotebookFileFormat(fileName) !== null
 }

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -35,6 +35,11 @@ export function detectNotebookFileFormat(
   return null
 }
 
+/**
+ * Rejects rename requests that change notebook format or use an unsupported
+ * extension. Extensionless names remain valid so each storage implementation
+ * can normalize them by appending the current notebook's extension.
+ */
 export function validateNotebookRenameFormat(
   currentName: string,
   nextName: string

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -9,6 +9,7 @@ import {
   encodeIpynbNotebook,
   encodeRunmeNotebook,
   isNotebookFileName,
+  validateNotebookRenameFormat,
 } from '../lib/notebookFormat'
 import { parser_pb } from '../runme/client'
 import { FsDatabase, WorkspaceRecord } from './fsdb'
@@ -146,17 +147,10 @@ function notebookNameForRename(oldName: string, name: string): string {
     throw new Error(`Unsupported notebook file extension: ${oldName}`)
   }
   const trimmed = name.trim()
+  validateNotebookRenameFormat(oldName, trimmed)
   const nextFormat = detectNotebookFileFormat(trimmed)
-  if (nextFormat && nextFormat !== oldFormat) {
-    throw new Error(
-      'Changing notebook formats by rename is not supported. Use Save as instead.'
-    )
-  }
   if (nextFormat) {
     return trimmed
-  }
-  if (/\.[^/]+$/.test(trimmed)) {
-    throw new Error(`Unsupported notebook file extension: ${name}`)
   }
   return `${trimmed}${oldFormat === 'ipynb' ? '.ipynb' : '.json'}`
 }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -14,6 +14,7 @@ import {
   detectNotebookFileFormat,
   encodeIpynbNotebook,
   isNotebookFileName,
+  validateNotebookRenameFormat,
 } from '../lib/notebookFormat'
 import { appState } from '../lib/runtime/AppState'
 import { parser_pb } from '../runme/client'
@@ -1951,14 +1952,7 @@ export class LocalNotebooks extends Dexie {
 
     const currentFormat = detectNotebookFileFormat(record.name)
     const requestedFormat = detectNotebookFileFormat(name)
-    if (currentFormat && requestedFormat && currentFormat !== requestedFormat) {
-      throw new Error(
-        'Changing notebook formats by rename is not supported. Use Save as instead.'
-      )
-    }
-    if (currentFormat && !requestedFormat && /\.[^/]+$/.test(name.trim())) {
-      throw new Error(`Unsupported notebook file extension: ${name}`)
-    }
+    validateNotebookRenameFormat(record.name, name)
     let nextName =
       currentFormat && !requestedFormat
         ? `${name.trim()}${currentFormat === 'ipynb' ? '.ipynb' : '.json'}`


### PR DESCRIPTION
## Summary

- request interactive Google Drive authorization before renaming Drive-backed Explorer items
- keep local notebook renames independent of Drive auth
- surface actionable authorization errors and emit structured rename logs
- validate notebook format changes before starting authorization
- add regression tests for Drive success, Drive auth failure, invalid Drive rename, and local rename

## Root cause

PR #326 made DriveNotebookStore.getFilesClient request tokens non-interactively. PR #332 then added scoped service-account authorization, which correctly rejects missing or expired cached tokens during non-interactive requests. Explorer rename did not perform an interactive preflight, and its catch handler replaced the real authorization error with a generic message.

## Review follow-up

The review correctly noted that validation must precede authorization. Rename-format validation is now shared by the Explorer, local store, and filesystem store, and a regression test confirms invalid Drive renames do not start OAuth.

## Verification

- pnpm -C app test --run src/components/Workspace/WorkspaceExplorer.test.tsx src/storage/fs.test.ts src/storage/local.test.ts (133 passed)
- pnpm -C app test --run (104 files, 1004 tests passed)
- runme run build test (passed)