### PR TITLE
Recover from stale workspace folder roots

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -186,6 +186,7 @@ jobs:
           CUJ_CMD_TIMEOUT_MS: "120000"
           CUJ_SCENARIO_TIMEOUT_MS: "240000"
           CUJ_SCENARIO_CMD_TIMEOUT_MS: "30000"
+          CUJ_SCENARIO_CMD_LOG_CHARS: "20000"
           CUJ_MOVIE_WAIT_TIMEOUT_MS: "30000"
           CUJ_RUNME_AGENT_BIN: ${{ github.workspace }}/bin/runme
         run: |

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -2,6 +2,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { appLogger } from '../../lib/logging/runtime'
 import { NotebookStoreItemType } from '../../storage/notebook'
 import { DriveCreateNotCommittedError } from '../../storage/drive'
 import { WorkspaceExplorer } from './WorkspaceExplorer'
@@ -287,6 +288,53 @@ describe('WorkspaceExplorer current document handling', () => {
     })
     await screen.findByText('Mounted folders are shown as roots')
     expect(screen.getAllByText('Nested mount')).toHaveLength(1)
+  })
+
+  it('removes and logs workspace roots whose local metadata is missing', async () => {
+    const staleUris = ['local://folder/stale-one', 'local://folder/stale-two']
+    const errorLog = vi.spyOn(appLogger, 'error')
+    mocks.workspaceItems = [
+      'local://folder/local',
+      'local://folder/valid',
+      ...staleUris,
+    ]
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (staleUris.includes(uri)) {
+        return null
+      }
+      return {
+        uri,
+        name: uri === 'local://folder/local' ? 'Local Notebooks' : 'Valid root',
+        type: NotebookStoreItemType.Folder,
+        children: [],
+        parents: [],
+      }
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Valid root')
+    await waitFor(() => {
+      for (const staleUri of staleUris) {
+        expect(mocks.removeItem).toHaveBeenCalledWith(staleUri)
+      }
+    })
+    expect(errorLog).toHaveBeenCalledTimes(staleUris.length)
+    for (const staleUri of staleUris) {
+      expect(screen.queryByText(staleUri)).toBeNull()
+      expect(errorLog).toHaveBeenCalledWith(
+        'Removing workspace entry with missing local metadata',
+        {
+          attrs: {
+            scope: 'storage.workspace',
+            code: 'WORKSPACE_LOCAL_METADATA_MISSING',
+            uri: staleUri,
+          },
+        }
+      )
+    }
+
+    errorLog.mockRestore()
   })
 
   it('shows a directly created Drive notebook in its mounted folder', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -168,6 +168,20 @@ function isVisibleDocumentFile(name: string): boolean {
   return isNotebookFileName(name) || isExcalidrawFileName(name)
 }
 
+/**
+ * Record that a workspace root outlived its separately persisted local
+ * metadata. The local URI is opaque and safe to include in diagnostics.
+ */
+function logMissingWorkspaceMetadata(uri: string): void {
+  appLogger.error("Removing workspace entry with missing local metadata", {
+    attrs: {
+      scope: "storage.workspace",
+      code: "WORKSPACE_LOCAL_METADATA_MISSING",
+      uri,
+    },
+  });
+}
+
 function isMovableDriveNode(data: TreeNode): boolean {
   return (
     Boolean(data.remoteUri) &&
@@ -512,16 +526,30 @@ export function WorkspaceExplorer() {
         }
 
         let metadata = await store.getMetadata(localUri);
-        if (metadata?.remoteUri && metadata.name === "Drive") {
+        if (!metadata) {
+          // Workspace roots and local notebook metadata are persisted separately.
+          // If the IndexedDB record is gone, retaining the root would expose the
+          // opaque local URI in the explorer and keep restoring it on every load.
+          logMissingWorkspaceMetadata(localUri);
+          removeItem(localUri);
+          continue;
+        }
+        if (metadata.remoteUri && metadata.name === "Drive") {
           try {
             await store.updateFolder(metadata.remoteUri);
-            metadata = await store.getMetadata(localUri);
+            const refreshedMetadata = await store.getMetadata(localUri);
+            if (!refreshedMetadata) {
+              logMissingWorkspaceMetadata(localUri);
+              removeItem(localUri);
+              continue;
+            }
+            metadata = refreshedMetadata;
           } catch (error) {
             console.error("Failed to refresh Drive folder name", error);
           }
         }
-        const name = metadata?.name ?? localUri;
-        const type = metadata?.type ?? NotebookStoreItemType.Folder;
+        const name = metadata.name;
+        const type = metadata.type;
         if (type !== NotebookStoreItemType.Folder) {
           continue;
         }


### PR DESCRIPTION
## Summary
- remove persisted local workspace roots when their IndexedDB metadata is confirmed missing
- omit stale local URIs from the explorer instead of rendering opaque identifiers
- emit structured storage.workspace errors with WORKSPACE_LOCAL_METADATA_MISSING
- cover multiple stale roots with a component regression test

## Design
https://drive.google.com/file/d/13_R_-zog5WRA-YUOjhJ1DYHq3x9hUFdz/view

## Validation
- pnpm --dir app exec vitest run: 104 files, 1034 tests passed
- pnpm run test:run: 7 tests passed
- pnpm run build: passed