### PR TITLE
Add copy action for selected markdown text

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -2653,6 +2653,58 @@ describe('Action component', () => {
     selection.removeAllRanges()
   })
 
+  it('copies rendered selected text when comments are unavailable', async () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'cell-md-selection-context-copy',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      outputs: [],
+      metadata: {},
+      value: 'Copy **this selected text** please.',
+    })
+    const stub = new StubCellData(cell)
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(
+      <Action cellData={stub as unknown as CellData} isFirst={false} readOnly />
+    )
+
+    const selectedSpan = screen.getByText('this selected text')
+    const range = document.createRange()
+    range.selectNodeContents(selectedSpan)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+      clientX: 40,
+      clientY: 20,
+    })
+    const copySelection = screen.getByRole('button', { name: 'Copy' })
+    expect(copySelection.dataset.runmeContextMenuAction).toBe('copy-selection')
+    expect(
+      screen.getByRole<HTMLButtonElement>('button', {
+        name: 'Comment on selected text',
+      }).disabled
+    ).toBe(true)
+
+    fireEvent.click(copySelection)
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('this selected text')
+    })
+    expect(toastMocks.showToast).toHaveBeenCalledWith({
+      message: 'Selected text copied',
+      tone: 'success',
+    })
+    expect(screen.queryByRole('button', { name: 'Copy' })).toBeNull()
+    selection.removeAllRanges()
+  })
+
   it('keeps the cell comment button independent of a selection menu', () => {
     const cell = create(parser_pb.CellSchema, {
       refId: 'cell-md-independent-comment',

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -703,6 +703,7 @@ export function Action({
   const [contextMenu, setContextMenu] = useState<{
     x: number
     y: number
+    selectedText?: string
     captureRenderedSelection?: () => RenderedMarkdownSelectionDraft | null
   } | null>(null)
   const [shareTarget, setShareTarget] = useState<{
@@ -808,7 +809,9 @@ export function Action({
     }
 
     const menuWidth = 200
-    const menuHeight = shareTargetUri && cell?.refId.trim() ? 164 : 88
+    const menuHeight =
+      (shareTargetUri && cell?.refId.trim() ? 164 : 88) +
+      (contextMenu.captureRenderedSelection ? 38 : 0)
     const left = Math.max(
       0,
       Math.min(contextMenu.x, window.innerWidth - menuWidth)
@@ -840,11 +843,13 @@ export function Action({
     (request: {
       x: number
       y: number
+      selectedText: string
       captureSelection: () => RenderedMarkdownSelectionDraft | null
     }) => {
       setContextMenu({
         x: request.x,
         y: request.y,
+        selectedText: request.selectedText,
         captureRenderedSelection: request.captureSelection,
       })
     },
@@ -1063,6 +1068,35 @@ export function Action({
     onStartComment(target)
     setContextMenu(null)
   }, [contextMenu, handleStartComment, onStartComment])
+
+  const handleCopySelectedText = useCallback(async () => {
+    const selectedText = contextMenu?.selectedText
+    if (selectedText === undefined) {
+      setContextMenu(null)
+      return
+    }
+
+    try {
+      await window.navigator.clipboard.writeText(selectedText)
+      showToast({ message: 'Selected text copied', tone: 'success' })
+    } catch (error) {
+      appLogger.error('Failed to copy selected Markdown text', {
+        attrs: {
+          scope: 'notebook.markdown-selection',
+          code: 'MARKDOWN_SELECTION_COPY_FAILED',
+          cellRefId: cell?.refId,
+          error: String(error),
+        },
+      })
+      showToast({
+        message:
+          'Could not copy the selected text. Check clipboard permissions and try again.',
+        tone: 'error',
+      })
+    } finally {
+      setContextMenu(null)
+    }
+  }, [cell?.refId, contextMenu?.selectedText])
 
   const sequenceLabel = useMemo(() => {
     if (!cell) {
@@ -1588,7 +1622,6 @@ export function Action({
               isWindowFocused={isWindowFocused}
               onFocusRoleChange={handleMarkdownFocusRoleChange}
               onLinkClick={handleMarkdownLinkClick}
-              commentsAvailable={commentsAvailable}
               commentRanges={commentRanges}
               onRenderedSelectionContextMenu={
                 handleRenderedSelectionContextMenu
@@ -1633,6 +1666,19 @@ export function Action({
             }}
             onContextMenu={(event) => event.preventDefault()}
           >
+            {contextMenu?.captureRenderedSelection && (
+              <button
+                type="button"
+                className="ctx-menu-item"
+                data-runme-context-menu-action="copy-selection"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void handleCopySelectedText()
+                }}
+              >
+                Copy
+              </button>
+            )}
             {canCopyCellLink && (
               <>
                 <button

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -545,7 +545,6 @@ describe("MarkdownCell", () => {
     const onRenderedSelectionContextMenu = vi.fn();
 
     renderMarkdownCell(new StubCellData(cell) as unknown as CellData, {
-      commentsAvailable: true,
       onRenderedSelectionContextMenu,
     });
 
@@ -583,7 +582,11 @@ describe("MarkdownCell", () => {
 
     expect(onRenderedSelectionContextMenu).toHaveBeenCalledOnce();
     const request = onRenderedSelectionContextMenu.mock.calls[0][0];
-    expect(request).toMatchObject({ x: 40, y: 20 });
+    expect(request).toMatchObject({
+      x: 40,
+      y: 20,
+      selectedText: "migration guide",
+    });
 
     selection.removeAllRanges();
     expect(request.captureSelection()).toEqual(

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -186,14 +186,13 @@ interface MarkdownCellProps {
   onLinkClick?: (href: string) => boolean
   /** Allow source inspection, but prevent content and metadata changes. */
   readOnly?: boolean
-  /** Whether the current Drive-backed notebook can accept comments. */
-  commentsAvailable?: boolean
   /** Resolved open-comment ranges to keep visible in rendered Markdown. */
   commentRanges?: readonly RenderedMarkdownCommentRange[]
   /** Open the cell context menu with a lazily captured rendered selection. */
   onRenderedSelectionContextMenu?: (request: {
     x: number
     y: number
+    selectedText: string
     captureSelection: () => RenderedMarkdownSelectionDraft | null
   }) => void
 }
@@ -240,7 +239,6 @@ const MarkdownCell = memo(
     onFocusRoleChange,
     onLinkClick,
     readOnly = false,
-    commentsAvailable = false,
     commentRanges = [],
     onRenderedSelectionContextMenu,
   }: MarkdownCellProps) => {
@@ -362,7 +360,6 @@ const MarkdownCell = memo(
           !projection ||
           !selection ||
           !cell?.refId ||
-          !commentsAvailable ||
           !onRenderedSelectionContextMenu ||
           selection.rangeCount !== 1 ||
           selection.isCollapsed
@@ -387,6 +384,7 @@ const MarkdownCell = memo(
         onRenderedSelectionContextMenu({
           x: hasPointerPosition ? event.clientX : (rangeRect?.left ?? 0),
           y: hasPointerPosition ? event.clientY : (rangeRect?.bottom ?? 0),
+          selectedText: selection.toString(),
           captureSelection: () =>
             captureRenderedMarkdownRange({
               root,
@@ -397,7 +395,7 @@ const MarkdownCell = memo(
             }),
         })
       },
-      [cell?.refId, commentsAvailable, onRenderedSelectionContextMenu, value]
+      [cell?.refId, onRenderedSelectionContextMenu, value]
     )
 
     /**
@@ -660,7 +658,6 @@ const MarkdownCell = memo(
       prevProps.onFocusRoleChange === nextProps.onFocusRoleChange &&
       prevProps.onLinkClick === nextProps.onLinkClick &&
       prevProps.readOnly === nextProps.readOnly &&
-      prevProps.commentsAvailable === nextProps.commentsAvailable &&
       sameCommentRanges(prevProps.commentRanges, nextProps.commentRanges) &&
       prevProps.onRenderedSelectionContextMenu ===
         nextProps.onRenderedSelectionContextMenu


### PR DESCRIPTION
## Summary
- add a Copy action to rendered Markdown selection context menus
- allow selection context menus even when comments are unavailable
- copy the exact rendered selection and report clipboard failures

## Verification
- pnpm -C app test --run src/components/Actions/Actions.test.tsx src/components/Actions/MarkdownCell.test.tsx
- runme run build test
- browser verification in a read-only/comments-unavailable local notebook confirmed the exact selected text was written to the clipboard