### PR TITLE
Recover mislabeled IPYNB notebooks without data loss

### DIFF
--- a/app/src/lib/ipynb.test.ts
+++ b/app/src/lib/ipynb.test.ts
@@ -1,7 +1,9 @@
 /// <reference types="vitest" />
 // @vitest-environment node
+import { create } from '@bufbuild/protobuf'
 import { describe, expect, it } from 'vitest'
 
+import { parser_pb } from '../runme/client'
 import {
   IPYNB_RAW_CELL_METADATA_KEY,
   decodeIpynb,
@@ -123,6 +125,11 @@ describe('ipynb codec', () => {
 
     expect(ids).toEqual(['invalid-id', 'invalid-id-2', 'code-cell'])
     expect(decoded.notebook.cells.map((cell) => cell.refId)).toEqual(ids)
+    expect(
+      JSON.parse(decoded.shadowText).cells.map(
+        (cell: { id: string }) => cell.id
+      )
+    ).toEqual(ids)
     expect(JSON.parse(encoded.text).cells[0].metadata).toMatchObject(
       sourceNotebook.cells[0].metadata
     )
@@ -187,6 +194,84 @@ describe('ipynb codec', () => {
     expect(reopened.metadata['runme.dev/notebookSetting']).toBe('keep')
     expect(reopened.cells[2]?.languageId).toBe('bash')
     expect(reopened.cells[2]?.metadata['runme.dev/runnerName']).toBe('shell')
+  })
+
+  it('prefers externally changed Jupyter outputs over stale Runme execution details', () => {
+    const decoded = decodeIpynb(JSON.stringify(sourceNotebook))
+    const codeCell = decoded.notebook.cells[2]!
+    codeCell.outputs[0]!.processInfo = create(
+      parser_pb.CellOutputProcessInfoSchema,
+      { pid: 42n }
+    )
+    codeCell.executionSummary = create(
+      parser_pb.CellExecutionSummarySchema,
+      {
+        executionOrder: 7,
+        success: true,
+        timing: create(parser_pb.ExecutionSummaryTimingSchema, {
+          startTime: 100n,
+          endTime: 200n,
+        }),
+      }
+    )
+    const encoded = encodeIpynb(
+      decoded.notebook,
+      JSON.stringify(sourceNotebook),
+      decoded
+    )
+    const externallyEdited = JSON.parse(encoded.text)
+    externallyEdited.cells[2].outputs[0].text = 'changed externally\n'
+
+    const reopened = decodeIpynb(JSON.stringify(externallyEdited)).notebook
+      .cells[2]!
+
+    expect(
+      new TextDecoder().decode(reopened.outputs[0]?.items[0]?.data)
+    ).toBe('changed externally\n')
+    expect(reopened.outputs[0]?.processInfo).toBeUndefined()
+    expect(reopened.executionSummary).toMatchObject({ executionOrder: 7 })
+    expect(reopened.executionSummary?.success).toBeUndefined()
+    expect(reopened.executionSummary?.timing).toBeUndefined()
+  })
+
+  it('preserves Runme execution details when Jupyter output keys are reordered', () => {
+    const decoded = decodeIpynb(JSON.stringify(sourceNotebook))
+    const displayOutput = decoded.notebook.cells[2]!.outputs[1]!
+    displayOutput.processInfo = create(parser_pb.CellOutputProcessInfoSchema, {
+      pid: 42n,
+    })
+    const encoded = encodeIpynb(
+      decoded.notebook,
+      JSON.stringify(sourceNotebook),
+      decoded
+    )
+    const reordered = JSON.parse(encoded.text)
+    const output = reordered.cells[2].outputs[1]
+    output.data = {
+      'application/json': output.data['application/json'],
+      'text/plain': output.data['text/plain'],
+    }
+    const reopened = decodeIpynb(JSON.stringify(reordered)).notebook.cells[2]!
+
+    expect(reopened.outputs[1]?.processInfo?.pid).toBe(42n)
+  })
+
+  it('ignores malformed optional Runme output metadata', () => {
+    const decoded = decodeIpynb(JSON.stringify(sourceNotebook))
+    const encoded = encodeIpynb(
+      decoded.notebook,
+      JSON.stringify(sourceNotebook),
+      decoded
+    )
+    const malformed = JSON.parse(encoded.text)
+    malformed.cells[2].metadata.runme.cell.outputs[1].metadata[
+      'runme.dev/ipynbOutputMetadata'
+    ] = '{not-json'
+
+    expect(() => decodeIpynb(JSON.stringify(malformed))).not.toThrow()
+    const reopened = decodeIpynb(JSON.stringify(malformed)).notebook.cells[2]!
+    expect(reopened.outputs).toHaveLength(2)
+    expect(reopened.outputs[1]?.processInfo).toBeUndefined()
   })
 
   it('rejects unsupported nbformat major versions', () => {

--- a/app/src/lib/ipynb.ts
+++ b/app/src/lib/ipynb.ts
@@ -48,6 +48,7 @@ export type IpynbOutput = JsonObject & {
 export interface DecodedIpynb {
   notebook: parser_pb.Notebook
   source: IpynbNotebook
+  shadowText: string
   jupyterIdByRunmeRefId: Record<string, string>
   baselineCellHashes: Record<string, string>
   baselineOutputHashes: Record<string, string>
@@ -76,6 +77,27 @@ function asObject(value: unknown, label: string): JsonObject {
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
+}
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJson)
+  }
+  if (value && typeof value === 'object') {
+    const object = value as JsonObject
+    return Object.fromEntries(
+      Object.keys(object)
+        .sort()
+        .map((key) => [key, canonicalJson(object[key])])
+    )
+  }
+  return value
+}
+
+function jsonStructurallyEqual(left: unknown, right: unknown): boolean {
+  return (
+    JSON.stringify(canonicalJson(left)) === JSON.stringify(canonicalJson(right))
+  )
 }
 
 function optionalObject(value: unknown): JsonObject | undefined {
@@ -122,8 +144,6 @@ function runmeCellEnvelope(cell: parser_pb.Cell): JsonObject {
   ) as JsonObject
   delete json.kind
   delete json.value
-  delete json.outputs
-  delete json.executionSummary
   delete json.refId
   const metadata = optionalObject(json.metadata)
   if (metadata) {
@@ -320,6 +340,60 @@ function runmeOutputToIpynb(output: parser_pb.CellOutput): IpynbOutput {
   }
 }
 
+function outputsFromIpynb(
+  sourceCell: IpynbCell,
+  id: string,
+  preservedCell: parser_pb.Cell | undefined
+): { outputs: parser_pb.CellOutput[]; preserved: boolean } {
+  const sourceOutputs = Array.isArray(sourceCell.outputs)
+    ? sourceCell.outputs
+    : []
+  const converted = sourceOutputs.map((output) =>
+    ipynbOutputToRunme(
+      asObject(output, `Jupyter output in cell ${id}`) as IpynbOutput
+    )
+  )
+  if (!preservedCell) {
+    return { outputs: converted, preserved: false }
+  }
+
+  // The Jupyter projection is authoritative when another editor changed it.
+  // When it still matches the embedded projection, retain the complete Runme
+  // messages so process information and non-Jupyter fields survive reopening.
+  try {
+    const preservedProjection = preservedCell.outputs.map(runmeOutputToIpynb)
+    const sourceProjection = converted.map(runmeOutputToIpynb)
+    if (jsonStructurallyEqual(preservedProjection, sourceProjection)) {
+      return { outputs: preservedCell.outputs, preserved: true }
+    }
+  } catch {
+    // Opaque Runme metadata is optional. A malformed envelope must not make
+    // an otherwise valid Jupyter notebook unreadable.
+  }
+  return { outputs: converted, preserved: false }
+}
+
+function executionSummaryFromIpynb(
+  sourceCell: IpynbCell,
+  preservedCell: parser_pb.Cell | undefined,
+  outputsPreserved: boolean
+): parser_pb.CellExecutionSummary | undefined {
+  const executionOrder =
+    typeof sourceCell.execution_count === 'number'
+      ? sourceCell.execution_count
+      : undefined
+  if (
+    outputsPreserved &&
+    preservedCell?.executionSummary &&
+    preservedCell.executionSummary.executionOrder === executionOrder
+  ) {
+    return preservedCell.executionSummary
+  }
+  return executionOrder === undefined
+    ? undefined
+    : create(parser_pb.CellExecutionSummarySchema, { executionOrder })
+}
+
 function outputHash(cell: parser_pb.Cell): string {
   return md5(
     JSON.stringify(
@@ -420,6 +494,10 @@ export function decodeIpynb(text: string): DecodedIpynb {
     if (sourceCell.cell_type === 'raw') {
       metadata[IPYNB_RAW_CELL_METADATA_KEY] = 'true'
     }
+    const decodedOutputs =
+      sourceCell.cell_type === 'code'
+        ? outputsFromIpynb(sourceCell, id, preservedCell)
+        : { outputs: [], preserved: false }
     const cell = create(parser_pb.CellSchema, {
       kind,
       refId,
@@ -433,20 +511,14 @@ export function decodeIpynb(text: string): DecodedIpynb {
             : 'markdown'),
       metadata,
       textRange: preservedCell?.textRange,
-      outputs:
-        sourceCell.cell_type === 'code' && Array.isArray(sourceCell.outputs)
-          ? sourceCell.outputs.map((output) =>
-              ipynbOutputToRunme(
-                asObject(output, `Jupyter output in cell ${id}`) as IpynbOutput
-              )
-            )
-          : [],
+      outputs: decodedOutputs.outputs,
       executionSummary:
-        sourceCell.cell_type === 'code' &&
-        typeof sourceCell.execution_count === 'number'
-          ? create(parser_pb.CellExecutionSummarySchema, {
-              executionOrder: sourceCell.execution_count,
-            })
+        sourceCell.cell_type === 'code'
+          ? executionSummaryFromIpynb(
+              sourceCell,
+              preservedCell,
+              decodedOutputs.preserved
+            )
           : undefined,
       role: preservedCell?.role,
       callId: preservedCell?.callId,
@@ -468,6 +540,10 @@ export function decodeIpynb(text: string): DecodedIpynb {
       frontmatter: preservedNotebook?.frontmatter,
     }),
     source,
+    // Use the validated in-memory source as the merge baseline. decodeIpynb
+    // may repair invalid or duplicate cell IDs, so retaining the original
+    // bytes would make the next merge miss those cells and lose opaque fields.
+    shadowText: `${JSON.stringify(source, null, 2)}\n`,
     jupyterIdByRunmeRefId,
     baselineCellHashes,
     baselineOutputHashes,

--- a/app/src/lib/notebookFormat.test.ts
+++ b/app/src/lib/notebookFormat.test.ts
@@ -1,0 +1,164 @@
+/// <reference types="vitest" />
+// @vitest-environment node
+import { create } from '@bufbuild/protobuf'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MimeType, parser_pb } from '../runme/client'
+import { appLogger } from './logging/runtime'
+import {
+  decodeNotebookFile,
+  encodeRunmeNotebook,
+  inspectRunmeNotebookJsonShape,
+} from './notebookFormat'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('notebook file format recovery', () => {
+  it('recovers Runme protobuf JSON mislabeled as IPYNB without losing cells', () => {
+    const cells = Array.from({ length: 15 }, (_, index) =>
+      create(parser_pb.CellSchema, {
+        refId: `cell-${index}`,
+        kind:
+          index % 2 === 0 ? parser_pb.CellKind.MARKUP : parser_pb.CellKind.CODE,
+        languageId: index % 2 === 0 ? 'markdown' : 'bash',
+        value: `cell value ${index}`,
+        metadata: {
+          name: `cell-name-${index}`,
+          ...(index === 1 ? { 'runme.dev/runnerName': 'local' } : {}),
+        },
+        outputs:
+          index === 1
+            ? [
+                create(parser_pb.CellOutputSchema, {
+                  metadata: { 'runme.dev/customOutput': 'preserve-me' },
+                  items: [
+                    create(parser_pb.CellOutputItemSchema, {
+                      mime: MimeType.VSCodeNotebookStdOut,
+                      type: 'TerminalBuffer',
+                      data: new TextEncoder().encode('preserved output\n'),
+                    }),
+                  ],
+                  processInfo: create(parser_pb.CellOutputProcessInfoSchema, {
+                    pid: 4242n,
+                    exitReason: create(
+                      parser_pb.ProcessInfoExitReasonSchema,
+                      { type: 'exit', code: 0 }
+                    ),
+                  }),
+                }),
+              ]
+            : [],
+        executionSummary:
+          index === 1
+            ? create(parser_pb.CellExecutionSummarySchema, {
+                executionOrder: 17,
+                success: true,
+                timing: create(parser_pb.ExecutionSummaryTimingSchema, {
+                  startTime: 100n,
+                  endTime: 250n,
+                }),
+              })
+            : undefined,
+      })
+    )
+    const source = create(parser_pb.NotebookSchema, {
+      cells,
+      metadata: {
+        'runme.dev/ipynb': 'true',
+        'runme.dev/notebookSetting': 'preserve-me',
+      },
+    })
+    const malformedIpynb = encodeRunmeNotebook(source)
+    const warn = vi
+      .spyOn(appLogger, 'warn')
+      .mockImplementation(() => null as never)
+
+    const decoded = decodeNotebookFile(
+      malformedIpynb,
+      'codex_instructions.ipynb'
+    )
+
+    expect(decoded.recovery).toEqual({
+      sourceFormat: 'runme-json',
+      reason: 'ipynb-content-mismatch',
+      cellCount: 15,
+    })
+    expect(decoded.notebook.cells).toHaveLength(15)
+    expect(decoded.notebook.cells.map((cell) => cell.value)).toEqual(
+      cells.map((cell) => cell.value)
+    )
+    expect(decoded.notebook.cells[1]?.metadata).toMatchObject({
+      name: 'cell-name-1',
+      'runme.dev/runnerName': 'local',
+    })
+    expect(decoded.notebook.cells[1]?.outputs[0]?.items[0]?.data).toEqual(
+      new TextEncoder().encode('preserved output\n')
+    )
+    expect(decoded.notebook.cells[1]?.outputs[0]).toMatchObject({
+      metadata: { 'runme.dev/customOutput': 'preserve-me' },
+      items: [{ type: 'TerminalBuffer' }],
+      processInfo: {
+        pid: 4242n,
+        exitReason: { type: 'exit', code: 0 },
+      },
+    })
+    expect(decoded.notebook.cells[1]?.executionSummary).toMatchObject({
+      executionOrder: 17,
+      success: true,
+      timing: { startTime: 100n, endTime: 250n },
+    })
+    expect(decoded.notebook.metadata['runme.dev/notebookSetting']).toBe(
+      'preserve-me'
+    )
+
+    const repaired = JSON.parse(decoded.ipynb?.shadowText ?? '')
+    expect(repaired).toMatchObject({ nbformat: 4, nbformat_minor: 5 })
+    expect(repaired.cells).toHaveLength(15)
+    expect(repaired.cells[0]).toMatchObject({
+      cell_type: 'markdown',
+      id: 'cell-0',
+      source: 'cell value 0',
+    })
+    expect(repaired.cells[0]).not.toHaveProperty('kind')
+    expect(() =>
+      decodeNotebookFile(decoded.ipynb?.shadowText ?? '', 'repaired.ipynb')
+    ).not.toThrow()
+    expect(warn).toHaveBeenCalledWith(
+      'Recovered IPYNB from Runme JSON content',
+      {
+        attrs: {
+          scope: 'notebook.format',
+          code: 'IPYNB_RUNME_JSON_RECOVERY',
+          sourceFormat: 'runme-json',
+          reason: 'ipynb-content-mismatch',
+          cellCount: 15,
+        },
+      }
+    )
+  })
+
+  it('requires positive Runme evidence before recovering malformed IPYNB', () => {
+    const ambiguous = JSON.stringify({
+      cells: [{ metadata: {} }],
+      metadata: {},
+    })
+    const mixed = JSON.stringify({
+      cells: [{ kind: 'CELL_KIND_MARKUP', source: '# mixed schemas' }],
+      metadata: { 'runme.dev/ipynb': 'true' },
+    })
+
+    expect(inspectRunmeNotebookJsonShape(ambiguous)).toEqual({
+      cellCount: 1,
+      hasRunmeEvidence: false,
+    })
+    expect(inspectRunmeNotebookJsonShape(mixed)).toBeNull()
+    expect(() => decodeNotebookFile(ambiguous, 'ambiguous.ipynb')).toThrow(
+      'Unsupported Jupyter nbformat major version: undefined'
+    )
+    expect(() => decodeNotebookFile(mixed, 'mixed.ipynb')).toThrow(
+      'Unsupported Jupyter nbformat major version: undefined'
+    )
+  })
+})

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -9,6 +9,7 @@ import {
   decodeIpynb,
   encodeIpynb,
 } from './ipynb'
+import { appLogger } from './logging/runtime'
 
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
@@ -20,6 +21,126 @@ export interface DecodedNotebookFile {
   format: NotebookFileFormat
   notebook: parser_pb.Notebook
   ipynb?: DecodedIpynb
+  recovery?: NotebookFileRecovery
+}
+
+export interface NotebookFileRecovery {
+  sourceFormat: 'runme-json'
+  reason: 'ipynb-content-mismatch'
+  cellCount: number
+}
+
+export interface RunmeNotebookJsonShape {
+  cellCount: number
+  hasRunmeEvidence: boolean
+}
+
+const RUNME_NOTEBOOK_JSON_FIELDS = new Set(['cells', 'metadata', 'frontmatter'])
+const RUNME_CELL_JSON_FIELDS = new Set([
+  'kind',
+  'value',
+  'languageId',
+  'language_id',
+  'metadata',
+  'textRange',
+  'text_range',
+  'outputs',
+  'executionSummary',
+  'execution_summary',
+  'refId',
+  'ref_id',
+  'role',
+  'callId',
+  'call_id',
+  'docResults',
+  'doc_results',
+])
+const RUNME_CELL_EVIDENCE_FIELDS = new Set([
+  'kind',
+  'value',
+  'languageId',
+  'language_id',
+  'textRange',
+  'text_range',
+  'executionSummary',
+  'execution_summary',
+  'refId',
+  'ref_id',
+  'role',
+  'callId',
+  'call_id',
+  'docResults',
+  'doc_results',
+])
+
+/**
+ * Recognizes protobuf JSON emitted for a Runme notebook without treating an
+ * arbitrary object with a `cells` array as valid. `hasRunmeEvidence` is false
+ * for default-only protobuf JSON such as `{}` and prevents current-file
+ * recovery from guessing when the bytes are ambiguous.
+ */
+export function inspectRunmeNotebookJsonShape(
+  text: string
+): RunmeNotebookJsonShape | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null
+  }
+
+  const notebook = parsed as Record<string, unknown>
+  if ('nbformat' in notebook) {
+    return null
+  }
+  if (
+    !Object.keys(notebook).every((key) => RUNME_NOTEBOOK_JSON_FIELDS.has(key))
+  ) {
+    return null
+  }
+  if (notebook.cells !== undefined && !Array.isArray(notebook.cells)) {
+    return null
+  }
+
+  const cells = (notebook.cells ?? []) as unknown[]
+  let hasRunmeEvidence = false
+  for (const cell of cells) {
+    if (!cell || typeof cell !== 'object' || Array.isArray(cell)) {
+      return null
+    }
+    const keys = Object.keys(cell)
+    if (!keys.every((key) => RUNME_CELL_JSON_FIELDS.has(key))) {
+      return null
+    }
+    if (keys.some((key) => RUNME_CELL_EVIDENCE_FIELDS.has(key))) {
+      hasRunmeEvidence = true
+    }
+  }
+
+  const metadata = notebook.metadata
+  if (
+    metadata &&
+    typeof metadata === 'object' &&
+    !Array.isArray(metadata) &&
+    Object.keys(metadata).some((key) => key.startsWith('runme.dev/'))
+  ) {
+    hasRunmeEvidence = true
+  }
+
+  return { cellCount: cells.length, hasRunmeEvidence }
+}
+
+function decodeRunmeNotebook(text: string): parser_pb.Notebook {
+  const notebook = text
+    ? fromJsonString(parser_pb.NotebookSchema, text, {
+        ignoreUnknownFields: true,
+      })
+    : create(parser_pb.NotebookSchema, { cells: [] })
+  migrateNotebookCellIds(notebook)
+  return notebook
 }
 
 export function detectNotebookFileFormat(
@@ -77,16 +198,42 @@ export function decodeNotebookFile(
     throw new Error(`Unsupported notebook file extension: ${fileName}`)
   }
   if (format === 'ipynb') {
-    const ipynb = decodeIpynb(text)
-    return { format, notebook: ipynb.notebook, ipynb }
+    try {
+      const ipynb = decodeIpynb(text)
+      return { format, notebook: ipynb.notebook, ipynb }
+    } catch (ipynbError) {
+      const shape = inspectRunmeNotebookJsonShape(text)
+      if (!shape?.hasRunmeEvidence) {
+        throw ipynbError
+      }
+
+      try {
+        const recovered = decodeRunmeNotebook(text)
+        const repaired = decodeIpynb(encodeIpynb(recovered).text)
+        const recovery: NotebookFileRecovery = {
+          sourceFormat: 'runme-json',
+          reason: 'ipynb-content-mismatch',
+          cellCount: shape.cellCount,
+        }
+        appLogger.warn('Recovered IPYNB from Runme JSON content', {
+          attrs: {
+            scope: 'notebook.format',
+            code: 'IPYNB_RUNME_JSON_RECOVERY',
+            ...recovery,
+          },
+        })
+        return {
+          format,
+          notebook: repaired.notebook,
+          ipynb: repaired,
+          recovery,
+        }
+      } catch {
+        throw ipynbError
+      }
+    }
   }
-  const notebook = text
-    ? fromJsonString(parser_pb.NotebookSchema, text, {
-        ignoreUnknownFields: true,
-      })
-    : create(parser_pb.NotebookSchema, { cells: [] })
-  migrateNotebookCellIds(notebook)
-  return { format, notebook }
+  return { format, notebook: decodeRunmeNotebook(text) }
 }
 
 export function encodeRunmeNotebook(notebook: parser_pb.Notebook): string {

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -736,9 +736,11 @@ describe("DriveNotebookStore", () => {
       });
 
     const store = new DriveNotebookStore(async () => "access-token");
+    const uri =
+      "https://drive.google.com/file/d/file123/view?resourcekey=file-key";
     await expect(
       store.saveContentIfVersion(
-        "https://drive.google.com/file/d/file123/view?resourcekey=file-key",
+        uri,
         '{"cells":[]}',
         "application/json",
         { checksum: "empty-checksum", revisionId: "empty-revision" },
@@ -771,9 +773,10 @@ describe("DriveNotebookStore", () => {
       });
 
     const store = new DriveNotebookStore(async () => "access-token");
+    const uri = "https://drive.google.com/file/d/file123/view";
     await expect(
       store.saveContentIfVersion(
-        "https://drive.google.com/file/d/file123/view",
+        uri,
         '{"cells":[]}',
         "application/json",
         { checksum: "empty-checksum", revisionId: "empty-revision" },
@@ -846,6 +849,237 @@ describe("DriveNotebookStore", () => {
     ).resolves.toEqual({ conflicted: false });
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
+
+  it("repairs Runme JSON content when saving an IPYNB file", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const source = create(parser_pb.NotebookSchema, {
+      metadata: { "runme.dev/ipynb": "true" },
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: "intro",
+          kind: parser_pb.CellKind.MARKUP,
+          languageId: "markdown",
+          value: "# Recovered",
+          metadata: { name: "intro" },
+        }),
+      ],
+    });
+    const malformedIpynb = encodeRunmeNotebook(source);
+    let metadataReads = 0;
+    let uploadedContent = "";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        if (url.pathname === "/drive/v3/files/file123") {
+          if (init?.method === "PATCH") {
+            expect(JSON.parse(String(init.body))).toMatchObject({
+              mimeType: "application/x-ipynb+json",
+            });
+            return new Response(
+              JSON.stringify({
+                id: "file123",
+                name: "codex_instructions.ipynb",
+                mimeType: "application/x-ipynb+json",
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          }
+          if (url.searchParams.get("alt") === "media") {
+            return new Response(malformedIpynb, {
+              status: 200,
+              headers: { "Content-Type": "application/x-ipynb+json" },
+            });
+          }
+          metadataReads += 1;
+          return new Response(
+            JSON.stringify({
+              name: "codex_instructions.ipynb",
+              mimeType: "application/x-ipynb+json",
+              md5Checksum:
+                metadataReads === 1
+                  ? "malformed-checksum"
+                  : "repaired-checksum",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        if (url.pathname === "/upload/drive/v3/files/file123") {
+          expect(init?.method).toBe("PATCH");
+          expect(new Headers(init?.headers).get("Content-Type")).toBe(
+            "application/x-ipynb+json",
+          );
+          uploadedContent = String(init?.body);
+          return new Response("", { status: 200 });
+        }
+        throw new Error(`Unexpected Drive request: ${url.toString()}`);
+      });
+    vi.spyOn(appLogger, "warn").mockImplementation(() => null as never);
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const result = await store.save(
+      "https://drive.google.com/file/d/file123/view",
+      source,
+    );
+
+    expect(result).toEqual({ conflicted: false });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    const repaired = JSON.parse(uploadedContent);
+    expect(repaired).toMatchObject({ nbformat: 4, nbformat_minor: 5 });
+    expect(repaired.cells).toHaveLength(1);
+    expect(repaired.cells[0]).toMatchObject({
+      cell_type: "markdown",
+      id: "intro",
+      source: "# Recovered",
+    });
+    expect(repaired.cells[0]).not.toHaveProperty("kind");
+  });
+
+  it("loads current IPYNB files through the Jupyter codec", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/file123");
+        if (url.searchParams.get("alt") === "media") {
+          return new Response(plainIpynb(), {
+            status: 200,
+            headers: { "Content-Type": "application/x-ipynb+json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            name: "notebook.ipynb",
+            mimeType: "application/x-ipynb+json",
+            md5Checksum: "ipynb-checksum",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    const loaded = await store.load(
+      "https://drive.google.com/file/d/file123/view",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(loaded.cells).toHaveLength(1);
+    expect(loaded.cells[0]).toMatchObject({
+      refId: "plain-cell",
+      kind: parser_pb.CellKind.CODE,
+      value: "print('hello')",
+    });
+  });
+
+  it.each([
+    "saveContent",
+    "saveContentIfVersion",
+    "externalEdit",
+  ] as const)(
+    "reloads IPYNB preservation state after %s",
+    async (writeMethod) => {
+      setGoogleDriveBaseUrl("https://drive.example.test");
+      const uri = "https://drive.google.com/file/d/file123/view";
+      const rawDocument = JSON.parse(plainIpynb());
+      rawDocument.metadata.after_raw_write = { keep: true };
+      const rawContent = JSON.stringify(rawDocument);
+      let remoteContent = plainIpynb();
+      let checksum = "initial-checksum";
+      let mediaReads = 0;
+      const uploads: string[] = [];
+
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        if (init?.method === "GET") {
+          if (url.searchParams.get("alt") === "media") {
+            mediaReads += 1;
+            return new Response(remoteContent, {
+              status: 200,
+              headers: { "Content-Type": "application/x-ipynb+json" },
+            });
+          }
+          return new Response(
+            JSON.stringify({
+              name: "notebook.ipynb",
+              mimeType: "application/x-ipynb+json",
+              md5Checksum: checksum,
+              headRevisionId: "revision-1",
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                ETag: '"drive-etag-1"',
+              },
+            },
+          );
+        }
+        if (url.pathname === "/drive/v3/files/file123") {
+          expect(init?.method).toBe("PATCH");
+          return new Response(
+            JSON.stringify({
+              id: "file123",
+              name: "notebook.ipynb",
+              mimeType: "application/x-ipynb+json",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        expect(url.pathname).toBe("/upload/drive/v3/files/file123");
+        expect(init?.method).toBe("PATCH");
+        remoteContent = String(init?.body);
+        uploads.push(remoteContent);
+        checksum = `checksum-${uploads.length}`;
+        return new Response("", { status: 200 });
+      });
+
+      const store = new DriveNotebookStore(async () => "access-token");
+      const notebook = await store.load(uri);
+      if (writeMethod === "saveContent") {
+        await store.saveContent(
+          uri,
+          rawContent,
+          "application/x-ipynb+json",
+        );
+      } else if (writeMethod === "saveContentIfVersion") {
+        await expect(
+          store.saveContentIfVersion(
+            uri,
+            rawContent,
+            "application/x-ipynb+json",
+            { checksum: "initial-checksum", revisionId: "revision-1" },
+          ),
+        ).resolves.toBe(true);
+      } else {
+        remoteContent = rawContent;
+        checksum = "external-checksum";
+      }
+      await store.getVersionMetadata(uri);
+      notebook.cells[0]!.value = "print('edited')";
+      await expect(store.save(uri, notebook)).resolves.toEqual({
+        conflicted: false,
+      });
+
+      expect(mediaReads).toBe(2);
+      expect(uploads).toHaveLength(writeMethod === "externalEdit" ? 1 : 2);
+      const saved = JSON.parse(uploads.at(-1)!);
+      expect(saved.metadata.after_raw_write).toEqual({ keep: true });
+      expect(saved.cells[0].source).toBe("print('edited')");
+    },
+  );
 
   it("uses shared drive name for shared drive root folder metadata", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1,13 +1,16 @@
 import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 
 import { getGoogleDriveBaseUrl } from '../lib/googleDriveRuntime'
-import { IPYNB_MIME_TYPE } from '../lib/ipynb'
+import { type DecodedIpynb, IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { LinkedResourceError } from '../lib/linkedResource'
 import { appLogger } from '../lib/logging/runtime'
 import {
   createInitialNotebookFile,
   decodeNotebookFile,
   detectNotebookFileFormat,
+  encodeIpynbNotebook,
+  encodeRunmeNotebook,
+  inspectRunmeNotebookJsonShape,
 } from '../lib/notebookFormat'
 import { parser_pb } from '../runme/client'
 import {
@@ -38,35 +41,6 @@ type IpynbRevisionShape = {
   cellsWithObjectRunmeMetadata: number
   notebookRunmeMetadataType: string
 }
-
-type RunmeRevisionShape = {
-  cellCount: number
-}
-
-const RUNME_NOTEBOOK_REVISION_FIELDS = new Set([
-  'cells',
-  'metadata',
-  'frontmatter',
-])
-const RUNME_CELL_REVISION_FIELDS = new Set([
-  'kind',
-  'value',
-  'languageId',
-  'language_id',
-  'metadata',
-  'textRange',
-  'text_range',
-  'outputs',
-  'executionSummary',
-  'execution_summary',
-  'refId',
-  'ref_id',
-  'role',
-  'callId',
-  'call_id',
-  'docResults',
-  'doc_results',
-])
 
 /**
  * Returns privacy-safe shape information when a revision body is a Jupyter
@@ -120,51 +94,6 @@ function inspectIpynbRevisionShape(body: string): IpynbRevisionShape | null {
 }
 
 /**
- * Recognizes protobuf JSON emitted for a Runme notebook without treating an
- * arbitrary object with a `cells` array as valid. Protobuf JSON may omit every
- * default-valued field, so recognition is based on the complete set of allowed
- * notebook and cell field names rather than requiring a populated field.
- */
-function inspectRunmeRevisionShape(body: string): RunmeRevisionShape | null {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(body)
-  } catch {
-    return null
-  }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return null
-  }
-
-  const notebook = parsed as Record<string, unknown>
-  if ('nbformat' in notebook) {
-    return null
-  }
-  const notebookKeys = Object.keys(notebook)
-  const hasOnlyRunmeNotebookFields = notebookKeys.every((key) =>
-    RUNME_NOTEBOOK_REVISION_FIELDS.has(key)
-  )
-  if (notebook.cells === undefined) {
-    return hasOnlyRunmeNotebookFields ? { cellCount: 0 } : null
-  }
-  if (!Array.isArray(notebook.cells)) {
-    return null
-  }
-  const cellsHaveOnlyRunmeFields = notebook.cells.every(
-    (cell) =>
-      !!cell &&
-      typeof cell === 'object' &&
-      !Array.isArray(cell) &&
-      Object.keys(cell).every((key) => RUNME_CELL_REVISION_FIELDS.has(key))
-  )
-  if (!hasOnlyRunmeNotebookFields || !cellsHaveOnlyRunmeFields) {
-    return null
-  }
-
-  return { cellCount: notebook.cells.length }
-}
-
-/**
  * Decodes a Drive revision using the filename-selected notebook format. Older
  * callers may omit the filename, so an IPYNB shape fallback preserves access
  * while emitting a structured warning that identifies the ambiguous path.
@@ -191,7 +120,7 @@ function decodeDriveRevision(
   }
 
   if (fileFormat === 'ipynb') {
-    const runmeShape = inspectRunmeRevisionShape(body)
+    const runmeShape = inspectRunmeNotebookJsonShape(body)
     if (runmeShape) {
       const notebook = decodeNotebookFile(body, 'revision.json').notebook
       appLogger.warn(
@@ -201,7 +130,7 @@ function decodeDriveRevision(
             scope: 'storage.drive.revision',
             code: 'DRIVE_REVISION_RUNME_JSON_DECODE_FALLBACK',
             initialFormat: 'ipynb',
-            ...runmeShape,
+            cellCount: runmeShape.cellCount,
           },
         }
       )
@@ -237,6 +166,7 @@ export type DriveDoc = {
   parents?: string[]
   driveId?: string
   headRevisionId?: string
+  md5Checksum?: string
   content?: string
   trashed?: boolean
   appProperties?: Record<string, string>
@@ -2113,6 +2043,14 @@ export class DriveNotebookStore {
   ) {}
 
   private readonly lastReadVersion = new Map<string, string>()
+  private readonly ipynbState = new Map<
+    string,
+    {
+      shadowText: string
+      state: DecodedIpynb
+      sourceChecksum: string | null
+    }
+  >()
 
   getAccessToken(options?: {
     interactive?: boolean
@@ -2851,13 +2789,11 @@ export class DriveNotebookStore {
     const metadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
-      //fields: "md5Checksum",
-      fields: VERSION_FIELDS,
+      fields: `${VERSION_FIELDS},name,mimeType`,
       resourceKey,
     })
-    const remoteMd5 =
-      (metadataResponse.result as { md5Checksum?: string } | undefined)
-        ?.md5Checksum ?? null
+    const remoteFile = (metadataResponse.result ?? {}) as DriveDoc
+    const remoteMd5 = remoteFile.md5Checksum ?? null
     const lastRead = this.lastReadVersion.get(uri) ?? null
     if (lastRead && remoteMd5 && remoteMd5 !== lastRead) {
       console.error(
@@ -2870,16 +2806,59 @@ export class DriveNotebookStore {
       )
       return { conflicted: true }
     }
-    const json = toJsonString(
-      parser_pb.NotebookSchema,
-      notebook,
-      NOTEBOOK_JSON_WRITE_OPTIONS
-    )
+    const isIpynb =
+      detectNotebookFileFormat(remoteFile.name ?? '') === 'ipynb' ||
+      (!remoteFile.name && remoteFile.mimeType === IPYNB_MIME_TYPE)
+    let content: string
+    let mimeType: string
+    let nextIpynbState: { shadowText: string; state: DecodedIpynb } | undefined
+    if (isIpynb) {
+      let preservation = this.ipynbState.get(uri)
+      if (preservation && preservation.sourceChecksum !== remoteMd5) {
+        this.ipynbState.delete(uri)
+        preservation = undefined
+      }
+      if (!preservation) {
+        const response = await client.get({
+          fileId: id,
+          supportsAllDrives: true,
+          alt: 'media',
+          resourceKey,
+        })
+        const decoded = decodeNotebookFile(
+          extractBody(response),
+          remoteFile.name ?? 'notebook.ipynb'
+        )
+        if (!decoded.ipynb) {
+          throw new Error('Expected IPYNB preservation state')
+        }
+        preservation = {
+          shadowText: decoded.ipynb.shadowText,
+          state: decoded.ipynb,
+          sourceChecksum: remoteMd5,
+        }
+      }
+      const encoded = encodeIpynbNotebook(
+        notebook,
+        preservation.shadowText,
+        preservation.state
+      )
+      content = encoded.text
+      mimeType = IPYNB_MIME_TYPE
+      const state = decodeNotebookFile(content, 'notebook.ipynb').ipynb
+      if (!state) {
+        throw new Error('Failed to establish IPYNB preservation state')
+      }
+      nextIpynbState = { shadowText: state.shadowText, state }
+    } else {
+      content = encodeRunmeNotebook(notebook)
+      mimeType = 'application/json'
+    }
 
     await client.update({
       id,
-      mimeType: 'application/json',
-      content: json,
+      mimeType,
+      content,
       resourceKey,
     })
     const updatedMetadataResponse = await client.get({
@@ -2896,6 +2875,14 @@ export class DriveNotebookStore {
     } else {
       this.lastReadVersion.delete(uri)
     }
+    if (nextIpynbState) {
+      this.ipynbState.set(uri, {
+        ...nextIpynbState,
+        sourceChecksum: updatedMd5,
+      })
+    } else {
+      this.ipynbState.delete(uri)
+    }
     return { conflicted: false }
   }
 
@@ -2908,12 +2895,11 @@ export class DriveNotebookStore {
     const metadataResponse = await client.get({
       fileId: id,
       supportsAllDrives: true,
-      fields: VERSION_FIELDS,
+      fields: `${VERSION_FIELDS},name,mimeType`,
       resourceKey,
     })
-    const md5 =
-      (metadataResponse.result as { md5Checksum?: string } | undefined)
-        ?.md5Checksum ?? null
+    const remoteFile = (metadataResponse.result ?? {}) as DriveDoc
+    const md5 = remoteFile.md5Checksum ?? null
     if (md5) {
       this.lastReadVersion.set(uri, md5)
     } else {
@@ -2927,10 +2913,25 @@ export class DriveNotebookStore {
     })
 
     const body = extractBody(response)
-
-    return fromJsonString(parser_pb.NotebookSchema, body, {
-      ignoreUnknownFields: true,
-    })
+    const fileName =
+      remoteFile.name ??
+      (remoteFile.mimeType === IPYNB_MIME_TYPE ? 'notebook.ipynb' : '')
+    if (!detectNotebookFileFormat(fileName)) {
+      return fromJsonString(parser_pb.NotebookSchema, body, {
+        ignoreUnknownFields: true,
+      })
+    }
+    const decoded = decodeNotebookFile(body, fileName)
+    if (decoded.ipynb) {
+      this.ipynbState.set(uri, {
+        shadowText: decoded.ipynb.shadowText,
+        state: decoded.ipynb,
+        sourceChecksum: md5,
+      })
+    } else {
+      this.ipynbState.delete(uri)
+    }
+    return decoded.notebook
   }
 
   async list(uri: string): Promise<NotebookStoreItem[]> {
@@ -3170,8 +3171,13 @@ export class DriveNotebookStore {
       resourceKey,
     })
     const result = metadataResponse.result as DriveVersionMetadata | undefined
-    if (result?.md5Checksum) {
-      this.lastReadVersion.set(uri, result.md5Checksum)
+    const checksum = result?.md5Checksum ?? null
+    const preservation = this.ipynbState.get(uri)
+    if (preservation && preservation.sourceChecksum !== checksum) {
+      this.ipynbState.delete(uri)
+    }
+    if (checksum) {
+      this.lastReadVersion.set(uri, checksum)
     } else {
       this.lastReadVersion.delete(uri)
     }
@@ -3414,6 +3420,7 @@ export class DriveNotebookStore {
       content,
       resourceKey,
     })
+    this.ipynbState.delete(uri)
   }
 
   /**
@@ -3452,7 +3459,17 @@ export class DriveNotebookStore {
       // validator needed to protect a collaborator's concurrent edit.
       return false
     }
-    return client.setContentIfMatch(id, content, mimeType, etag, resourceKey)
+    const saved = await client.setContentIfMatch(
+      id,
+      content,
+      mimeType,
+      etag,
+      resourceKey
+    )
+    if (saved) {
+      this.ipynbState.delete(uri)
+    }
+    return saved
   }
 
   async loadContent(uri: string): Promise<string> {

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -389,7 +389,7 @@ export class FilesystemNotebookStore {
     const notebook = decoded.notebook
     if (decoded.ipynb) {
       this.ipynbState.set(recId, {
-        shadowText: text,
+        shadowText: decoded.ipynb.shadowText,
         state: decoded.ipynb,
       })
     }
@@ -430,7 +430,7 @@ export class FilesystemNotebookStore {
         const currentText = await (await fileHandle.getFile()).text()
         const decoded = decodeNotebookFile(currentText, parsed.relativePath)
         preservation = decoded.ipynb
-          ? { shadowText: currentText, state: decoded.ipynb }
+          ? { shadowText: decoded.ipynb.shadowText, state: decoded.ipynb }
           : undefined
       }
       const encoded = encodeIpynbNotebook(
@@ -708,7 +708,7 @@ export class FilesystemNotebookStore {
     })
     if (decoded?.ipynb) {
       this.ipynbState.set(recId, {
-        shadowText: content,
+        shadowText: decoded.ipynb.shadowText,
         state: decoded.ipynb,
       })
     }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -9,6 +9,7 @@ import {
   setGoogleDriveBaseUrl,
 } from '../lib/googleDriveRuntime'
 import { IPYNB_MIME_TYPE } from '../lib/ipynb'
+import { appLogger } from '../lib/logging/runtime'
 import { encodeIpynbNotebook, encodeRunmeNotebook } from '../lib/notebookFormat'
 import { MimeType, parser_pb } from '../runme/client'
 import { MemoryConflictDocStorage } from './conflictDocs'
@@ -1645,6 +1646,69 @@ describe('LocalNotebooks pending Drive create', () => {
 })
 
 describe('LocalNotebooks ipynb conversion', () => {
+  it('recovers a Drive IPYNB containing Runme JSON instead of showing an empty notebook', async () => {
+    const localUri = 'local://file/recover-ipynb'
+    const remoteUri = 'https://drive.google.com/file/d/recover123/view'
+    const source = create(parser_pb.NotebookSchema, {
+      metadata: { 'runme.dev/ipynb': 'true' },
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'title',
+          kind: parser_pb.CellKind.MARKUP,
+          languageId: 'markdown',
+          value: '# Still here',
+        }),
+      ],
+    })
+    const malformedIpynb = encodeRunmeNotebook(source)
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: remoteUri,
+        name: 'codex_instructions.ipynb',
+        type: NotebookStoreItemType.File,
+        children: [],
+        mimeType: IPYNB_MIME_TYPE,
+        parents: [],
+      })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: 'malformed-checksum',
+        headRevisionId: 'malformed-revision',
+      })),
+      loadContent: vi.fn(async () => malformedIpynb),
+    }
+    const shadowStorage = new MemoryIpynbShadowStorage()
+    const store = createTestStore(driveStore, {
+      ipynbShadowStorage: shadowStorage,
+    })
+    await store.files.put({
+      id: localUri,
+      name: 'codex_instructions.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+    vi.spyOn(appLogger, 'warn').mockImplementation(() => null as never)
+
+    const loaded = await store.load(localUri)
+
+    expect(loaded.cells).toHaveLength(1)
+    expect(loaded.cells[0]).toMatchObject({
+      refId: 'title',
+      kind: parser_pb.CellKind.MARKUP,
+      value: '# Still here',
+    })
+    const preservation = (await store.files.get(localUri))?.ipynbPreservation
+    expect(preservation).toBeDefined()
+    const repaired = JSON.parse(
+      await shadowStorage.read(preservation!.shadowRef)
+    )
+    expect(repaired).toMatchObject({ nbformat: 4, nbformat_minor: 5 })
+    expect(repaired.cells).toHaveLength(1)
+  })
+
   it('migrates cached kind-prefixed identities through the preservation map', async () => {
     const shadowStorage = new MemoryIpynbShadowStorage()
     const shadowText = JSON.stringify({
@@ -2643,6 +2707,70 @@ describe('LocalNotebooks Drive conflict resolution', () => {
     ).resolves.toMatchObject({
       status: 'synced',
     })
+  })
+
+  it('saves the local conflict winner as nbformat for an IPYNB file', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/ipynb123/view'
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'local-cell',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: "print('local wins')",
+        }),
+      ],
+    })
+    const localDoc = encodeRunmeNotebook(notebook)
+    let savedContent = ''
+    const driveStore = {
+      getVersionMetadata: vi
+        .fn()
+        .mockResolvedValueOnce({ md5Checksum: 'upstream-checksum' })
+        .mockResolvedValueOnce({ md5Checksum: 'saved-checksum' }),
+      saveContent: vi.fn(
+        async (uri: string, content: string, mimeType: string) => {
+          expect(uri).toBe(remoteUri)
+          expect(mimeType).toBe(IPYNB_MIME_TYPE)
+          savedContent = content
+        }
+      ),
+    }
+    const store = createTestStore(driveStore)
+    await store.files.put({
+      id: 'local://file/ipynb-conflict',
+      name: 'notebook.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: remoteUri,
+      lastRemoteChecksum: 'base-checksum',
+      lastSynced: '',
+      doc: localDoc,
+      md5Checksum: 'local-checksum',
+      conflict: {
+        detectedAt: '2026-09-01T00:00:00.000Z',
+        upstreamChecksum: 'upstream-checksum',
+        upstreamDoc: encodeRunmeNotebook(
+          create(parser_pb.NotebookSchema, { cells: [] })
+        ),
+        localChecksumAtDetection: 'local-checksum',
+      },
+    })
+
+    await store.resolveConflictWithLocal('local://file/ipynb-conflict')
+
+    expect(driveStore.saveContent).toHaveBeenCalledWith(
+      remoteUri,
+      expect.any(String),
+      IPYNB_MIME_TYPE
+    )
+    const saved = JSON.parse(savedContent)
+    expect(saved).toMatchObject({ nbformat: 4, nbformat_minor: 5 })
+    expect(saved.cells[0]).toMatchObject({
+      cell_type: 'code',
+      id: 'local-cell',
+      source: "print('local wins')",
+    })
+    expect(saved.cells[0]).not.toHaveProperty('kind')
   })
 
   it('requires force when upstream changed again before saving local version', async () => {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1333,7 +1333,10 @@ export class LocalNotebooks extends Dexie {
         throw new Error(`Expected ipynb content for ${record.name}`)
       }
       const serialized = serializeNotebook(decoded.notebook)
-      const shadowRef = await this.ipynbShadowStorage.write(uri, content)
+      const shadowRef = await this.ipynbShadowStorage.write(
+        uri,
+        decoded.ipynb.shadowText
+      )
       const previousRef = record.ipynbPreservation?.shadowRef
       await this.files.update(uri, {
         doc: serialized,
@@ -1744,7 +1747,7 @@ export class LocalNotebooks extends Dexie {
       localContent = serializeNotebook(decoded.notebook)
       const shadowRef = await this.ipynbShadowStorage.write(
         fileUri,
-        initialIpynb
+        decoded.ipynb?.shadowText ?? initialIpynb
       )
       ipynbPreservation = {
         upstreamFingerprint: '',
@@ -2459,7 +2462,10 @@ export class LocalNotebooks extends Dexie {
     if (!decoded.ipynb) {
       return { notebook: decoded.notebook, serialized }
     }
-    const shadowRef = await this.ipynbShadowStorage.write(localUri, content)
+    const shadowRef = await this.ipynbShadowStorage.write(
+      localUri,
+      decoded.ipynb.shadowText
+    )
     return {
       notebook: decoded.notebook,
       serialized,


### PR DESCRIPTION
## Summary

- recover Runme protobuf JSON stored under an .ipynb filename using a conservative, evidence-based fallback
- preserve Runme-only output/process/execution data in the Jupyter metadata envelope without overriding later external Jupyter edits
- keep canonical Jupyter shadow content after recovery and cell-ID repair
- make Drive notebook load/save format-aware so lower-level callers cannot write protobuf JSON back to .ipynb files
- cover the reported 15-cell shape, local mirror recovery, direct Drive repair, and diff-view Save local version flow

## Root cause

The malformed Drive bytes match the old format-agnostic DriveNotebookStore.save serializer exactly. The current diff-view conflict action already uses the Jupyter encoder, so the revision metadata does not prove that UI action was the trigger; it could have occurred through another lower-level caller, an older deployed client, or a mirror whose filename was stale. This change enforces the invariant at the storage boundary and recovers files already affected.

## Verification

- pnpm -C app exec vitest run: 105 files, 1,046 tests passed
- pnpm -C app run build
- changed-file ESLint: no errors
- changed-path typecheck: no errors
- git diff --check

Repository-wide typecheck and lint still report unrelated pre-existing baseline failures outside the changed code.

## Review findings addressed

- preserve complete Runme output metadata, item details, process info, and execution summary during recovery
- keep externally changed Jupyter outputs authoritative over stale embedded Runme data, even when execution_count is unchanged
- compare output projections structurally so object-key reordering does not discard Runme-only details
- ignore malformed optional Runme output metadata and fall back to valid Jupyter outputs
- invalidate cached IPYNB preservation state after successful raw Drive writes so later structured saves re-read and retain the new bytes
- bind cached IPYNB preservation state to its source checksum and discard it after externally observed Drive changes
- amend the commit with the required DCO signoff

## Design

https://drive.google.com/file/d/1YGkh35GTZ8PShRyl6aG7iaj1ubl9T5wD/view
