### PR TITLE
Preserve Drive identity during Explorer rename

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -633,7 +633,8 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(mocks.ensureAccessToken).toHaveBeenCalledWith({ interactive: true })
     expect(mocks.store.rename).toHaveBeenCalledWith(
       'local://file/drive',
-      'renamed.json'
+      'renamed.json',
+      'https://drive.google.com/file/d/file123/view'
     )
   })
 

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -1219,7 +1219,18 @@ function formatShortTimestamp(date: Date): string {
         if (target.remoteUri && isDriveItemUri(target.remoteUri)) {
           await ensureAccessToken({ interactive: true });
         }
-        await targetStore.rename(target.uri, nextName);
+        if (
+          targetStore === store &&
+          target.remoteUri &&
+          isDriveItemUri(target.remoteUri)
+        ) {
+          // The Explorer already has the resolved upstream identity. Pass it
+          // through so a stale local mirror cannot silently downgrade a Drive
+          // rename into a local-only metadata update.
+          await store.rename(target.uri, nextName, target.remoteUri);
+        } else {
+          await targetStore.rename(target.uri, nextName);
+        }
         const parentUri = node.parent?.data.uri;
         if (parentUri) {
           await fetchChildren(parentUri);

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -2088,6 +2088,46 @@ describe('LocalNotebooks rename', () => {
     )
   })
 
+  it('uses a resolved Drive URI when the local mirror upstream metadata is stale', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const driveStore = {
+      rename: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'renamed.json',
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri,
+        parents: [],
+      })),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/drive',
+      name: 'original.json',
+      remoteId: '',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    const result = await store.rename(
+      'local://file/drive',
+      'renamed.json',
+      remoteUri
+    )
+
+    expect(driveStore.rename).toHaveBeenCalledWith(remoteUri, 'renamed.json')
+    expect(result).toMatchObject({
+      uri: 'local://file/drive',
+      name: 'renamed.json',
+      remoteUri,
+    })
+    expect((await store.files.get('local://file/drive'))?.remoteId).toBe(
+      remoteUri
+    )
+  })
+
   it('renames Drive-backed folders upstream before updating the local mirror', async () => {
     const remoteUri = 'https://drive.google.com/drive/folders/folder123'
     const renamedRemoteUri = 'https://drive.google.com/drive/folders/folder123'

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1887,7 +1887,19 @@ export class LocalNotebooks extends Dexie {
     }
   }
 
-  async rename(uri: string, name: string): Promise<NotebookStoreItem> {
+  /**
+   * Rename a local mirror and, when known, its upstream Drive item first.
+   *
+   * `remoteUriOverride` lets callers that already resolved the visible Drive
+   * item preserve that upstream identity when an older or partially repaired
+   * local mirror has stale `remoteId` metadata. The override is accepted only
+   * for a canonical Drive item URI; local-only renames remain local-only.
+   */
+  async rename(
+    uri: string,
+    name: string,
+    remoteUriOverride?: string
+  ): Promise<NotebookStoreItem> {
     if (uri.startsWith('local://folder/')) {
       const record = await this.folders.get(uri)
       if (!record) {
@@ -1897,8 +1909,14 @@ export class LocalNotebooks extends Dexie {
       let nextName = name
       let nextRemoteId = record.remoteId
 
-      if (isDriveUri(record.remoteId)) {
-        const remoteItem = await this.driveStore.rename(record.remoteId, name)
+      const remoteUri = isDriveUri(remoteUriOverride)
+        ? remoteUriOverride
+        : isDriveUri(record.remoteId)
+          ? record.remoteId
+          : undefined
+
+      if (remoteUri) {
+        const remoteItem = await this.driveStore.rename(remoteUri, name)
         nextName = remoteItem.name || name
         nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId
       }
@@ -1959,8 +1977,14 @@ export class LocalNotebooks extends Dexie {
         : name
     let nextRemoteId = record.remoteId
 
-    if (isDriveUri(record.remoteId)) {
-      const remoteItem = await this.driveStore.rename(record.remoteId, nextName)
+    const remoteUri = isDriveUri(remoteUriOverride)
+      ? remoteUriOverride
+      : isDriveUri(record.remoteId)
+        ? record.remoteId
+        : undefined
+
+    if (remoteUri) {
+      const remoteItem = await this.driveStore.rename(remoteUri, nextName)
       nextName = remoteItem.name || nextName
       nextRemoteId = remoteItem.remoteUri ?? remoteItem.uri ?? record.remoteId
     }


### PR DESCRIPTION
## Summary

- pass the Explorer-resolved Drive URI through the local mirror rename path
- prevent stale mirror metadata from silently downgrading a Drive rename to a local-only update
- heal the mirror remote URI from the successful upstream rename

This is a production-verification follow-up to #339. The authorization/error-surfacing fix deployed correctly, but a valid rename returned without updating Drive when the local mirror did not dispatch upstream. A direct Drive metadata write using the same authenticated session succeeded, isolating the remaining problem to local-mirror routing.

## Verification

- `pnpm -C app test --run src/components/Workspace/WorkspaceExplorer.test.tsx src/storage/local.test.ts` (71 tests)
- `pnpm -C app test --run` (104 files, 1010 tests)
- `runme run build test`
- production direct Drive rename/restore probe succeeded; temporary probe cell removed
