### PR TITLE
Fix Google Drive metadata renames

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -675,6 +675,38 @@ describe('WorkspaceExplorer current document handling', () => {
     ).toBeTruthy()
   })
 
+  it('surfaces a Drive rename response that did not apply the requested name', async () => {
+    const renameError =
+      'Google Drive returned success without applying the requested rename to "renamed.json".'
+    mocks.currentDoc = 'local://file/current'
+    mocks.isDriveItemUri.mockReturnValue(true)
+    mocks.store.rename.mockRejectedValueOnce(new Error(renameError))
+    const reset = vi.fn()
+
+    render(<WorkspaceExplorer />)
+
+    await waitFor(() => expect(mocks.treeProps).toBeTruthy())
+    await act(async () => {
+      await mocks.treeProps.onRename({
+        id: 'local://file/drive',
+        name: 'renamed.json',
+        node: {
+          data: {
+            uri: 'local://file/drive',
+            name: 'original.json',
+            type: NotebookStoreItemType.File,
+            remoteUri: 'https://drive.google.com/file/d/file123/view',
+          },
+          parent: null,
+          reset,
+        },
+      })
+    })
+
+    expect(reset).toHaveBeenCalled()
+    expect(await screen.findByText(renameError)).toBeTruthy()
+  })
+
   it('validates a Drive rename before requesting authorization', async () => {
     mocks.currentDoc = 'local://file/current'
     mocks.isDriveItemUri.mockReturnValue(true)

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -122,7 +122,8 @@ function renameErrorMessage(error: unknown): string {
   }
   if (
     message.startsWith("Changing notebook formats by rename") ||
-    message.startsWith("Unsupported notebook file extension")
+    message.startsWith("Unsupported notebook file extension") ||
+    message.startsWith("Google Drive returned success without applying")
   ) {
     return message;
   }

--- a/app/src/storage/drive.gapi.test.ts
+++ b/app/src/storage/drive.gapi.test.ts
@@ -12,7 +12,107 @@ afterEach(() => {
   window.gapi = originalGapi
 })
 
-describe('GAPI Drive media downloads', () => {
+/** Installs an authenticated mock GAPI Drive client for one browser test. */
+function installGapi(filesUpdate = vi.fn()) {
+  window.gapi = {
+    load: (_name, options) => options.callback(),
+    client: {
+      load: vi.fn().mockResolvedValue(undefined),
+      setToken: vi.fn(),
+      getToken: () => ({ access_token: 'access-token' }),
+      drive: {
+        files: {
+          create: vi.fn(),
+          update: filesUpdate,
+          get: vi.fn(),
+          list: vi.fn(),
+        },
+        drives: { get: vi.fn() },
+        revisions: { get: vi.fn(), list: vi.fn() },
+      },
+      request: vi.fn(),
+    },
+  }
+}
+
+describe('GAPI Drive client', () => {
+  it('sends rename metadata through the REST request path', async () => {
+    const filesUpdate = vi.fn().mockResolvedValue({
+      result: {
+        id: 'file123',
+        name: 'original.json',
+        mimeType: 'application/json',
+      },
+    })
+
+    installGapi(filesUpdate)
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input))
+        expect(url.pathname).toBe('/drive/v3/files/file123')
+        expect(url.searchParams.get('supportsAllDrives')).toBe('true')
+        expect(init?.method).toBe('PATCH')
+        expect(JSON.parse(String(init?.body))).toEqual({
+          name: 'renamed.json',
+        })
+        return new Response(
+          JSON.stringify({
+            id: 'file123',
+            name: 'renamed.json',
+            mimeType: 'application/json',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      })
+
+    const store = new DriveNotebookStore(async () => 'access-token')
+    await expect(
+      store.rename(
+        'https://drive.google.com/file/d/file123/view',
+        'renamed.json'
+      )
+    ).resolves.toMatchObject({
+      uri: 'https://drive.google.com/file/d/file123/view',
+      name: 'renamed.json',
+      remoteUri: 'https://drive.google.com/file/d/file123/view',
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(filesUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a rename response that kept the old name', async () => {
+    installGapi()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'file123',
+          name: 'original.json',
+          mimeType: 'application/json',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    )
+
+    const store = new DriveNotebookStore(async () => 'access-token')
+    await expect(
+      store.rename(
+        'https://drive.google.com/file/d/file123/view',
+        'renamed.json'
+      )
+    ).rejects.toThrow(
+      'Google Drive returned success without applying the requested rename to "renamed.json".'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('decodes UTF-8 file and revision content without emoji mojibake', async () => {
     const mojibake = '{"text":"ðð½"}'
     const filesGet = vi.fn().mockResolvedValue({ body: mojibake })

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -739,13 +739,22 @@ class GapiDriveFilesClient implements DriveFilesClient {
     const resource = this.buildResource(doc)
     let file: DriveDoc = { id: doc.id }
     if (Object.keys(resource).length > 0) {
-      const response = (await this.files.update({
-        fileId: doc.id,
-        resource,
-        fields: 'id,name,mimeType,parents',
-        supportsAllDrives: true,
-        resourceKey: doc.resourceKey,
-      } as Record<string, unknown>)) as DriveUpdateResponse
+      // Use the REST request path for metadata updates. The discovery client's
+      // files.update method can acknowledge a request while dropping its
+      // resource body, which makes renames appear successful but leaves the
+      // Drive item unchanged.
+      const response = (await this.request(
+        'PATCH',
+        `/drive/v3/files/${encodeURIComponent(doc.id)}`,
+        {
+          params: {
+            fields: 'id,name,mimeType,parents',
+            supportsAllDrives: true,
+            resourceKey: doc.resourceKey,
+          },
+          body: JSON.stringify(resource),
+        }
+      )) as DriveUpdateResponse
       file = response.result ?? { id: doc.id }
     } else {
       file = {
@@ -3086,6 +3095,11 @@ export class DriveNotebookStore {
       name,
       resourceKey,
     })
+    if (file.name !== name) {
+      throw new Error(
+        `Google Drive returned success without applying the requested rename to "${name}".`
+      )
+    }
     appLogger.info('Drive rename completed', {
       attrs: {
         scope: 'storage.rename',


### PR DESCRIPTION
## Summary

- send GAPI metadata updates through an explicit REST PATCH so the rename body is applied
- reject Drive responses that report success without returning the requested name
- surface that mismatch in the Explorer instead of reporting a false success
- add GAPI transport and error-surfacing regression coverage

## Production evidence

PR #341 added boundary logging. On production commit 864a95f, an Explorer rename reached every layer, but Drive returned the original name:

- requested: 20260821_testing_web_runme_dev-rename-verified.ipynb
- returned: 20260821_testing_web_runme_dev.ipynb

This isolates the remaining no-op to the GAPI discovery client's metadata-update transport. The explicit REST request path is already used by the same client for authenticated Drive operations and preserves the JSON resource body.

## Verification

- focused rename/Drive tests: 116 passed
- full app suite: 104 files, 1,013 tests passed
- runme run build test: passed