### PR TITLE
Separate notebook opening from focus

### DIFF
--- a/app/src/components/AppConsole/AppConsole.tsx
+++ b/app/src/components/AppConsole/AppConsole.tsx
@@ -426,10 +426,19 @@ export default function AppConsole({
       },
       openNotebook: async (uri) => {
         const result = await openNotebook(uri)
-        showDocument(result.localUri, {
-          title: result.entry.name,
+        return result.localUri
+      },
+      focusNotebook: async (uri) => {
+        const notebook = getNotebookData(uri)
+        if (!notebook) {
+          throw new Error(
+            `Notebook ${uri} is not open. Call notebooks.open(reference) before notebooks.focus(reference).`
+          )
+        }
+        showDocument(uri, {
+          title: notebook.getName(),
         })
-        setCurrentDoc(result.localUri)
+        setCurrentDoc(uri)
       },
       resolveNotebook: resolveNotebookData,
       requestNotebookWriteAccess: requestWriteAccess,

--- a/app/src/components/DriveLinkCoordinatorHost.tsx
+++ b/app/src/components/DriveLinkCoordinatorHost.tsx
@@ -45,12 +45,14 @@ export function DriveLinkCoordinatorHost() {
       addWorkspaceItem: addItem,
       removeWorkspaceItem: removeItem,
       getWorkspaceItems: getItems,
-      openNotebook: async (localUri: string) => {
+      openNotebook: async (localUri: string, options?: { focus?: boolean }) => {
         const result = await openNotebook(localUri);
-        showDocument(result.localUri, {
-          title: result.entry.name,
-        });
-        setCurrentDoc(result.localUri);
+        if (options?.focus !== false) {
+          showDocument(result.localUri, {
+            title: result.entry.name,
+          });
+          setCurrentDoc(result.localUri);
+        }
       },
     });
 

--- a/app/src/contexts/NotebookContext.tsx
+++ b/app/src/contexts/NotebookContext.tsx
@@ -36,12 +36,16 @@ type NotebookContextValue = {
   removeNotebook: (uri: string) => string | null;
 };
 
-const NotebookContext = createContext<NotebookContextValue | undefined>(undefined);
+const NotebookContext = createContext<NotebookContextValue | undefined>(
+  undefined,
+);
 
 export function useNotebookContext() {
   const ctx = useContext(NotebookContext);
   if (!ctx) {
-    throw new Error("useNotebookContext must be used within a NotebookProvider");
+    throw new Error(
+      "useNotebookContext must be used within a NotebookProvider",
+    );
   }
   return ctx;
 }
@@ -127,10 +131,27 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
     appState.setOpenNotebookHandler(async (uri: string) => {
       await openAndSelectNotebook(uri);
     });
+    appState.setLoadNotebookHandler(async (uri: string) => {
+      const result = await controller.openNotebook(uri);
+      return result.localUri;
+    });
+    appState.setFocusNotebookHandler(async (uri: string) => {
+      const localUri = uri.trim();
+      if (
+        !controller.getOpenNotebooks().some((item) => item.uri === localUri)
+      ) {
+        throw new Error(
+          `Notebook ${localUri} is not open. Call notebooks.open(reference) before notebooks.focus(reference).`,
+        );
+      }
+      setCurrentDoc(localUri);
+    });
     return () => {
       appState.setOpenNotebookHandler(null);
+      appState.setLoadNotebookHandler(null);
+      appState.setFocusNotebookHandler(null);
     };
-  }, [openAndSelectNotebook]);
+  }, [controller, openAndSelectNotebook, setCurrentDoc]);
 
   useEffect(() => {
     const openNotebooks = controller.getOpenNotebooks();
@@ -177,5 +198,9 @@ export function NotebookProvider({ children }: { children: ReactNode }) {
     ],
   );
 
-  return <NotebookContext.Provider value={value}>{children}</NotebookContext.Provider>;
+  return (
+    <NotebookContext.Provider value={value}>
+      {children}
+    </NotebookContext.Provider>
+  );
 }

--- a/app/src/lib/driveLinkCoordinator.test.ts
+++ b/app/src/lib/driveLinkCoordinator.test.ts
@@ -64,6 +64,7 @@ function createStoredIntent(overrides: Partial<Record<string, unknown>> = {}) {
     remoteUri: "https://drive.google.com/file/d/file123/view",
     action: "open_shared_file",
     source: "url",
+    focus: true,
     status: "pending",
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
@@ -91,9 +92,7 @@ describe("isDriveAuthError", () => {
 
   it("treats explicit authorization-required failures as auth errors", () => {
     expect(
-      isDriveAuthError(
-        new Error("Google Drive authorization is required."),
-      ),
+      isDriveAuthError(new Error("Google Drive authorization is required.")),
     ).toBe(true);
   });
 });
@@ -110,7 +109,9 @@ describe("isDriveMissingOrAccessDeniedError", () => {
   it("treats 403 drive API failures as terminal", () => {
     expect(
       isDriveMissingOrAccessDeniedError(
-        new Error("Drive request failed (403 Forbidden): insufficientFilePermissions"),
+        new Error(
+          "Drive request failed (403 Forbidden): insufficientFilePermissions",
+        ),
       ),
     ).toBe(true);
   });
@@ -216,7 +217,9 @@ describe("driveLinkCoordinator intent storage", () => {
         },
       }),
     );
-    expect(deps.openNotebook).toHaveBeenCalledWith("local://file/file123");
+    expect(deps.openNotebook).toHaveBeenCalledWith("local://file/file123", {
+      focus: true,
+    });
     expect(driveLinkCoordinator.getSnapshot().intents).toEqual([]);
 
     const { loadSharedNotebookTrustRecords } = await import(
@@ -229,6 +232,19 @@ describe("driveLinkCoordinator intent storage", () => {
         basis: "same_domain",
       }),
     ]);
+  });
+
+  it("imports a Drive notebook in the background when focus is disabled", async () => {
+    const remoteUri = "https://drive.google.com/file/d/file123/view";
+    const { driveLinkCoordinator } = await import("./driveLinkCoordinator");
+    const deps = createCoordinatorDeps();
+    driveLinkCoordinator.configure(deps);
+
+    await driveLinkCoordinator.enqueue(remoteUri, "manual", { focus: false });
+
+    expect(deps.openNotebook).toHaveBeenCalledWith("local://file/file123", {
+      focus: false,
+    });
   });
 
   it("does not download an external notebook before review", async () => {
@@ -264,7 +280,9 @@ describe("driveLinkCoordinator intent storage", () => {
     await driveLinkCoordinator.trustAndOpen(intent.id);
 
     expect(deps.importFile).toHaveBeenCalledTimes(1);
-    expect(deps.openNotebook).toHaveBeenCalledTimes(1);
+    expect(deps.openNotebook).toHaveBeenCalledWith("local://file/file123", {
+      focus: true,
+    });
     expect(driveLinkCoordinator.getSnapshot().intents).toEqual([]);
     const { loadSharedNotebookTrustRecords } = await import(
       "./sharedNotebookTrust"

--- a/app/src/lib/driveLinkCoordinator.ts
+++ b/app/src/lib/driveLinkCoordinator.ts
@@ -27,6 +27,8 @@ export interface DriveLinkIntent {
   remoteUri: string;
   action: DriveLinkIntentAction;
   source: "url" | "manual";
+  /** Whether the imported notebook should become the visible document. */
+  focus: boolean;
   status: DriveLinkIntentStatus;
   createdAt: string;
   updatedAt: string;
@@ -70,7 +72,10 @@ type DriveLinkCoordinatorDeps = {
   addWorkspaceItem: (localUri: string) => void;
   removeWorkspaceItem: (uri: string) => void;
   getWorkspaceItems: () => string[];
-  openNotebook: (localUri: string) => Promise<void> | void;
+  openNotebook: (
+    localUri: string,
+    options?: { focus?: boolean },
+  ) => Promise<void> | void;
 };
 
 function createIntentId(): string {
@@ -175,6 +180,8 @@ function loadIntents(): DriveLinkIntent[] {
       )
       .map((intent) => ({
         ...intent,
+        // Intents written by older builds always focused the imported file.
+        focus: intent.focus !== false,
         // "processing" can be left behind in sessionStorage after reload/crash.
         // Treat it as pending so the coordinator can resume it.
         status:
@@ -221,7 +228,8 @@ class DriveLinkCoordinatorRuntime {
 
   configure(deps: DriveLinkCoordinatorDeps | null): void {
     this.deps = deps;
-    const nextPrincipal = deps?.getEffectivePrincipal()?.trim().toLowerCase() ?? null;
+    const nextPrincipal =
+      deps?.getEffectivePrincipal()?.trim().toLowerCase() ?? null;
     const principalChanged = nextPrincipal !== this.configuredPrincipal;
     this.configuredPrincipal = nextPrincipal;
 
@@ -277,12 +285,17 @@ class DriveLinkCoordinatorRuntime {
   async enqueue(
     remoteUri: string,
     source: "url" | "manual" = "manual",
+    options: { focus?: boolean } = {},
   ): Promise<void> {
     const action = this.resolveAction(remoteUri);
+    const focus = options.focus !== false;
     const existing = this.intents.find(
       (intent) => intent.remoteUri === remoteUri && intent.action === action,
     );
     if (existing) {
+      if (focus && !existing.focus) {
+        this.updateIntent(existing.id, { focus: true });
+      }
       return;
     }
 
@@ -294,6 +307,7 @@ class DriveLinkCoordinatorRuntime {
         remoteUri,
         action,
         source,
+        focus,
         status: "pending",
         createdAt: nowIso(),
         updatedAt: nowIso(),
@@ -390,6 +404,8 @@ class DriveLinkCoordinatorRuntime {
     );
     this.updateIntent(intentId, {
       status: "pending",
+      // The user explicitly chose the "Trust This Document And Open" action.
+      focus: true,
       lastErrorMessage: undefined,
     });
     await this.processPending();
@@ -533,7 +549,7 @@ class DriveLinkCoordinatorRuntime {
           },
         });
         deps.removeWorkspaceItem(intent.remoteUri);
-        await deps.openNotebook(localFileUri);
+        await deps.openNotebook(localFileUri, { focus: intent.focus });
 
         if (trustDecision.basis && trustDecision.effectivePrincipal) {
           rememberSharedNotebookTrust(

--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -267,6 +267,8 @@ afterEach(async () => {
   appState.setDriveNotebookStore(null);
   appState.setLocalNotebooks(null);
   appState.setOpenNotebookHandler(null);
+  appState.setLoadNotebookHandler(null);
+  appState.setFocusNotebookHandler(null);
   runnerStore.clear();
   defaultRunnerName = null;
   tokenMocks.getAuthData.mockReset().mockResolvedValue(null);
@@ -1676,10 +1678,8 @@ describe("NotebookData.runCodeCell", () => {
         notebooksByUri.set(uri, createdModel);
       });
     appState.setLocalNotebooks({ create: createLocal, save: saveLocal } as any);
-    const openNotebook = vi.fn().mockImplementation(async (uri: string) => {
-      activeUri = uri;
-    });
-    appState.setOpenNotebookHandler(openNotebook);
+    const loadNotebook = vi.fn(async (uri: string) => uri);
+    appState.setLoadNotebookHandler(loadNotebook);
 
     const cell = create(parser_pb.CellSchema, {
       refId: "cell-appkernel-notebook-create-helpers",
@@ -1733,7 +1733,8 @@ describe("NotebookData.runCodeCell", () => {
 
     expect(createLocal).toHaveBeenCalledWith(LOCAL_FOLDER_URI, "helloworld");
     expect(saveLocal).toHaveBeenCalled();
-    expect(openNotebook).toHaveBeenCalledWith("local://file/helloworld");
+    expect(loadNotebook).toHaveBeenCalledWith("local://file/helloworld");
+    expect(activeUri).toBe("nb://seed");
 
     const createdModel = notebooksByUri.get("local://file/helloworld");
     expect(createdModel).toBeTruthy();

--- a/app/src/lib/runtime/AppState.ts
+++ b/app/src/lib/runtime/AppState.ts
@@ -37,6 +37,11 @@ export class AppState {
   localComments: LocalComments | null = null;
   private openNotebookHandler: ((uri: string) => void | Promise<void>) | null =
     null;
+  private loadNotebookHandler:
+    | ((uri: string) => string | Promise<string>)
+    | null = null;
+  private focusNotebookHandler: ((uri: string) => void | Promise<void>) | null =
+    null;
   private googleDriveOAuthHandler:
     | ((
         options?: StartGoogleDriveOAuthOptions,
@@ -81,6 +86,20 @@ export class AppState {
     handler: ((uri: string) => void | Promise<void>) | null,
   ): void {
     this.openNotebookHandler = handler;
+  }
+
+  /** Registers notebook loading without changing the visible document. */
+  setLoadNotebookHandler(
+    handler: ((uri: string) => string | Promise<string>) | null,
+  ): void {
+    this.loadNotebookHandler = handler;
+  }
+
+  /** Registers selection of an already-open notebook. */
+  setFocusNotebookHandler(
+    handler: ((uri: string) => void | Promise<void>) | null,
+  ): void {
+    this.focusNotebookHandler = handler;
   }
 
   setGoogleDriveOAuthHandler(
@@ -153,6 +172,20 @@ export class AppState {
       throw new Error("Notebook navigation is not initialized");
     }
     await this.openNotebookHandler(uri);
+  }
+
+  async loadNotebook(uri: string): Promise<string> {
+    if (!this.loadNotebookHandler) {
+      throw new Error("Notebook loading is not initialized");
+    }
+    return await this.loadNotebookHandler(uri);
+  }
+
+  async focusNotebook(uri: string): Promise<void> {
+    if (!this.focusNotebookHandler) {
+      throw new Error("Notebook focus is not initialized");
+    }
+    await this.focusNotebookHandler(uri);
   }
 
   async startGoogleDriveOAuth(

--- a/app/src/lib/runtime/aiAgentInstructions.test.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.test.ts
@@ -79,6 +79,14 @@ describe('readInstructionsForAIAgents', () => {
     expect(instructions).toContain('doc.notebook.cells')
     expect(instructions).toContain('There is no `notebooks.read` method')
     expect(instructions).toContain('await notebooks.help()')
+    expect(instructions).toContain('notebooks.open(reference)')
+    expect(instructions).toContain('notebooks.focus(opened.localUri')
+    expect(instructions).toContain(
+      'without changing the notebook the user is viewing'
+    )
+    expect(instructions).toContain(
+      '`notebooks.show(reference)` is a compatibility helper'
+    )
     expect(instructions).toContain('opaque canonical identifier')
     expect(instructions).toContain('IPYNB `cell.id`')
     expect(instructions).toContain(

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -187,6 +187,20 @@ console.log(await app.getSessionID())
 
 Continue only when the printed value matches the selected tab's \`session\` query parameter. If they differ, do not mutate a notebook in that tab.
 
+## Open notebooks without stealing focus
+
+- Use \`await notebooks.open(reference)\` to load a notebook or start a Drive import. This adds the notebook to Runme without changing the notebook the user is viewing.
+- Change the visible notebook only when the user asks or the task genuinely requires it. First open the notebook, then call \`await notebooks.focus(opened.localUri || opened.opened)\`.
+- \`notebooks.focus(reference)\` selects an already-open local notebook and does not load it. A Drive reference must finish importing before it can be focused.
+- \`notebooks.show(reference)\` is a compatibility helper that both opens and focuses. Avoid it for background reads, edits, and execution because the user may be interacting with another notebook.
+
+\`\`\`js
+const opened = await notebooks.open(notebookUri)
+
+// Only when visible focus should move:
+await notebooks.focus(opened.localUri || opened.opened)
+\`\`\`
+
 ## Create notebooks in the requested storage
 
 Treat an explicit Google Drive destination as authoritative. Call the direct \`createDriveNotebook\` WebMCP tool, not \`ExecuteCode\`:

--- a/app/src/lib/runtime/appJsGlobals.test.ts
+++ b/app/src/lib/runtime/appJsGlobals.test.ts
@@ -99,6 +99,8 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     appState.setDriveNotebookStore(null)
     appState.setLocalNotebooks(null)
     appState.setOpenNotebookHandler(null)
+    appState.setLoadNotebookHandler(null)
+    appState.setFocusNotebookHandler(null)
     appState.setGoogleDriveOAuthHandler(null)
     appState.setWorkspaceRenameHandler(null)
     window.localStorage.clear()
@@ -193,19 +195,57 @@ describe('createAppJsGlobals notebook reference helpers', () => {
     await expect(waiting).resolves.toMatchObject({ timedOut: false })
   })
 
-  it('opens a local URI from a Runme share URL', async () => {
-    const opened = vi.fn()
-    appState.setOpenNotebookHandler(opened)
+  it('opens a local URI from a Runme share URL without changing focus', async () => {
+    const opened = vi.fn(async (uri: string) => uri)
+    const focused = vi.fn()
     const globals = createAppJsGlobals({
       runme: createRunme(),
+      openNotebook: opened,
+      focusNotebook: focused,
     })
 
-    const info = await globals.notebooks.show(
+    const info = await globals.notebooks.open(
       'https://runme.example/?doc=local%3A%2F%2Ffile%2Fopened'
     )
 
     expect(opened).toHaveBeenCalledWith('local://file/opened')
+    expect(focused).not.toHaveBeenCalled()
     expect(info.opened).toBe('local://file/opened')
+  })
+
+  it('focuses an already-open notebook separately from opening it', async () => {
+    const opened = vi.fn(async (uri: string) => uri)
+    const focused = vi.fn()
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+      openNotebook: opened,
+      focusNotebook: focused,
+    })
+
+    const info = await globals.notebooks.focus('local://file/opened')
+
+    expect(opened).not.toHaveBeenCalled()
+    expect(focused).toHaveBeenCalledWith('local://file/opened')
+    expect(info.focused).toBe('local://file/opened')
+  })
+
+  it('keeps notebooks.show as an open-and-focus compatibility helper', async () => {
+    const opened = vi.fn(async (uri: string) => uri)
+    const focused = vi.fn()
+    const globals = createAppJsGlobals({
+      runme: createRunme(),
+      openNotebook: opened,
+      focusNotebook: focused,
+    })
+
+    const info = await globals.notebooks.show('local://file/opened')
+
+    expect(opened).toHaveBeenCalledWith('local://file/opened')
+    expect(focused).toHaveBeenCalledWith('local://file/opened')
+    expect(info).toMatchObject({
+      opened: 'local://file/opened',
+      focused: 'local://file/opened',
+    })
   })
 
   it('uses the current notebook when no reference is passed', async () => {

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -363,6 +363,7 @@ export function createAppJsGlobals({
   ensureFilesystemStore = defaultEnsureFilesystemStore,
   workspace,
   openNotebook,
+  focusNotebook,
   runnerSync,
   resolveNotebook,
   listNotebooks,
@@ -377,7 +378,8 @@ export function createAppJsGlobals({
   resolveNotebookStore?: () => RuntimeNotebookStore | null
   ensureFilesystemStore?: () => FilesystemNotebookStore | null
   workspace?: WorkspaceApi
-  openNotebook?: (uri: string) => void | Promise<void>
+  openNotebook?: (uri: string) => string | void | Promise<string | void>
+  focusNotebook?: (uri: string) => void | Promise<void>
   runnerSync?: RunnerSync
   resolveNotebook?: (target?: unknown) => NotebookDataLike | null
   listNotebooks?: () => NotebookDataLike[]
@@ -410,12 +412,19 @@ export function createAppJsGlobals({
     appState.startWorkspaceItemRename(uri)
   }
   const resolveStore = () => resolveNotebookStore?.() ?? appState.localNotebooks
-  const openNotebookForRuntime = async (uri: string) => {
+  const openNotebookForRuntime = async (uri: string): Promise<string> => {
     if (openNotebook) {
-      await openNotebook(uri)
+      const openedUri = await openNotebook(uri)
+      return typeof openedUri === 'string' ? openedUri : uri
+    }
+    return await appState.loadNotebook(uri)
+  }
+  const focusNotebookForRuntime = async (uri: string) => {
+    if (focusNotebook) {
+      await focusNotebook(uri)
       return
     }
-    await appState.openNotebook(uri)
+    await appState.focusNotebook(uri)
   }
   const resolveLocalMirrorStore = () => {
     if (!appState.localNotebooks) {
@@ -900,17 +909,27 @@ export function createAppJsGlobals({
     }
   }
 
-  const showNotebookReference = async (reference?: unknown) => {
+  const openNotebookReference = async (
+    reference?: unknown,
+    options: { focus: boolean } = { focus: false }
+  ) => {
     const info = await resolveNotebookReference(reference)
     if (info.localUri?.startsWith('local://file/')) {
-      await openNotebookForRuntime(info.localUri)
+      const opened = await openNotebookForRuntime(info.localUri)
+      if (options.focus) {
+        await focusNotebookForRuntime(opened)
+      }
       return {
         ...info,
-        opened: info.localUri,
+        localUri: opened,
+        opened,
+        ...(options.focus ? { focused: opened } : {}),
       }
     }
     if (info.remoteUri && isDriveItemUri(info.remoteUri)) {
-      await driveLinkCoordinator.enqueue(info.remoteUri, 'manual')
+      await driveLinkCoordinator.enqueue(info.remoteUri, 'manual', {
+        focus: options.focus,
+      })
       return {
         ...info,
         opened: info.remoteUri,
@@ -921,6 +940,23 @@ export function createAppJsGlobals({
       `Unable to show notebook reference ${info.uri}. Expected a local file URI or Drive file URL.`
     )
   }
+
+  const focusNotebookReference = async (reference?: unknown) => {
+    const info = await resolveNotebookReference(reference)
+    if (!info.localUri?.startsWith('local://file/')) {
+      throw new Error(
+        `Unable to focus notebook reference ${info.uri}. Call notebooks.open(reference) first and wait for any Drive import to finish.`
+      )
+    }
+    await focusNotebookForRuntime(info.localUri)
+    return {
+      ...info,
+      focused: info.localUri,
+    }
+  }
+
+  const showNotebookReference = async (reference?: unknown) =>
+    openNotebookReference(reference, { focus: true })
 
   const embedImageForRuntime = async (
     source: EmbeddedImageSource,
@@ -987,7 +1023,7 @@ export function createAppJsGlobals({
     ...notebooksApi,
     help: async (topic?: string) => {
       if (topic === 'createLocal') {
-        return 'notebooks.createLocal(name, options?: { folderUri?: string }): Promise<NotebookDocument>. Creates a new local notebook, opens it in the UI, and returns the notebook document.'
+        return 'notebooks.createLocal(name, options?: { folderUri?: string }): Promise<NotebookDocument>. Creates a new local notebook, adds it to the open notebook list without changing focus, and returns the notebook document.'
       }
       if (topic === 'appendCell') {
         return 'notebooks.appendCell({ target?, at?, kind, languageId?, value?, metadata?, execute?, reason? }): Promise<{ handle, cell }>. Inserts a cell into the current or targeted notebook. kind must be "code" or "markup".'
@@ -1002,7 +1038,13 @@ export function createAppJsGlobals({
         return 'notebooks.resolve(reference?): Promise<NotebookReferenceInfo>. Accepts a local URI, Drive URL, Runme share URL, Markdown link, or notebook target and returns title, localUri, remoteUri, shareUrl, and markdownLink.'
       }
       if (topic === 'show') {
-        return 'notebooks.show(reference?): Promise<NotebookReferenceInfo & { opened | status }>. Opens local notebook references directly and queues Drive references through shared-link coordination.'
+        return 'notebooks.show(reference?): Promise<NotebookReferenceInfo & { opened | focused | status }>. Compatibility helper that opens and focuses a notebook. Prefer notebooks.open(reference), then notebooks.focus(reference) only when the user wants visible focus to change.'
+      }
+      if (topic === 'open') {
+        return 'notebooks.open(reference?): Promise<NotebookReferenceInfo & { opened | status }>. Opens or imports a notebook without changing the visible notebook focus.'
+      }
+      if (topic === 'focus') {
+        return 'notebooks.focus(reference?): Promise<NotebookReferenceInfo & { focused }>. Focuses an already-open notebook without loading it. Call notebooks.open(reference) first.'
       }
       if (topic === 'shareUrl') {
         return 'notebooks.shareUrl(reference?): Promise<string>. Returns the Runme share URL for a local, Drive, share, or Markdown notebook reference.'
@@ -1021,6 +1063,8 @@ export function createAppJsGlobals({
         '- notebooks.embed(source, options?)',
         '- notebooks.attach(source, { target, folderUri?, mode?, title?, altText?, expectedRevision?, operationId? })',
         '- notebooks.resolve(reference?)',
+        '- notebooks.open(reference?)',
+        '- notebooks.focus(reference?)',
         '- notebooks.show(reference?)',
         '- notebooks.shareUrl(reference?)',
         '- notebooks.markdownLink(reference?)',
@@ -1068,6 +1112,8 @@ export function createAppJsGlobals({
     embed: embedImageForRuntime,
     attach: attachResourceForRuntime,
     resolve: resolveNotebookReference,
+    open: openNotebookReference,
+    focus: focusNotebookReference,
     show: showNotebookReference,
     shareUrl: async (reference?: unknown) => {
       const info = await resolveNotebookReference(reference)
@@ -1649,6 +1695,14 @@ export function createAppJsGlobals({
         }
         await openNotebookForRuntime(uri)
         emitLine(sendOutput, `Opened notebook ${uri}`)
+        return uri
+      },
+      focusNotebook: async (uri: string) => {
+        if (!uri?.trim()) {
+          throw new Error('Usage: app.focusNotebook(localUri)')
+        }
+        await focusNotebookForRuntime(uri)
+        emitLine(sendOutput, `Focused notebook ${uri}`)
         return uri
       },
       startGoogleDriveOAuth: startGoogleDriveOAuthForRuntime,

--- a/app/src/lib/runtime/codeModeExecutor.test.ts
+++ b/app/src/lib/runtime/codeModeExecutor.test.ts
@@ -32,6 +32,8 @@ describe('codeModeExecutor', () => {
     appState.setDriveNotebookStore(null)
     appState.setLocalNotebooks(null)
     appState.setOpenNotebookHandler(null)
+    appState.setLoadNotebookHandler(null)
+    appState.setFocusNotebookHandler(null)
     __resetTabIdForTests()
     window.history.replaceState(null, '', '/')
   })
@@ -215,6 +217,55 @@ describe('codeModeExecutor', () => {
           uri: 'local://test.runme.md',
         }),
       })
+    )
+  })
+
+  it('opens notebooks without focus and focuses them only when requested', async () => {
+    const notebook = createNotebook()
+    const loadNotebook = vi.fn(async (uri: string) => uri)
+    const focusNotebook = vi.fn(async () => undefined)
+    let focusCallsAfterOpen = -1
+    let openedResult: unknown
+    let focusedResult: unknown
+    appState.setLoadNotebookHandler(loadNotebook)
+    appState.setFocusNotebookHandler(focusNotebook)
+    vi.spyOn(SandboxJSKernel.prototype, 'run').mockImplementation(
+      async function (this: SandboxJSKernel) {
+        const bridge = (
+          this as unknown as {
+            bridge: {
+              call: (method: string, args: unknown[]) => Promise<unknown>
+            }
+          }
+        ).bridge
+        openedResult = await bridge.call('notebooks.open', [
+          'local://file/background',
+        ])
+        focusCallsAfterOpen = focusNotebook.mock.calls.length
+        focusedResult = await bridge.call('notebooks.focus', [
+          'local://file/background',
+        ])
+      }
+    )
+    const executor = createCodeModeExecutor({
+      mode: 'sandbox',
+      resolveNotebook: () => notebook,
+      listNotebooks: () => [notebook],
+    })
+
+    await executor.execute({
+      source: 'webmcp',
+      code: "const opened = await notebooks.open('local://file/background'); await notebooks.focus(opened.opened);",
+    })
+
+    expect(loadNotebook).toHaveBeenCalledWith('local://file/background')
+    expect(focusCallsAfterOpen).toBe(0)
+    expect(focusNotebook).toHaveBeenCalledWith('local://file/background')
+    expect(openedResult).toEqual(
+      expect.objectContaining({ opened: 'local://file/background' })
+    )
+    expect(focusedResult).toEqual(
+      expect.objectContaining({ focused: 'local://file/background' })
     )
   })
 

--- a/app/src/lib/runtime/notebooksApiBridge.test.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.test.ts
@@ -198,8 +198,12 @@ describe('createNotebooksApiBridgeServer', () => {
       uri: 'local://file/demo',
       title: 'demo',
     }))
+    const open = vi.fn(async () => ({ opened: 'local://file/demo' }))
+    const focus = vi.fn(async () => ({ focused: 'local://file/demo' }))
     const bridgeServer = createBridgeServer({
       resolve,
+      open,
+      focus,
     } as Partial<NotebooksApi>)
 
     await expect(
@@ -212,6 +216,21 @@ describe('createNotebooksApiBridgeServer', () => {
       title: 'demo',
     })
     expect(resolve).toHaveBeenCalledWith('local://file/demo')
+
+    await expect(
+      bridgeServer.handleMessage({
+        method: 'notebooks.open',
+        args: ['local://file/demo'],
+      })
+    ).resolves.toEqual({ opened: 'local://file/demo' })
+    await expect(
+      bridgeServer.handleMessage({
+        method: 'notebooks.focus',
+        args: ['local://file/demo'],
+      })
+    ).resolves.toEqual({ focused: 'local://file/demo' })
+    expect(open).toHaveBeenCalledWith('local://file/demo')
+    expect(focus).toHaveBeenCalledWith('local://file/demo')
   })
 
   it('delegates write access requests to the host notebook API', async () => {

--- a/app/src/lib/runtime/notebooksApiBridge.ts
+++ b/app/src/lib/runtime/notebooksApiBridge.ts
@@ -25,6 +25,8 @@ export const SANDBOX_NOTEBOOKS_API_METHODS = [
   'notebooks.execute',
   'notebooks.requestWriteAccess',
   'notebooks.resolve',
+  'notebooks.open',
+  'notebooks.focus',
   'notebooks.show',
   'notebooks.shareUrl',
   'notebooks.markdownLink',
@@ -33,6 +35,8 @@ export const SANDBOX_NOTEBOOKS_API_METHODS = [
 
 type NotebookReferenceApi = {
   resolve?: (reference?: unknown) => Promise<unknown>
+  open?: (reference?: unknown) => Promise<unknown>
+  focus?: (reference?: unknown) => Promise<unknown>
   show?: (reference?: unknown) => Promise<unknown>
   shareUrl?: (reference?: unknown) => Promise<string>
   markdownLink?: (reference?: unknown) => Promise<string>
@@ -127,6 +131,14 @@ export function createNotebooksApiBridgeServer({
         case 'notebooks.resolve':
           return callJsonSafe(() =>
             requireReferenceMethod(notebooksApi, 'resolve')(args[0])
+          )
+        case 'notebooks.open':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'open')(args[0])
+          )
+        case 'notebooks.focus':
+          return callJsonSafe(() =>
+            requireReferenceMethod(notebooksApi, 'focus')(args[0])
           )
         case 'notebooks.show':
           return callJsonSafe(() =>

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -374,6 +374,8 @@ export function buildSandboxSrcDoc(options: {
           embed: (source, options) => callHost("notebooks.embed", [source, options]),
           attach: (source, options) => callHost("notebooks.attach", [source, options]),
           resolve: (reference) => callHost("notebooks.resolve", [reference]),
+          open: (reference) => callHost("notebooks.open", [reference]),
+          focus: (reference) => callHost("notebooks.focus", [reference]),
           show: (reference) => callHost("notebooks.show", [reference]),
           shareUrl: (reference) => callHost("notebooks.shareUrl", [reference]),
           markdownLink: (reference) => callHost("notebooks.markdownLink", [reference]),
@@ -509,6 +511,8 @@ export function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebooks.attach(source, { target: { uri }, folderUri?, mode?, title?, altText?, expectedRevision?, operationId? })");
           consoleProxy.log("- notebooks.resolve([reference])");
           consoleProxy.log("- notebooks.show([reference])");
+          consoleProxy.log("- notebooks.open([reference])");
+          consoleProxy.log("- notebooks.focus([reference])");
           consoleProxy.log("- notebooks.shareUrl([reference])");
           consoleProxy.log("- notebooks.markdownLink([reference])");
           consoleProxy.log("- documents.list()");

--- a/docs/03-local-notebooks-and-browser-storage.md
+++ b/docs/03-local-notebooks-and-browser-storage.md
@@ -31,11 +31,13 @@ These notebooks are a first-class backend, not just a temporary cache.
 In App Console, the fastest way to create a local notebook is:
 
 ```js
-await notebooks.createLocal('helloworld')
+const created = await notebooks.createLocal('helloworld')
 ```
 
-That creates a browser-local notebook, opens it in the UI, and returns the
-new notebook document.
+That creates a browser-local notebook, adds it to the open notebook list without
+changing the visible notebook, and returns the new notebook document. Call
+`await notebooks.focus(created.handle.uri)` only when the visible notebook
+should change.
 
 ## Sync states
 

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -216,7 +216,7 @@ notebook APIs without constructing a Drive URL:
 if (result.files.length !== 1) {
   throw new Error(`Expected one notebook, found ${result.files.length}`)
 }
-await notebooks.show(result.files[0].uri)
+await notebooks.open(result.files[0].uri)
 ```
 
 Use `nextPageToken` to retrieve every matching file:

--- a/docs/06-sharing-and-opening-drive-links.md
+++ b/docs/06-sharing-and-opening-drive-links.md
@@ -71,17 +71,20 @@ It returns the display title, `localUri`, `remoteUri`, `shareTarget`,
 Runme share links: the Drive URL when the local notebook has a remote backing
 file, otherwise the local URI.
 
-To open a reference, run:
+To open a reference without changing the notebook the user is viewing, run:
 
 ```js
-await notebooks.show(
+const opened = await notebooks.open(
   'https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F149JKKTgljRiwszwb06Ms74GOYhCOPMNg%2Fview'
 )
 ```
 
 Local references open directly in a notebook tab. Drive references are queued
 through the shared-link coordinator, which handles auth, local mirroring, and
-opening the resulting local notebook.
+opening the resulting local notebook. Neither path changes visible focus. When
+the user wants to switch to the opened notebook, call
+`await notebooks.focus(opened.localUri || opened.opened)`. The legacy
+`notebooks.show(reference)` helper performs both operations.
 
 ## Key facts
 

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -339,7 +339,7 @@ const result = await drive.search({
 if (result.files.length !== 1) {
   throw new Error(`Expected one notebook, found ${result.files.length}`)
 }
-await notebooks.show(result.files[0].uri)
+await notebooks.open(result.files[0].uri)
 ```
 
 `drive.search` accepts a Google Drive v3 `files.list` request, including its

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -78,19 +78,22 @@ await notebooks.appendCell({
 })
 ```
 
-Resolve and open notebook references:
+Resolve and open notebook references without changing the visible notebook:
 
 ```js
 await notebooks.resolve('local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018')
 await notebooks.markdownLink(
   'local://file/cb1c8a9f-6dad-4e1a-9cbc-467ddebc3018'
 )
-await notebooks.show(
+const opened = await notebooks.open(
   'https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F149JKKTgljRiwszwb06Ms74GOYhCOPMNg%2Fview'
 )
-await notebooks.show(
+await notebooks.open(
   '[Notebook](https://drive.google.com/file/d/149JKKTgljRiwszwb06Ms74GOYhCOPMNg/view)'
 )
+
+// Only move visible focus when the user asks for it.
+await notebooks.focus(opened.localUri || opened.opened)
 ```
 
 Request write access when another Runme session owns a notebook:
@@ -304,7 +307,7 @@ const result = await drive.search({
     'nextPageToken,incompleteSearch,files(id,name,mimeType,parents,modifiedTime)',
 })
 console.table(result.files)
-await notebooks.show(result.files[0].uri)
+await notebooks.open(result.files[0].uri)
 ```
 
 The request is passed through unchanged, so use Google Drive's native `q`,
@@ -333,8 +336,10 @@ app.setConfig(app.getDefaultConfigUrl())
 - Use `notebooks.resolve(reference)` to turn local URIs, Runme share URLs,
   Drive URLs, and Markdown links into a title, `localUri`, `remoteUri`,
   `shareUrl`, and replacement-ready `markdownLink`.
-- Use `notebooks.show(reference)` when automation needs one command that opens a
-  local notebook tab or hands a Drive reference to shared-link coordination.
+- Use `notebooks.open(reference)` by default. It opens a local notebook tab or
+  hands a Drive reference to shared-link coordination without changing focus.
+- Use `notebooks.focus(reference)` only when the visible notebook should change.
+  `notebooks.show(reference)` remains as an open-and-focus compatibility helper.
 - Prefer `drive.search(...)` over DOM inspection when automation knows a Drive file
   name or can express the intended file with the Drive query grammar. Resolve a
-  unique result, then pass its `uri` to `notebooks.show(...)`.
+  unique result, then pass its `uri` to `notebooks.open(...)`.


### PR DESCRIPTION
## Summary

- add `notebooks.open(reference)` to load or import notebooks without changing the visible notebook
- add `notebooks.focus(reference)` to explicitly focus an already-open notebook
- retain `notebooks.show(reference)` as the compatibility open-and-focus helper
- preserve deferred focus intent for Google Drive imports and document the new default for agents

## Verification

- `runme run build test`
- `pnpm -C app exec vitest run` (104 files, 1,014 tests)
- `git diff --check`

## Notes

- The repository's standalone typecheck currently reports existing repo-wide errors unrelated to this change.
- The configured lint script cannot run because the workspace does not declare/install an `eslint` executable.
