### PR TITLE
Instrument Explorer Drive rename dispatch

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -1219,6 +1219,7 @@ function formatShortTimestamp(date: Date): string {
         if (target.remoteUri && isDriveItemUri(target.remoteUri)) {
           await ensureAccessToken({ interactive: true });
         }
+        let renamedItem: NotebookStoreItem;
         if (
           targetStore === store &&
           target.remoteUri &&
@@ -1227,10 +1228,25 @@ function formatShortTimestamp(date: Date): string {
           // The Explorer already has the resolved upstream identity. Pass it
           // through so a stale local mirror cannot silently downgrade a Drive
           // rename into a local-only metadata update.
-          await store.rename(target.uri, nextName, target.remoteUri);
+          renamedItem = await store.rename(
+            target.uri,
+            nextName,
+            target.remoteUri,
+          );
         } else {
-          await targetStore.rename(target.uri, nextName);
+          renamedItem = await targetStore.rename(target.uri, nextName);
         }
+        appLogger.info("Renamed workspace item", {
+          attrs: {
+            scope: "storage.rename",
+            code: "EXPLORER_RENAME_SUCCEEDED",
+            uri: target.uri,
+            remoteUri: target.remoteUri,
+            requestedName: nextName,
+            renamedName: renamedItem.name,
+            renamedRemoteUri: renamedItem.remoteUri,
+          },
+        });
         const parentUri = node.parent?.data.uri;
         if (parentUri) {
           await fetchChildren(parentUri);

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -3,6 +3,7 @@ import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 import { getGoogleDriveBaseUrl } from '../lib/googleDriveRuntime'
 import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { LinkedResourceError } from '../lib/linkedResource'
+import { appLogger } from '../lib/logging/runtime'
 import {
   createInitialNotebookFile,
   detectNotebookFileFormat,
@@ -3070,10 +3071,31 @@ export class DriveNotebookStore {
       throw new Error('DriveNotebookStore.rename expects a file or folder URI')
     }
     const client = await this.getFilesClient()
+    appLogger.info('Dispatching Drive rename', {
+      attrs: {
+        scope: 'storage.rename',
+        code: 'DRIVE_RENAME_REQUESTED',
+        uri,
+        fileId: id,
+        requestedName: name,
+        itemType: type,
+      },
+    })
     const file = await client.update({
       id,
       name,
       resourceKey,
+    })
+    appLogger.info('Drive rename completed', {
+      attrs: {
+        scope: 'storage.rename',
+        code: 'DRIVE_RENAME_COMPLETED',
+        uri,
+        fileId: file.id ?? id,
+        requestedName: name,
+        returnedName: file.name,
+        returnedMimeType: file.mimeType,
+      },
     })
 
     const fileId = file.id ?? id

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1915,6 +1915,17 @@ export class LocalNotebooks extends Dexie {
           ? record.remoteId
           : undefined
 
+      appLogger.info('Resolved folder rename destination', {
+        attrs: {
+          scope: 'storage.rename',
+          code: 'LOCAL_FOLDER_RENAME_DESTINATION_RESOLVED',
+          uri,
+          recordRemoteUri: record.remoteId,
+          remoteUriOverride,
+          remoteUri,
+        },
+      })
+
       if (remoteUri) {
         const remoteItem = await this.driveStore.rename(remoteUri, name)
         nextName = remoteItem.name || name
@@ -1982,6 +1993,18 @@ export class LocalNotebooks extends Dexie {
       : isDriveUri(record.remoteId)
         ? record.remoteId
         : undefined
+
+    appLogger.info('Resolved notebook rename destination', {
+      attrs: {
+        scope: 'storage.rename',
+        code: 'LOCAL_FILE_RENAME_DESTINATION_RESOLVED',
+        uri,
+        recordRemoteUri: record.remoteId,
+        remoteUriOverride,
+        remoteUri,
+        requestedName: nextName,
+      },
+    })
 
     if (remoteUri) {
       const remoteItem = await this.driveStore.rename(remoteUri, nextName)


### PR DESCRIPTION
## Summary

- log the resolved local-mirror rename destination
- log Drive rename request and response metadata
- log the Explorer rename result

This is a narrow production diagnostic follow-up to #339 and #340. Production is running #340, authentication succeeds, and the Explorer handler runs, but a valid rename still does not update Drive. These events identify whether the request stops at the Explorer, local mirror, or Drive boundary.

## Verification

- pnpm -C app test --run src/components/Workspace/WorkspaceExplorer.test.tsx src/storage/local.test.ts src/storage/drive.test.ts (111 tests)
- pnpm -C app test --run (104 files, 1,010 tests)
- runme run build test