### PR TITLE
Fix IPYNB Drive revision decoding

### DIFF
--- a/app/src/lib/notebookDiff/runtime.test.ts
+++ b/app/src/lib/notebookDiff/runtime.test.ts
@@ -182,7 +182,7 @@ describe('createNotebookDiffRuntimeApi', () => {
     const localNotebooks = {
       getMetadata: vi.fn().mockResolvedValue({
         uri: 'local://file/one',
-        name: 'Notebook',
+        name: 'Notebook.ipynb',
         type: NotebookStoreItemType.File,
         children: [],
         remoteUri: 'https://drive.google.com/file/d/drive-file/view',
@@ -205,7 +205,8 @@ describe('createNotebookDiffRuntimeApi', () => {
 
     expect(driveStore.loadRevision).toHaveBeenCalledWith(
       'https://drive.google.com/file/d/drive-file/view',
-      'revision-1'
+      'revision-1',
+      'Notebook.ipynb'
     )
     expect(doc.base.revisionId).toBe('revision-1')
     expect(doc.compare.revisionId).toBe('local-revision')

--- a/app/src/lib/notebookDiff/runtime.ts
+++ b/app/src/lib/notebookDiff/runtime.ts
@@ -170,7 +170,7 @@ export function createNotebookDiffRuntimeApi({
         `Notebook ${doc.handle.uri} is not backed by a Google Drive file.`
       )
     }
-    return { doc, remoteUri }
+    return { doc, remoteUri, fileName: metadata.name }
   }
 
   const requireDriveStore = () => {
@@ -290,11 +290,14 @@ export function createNotebookDiffRuntimeApi({
       if (!args?.revisionId?.trim()) {
         throw new Error('notebookDiff.diffDriveRevision requires revisionId.')
       }
-      const { doc, remoteUri } = await resolveDriveRemoteUri(args.target)
+      const { doc, remoteUri, fileName } = await resolveDriveRemoteUri(
+        args.target
+      )
       const driveStore = requireDriveStore()
       const baseNotebook = await driveStore.loadRevision(
         remoteUri,
-        args.revisionId
+        args.revisionId,
+        fileName
       )
       const diff = computeNotebookDiff(baseNotebook, doc.notebook, {
         includeOutputs: args.includeOutputs ?? true,

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -1585,6 +1585,40 @@ describe("DriveNotebookStore", () => {
     },
   );
 
+  it("recognizes default-only Runme cells under the current IPYNB filename", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"cells":[{"value":"echo hi"},{}]}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.loadRevision(
+      "https://drive.google.com/file/d/file123/view",
+      "revision-1",
+      "notebook.ipynb",
+    );
+
+    expect(loaded.cells).toHaveLength(2);
+    expect(loaded.cells[0]?.value).toBe("echo hi");
+    expect(warn).toHaveBeenCalledWith(
+      "Recovered Drive revision with Runme JSON shape fallback",
+      {
+        attrs: {
+          scope: "storage.drive.revision",
+          code: "DRIVE_REVISION_RUNME_JSON_DECODE_FALLBACK",
+          initialFormat: "ipynb",
+          cellCount: 2,
+        },
+      },
+    );
+  });
+
   it("does not reinterpret invalid Runme JSON as IPYNB", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -20,6 +20,24 @@ import {
 } from "./drive";
 import { NotebookStoreItemType } from "./notebook";
 
+function plainIpynb(): string {
+  return JSON.stringify({
+    nbformat: 4,
+    nbformat_minor: 5,
+    metadata: {},
+    cells: [
+      {
+        cell_type: "code",
+        id: "plain-cell",
+        metadata: {},
+        source: "print('hello')",
+        outputs: [],
+        execution_count: null,
+      },
+    ],
+  });
+}
+
 afterEach(() => {
   clearGoogleDriveRuntime();
   vi.restoreAllMocks();
@@ -1414,23 +1432,8 @@ describe("DriveNotebookStore", () => {
 
   it("detects plain Jupyter revisions before protobuf decoding", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
-    const ipynb = JSON.stringify({
-      nbformat: 4,
-      nbformat_minor: 5,
-      metadata: {},
-      cells: [
-        {
-          cell_type: "code",
-          id: "plain-cell",
-          metadata: {},
-          source: "print('hello')",
-          outputs: [],
-          execution_count: null,
-        },
-      ],
-    });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(ipynb, {
+      new Response(plainIpynb(), {
         status: 200,
         headers: { "Content-Type": "application/x-ipynb+json" },
       }),
@@ -1443,6 +1446,42 @@ describe("DriveNotebookStore", () => {
     const loaded = await store.loadRevision(
       "https://drive.google.com/file/d/file123/view",
       "revision-1",
+    );
+
+    expect(loaded.cells).toHaveLength(1);
+    expect(loaded.cells[0]?.value).toBe("print('hello')");
+    expect(warn).toHaveBeenCalledWith(
+      "Recovered Drive revision with IPYNB shape fallback",
+      {
+        attrs: {
+          scope: "storage.drive.revision",
+          code: "DRIVE_REVISION_IPYNB_DECODE_FALLBACK",
+          initialFormat: "runme-json",
+          cellCount: 1,
+          cellsWithObjectRunmeMetadata: 0,
+          notebookRunmeMetadataType: "undefined",
+        },
+      },
+    );
+  });
+
+  it("prefers revision IPYNB shape over the current JSON filename", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(plainIpynb(), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.loadRevision(
+      "https://drive.google.com/file/d/file123/view",
+      "revision-1",
+      "notebook.json",
     );
 
     expect(loaded.cells).toHaveLength(1);

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -1412,6 +1412,56 @@ describe("DriveNotebookStore", () => {
     );
   });
 
+  it("detects plain Jupyter revisions before protobuf decoding", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const ipynb = JSON.stringify({
+      nbformat: 4,
+      nbformat_minor: 5,
+      metadata: {},
+      cells: [
+        {
+          cell_type: "code",
+          id: "plain-cell",
+          metadata: {},
+          source: "print('hello')",
+          outputs: [],
+          execution_count: null,
+        },
+      ],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(ipynb, {
+        status: 200,
+        headers: { "Content-Type": "application/x-ipynb+json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.loadRevision(
+      "https://drive.google.com/file/d/file123/view",
+      "revision-1",
+    );
+
+    expect(loaded.cells).toHaveLength(1);
+    expect(loaded.cells[0]?.value).toBe("print('hello')");
+    expect(warn).toHaveBeenCalledWith(
+      "Recovered Drive revision with IPYNB shape fallback",
+      {
+        attrs: {
+          scope: "storage.drive.revision",
+          code: "DRIVE_REVISION_IPYNB_DECODE_FALLBACK",
+          initialFormat: "runme-json",
+          cellCount: 1,
+          cellsWithObjectRunmeMetadata: 0,
+          notebookRunmeMetadataType: "undefined",
+        },
+      },
+    );
+  });
+
   it("does not reinterpret invalid Runme JSON as IPYNB", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -6,6 +6,8 @@ import {
   clearGoogleDriveRuntime,
   setGoogleDriveBaseUrl,
 } from "../lib/googleDriveRuntime";
+import { appLogger } from "../lib/logging/runtime";
+import { encodeIpynbNotebook } from "../lib/notebookFormat";
 import { parser_pb } from "../runme/client";
 import {
   DriveCreateNotCommittedError,
@@ -1321,5 +1323,114 @@ describe("DriveNotebookStore", () => {
       "{}",
     );
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("decodes IPYNB revisions using the supplied filename without warning", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const source = create(parser_pb.NotebookSchema, {
+      metadata: { owner: "runme" },
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: "cell-1",
+          kind: parser_pb.CellKind.CODE,
+          languageId: "bash",
+          value: "echo hello",
+          metadata: { name: "hello", "runme.dev/runnerName": "local" },
+        }),
+      ],
+    });
+    const ipynb = encodeIpynbNotebook(source).text;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(ipynb, {
+        status: 200,
+        headers: { "Content-Type": "application/x-ipynb+json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.loadRevision(
+      "https://drive.google.com/file/d/file123/view",
+      "revision-1",
+      "notebook.ipynb",
+    );
+
+    expect(loaded.metadata.owner).toBe("runme");
+    expect(loaded.cells).toHaveLength(1);
+    expect(loaded.cells[0]?.metadata).toMatchObject({
+      name: "hello",
+      "runme.dev/runnerName": "local",
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to IPYNB decoding with a structured warning", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const source = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: "cell-1",
+          kind: parser_pb.CellKind.MARKUP,
+          languageId: "markdown",
+          value: "# Hello",
+          metadata: { name: "hello" },
+        }),
+      ],
+    });
+    const ipynb = encodeIpynbNotebook(source).text;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(ipynb, {
+        status: 200,
+        headers: { "Content-Type": "application/x-ipynb+json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.loadRevision(
+      "https://drive.google.com/file/d/file123/view",
+      "revision-1",
+    );
+
+    expect(loaded.cells[0]?.value).toBe("# Hello");
+    expect(warn).toHaveBeenCalledWith(
+      "Recovered Drive revision with IPYNB shape fallback",
+      {
+        attrs: {
+          scope: "storage.drive.revision",
+          code: "DRIVE_REVISION_IPYNB_DECODE_FALLBACK",
+          initialFormat: "runme-json",
+          cellCount: 1,
+          cellsWithObjectRunmeMetadata: 1,
+          notebookRunmeMetadataType: "object",
+        },
+      },
+    );
+  });
+
+  it("does not reinterpret invalid Runme JSON as IPYNB", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"metadata":{"runme":{"unexpected":true}}}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    await expect(
+      store.loadRevision(
+        "https://drive.google.com/file/d/file123/view",
+        "revision-1",
+      ),
+    ).rejects.toThrow();
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -1549,6 +1549,42 @@ describe("DriveNotebookStore", () => {
     );
   });
 
+  it.each(["{}", '{"cells":[]}'])(
+    "recognizes default-omitting Runme JSON under the current IPYNB filename: %s",
+    async (body) => {
+      setGoogleDriveBaseUrl("https://drive.example.test");
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const warn = vi
+        .spyOn(appLogger, "warn")
+        .mockImplementation(() => null as never);
+
+      const store = new DriveNotebookStore(async () => "access-token");
+      const loaded = await store.loadRevision(
+        "https://drive.google.com/file/d/file123/view",
+        "revision-1",
+        "notebook.ipynb",
+      );
+
+      expect(loaded.cells).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(
+        "Recovered Drive revision with Runme JSON shape fallback",
+        {
+          attrs: {
+            scope: "storage.drive.revision",
+            code: "DRIVE_REVISION_RUNME_JSON_DECODE_FALLBACK",
+            initialFormat: "ipynb",
+            cellCount: 0,
+          },
+        },
+      );
+    },
+  );
+
   it("does not reinterpret invalid Runme JSON as IPYNB", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -7,7 +7,10 @@ import {
   setGoogleDriveBaseUrl,
 } from "../lib/googleDriveRuntime";
 import { appLogger } from "../lib/logging/runtime";
-import { encodeIpynbNotebook } from "../lib/notebookFormat";
+import {
+  encodeIpynbNotebook,
+  encodeRunmeNotebook,
+} from "../lib/notebookFormat";
 import { parser_pb } from "../runme/client";
 import {
   DriveCreateNotCommittedError,
@@ -1496,6 +1499,51 @@ describe("DriveNotebookStore", () => {
           cellCount: 1,
           cellsWithObjectRunmeMetadata: 0,
           notebookRunmeMetadataType: "undefined",
+        },
+      },
+    );
+  });
+
+  it("prefers revision Runme JSON shape over the current IPYNB filename", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const source = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: "cell-1",
+          kind: parser_pb.CellKind.CODE,
+          languageId: "bash",
+          value: "echo hello",
+          metadata: { name: "hello" },
+        }),
+      ],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(encodeRunmeNotebook(source), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const warn = vi
+      .spyOn(appLogger, "warn")
+      .mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.loadRevision(
+      "https://drive.google.com/file/d/file123/view",
+      "revision-1",
+      "notebook.ipynb",
+    );
+
+    expect(loaded.cells).toHaveLength(1);
+    expect(loaded.cells[0]?.value).toBe("echo hello");
+    expect(warn).toHaveBeenCalledWith(
+      "Recovered Drive revision with Runme JSON shape fallback",
+      {
+        attrs: {
+          scope: "storage.drive.revision",
+          code: "DRIVE_REVISION_RUNME_JSON_DECODE_FALLBACK",
+          initialFormat: "ipynb",
+          cellCount: 1,
         },
       },
     );

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -39,6 +39,10 @@ type IpynbRevisionShape = {
   notebookRunmeMetadataType: string
 }
 
+type RunmeRevisionShape = {
+  cellCount: number
+}
+
 /**
  * Returns privacy-safe shape information when a revision body is a Jupyter
  * notebook. The structured `metadata.runme` envelope is valid IPYNB metadata,
@@ -91,6 +95,44 @@ function inspectIpynbRevisionShape(body: string): IpynbRevisionShape | null {
 }
 
 /**
+ * Recognizes protobuf JSON emitted for a Runme notebook without treating an
+ * arbitrary object with a `cells` array as valid. `frontmatter` is a
+ * notebook-level Runme field; non-empty notebooks also expose cell fields that
+ * do not occur in Jupyter's cell schema.
+ */
+function inspectRunmeRevisionShape(body: string): RunmeRevisionShape | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null
+  }
+
+  const notebook = parsed as Record<string, unknown>
+  if ('nbformat' in notebook || !Array.isArray(notebook.cells)) {
+    return null
+  }
+  const hasRunmeNotebookField = 'frontmatter' in notebook
+  const cellsHaveRunmeFields =
+    notebook.cells.length > 0 &&
+    notebook.cells.every(
+      (cell) =>
+        !!cell &&
+        typeof cell === 'object' &&
+        !Array.isArray(cell) &&
+        ('kind' in cell || 'value' in cell || 'refId' in cell)
+    )
+  if (!hasRunmeNotebookField && !cellsHaveRunmeFields) {
+    return null
+  }
+
+  return { cellCount: notebook.cells.length }
+}
+
+/**
  * Decodes a Drive revision using the filename-selected notebook format. Older
  * callers may omit the filename, so an IPYNB shape fallback preserves access
  * while emitting a structured warning that identifies the ambiguous path.
@@ -114,6 +156,25 @@ function decodeDriveRevision(
       })
     }
     return notebook
+  }
+
+  if (fileFormat === 'ipynb') {
+    const runmeShape = inspectRunmeRevisionShape(body)
+    if (runmeShape) {
+      const notebook = decodeNotebookFile(body, 'revision.json').notebook
+      appLogger.warn(
+        'Recovered Drive revision with Runme JSON shape fallback',
+        {
+          attrs: {
+            scope: 'storage.drive.revision',
+            code: 'DRIVE_REVISION_RUNME_JSON_DECODE_FALLBACK',
+            initialFormat: 'ipynb',
+            ...runmeShape,
+          },
+        }
+      )
+      return notebook
+    }
   }
 
   if (fileName && fileFormat) {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -43,6 +43,31 @@ type RunmeRevisionShape = {
   cellCount: number
 }
 
+const RUNME_NOTEBOOK_REVISION_FIELDS = new Set([
+  'cells',
+  'metadata',
+  'frontmatter',
+])
+const RUNME_CELL_REVISION_FIELDS = new Set([
+  'kind',
+  'value',
+  'languageId',
+  'language_id',
+  'metadata',
+  'textRange',
+  'text_range',
+  'outputs',
+  'executionSummary',
+  'execution_summary',
+  'refId',
+  'ref_id',
+  'role',
+  'callId',
+  'call_id',
+  'docResults',
+  'doc_results',
+])
+
 /**
  * Returns privacy-safe shape information when a revision body is a Jupyter
  * notebook. The structured `metadata.runme` envelope is valid IPYNB metadata,
@@ -96,9 +121,9 @@ function inspectIpynbRevisionShape(body: string): IpynbRevisionShape | null {
 
 /**
  * Recognizes protobuf JSON emitted for a Runme notebook without treating an
- * arbitrary object with a `cells` array as valid. `frontmatter` is a
- * notebook-level Runme field; non-empty notebooks also expose cell fields that
- * do not occur in Jupyter's cell schema.
+ * arbitrary object with a `cells` array as valid. Protobuf JSON may omit every
+ * default-valued field, so recognition is based on the complete set of allowed
+ * notebook and cell field names rather than requiring a populated field.
  */
 function inspectRunmeRevisionShape(body: string): RunmeRevisionShape | null {
   let parsed: unknown
@@ -117,7 +142,7 @@ function inspectRunmeRevisionShape(body: string): RunmeRevisionShape | null {
   }
   const notebookKeys = Object.keys(notebook)
   const hasOnlyRunmeNotebookFields = notebookKeys.every((key) =>
-    ['cells', 'metadata', 'frontmatter'].includes(key)
+    RUNME_NOTEBOOK_REVISION_FIELDS.has(key)
   )
   if (notebook.cells === undefined) {
     return hasOnlyRunmeNotebookFields ? { cellCount: 0 } : null
@@ -125,20 +150,14 @@ function inspectRunmeRevisionShape(body: string): RunmeRevisionShape | null {
   if (!Array.isArray(notebook.cells)) {
     return null
   }
-  if (notebook.cells.length === 0 && hasOnlyRunmeNotebookFields) {
-    return { cellCount: 0 }
-  }
-  const hasRunmeNotebookField = 'frontmatter' in notebook
-  const cellsHaveRunmeFields =
-    notebook.cells.length > 0 &&
-    notebook.cells.every(
-      (cell) =>
-        !!cell &&
-        typeof cell === 'object' &&
-        !Array.isArray(cell) &&
-        ('kind' in cell || 'value' in cell || 'refId' in cell)
-    )
-  if (!hasRunmeNotebookField && !cellsHaveRunmeFields) {
+  const cellsHaveOnlyRunmeFields = notebook.cells.every(
+    (cell) =>
+      !!cell &&
+      typeof cell === 'object' &&
+      !Array.isArray(cell) &&
+      Object.keys(cell).every((key) => RUNME_CELL_REVISION_FIELDS.has(key))
+  )
+  if (!hasOnlyRunmeNotebookFields || !cellsHaveOnlyRunmeFields) {
     return null
   }
 

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -6,6 +6,7 @@ import { LinkedResourceError } from '../lib/linkedResource'
 import { appLogger } from '../lib/logging/runtime'
 import {
   createInitialNotebookFile,
+  decodeNotebookFile,
   detectNotebookFileFormat,
 } from '../lib/notebookFormat'
 import { parser_pb } from '../runme/client'
@@ -31,6 +32,99 @@ export const DRIVE_CREATE_EXPECTED_REQUEST_PROPERTY =
   'runmeCreateExpectedRequest'
 export const DRIVE_CREATE_COMPLETED_CHECKSUM_PROPERTY =
   'runmeCreateCompletedChecksum'
+
+type IpynbRevisionShape = {
+  cellCount: number
+  cellsWithObjectRunmeMetadata: number
+  notebookRunmeMetadataType: string
+}
+
+/**
+ * Returns privacy-safe shape information when a revision body is a Jupyter
+ * notebook. The structured `metadata.runme` envelope is valid IPYNB metadata,
+ * but it cannot be decoded as the Runme proto's `map<string, string>` metadata.
+ */
+function inspectIpynbRevisionShape(body: string): IpynbRevisionShape | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null
+  }
+
+  const notebook = parsed as Record<string, unknown>
+  if (notebook.nbformat !== 4 || !Array.isArray(notebook.cells)) {
+    return null
+  }
+  const notebookMetadata =
+    notebook.metadata &&
+    typeof notebook.metadata === 'object' &&
+    !Array.isArray(notebook.metadata)
+      ? (notebook.metadata as Record<string, unknown>)
+      : {}
+  const notebookRunmeMetadata = notebookMetadata.runme
+  const notebookRunmeMetadataType = Array.isArray(notebookRunmeMetadata)
+    ? 'array'
+    : notebookRunmeMetadata === null
+      ? 'null'
+      : typeof notebookRunmeMetadata
+  const cellsWithObjectRunmeMetadata = notebook.cells.filter((cell) => {
+    if (!cell || typeof cell !== 'object' || Array.isArray(cell)) {
+      return false
+    }
+    const metadata = (cell as Record<string, unknown>).metadata
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return false
+    }
+    const runme = (metadata as Record<string, unknown>).runme
+    return !!runme && typeof runme === 'object' && !Array.isArray(runme)
+  }).length
+
+  return {
+    cellCount: notebook.cells.length,
+    cellsWithObjectRunmeMetadata,
+    notebookRunmeMetadataType,
+  }
+}
+
+/**
+ * Decodes a Drive revision using the filename-selected notebook format. Older
+ * callers may omit the filename, so an IPYNB shape fallback preserves access
+ * while emitting a structured warning that identifies the ambiguous path.
+ */
+function decodeDriveRevision(
+  body: string,
+  fileName?: string
+): parser_pb.Notebook {
+  if (fileName && detectNotebookFileFormat(fileName)) {
+    return decodeNotebookFile(body, fileName).notebook
+  }
+
+  try {
+    return fromJsonString(parser_pb.NotebookSchema, body, {
+      ignoreUnknownFields: true,
+    })
+  } catch (error) {
+    const ipynbShape = inspectIpynbRevisionShape(body)
+    if (!ipynbShape) {
+      throw error
+    }
+
+    const notebook = decodeNotebookFile(body, 'revision.ipynb').notebook
+    appLogger.warn('Recovered Drive revision with IPYNB shape fallback', {
+      attrs: {
+        scope: 'storage.drive.revision',
+        code: 'DRIVE_REVISION_IPYNB_DECODE_FALLBACK',
+        initialFormat: 'runme-json',
+        ...ipynbShape,
+      },
+    })
+    return notebook
+  }
+}
 
 let gapiScriptPromise: Promise<void> | null = null
 let clientPromise: Promise<DriveFilesClient> | null = null
@@ -3021,7 +3115,8 @@ export class DriveNotebookStore {
 
   async loadRevision(
     uri: string,
-    revisionId: string
+    revisionId: string,
+    fileName?: string
   ): Promise<parser_pb.Notebook> {
     const item = parseDriveItem(uri)
     if (item.type !== NotebookStoreItemType.File) {
@@ -3041,9 +3136,7 @@ export class DriveNotebookStore {
       driveResourceKeyHeaders(item)
     )
     const body = extractBody(response)
-    return fromJsonString(parser_pb.NotebookSchema, body, {
-      ignoreUnknownFields: true,
-    })
+    return decodeDriveRevision(body, fileName)
   }
 
   async loadRevisionContent(uri: string, revisionId: string): Promise<string> {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -99,22 +99,25 @@ function decodeDriveRevision(
   body: string,
   fileName?: string
 ): parser_pb.Notebook {
-  if (fileName && detectNotebookFileFormat(fileName)) {
-    return decodeNotebookFile(body, fileName).notebook
-  }
-
+  const fileFormat = fileName ? detectNotebookFileFormat(fileName) : null
   const ipynbShape = inspectIpynbRevisionShape(body)
   if (ipynbShape) {
     const notebook = decodeNotebookFile(body, 'revision.ipynb').notebook
-    appLogger.warn('Recovered Drive revision with IPYNB shape fallback', {
-      attrs: {
-        scope: 'storage.drive.revision',
-        code: 'DRIVE_REVISION_IPYNB_DECODE_FALLBACK',
-        initialFormat: 'runme-json',
-        ...ipynbShape,
-      },
-    })
+    if (fileFormat !== 'ipynb') {
+      appLogger.warn('Recovered Drive revision with IPYNB shape fallback', {
+        attrs: {
+          scope: 'storage.drive.revision',
+          code: 'DRIVE_REVISION_IPYNB_DECODE_FALLBACK',
+          initialFormat: fileFormat ?? 'runme-json',
+          ...ipynbShape,
+        },
+      })
+    }
     return notebook
+  }
+
+  if (fileName && fileFormat) {
+    return decodeNotebookFile(body, fileName).notebook
   }
 
   return fromJsonString(parser_pb.NotebookSchema, body, {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -103,16 +103,8 @@ function decodeDriveRevision(
     return decodeNotebookFile(body, fileName).notebook
   }
 
-  try {
-    return fromJsonString(parser_pb.NotebookSchema, body, {
-      ignoreUnknownFields: true,
-    })
-  } catch (error) {
-    const ipynbShape = inspectIpynbRevisionShape(body)
-    if (!ipynbShape) {
-      throw error
-    }
-
+  const ipynbShape = inspectIpynbRevisionShape(body)
+  if (ipynbShape) {
     const notebook = decodeNotebookFile(body, 'revision.ipynb').notebook
     appLogger.warn('Recovered Drive revision with IPYNB shape fallback', {
       attrs: {
@@ -124,6 +116,10 @@ function decodeDriveRevision(
     })
     return notebook
   }
+
+  return fromJsonString(parser_pb.NotebookSchema, body, {
+    ignoreUnknownFields: true,
+  })
 }
 
 let gapiScriptPromise: Promise<void> | null = null

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -112,8 +112,21 @@ function inspectRunmeRevisionShape(body: string): RunmeRevisionShape | null {
   }
 
   const notebook = parsed as Record<string, unknown>
-  if ('nbformat' in notebook || !Array.isArray(notebook.cells)) {
+  if ('nbformat' in notebook) {
     return null
+  }
+  const notebookKeys = Object.keys(notebook)
+  const hasOnlyRunmeNotebookFields = notebookKeys.every((key) =>
+    ['cells', 'metadata', 'frontmatter'].includes(key)
+  )
+  if (notebook.cells === undefined) {
+    return hasOnlyRunmeNotebookFields ? { cellCount: 0 } : null
+  }
+  if (!Array.isArray(notebook.cells)) {
+    return null
+  }
+  if (notebook.cells.length === 0 && hasOnlyRunmeNotebookFields) {
+    return { cellCount: 0 }
   }
   const hasRunmeNotebookField = 'frontmatter' in notebook
   const cellsHaveRunmeFields =

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -2353,8 +2353,45 @@ describe('LocalNotebooks Drive conflict resolution', () => {
     expect(driveStore.loadRevision).toHaveBeenCalledTimes(1)
     expect(driveStore.loadRevision).toHaveBeenCalledWith(
       remoteUri,
-      'revision-1'
+      'revision-1',
+      'notebook.json'
     )
+  })
+
+  it('routes cached IPYNB revision diffs through format-aware loading', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/file123/view'
+    const revisionNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          value: 'echo historical runme json',
+        }),
+      ],
+    })
+    const driveStore = {
+      loadRevision: vi.fn(async () => revisionNotebook),
+      loadRevisionContent: vi.fn(),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/drive',
+      name: 'notebook.ipynb',
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '2026-05-01T00:00:00.000Z',
+      doc: notebookJson("print('local')"),
+      md5Checksum: 'local-checksum',
+    })
+
+    await expect(
+      store.getDriveRevisionDoc('local://file/drive', 'revision-1')
+    ).resolves.toContain('echo historical runme json')
+    expect(driveStore.loadRevision).toHaveBeenCalledWith(
+      remoteUri,
+      'revision-1',
+      'notebook.ipynb'
+    )
+    expect(driveStore.loadRevisionContent).not.toHaveBeenCalled()
   })
 
   it('records a conflict instead of creating a timestamped Drive copy', async () => {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1606,23 +1606,13 @@ export class LocalNotebooks extends Dexie {
       // the exact Drive revision and storing it in OPFS for future diffs.
     }
 
-    const revisionDoc =
-      detectNotebookFileFormat(record.name) === 'ipynb'
-        ? serializeNotebook(
-            decodeNotebookFile(
-              await this.driveStore.loadRevisionContent(
-                record.remoteId,
-                normalizedRevisionId
-              ),
-              record.name
-            ).notebook
-          )
-        : serializeNotebook(
-            await this.driveStore.loadRevision(
-              record.remoteId,
-              normalizedRevisionId
-            )
-          )
+    const revisionDoc = serializeNotebook(
+      await this.driveStore.loadRevision(
+        record.remoteId,
+        normalizedRevisionId,
+        record.name
+      )
+    )
     await this.getRevisionDocStorage().write(
       localUri,
       normalizedRevisionId,


### PR DESCRIPTION
## Summary

- decode Google Drive revisions using the notebook format selected by the resolved filename
- recover unlabelled IPYNB-shaped revisions through the existing object-aware IPYNB decoder
- choose the decoder from revision content when historical IPYNB/Runme JSON format differs from the current filename
- emit a privacy-safe structured warning when the fallback path is required
- pass the Drive filename from notebook diff operations and preserve nested Runme metadata

The affected notebook was valid IPYNB. Its `metadata.runme` value is intentionally an object containing `{ version, cell }` or `{ version, notebook }`; the failure came from sending the entire IPYNB document to the Runme protobuf JSON decoder, whose metadata values must be strings.

## Design

[Format-aware decoding for Google Drive IPYNB revisions](https://drive.google.com/file/d/1A-gFxafuZTci-lkiwyOSQxCBnEfLR2-Z/view)

## Validation

- `pnpm -C app exec vitest run src/storage/drive.test.ts src/storage/local.test.ts src/lib/notebookDiff/runtime.test.ts` (109 tests passed)
- `runme run build test`
- production app build
- `git diff --check`

Full app type checking currently reports unrelated pre-existing errors on `main`; none reference the files changed by this PR.
