### PR TITLE
Make .runme notebooks the default

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -62,6 +62,8 @@ const contextMocks = vi.hoisted(() => ({
     requestedUri: string
     name: string
     state: 'loading' | 'loaded' | 'blocked' | 'error'
+    operationLog?: boolean
+    refreshErrorMessage?: string
   }>,
   currentDoc: null as string | null,
   setCurrentDoc: vi.fn(),
@@ -1022,6 +1024,116 @@ describe('Actions tabs', () => {
     expect(screen.getByText('Loading notebook from Google Drive')).toBeTruthy()
     expect(screen.queryByText('This notebook has no cells yet.')).toBeNull()
     expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
+  it('keeps local operation-log refresh separate from Drive sync', async () => {
+    const uri = 'local://file/shared-runme'
+    const remoteId = 'https://drive.google.com/file/d/file123/view'
+    const sync = vi.fn(async () => undefined)
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'shared.runme',
+        requestedUri: remoteId,
+        state: 'loaded',
+        refreshErrorMessage: 'Could not refresh operation log: OPFS unavailable',
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {},
+        cells: [],
+      }),
+    })
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(),
+      getSyncState: vi.fn(async () => ({
+        status: 'synced',
+        localUri: uri,
+        remoteId,
+      })),
+      rename: vi.fn(),
+      sync,
+      subscribeSync: vi.fn(() => () => {}),
+    }
+
+    render(<Actions />)
+
+    const refresh = await screen.findByRole('button', {
+      name: 'Refresh shared.runme from local operation log',
+    })
+    const driveSync = await screen.findByRole('button', {
+      name: 'Notebook is synced with Google Drive. Click to sync now.',
+    })
+
+    expect(
+      refresh.compareDocumentPosition(driveSync) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    fireEvent.click(refresh)
+    expect(contextMocks.refreshReadOnlyNotebook).toHaveBeenCalledWith(uri)
+    expect(sync).not.toHaveBeenCalled()
+
+    fireEvent.click(driveSync)
+    expect(sync).toHaveBeenCalledWith(uri)
+    expect(screen.queryByTestId('notebook-operation-log-banner')).toBeNull()
+    expect(
+      screen.getByTestId('notebook-operation-log-refresh-error').textContent
+    ).toContain('OPFS unavailable')
+  })
+
+  it('does not make non-Drive status indicators trigger upstream sync', async () => {
+    const localUri = 'local://file/local-runme'
+    const filesystemUri = 'local://file/filesystem-runme'
+    const sync = vi.fn(async () => undefined)
+    contextMocks.currentDoc = localUri
+    contextMocks.workspaceDocuments = [
+      { uri: localUri, title: 'local.runme', state: 'loaded' },
+      { uri: filesystemUri, title: 'filesystem.runme', state: 'loaded' },
+    ]
+    for (const uri of [localUri, filesystemUri]) {
+      contextMocks.notebookSnapshots.set(uri, {
+        uri,
+        loaded: true,
+        notebook: create(parser_pb.NotebookSchema, {
+          metadata: {},
+          cells: [],
+        }),
+      })
+    }
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(),
+      getSyncState: vi.fn(async (uri: string) =>
+        uri === localUri
+          ? { status: 'local-only', localUri: uri, remoteId: uri }
+          : {
+              status: 'synced',
+              localUri: uri,
+              remoteId: 'fs://workspace/shared.runme',
+            }
+      ),
+      rename: vi.fn(),
+      sync,
+      subscribeSync: vi.fn(() => () => {}),
+    }
+
+    render(<Actions />)
+
+    const localStatus = await screen.findByRole('button', {
+      name: 'Notebook is stored only in this browser',
+    })
+    const filesystemStatus = await screen.findByRole('button', {
+      name: 'Notebook is synced',
+    })
+    fireEvent.click(localStatus)
+    fireEvent.click(filesystemStatus)
+
+    expect(sync).not.toHaveBeenCalled()
+    expect(
+      screen.queryByLabelText(/Click to sync now/)
+    ).toBeNull()
   })
 
   it('defers rendering inactive read-only notebook cells', () => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -15,6 +15,7 @@ import { create } from '@bufbuild/protobuf'
 import { Button, ScrollArea, Tabs, Text, Tooltip } from '@radix-ui/themes'
 
 import {
+  ArrowPathIcon,
   ChatBubbleLeftIcon,
   LinkIcon,
   LockClosedIcon,
@@ -349,11 +350,19 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
   const syncState = useNotebookSyncState(docUri)
 
   const presentation = syncIndicatorPresentation(syncState)
+  const canSyncDrive = isDriveItemUri(syncState?.remoteId)
+  const clickable =
+    presentation.clickable ||
+    (canSyncDrive && syncState?.status === 'synced')
+  const label =
+    syncState?.status === 'synced' && canSyncDrive
+      ? 'Notebook is synced with Google Drive. Click to sync now.'
+      : presentation.label
   const handleClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
       event.preventDefault()
       event.stopPropagation()
-      if (!store || !presentation.clickable) {
+      if (!store || !clickable) {
         return
       }
       if (syncState?.status === 'conflicted') {
@@ -382,7 +391,7 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
         })
       })
     },
-    [docUri, presentation.clickable, store, syncState?.status]
+    [clickable, docUri, store, syncState?.status]
   )
 
   if (!store || !docUri.startsWith('local://file/')) {
@@ -392,8 +401,8 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
   return (
     <button
       type="button"
-      aria-label={presentation.label}
-      title={presentation.label}
+      aria-label={label}
+      title={label}
       className="inline-flex h-5 w-5 items-center justify-center rounded-full"
       onClick={handleClick}
       onMouseDown={(event) => event.stopPropagation()}
@@ -401,6 +410,34 @@ function NotebookSyncIndicator({ docUri }: { docUri: string }) {
       <span
         className={`block h-2.5 w-2.5 rounded-full ${presentation.className}`}
       />
+    </button>
+  )
+}
+
+function OperationLogRefreshButton({
+  docUri,
+  displayName,
+}: {
+  docUri: string
+  displayName: string
+}) {
+  const { refreshReadOnlyNotebook } = useNotebookContext()
+  const label = `Refresh ${displayName} from local operation log`
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title="Refresh from local operation log"
+      className="inline-flex h-5 w-5 items-center justify-center rounded-nb-xs text-nb-text-faint transition-all duration-150 hover:bg-nb-surface-2 hover:text-nb-text"
+      onClick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        void refreshReadOnlyNotebook(docUri)
+      }}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <ArrowPathIcon className="h-3.5 w-3.5" />
     </button>
   )
 }
@@ -3482,27 +3519,16 @@ function NotebookTabContent({
         {/* Full-width notebook column with horizontal padding for breathing room.
             Cells expand to fill the available width of the tab content area. */}
         <div id="notebook-column" className="w-full py-2 px-8">
-          {entry.operationLog && !readOnly && !releasePending ? (
+          {entry.operationLog &&
+          !readOnly &&
+          !releasePending &&
+          entry.refreshErrorMessage ? (
             <div
-              className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
-              data-testid="notebook-operation-log-banner"
+              className="mb-3 rounded-nb-sm border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600"
+              role="alert"
+              data-testid="notebook-operation-log-refresh-error"
             >
-              <span>
-                Concurrent changes are incorporated when you refresh this
-                operation-log notebook.
-              </span>
-              <Button
-                size="1"
-                variant="soft"
-                onClick={() => void refreshReadOnlyNotebook(docUri)}
-              >
-                Refresh
-              </Button>
-              {entry.refreshErrorMessage && (
-                <p className="w-full text-red-600">
-                  {entry.refreshErrorMessage}
-                </p>
-              )}
+              {entry.refreshErrorMessage}
             </div>
           ) : releasePending ? (
             <div
@@ -4692,6 +4718,14 @@ export default function Actions() {
                       </span>
                       {doc.readOnly && <ReadOnlyTabIndicator />}
                     </Tabs.Trigger>
+                    {isNotebook &&
+                      detectNotebookFileFormat(doc.title) ===
+                        'runme-operation-log' && (
+                        <OperationLogRefreshButton
+                          docUri={doc.uri}
+                          displayName={displayName}
+                        />
+                      )}
                     {isNotebook && <NotebookSyncIndicator docUri={doc.uri} />}
                     <button
                       type="button"

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -554,6 +554,119 @@ describe('WorkspaceExplorer current document handling', () => {
     })
   })
 
+  it('makes the operation-log notebook the first creation option', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    const driveRoot = await screen.findByText('Drive Root')
+    fireEvent.contextMenu(driveRoot)
+
+    const menuLabels = screen
+      .getAllByRole('button')
+      .filter((button) => button.classList.contains('ctx-menu-item'))
+      .map((button) => button.textContent?.trim())
+    expect(menuLabels.slice(0, 7)).toEqual([
+      'Sync',
+      'Rename',
+      'New Notebook (.runme)',
+      'New Jupyter Notebook (.ipynb)',
+      'New Excalidraw Diagram',
+      'New Google Drive Folder',
+      'Legacy Runme Notebook (.json)',
+    ])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'New Notebook (.runme)' })
+    )
+    await waitFor(() => {
+      expect(mocks.store.create).toHaveBeenCalledWith(
+        'local://folder/drive',
+        expect.stringMatching(/^untitled-\d{8}-\d{4}\.runme$/)
+      )
+    })
+
+    fireEvent.contextMenu(driveRoot)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Legacy Runme Notebook (.json)' })
+    )
+    await waitFor(() => {
+      expect(mocks.store.create).toHaveBeenLastCalledWith(
+        'local://folder/drive',
+        expect.stringMatching(/^untitled-\d{8}-\d{4}\.json$/)
+      )
+    })
+  })
+
+  it('uses the same creation order from a notebook context menu', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/notebook'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/notebook') {
+        return {
+          uri,
+          name: 'notebook.runme',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/notebook/view',
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('notebook.runme'))
+
+    const menuLabels = screen
+      .getAllByRole('button')
+      .filter((button) => button.classList.contains('ctx-menu-item'))
+      .map((button) => button.textContent?.trim())
+    expect(menuLabels.slice(0, 6)).toEqual([
+      'Sync',
+      'Rename',
+      'New Notebook (.runme)',
+      'New Jupyter Notebook (.ipynb)',
+      'New Excalidraw Diagram',
+      'Legacy Runme Notebook (.json)',
+    ])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'New Notebook (.runme)' })
+    )
+    await waitFor(() => {
+      expect(mocks.store.create).toHaveBeenCalledWith(
+        'local://folder/drive',
+        expect.stringMatching(/^untitled-\d{8}-\d{4}\.runme$/)
+      )
+    })
+  })
+
   it('creates a Jupyter notebook from a folder context menu', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     mocks.store.getMetadata.mockImplementation(async (uri: string) => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -996,7 +996,10 @@ export function WorkspaceExplorer() {
   );
 
   const handleCreateDocument = useCallback(
-    async (folderUri: string, format: NotebookFileFormat = 'runme-json') => {
+    async (
+      folderUri: string,
+      format: NotebookFileFormat = 'runme-operation-log'
+    ) => {
       const targetStore = storeForUri(folderUri, store, fsStore)
       if (!targetStore) {
         return;
@@ -1700,10 +1703,7 @@ function formatShortTimestamp(date: Date): string {
                   event.stopPropagation();
                   setContextMenu(null);
                   if (adjustedContextMenu.parentUri) {
-                    void handleCreateDocument(
-                      adjustedContextMenu.parentUri,
-                      'runme-json'
-                    )
+                    void handleCreateDocument(adjustedContextMenu.parentUri)
                   } else {
                     console.warn(
                       "Cannot create document: no parent folder for",
@@ -1712,24 +1712,7 @@ function formatShortTimestamp(date: Date): string {
                   }
                 }}
               >
-                New Runme Notebook (.json)
-              </button>
-              <button
-                type="button"
-                className="ctx-menu-item"
-                onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  setContextMenu(null)
-                  if (adjustedContextMenu.parentUri) {
-                    void handleCreateDocument(
-                      adjustedContextMenu.parentUri,
-                      'runme-operation-log'
-                    )
-                  }
-                }}
-              >
-                New Concurrent Runme Notebook (.runme)
+                New Notebook (.runme)
               </button>
               <button
                 type="button"
@@ -1768,6 +1751,23 @@ function formatShortTimestamp(date: Date): string {
                 }}
               >
                 New Excalidraw Diagram
+              </button>
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setContextMenu(null)
+                  if (adjustedContextMenu.parentUri) {
+                    void handleCreateDocument(
+                      adjustedContextMenu.parentUri,
+                      'runme-json'
+                    )
+                  }
+                }}
+              >
+                Legacy Runme Notebook (.json)
               </button>
               {adjustedContextMenu.remoteUri && (
                 <button
@@ -1891,13 +1891,10 @@ function formatShortTimestamp(date: Date): string {
                 onClick={(event) => {
                   event.stopPropagation()
                   setContextMenu(null)
-                  void handleCreateDocument(
-                    adjustedContextMenu.uri,
-                    'runme-json'
-                  )
+                  void handleCreateDocument(adjustedContextMenu.uri)
                 }}
               >
-                New Runme Notebook (.json)
+                New Notebook (.runme)
               </button>
               <button
                 type="button"
@@ -1908,20 +1905,8 @@ function formatShortTimestamp(date: Date): string {
                   setContextMenu(null)
                   void handleCreateDocument(
                     adjustedContextMenu.uri,
-                    'runme-operation-log'
+                    'ipynb'
                   )
-                }}
-              >
-                New Concurrent Runme Notebook (.runme)
-              </button>
-              <button
-                type="button"
-                className="ctx-menu-item"
-                onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  setContextMenu(null)
-                  void handleCreateDocument(adjustedContextMenu.uri, 'ipynb')
                 }}
               >
                 New Jupyter Notebook (.ipynb)
@@ -1956,6 +1941,21 @@ function formatShortTimestamp(date: Date): string {
                   New Google Drive Folder
                 </button>
               )}
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setContextMenu(null)
+                  void handleCreateDocument(
+                    adjustedContextMenu.uri,
+                    'runme-json'
+                  )
+                }}
+              >
+                Legacy Runme Notebook (.json)
+              </button>
               {adjustedContextMenu.remoteUri && (
                 <button
                   type="button"

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -90,6 +90,13 @@ function createFakeLocalNotebooks() {
       }
       return record.notebook
     }),
+    loadOperationLogSnapshot: vi.fn(async (uri: string) => {
+      const record = records.get(uri)
+      if (!record) {
+        throw new Error(`Local notebook record not found for ${uri}`)
+      }
+      return record.notebook
+    }),
     sync: vi.fn(async () => undefined),
     operationLogSupportsConcurrentWriters: vi.fn(() => true),
     save: vi.fn(),
@@ -245,7 +252,7 @@ describe('NotebookDataController', () => {
     expect(localStore.createOperationLogSaveStore).not.toHaveBeenCalled()
   })
 
-  it('forces upstream sync before refreshing a .runme snapshot', async () => {
+  it('refreshes a .runme snapshot from OPFS without syncing upstream', async () => {
     const uri = 'local://file/shared'
     const localStore = createFakeLocalNotebooks()
     localStore.records.set(uri, {
@@ -254,8 +261,9 @@ describe('NotebookDataController', () => {
       remoteId: 'https://drive.google.com/file/d/shared/view',
       notebook: createNotebook('before'),
     })
-    localStore.sync.mockImplementation(async () => {
+    localStore.loadOperationLogSnapshot.mockImplementation(async () => {
       localStore.records.get(uri)!.notebook = createNotebook('after')
+      return localStore.records.get(uri)!.notebook
     })
     const controller = getNotebookDataController()
     controller.configureOwnershipManager(createFakeOwnershipManager())
@@ -263,13 +271,20 @@ describe('NotebookDataController', () => {
       localNotebooks: localStore as unknown as LocalNotebooks,
     })
     await controller.openNotebook(uri)
+    const notebookData = controller.getNotebookData(uri)!
+    const flushPendingPersist = vi.spyOn(
+      notebookData,
+      'flushPendingPersist'
+    )
 
     await controller.refreshReadOnlyNotebook(uri)
 
-    expect(localStore.sync).toHaveBeenCalledWith(uri)
-    expect(localStore.load.mock.invocationCallOrder.at(-1)).toBeGreaterThan(
-      localStore.sync.mock.invocationCallOrder.at(-1)!
-    )
+    expect(localStore.sync).not.toHaveBeenCalled()
+    expect(localStore.loadOperationLogSnapshot).toHaveBeenCalledWith(uri)
+    expect(flushPendingPersist).toHaveBeenCalledOnce()
+    expect(
+      localStore.loadOperationLogSnapshot.mock.invocationCallOrder.at(-1)
+    ).toBeGreaterThan(flushPendingPersist.mock.invocationCallOrder.at(-1)!)
     expect(controller.getNotebookData(uri)?.getNotebook().cells[0]?.value).toBe(
       'after'
     )
@@ -284,7 +299,9 @@ describe('NotebookDataController', () => {
       remoteId: 'https://drive.google.com/file/d/shared/view',
       notebook: createNotebook('current'),
     })
-    localStore.sync.mockRejectedValue(new Error('remote unavailable'))
+    localStore.loadOperationLogSnapshot.mockRejectedValue(
+      new Error('OPFS unavailable')
+    )
     const controller = getNotebookDataController()
     controller.configureOwnershipManager(createFakeOwnershipManager())
     controller.configureStores({
@@ -298,7 +315,39 @@ describe('NotebookDataController', () => {
       'current'
     )
     expect(controller.getOpenNotebooks()[0]?.refreshErrorMessage).toContain(
-      'remote unavailable'
+      'OPFS unavailable'
+    )
+    expect(localStore.sync).not.toHaveBeenCalled()
+  })
+
+  it('does not replace a .runme snapshot when pending persistence fails', async () => {
+    const uri = 'local://file/shared'
+    const localStore = createFakeLocalNotebooks()
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'shared.runme',
+      remoteId: 'https://drive.google.com/file/d/shared/view',
+      notebook: createNotebook('current'),
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    await controller.openNotebook(uri)
+    vi.spyOn(
+      controller.getNotebookData(uri)!,
+      'flushPendingPersist'
+    ).mockRejectedValue(new Error('OPFS write failed'))
+
+    await controller.refreshReadOnlyNotebook(uri)
+
+    expect(localStore.loadOperationLogSnapshot).not.toHaveBeenCalled()
+    expect(controller.getNotebookData(uri)?.getNotebook().cells[0]?.value).toBe(
+      'current'
+    )
+    expect(controller.getOpenNotebooks()[0]?.refreshErrorMessage).toContain(
+      'OPFS write failed'
     )
   })
 

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -498,10 +498,11 @@ export class NotebookDataController {
       if (!handle) return
       try {
         await handle.data.flushPendingPersist()
-        // Refresh is an explicit request to incorporate operations written by
-        // other sessions, so bypass load()'s normal eight-hour sync throttle.
-        await this.localNotebooks.sync(localUri)
-        const notebook = await this.localNotebooks.load(localUri)
+        // Refresh only materializes the shared OPFS journal. Upstream Drive
+        // synchronization is an independent action exposed by the tab status
+        // control.
+        const notebook =
+          await this.localNotebooks.loadOperationLogSnapshot(localUri)
         const store =
           await this.localNotebooks.createOperationLogSaveStore(localUri)
         handle.data.loadNotebook(notebook, { persist: false })

--- a/app/src/lib/runtime/runmeConsole.ts
+++ b/app/src/lib/runtime/runmeConsole.ts
@@ -728,7 +728,7 @@ export function createNotebooksApi({
       return 'notebooks.execute({ target, refIds: string[] }): Promise<{ handle, cells }>. target is required.'
     }
     if (topic === 'refresh') {
-      return 'notebooks.refresh({ target }): Promise<NotebookDocument>. Explicitly incorporates newly observed operations into a .runme tab snapshot. target is required.'
+      return 'notebooks.refresh({ target }): Promise<NotebookDocument>. Materializes the local OPFS operation log into a .runme tab snapshot without upstream Drive I/O. target is required.'
     }
     if (topic === 'requestWriteAccess') {
       return 'notebooks.requestWriteAccess({ target }): Promise<NotebookDocument>. Cooperatively asks the current owner to save and release the notebook, then returns the refreshed document. target is required.'

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -208,6 +208,76 @@ describe('LocalNotebooks operation-log storage', () => {
     })
   })
 
+  it('retries first-time Drive mirror hydration until bytes match metadata', async () => {
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'notebook_first_hydration_race',
+      created_by: 'actor_seed',
+      created_at: '2026-09-03T00:00:00Z',
+    }
+    const remoteOperation = createRunmeOperation({
+      actorId: 'actor_remote',
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'notebook.update',
+      payload: { frontmatter: { remote: 'true' }, metadata: {} },
+    })
+    const staleDocument = serializeOperationLog(header, [])
+    const latestDocument = serializeOperationLog(header, [remoteOperation])
+    let remoteDocument = staleDocument
+    let remoteVersion = {
+      md5Checksum: md5(staleDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    let loadCount = 0
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => {
+        loadCount += 1
+        if (loadCount === 1) {
+          remoteDocument = latestDocument
+          remoteVersion = {
+            md5Checksum: md5(latestDocument),
+            headRevisionId: 'revision-2',
+            version: '2',
+          }
+          return staleDocument
+        }
+        return remoteDocument
+      }),
+    }
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const store = createTestStore(driveStore, { operationLogStorage })
+    const uri = 'local://file/first-hydration-race'
+    await store.files.put({
+      id: uri,
+      name: 'shared.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/first-hydration-race/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.reconcileDriveNotebook(uri)
+
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(2)
+    expect(await store.loadContent(uri)).toBe(latestDocument)
+    expect(await store.files.get(uri)).toMatchObject({
+      md5Checksum: md5(latestDocument),
+      lastRemoteChecksum: md5(latestDocument),
+      lastUpstreamVersion: {
+        checksum: md5(latestDocument),
+        revisionId: 'revision-2',
+      },
+      lastSyncError: undefined,
+    })
+  })
+
   it('keeps local .runme bytes in OPFS storage instead of IndexedDB', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const store = createTestStore({}, { operationLogStorage })
@@ -498,6 +568,316 @@ describe('LocalNotebooks operation-log storage', () => {
     })
     expect(appendOperationLog).toHaveBeenCalledTimes(1)
     expect(replaceOperationLog).not.toHaveBeenCalled()
+  })
+
+  it('rejects stale bytes, then accepts a newer self-consistent Drive snapshot', async () => {
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'notebook_drive_race',
+      created_by: 'actor_seed',
+      created_at: '2026-09-03T00:00:00Z',
+    }
+    const localOperation = createRunmeOperation({
+      actorId: 'actor_local',
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'notebook.update',
+      payload: { frontmatter: { local: 'true' }, metadata: {} },
+    })
+    const remoteOperation = createRunmeOperation({
+      actorId: 'actor_remote',
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'notebook.update',
+      payload: { frontmatter: { remote: 'true' }, metadata: {} },
+    })
+    const laterRemoteOperation = createRunmeOperation({
+      actorId: 'actor_remote',
+      actorSequence: 2,
+      dependencies: [remoteOperation.op_id],
+      knownOperations: [remoteOperation],
+      kind: 'notebook.update',
+      payload: { frontmatter: { laterRemote: 'true' }, metadata: {} },
+    })
+    const localDocument = serializeOperationLog(header, [localOperation])
+    let remoteDocument = serializeOperationLog(header, [])
+    let remoteVersion = {
+      md5Checksum: md5(remoteDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    let loadCount = 0
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => {
+        loadCount += 1
+        const downloaded = remoteDocument
+        const operations =
+          loadCount === 1
+            ? [remoteOperation]
+            : [remoteOperation, laterRemoteOperation]
+        // On the first attempt Drive returns stale bytes alongside newer
+        // metadata. On the second, the response bytes and newer metadata agree.
+        remoteDocument = serializeOperationLog(header, operations)
+        remoteVersion = {
+          md5Checksum: md5(remoteDocument),
+          headRevisionId: `revision-${loadCount + 1}`,
+          version: String(loadCount + 1),
+        }
+        return loadCount === 1 ? downloaded : remoteDocument
+      }),
+      saveContentIfVersion: vi.fn(
+        async (
+          _uri: string,
+          content: string,
+          _mimeType: string,
+          expected: { checksum?: string; revisionId?: string }
+        ) => {
+          expect(expected).toEqual({
+            checksum: remoteVersion.md5Checksum,
+            revisionId: remoteVersion.headRevisionId,
+          })
+          remoteDocument = content
+          remoteVersion = {
+            md5Checksum: md5(content),
+            headRevisionId: 'revision-4',
+            version: '4',
+          }
+          return true
+        }
+      ),
+    }
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const local = await operationLogStorage.initialize(
+      'local://file/drive-race',
+      localDocument
+    )
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.files.put({
+      id: 'local://file/drive-race',
+      name: 'shared.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/drive-race/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: local.checksum,
+      operationLogRef: local.ref,
+    })
+
+    await store.reconcileDriveNotebook('local://file/drive-race')
+
+    const localAfter = await store.loadContent('local://file/drive-race')
+    const expectedOperationIds = new Set([
+      localOperation.op_id,
+      remoteOperation.op_id,
+      laterRemoteOperation.op_id,
+    ])
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(2)
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(1)
+    expect(
+      new Set(
+        parseOperationLog(remoteDocument).operations.map(
+          (operation) => operation.op_id
+        )
+      )
+    ).toEqual(expectedOperationIds)
+    expect(
+      new Set(
+        parseOperationLog(localAfter).operations.map(
+          (operation) => operation.op_id
+        )
+      )
+    ).toEqual(expectedOperationIds)
+    expect(await store.files.get('local://file/drive-race')).toMatchObject({
+      md5Checksum: md5(localAfter),
+      lastRemoteChecksum: md5(localAfter),
+      lastSyncError: undefined,
+    })
+  })
+
+  it('merges every competing operation through the eighth Drive CAS attempt', async () => {
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'notebook_drive_contention',
+      created_by: 'actor_seed',
+      created_at: '2026-09-03T00:00:00Z',
+    }
+    const localOperation = createRunmeOperation({
+      actorId: 'actor_local',
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'notebook.update',
+      payload: { frontmatter: { local: 'true' }, metadata: {} },
+    })
+    const competingOperations = Array.from({ length: 7 }, (_, index) =>
+      createRunmeOperation({
+        actorId: `actor_remote_${index + 1}`,
+        actorSequence: 1,
+        dependencies: [],
+        knownOperations: [],
+        kind: 'notebook.update',
+        payload: {
+          frontmatter: { [`remote_${index + 1}`]: 'true' },
+          metadata: {},
+        },
+      })
+    )
+    const localDocument = serializeOperationLog(header, [localOperation])
+    let remoteDocument = serializeOperationLog(header, [])
+    let remoteVersion = {
+      md5Checksum: md5(remoteDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    let collisions = 0
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => remoteDocument),
+      saveContentIfVersion: vi.fn(
+        async (
+          _uri: string,
+          content: string,
+          _mimeType: string,
+          expected: { checksum?: string; revisionId?: string }
+        ) => {
+          expect(expected).toEqual({
+            checksum: remoteVersion.md5Checksum,
+            revisionId: remoteVersion.headRevisionId,
+          })
+          collisions += 1
+          if (collisions <= competingOperations.length) {
+            remoteDocument = serializeOperationLog(
+              header,
+              competingOperations.slice(0, collisions)
+            )
+            remoteVersion = {
+              md5Checksum: md5(remoteDocument),
+              headRevisionId: `revision-${collisions + 1}`,
+              version: String(collisions + 1),
+            }
+            return false
+          }
+          remoteDocument = content
+          remoteVersion = {
+            md5Checksum: md5(content),
+            headRevisionId: 'revision-9',
+            version: '9',
+          }
+          return true
+        }
+      ),
+    }
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const local = await operationLogStorage.initialize(
+      'local://file/drive-contention',
+      localDocument
+    )
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.files.put({
+      id: 'local://file/drive-contention',
+      name: 'shared.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/drive-contention/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: local.checksum,
+      operationLogRef: local.ref,
+    })
+
+    await expect(
+      store.reconcileDriveNotebook('local://file/drive-contention')
+    ).resolves.toBeUndefined()
+
+    const localAfter = await store.loadContent('local://file/drive-contention')
+    const expectedOperationIds = new Set([
+      localOperation.op_id,
+      ...competingOperations.map((operation) => operation.op_id),
+    ])
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(8)
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(8)
+    expect(
+      new Set(
+        parseOperationLog(remoteDocument).operations.map(
+          (operation) => operation.op_id
+        )
+      )
+    ).toEqual(expectedOperationIds)
+    expect(
+      new Set(
+        parseOperationLog(localAfter).operations.map(
+          (operation) => operation.op_id
+        )
+      )
+    ).toEqual(expectedOperationIds)
+  })
+
+  it('reports contention after all eight Drive CAS attempts are exhausted', async () => {
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'notebook_drive_exhaustion',
+      created_by: 'actor_seed',
+      created_at: '2026-09-03T00:00:00Z',
+    }
+    const localOperation = createRunmeOperation({
+      actorId: 'actor_local',
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'notebook.update',
+      payload: { frontmatter: { local: 'true' }, metadata: {} },
+    })
+    const localDocument = serializeOperationLog(header, [localOperation])
+    const remoteDocument = serializeOperationLog(header, [])
+    let revision = 1
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: md5(remoteDocument),
+        headRevisionId: `revision-${revision}`,
+        version: String(revision),
+      })),
+      loadContent: vi.fn(async () => remoteDocument),
+      saveContentIfVersion: vi.fn(async () => {
+        revision += 1
+        return false
+      }),
+    }
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const local = await operationLogStorage.initialize(
+      'local://file/drive-exhaustion',
+      localDocument
+    )
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.files.put({
+      id: 'local://file/drive-exhaustion',
+      name: 'shared.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/drive-exhaustion/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: local.checksum,
+      operationLogRef: local.ref,
+    })
+
+    await expect(
+      store.reconcileDriveNotebook('local://file/drive-exhaustion')
+    ).rejects.toThrow(
+      'Drive operation log changed during 8 merge attempts for local://file/drive-exhaustion'
+    )
+
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(8)
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(8)
   })
 
   it('unions concurrent local and filesystem operation logs as raw bytes', async () => {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -306,6 +306,52 @@ describe('LocalNotebooks operation-log storage', () => {
     expect((await store.load(created.uri)).cells).toEqual([])
   })
 
+  it('materializes a .runme OPFS snapshot without reading from Drive', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const driveStore = {
+      loadContent: vi.fn(async () => {
+        throw new Error('Drive should not be read')
+      }),
+      getVersionMetadata: vi.fn(async () => {
+        throw new Error('Drive should not be read')
+      }),
+    }
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local Notebooks',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    const created = await store.create(LOCAL_FOLDER_URI, 'shared.runme')
+    const saveStore = await store.createOperationLogSaveStore(created.uri, {
+      actorId: 'actor_test',
+    })
+    await saveStore.save(
+      created.uri,
+      create(parser_pb.NotebookSchema, {
+        cells: [
+          create(parser_pb.CellSchema, {
+            refId: 'cell_one',
+            kind: parser_pb.CellKind.MARKUP,
+            languageId: 'markdown',
+            value: 'Local OPFS value',
+          }),
+        ],
+      })
+    )
+    await store.files.update(created.uri, {
+      remoteId: 'https://drive.google.com/file/d/shared/view',
+    })
+
+    const snapshot = await store.loadOperationLogSnapshot(created.uri)
+
+    expect(snapshot.cells[0]?.value).toBe('Local OPFS value')
+    expect(driveStore.loadContent).not.toHaveBeenCalled()
+    expect(driveStore.getVersionMetadata).not.toHaveBeenCalled()
+  })
+
   it('adapts editor snapshots into appended cell operations', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const store = createTestStore({}, { operationLogStorage })
@@ -433,7 +479,7 @@ describe('LocalNotebooks operation-log storage', () => {
     ).toEqual(['comment.add', 'comment.reply', 'thread.set_status'])
   })
 
-  it('unions differently ordered local and Drive operations without leaving sync pending', async () => {
+  it('loads stale Drive-backed .runme data by merging local and remote operations', async () => {
     const header: NotebookLogHeader = {
       record_type: 'runme.notebook',
       format_version: 1,
@@ -543,9 +589,12 @@ describe('LocalNotebooks operation-log storage', () => {
       operationLogRef: local.ref,
     })
 
-    await store.reconcileDriveNotebook('local://file/shared')
+    const loaded = await store.load('local://file/shared')
 
     const localAfter = await store.loadContent('local://file/shared')
+    expect(new Set(loaded.cells.map((cell) => cell.value))).toEqual(
+      new Set(['Alice', 'Bob'])
+    )
     expect(
       new Set(
         parseOperationLog(localAfter).operations.map(

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -90,6 +90,11 @@ const NOTEBOOK_MIME_TYPE = 'application/json'
 // let authoritative listings remove files that were moved or trashed elsewhere.
 const PROVISIONAL_DRIVE_CHILD_TTL_MS = 60_000
 
+// A collaborator can win several Drive compare-and-swap races in a row while
+// both sessions are actively editing. Each attempt performs network I/O, so a
+// larger bounded budget improves convergence without creating a tight loop.
+const DRIVE_OPERATION_LOG_MERGE_ATTEMPTS = 8
+
 /**
  * LocalFileRecord captures the information needed to persist a notebook locally.
  *
@@ -3466,14 +3471,53 @@ export class LocalNotebooks extends Dexie {
     await this.driveStore.saveContent(remoteUri, localDoc, 'application/json')
   }
 
+  /** Download .runme bytes only when they match the observed Drive version. */
+  private async loadConsistentDriveOperationLogSnapshot(
+    remoteId: string
+  ): Promise<{
+    content: string
+    version: DriveVersionMetadata | null
+  } | null> {
+    const before = await this.driveStore.getVersionMetadata(remoteId)
+    const content = await this.driveStore.loadContent(remoteId)
+    const after = await this.driveStore.getVersionMetadata(remoteId)
+    if (after?.md5Checksum !== undefined) {
+      // When another tab saves between the first metadata read and the media
+      // download, the downloaded bytes can already be the newer complete
+      // revision. Accept that self-consistent snapshot instead of discarding
+      // it solely because `before` is stale.
+      if (md5(content) !== after.md5Checksum) return null
+    } else if (!sameDriveVersion(before, after)) {
+      return null
+    }
+    return { content, version: after }
+  }
+
   /** Merge a raw .runme operation set with Drive using bounded CAS retries. */
   private async syncOperationLogDrive(
     localUri: string,
     record: LocalFileRecord
   ): Promise<void> {
     if (!record.operationLogRef) {
-      const remoteContent = await this.driveStore.loadContent(record.remoteId)
-      const remote = parseOperationLog(remoteContent)
+      let snapshot: {
+        content: string
+        version: DriveVersionMetadata | null
+      } | null = null
+      for (
+        let attempt = 0;
+        attempt < DRIVE_OPERATION_LOG_MERGE_ATTEMPTS && !snapshot;
+        attempt += 1
+      ) {
+        snapshot = await this.loadConsistentDriveOperationLogSnapshot(
+          record.remoteId
+        )
+      }
+      if (!snapshot) {
+        throw new Error(
+          `Drive operation log changed during ${DRIVE_OPERATION_LOG_MERGE_ATTEMPTS} merge attempts for ${localUri}`
+        )
+      }
+      const remote = parseOperationLog(snapshot.content)
       const stored = await this.operationLogStorage.initialize(
         localUri,
         serializeOperationLog(remote.header, remote.operations, {
@@ -3481,13 +3525,13 @@ export class LocalNotebooks extends Dexie {
         })
       )
       const version = driveMetadataToUpstreamVersion(
-        await this.driveStore.getVersionMetadata(record.remoteId)
+        snapshot.version
       )
       await this.files.update(localUri, {
         doc: '',
         operationLogRef: stored.ref,
         md5Checksum: stored.checksum,
-        lastRemoteChecksum: version.checksum ?? md5(remoteContent),
+        lastRemoteChecksum: version.checksum ?? md5(snapshot.content),
         lastUpstreamVersion: version,
         lastSynced: nowIsoString(),
         lastSyncError: undefined,
@@ -3495,12 +3539,17 @@ export class LocalNotebooks extends Dexie {
       return
     }
 
-    for (let attempt = 0; attempt < 3; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < DRIVE_OPERATION_LOG_MERGE_ATTEMPTS;
+      attempt += 1
+    ) {
       const local = await this.operationLogStorage.read(record.operationLogRef)
-      const before = await this.driveStore.getVersionMetadata(record.remoteId)
-      const remoteContent = await this.driveStore.loadContent(record.remoteId)
-      const after = await this.driveStore.getVersionMetadata(record.remoteId)
-      if (!sameDriveVersion(before, after)) continue
+      const snapshot = await this.loadConsistentDriveOperationLogSnapshot(
+        record.remoteId
+      )
+      if (!snapshot) continue
+      const remoteContent = snapshot.content
 
       const localLog = parseOperationLog(local.document)
       const remoteLog = parseOperationLog(remoteContent)
@@ -3552,8 +3601,8 @@ export class LocalNotebooks extends Dexie {
           mergedDocument,
           RUNME_OPERATION_LOG_MIME_TYPE,
           {
-            checksum: after?.md5Checksum,
-            revisionId: after?.headRevisionId,
+            checksum: snapshot.version?.md5Checksum,
+            revisionId: snapshot.version?.headRevisionId,
           }
         )
         if (!saved) continue
@@ -3584,7 +3633,7 @@ export class LocalNotebooks extends Dexie {
     }
 
     throw new Error(
-      `Drive operation log changed during three merge attempts for ${localUri}`
+      `Drive operation log changed during ${DRIVE_OPERATION_LOG_MERGE_ATTEMPTS} merge attempts for ${localUri}`
     )
   }
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1664,6 +1664,30 @@ export class LocalNotebooks extends Dexie {
     return content
   }
 
+  /** Materialize the current local .runme OPFS log without upstream I/O. */
+  async loadOperationLogSnapshot(uri: string): Promise<parser_pb.Notebook> {
+    if (!uri.startsWith('local://file/')) {
+      throw new Error(
+        'LocalNotebooks.loadOperationLogSnapshot expects a local://file/ URI; got ' +
+          uri
+      )
+    }
+    const record = await this.files.get(uri)
+    if (!record) {
+      throw new Error(`Local notebook record not found for ${uri}`)
+    }
+    if (detectNotebookFileFormat(record.name) !== 'runme-operation-log') {
+      throw new Error(`Notebook is not an operation log: ${uri}`)
+    }
+    if (!record.operationLogRef) {
+      throw new Error(`Operation-log reference missing for ${uri}`)
+    }
+    const content = (
+      await this.operationLogStorage.read(record.operationLogRef)
+    ).document
+    return decodeNotebookFile(content, record.name).notebook
+  }
+
   async saveContent(
     uri: string,
     content: string,
@@ -2062,13 +2086,7 @@ export class LocalNotebooks extends Dexie {
     }
 
     if (detectNotebookFileFormat(record.name) === 'runme-operation-log') {
-      if (!record.operationLogRef) {
-        throw new Error(`Operation-log reference missing for ${uri}`)
-      }
-      const content = (
-        await this.operationLogStorage.read(record.operationLogRef)
-      ).document
-      return decodeNotebookFile(content, record.name).notebook
+      return this.loadOperationLogSnapshot(uri)
     }
 
     if (!record.doc) {

--- a/docs-dev/CUJs/runme-operation-log-concurrency.md
+++ b/docs-dev/CUJs/runme-operation-log-concurrency.md
@@ -3,8 +3,9 @@
 ## Goal
 
 Two independent browser sessions can edit the same Drive-backed `.runme`
-notebook without lifetime ownership, then explicitly refresh and converge on
-the same deterministic cell and comment state.
+notebook without lifetime ownership, explicitly sync with Drive, then refresh
+from each session's local OPFS journal and converge on the same deterministic
+cell and comment state.
 
 ## Preconditions
 
@@ -17,17 +18,24 @@ the same deterministic cell and comment state.
 
 1. Open the same notebook in sessions A and B and verify both are writable.
 2. Insert one different cell in each session between the same two anchors.
-3. Save/sync both sessions and click **Refresh** in each.
-4. Verify both snapshots contain both insertions in identical position order.
-5. In A, add a comment; in B, refresh, reply, resolve, and reopen the thread.
-6. Refresh A and verify the same thread content and final open state.
-7. Reload both sessions and verify the converged state is durable.
+3. In each session, click the circular Google status control to sync with
+   Drive and wait for the status to return to synced.
+4. Click the tab **Refresh** icon in each session to materialize its current
+   local OPFS operation log.
+5. Verify both snapshots contain both insertions in identical position order.
+6. In A, add and Drive-sync a comment. In B, Drive-sync, refresh from OPFS,
+   reply, resolve, reopen the thread, and Drive-sync those operations.
+7. In A, Drive-sync and refresh from OPFS, then verify the same thread content
+   and final open state.
+8. Reload both sessions and verify the converged state is durable.
 
 ## Acceptance Criteria
 
 - Neither session displays or requests a lifetime ownership transfer.
 - Both same-gap inserts survive and their order is deterministic.
-- Refresh performs an upstream sync even when the local mirror synced recently.
+- The circular Google status control performs explicit upstream Drive sync.
+- The tab Refresh control reads only the local OPFS journal and performs no
+  upstream I/O.
 - Comment, reply, resolve, and reopen operations materialize identically.
 - Delete followed by Undo restores a stable cell ID without a duplicate create.
 - Reloading preserves every operation and the same final snapshot.
@@ -37,6 +45,7 @@ the same deterministic cell and comment state.
 ## Automation
 
 The browser scenario should use two isolated `agent-browser` sessions and the
-shared Go fake Drive service. It must be registered in
-`app/test/browser/run-cuj-scenarios.ts`; unit tests alone are not sufficient
-because the scenario must exercise browser OPFS and Web Locks.
+shared Go fake Drive service. It must observe the Drive revision before and
+after local Refresh to prove Refresh performs no upstream I/O, and it must be
+registered in `app/test/browser/run-cuj-scenarios.ts`; unit tests alone are not
+sufficient because the scenario must exercise browser OPFS and Web Locks.

--- a/docs-dev/cujs/README.md
+++ b/docs-dev/cujs/README.md
@@ -28,7 +28,8 @@ from `docs-dev/cujs/`.
   - verify Explorer shows exactly one notebook entry.
 - `runme-operation-log-concurrency.md` — concurrent `.runme` flow:
   - edit one Drive-backed notebook from two isolated sessions,
-  - explicitly refresh and verify deterministic convergence,
+  - explicitly Drive-sync, refresh each local OPFS view, and verify
+    deterministic convergence,
   - exercise operation-log comment lifecycle and durable reload.
 
 ## How CUJs are executed


### PR DESCRIPTION
## Summary
- make New Notebook create the append-only .runme format and place it first
- relabel and move the .json option to Legacy Runme Notebook
- harden Drive operation-log refresh against concurrent revision changes and CAS contention
- validate first-time Drive hydration against matching content metadata

## Verification
- 91 focused storage and explorer tests pass
- git diff --check passes
- verified the local context menu at http://localhost:5173
- two independent reviews completed with all comments addressed

## Baseline limitation
- full app typecheck remains red on pre-existing unrelated errors on origin/main