### PR TITLE
Initialize empty Drive operation logs during sync

### DIFF
--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -749,6 +749,33 @@ describe("DriveNotebookStore", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects a repair when the checked Drive version no longer matches", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (_input, init) => {
+        expect(init?.method).toBe("GET");
+        return new Response(JSON.stringify({ version: "2" }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            ETag: '"drive-etag-2"',
+          },
+        });
+      });
+
+    const store = new DriveNotebookStore(async () => "access-token");
+    await expect(
+      store.saveContentIfVersion(
+        "https://drive.google.com/file/d/file123/view",
+        '{"cells":[]}',
+        "application/json",
+        { version: "1" },
+      ),
+    ).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects a repair when Drive changes during the conditional upload", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -3432,7 +3432,7 @@ export class DriveNotebookStore {
     uri: string,
     content: string,
     mimeType: string,
-    expected: { checksum?: string; revisionId?: string }
+    expected: { checksum?: string; revisionId?: string; version?: string }
   ): Promise<boolean> {
     const { id, type, resourceKey } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
@@ -3450,7 +3450,8 @@ export class DriveNotebookStore {
     if (
       actualChecksum !== expectedChecksum ||
       (expected.revisionId !== undefined &&
-        metadata?.headRevisionId !== expected.revisionId)
+        metadata?.headRevisionId !== expected.revisionId) ||
+      (expected.version !== undefined && metadata?.version !== expected.version)
     ) {
       return false
     }

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -551,11 +551,16 @@ describe('LocalNotebooks operation-log storage', () => {
           _uri: string,
           content: string,
           _mimeType: string,
-          expected: { checksum?: string; revisionId?: string }
+          expected: {
+            checksum?: string
+            revisionId?: string
+            version?: string
+          }
         ) => {
           if (
             expected.checksum !== remoteVersion.md5Checksum ||
-            expected.revisionId !== remoteVersion.headRevisionId
+            expected.revisionId !== remoteVersion.headRevisionId ||
+            expected.version !== remoteVersion.version
           ) {
             return false
           }
@@ -617,6 +622,192 @@ describe('LocalNotebooks operation-log storage', () => {
     })
     expect(appendOperationLog).toHaveBeenCalledTimes(1)
     expect(replaceOperationLog).not.toHaveBeenCalled()
+  })
+
+  it('initializes an empty Drive file from the local .runme operation log', async () => {
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'notebook_empty_drive',
+      created_by: 'actor_seed',
+      created_at: '2026-09-03T00:00:00Z',
+    }
+    const localDocument = serializeOperationLog(header, [])
+    let remoteDocument = ''
+    let remoteVersion = {
+      md5Checksum: md5(remoteDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => remoteDocument),
+      saveContentIfVersion: vi.fn(
+        async (
+          _uri: string,
+          content: string,
+          _mimeType: string,
+          expected: {
+            checksum?: string
+            revisionId?: string
+            version?: string
+          }
+        ) => {
+          expect(expected).toEqual({
+            checksum: remoteVersion.md5Checksum,
+            revisionId: remoteVersion.headRevisionId,
+            version: remoteVersion.version,
+          })
+          remoteDocument = content
+          remoteVersion = {
+            md5Checksum: md5(content),
+            headRevisionId: 'revision-2',
+            version: '2',
+          }
+          return true
+        }
+      ),
+    }
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const local = await operationLogStorage.initialize(
+      'local://file/empty-drive',
+      localDocument
+    )
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.files.put({
+      id: 'local://file/empty-drive',
+      name: 'shared.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/empty-drive/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: local.checksum,
+      operationLogRef: local.ref,
+    })
+
+    await store.reconcileDriveNotebook('local://file/empty-drive')
+
+    expect(remoteDocument).toBe(localDocument)
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledOnce()
+    expect(await store.files.get('local://file/empty-drive')).toMatchObject({
+      lastRemoteChecksum: md5(localDocument),
+      lastUpstreamVersion: {
+        checksum: md5(localDocument),
+        revisionId: 'revision-2',
+      },
+      lastSyncError: undefined,
+    })
+  })
+
+  it('creates an operation-log identity when a new Drive mirror is empty', async () => {
+    let remoteDocument = ''
+    let remoteVersion = {
+      md5Checksum: md5(remoteDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => remoteDocument),
+      saveContentIfVersion: vi.fn(
+        async (
+          _uri: string,
+          content: string,
+          _mimeType: string,
+          expected: {
+            checksum?: string
+            revisionId?: string
+            version?: string
+          }
+        ) => {
+          expect(expected).toEqual({
+            checksum: remoteVersion.md5Checksum,
+            revisionId: remoteVersion.headRevisionId,
+            version: remoteVersion.version,
+          })
+          remoteDocument = content
+          remoteVersion = {
+            md5Checksum: md5(content),
+            headRevisionId: 'revision-2',
+            version: '2',
+          }
+          return true
+        }
+      ),
+    }
+    const store = createTestStore(driveStore)
+    const uri = 'local://file/new-empty-drive-mirror'
+    await store.files.put({
+      id: uri,
+      name: 'empty.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/new-empty/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await store.reconcileDriveNotebook(uri)
+
+    expect(parseOperationLog(remoteDocument).operations).toEqual([])
+    expect(remoteDocument.endsWith('\n')).toBe(true)
+    expect(await store.loadContent(uri)).toBe(remoteDocument)
+    expect(await store.files.get(uri)).toMatchObject({
+      lastRemoteChecksum: md5(remoteDocument),
+      lastUpstreamVersion: {
+        checksum: md5(remoteDocument),
+        revisionId: 'revision-2',
+      },
+      lastSyncError: undefined,
+    })
+  })
+
+  it('does not overwrite a non-empty malformed Drive operation log', async () => {
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'notebook_malformed_drive',
+      created_by: 'actor_seed',
+      created_at: '2026-09-03T00:00:00Z',
+    }
+    const localDocument = serializeOperationLog(header, [])
+    const remoteDocument = '{}'
+    const remoteVersion = {
+      md5Checksum: md5(remoteDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => remoteDocument),
+      saveContentIfVersion: vi.fn(),
+    }
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const local = await operationLogStorage.initialize(
+      'local://file/malformed-drive',
+      localDocument
+    )
+    const store = createTestStore(driveStore, { operationLogStorage })
+    const uri = 'local://file/malformed-drive'
+    await store.files.put({
+      id: uri,
+      name: 'malformed.runme',
+      mimeType: 'application/vnd.runme.notebook+jsonl',
+      remoteId: 'https://drive.google.com/file/d/malformed/view',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: local.checksum,
+      operationLogRef: local.ref,
+    })
+
+    await expect(store.reconcileDriveNotebook(uri)).rejects.toThrow(
+      'Operation log must end with LF'
+    )
+    expect(driveStore.saveContentIfVersion).not.toHaveBeenCalled()
   })
 
   it('rejects stale bytes, then accepts a newer self-consistent Drive snapshot', async () => {
@@ -684,11 +875,16 @@ describe('LocalNotebooks operation-log storage', () => {
           _uri: string,
           content: string,
           _mimeType: string,
-          expected: { checksum?: string; revisionId?: string }
+          expected: {
+            checksum?: string
+            revisionId?: string
+            version?: string
+          }
         ) => {
           expect(expected).toEqual({
             checksum: remoteVersion.md5Checksum,
             revisionId: remoteVersion.headRevisionId,
+            version: remoteVersion.version,
           })
           remoteDocument = content
           remoteVersion = {
@@ -795,11 +991,16 @@ describe('LocalNotebooks operation-log storage', () => {
           _uri: string,
           content: string,
           _mimeType: string,
-          expected: { checksum?: string; revisionId?: string }
+          expected: {
+            checksum?: string
+            revisionId?: string
+            version?: string
+          }
         ) => {
           expect(expected).toEqual({
             checksum: remoteVersion.md5Checksum,
             revisionId: remoteVersion.headRevisionId,
+            version: remoteVersion.version,
           })
           collisions += 1
           if (collisions <= competingOperations.length) {
@@ -1102,6 +1303,146 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
       lastSynced: '',
       lastRemoteChecksum: '',
     })
+  })
+
+  it('initializes a trusted zero-byte .runme snapshot through Drive CAS', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/empty-trusted/view'
+    let remoteDocument = ''
+    let version = {
+      md5Checksum: md5(remoteDocument),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => version),
+      loadContent: vi.fn(async () => remoteDocument),
+      saveContentIfVersion: vi.fn(
+        async (
+          _uri: string,
+          content: string,
+          _mimeType: string,
+          expected: {
+            checksum?: string
+            revisionId?: string
+            version?: string
+          }
+        ) => {
+          expect(expected).toEqual({
+            checksum: version.md5Checksum,
+            revisionId: version.headRevisionId,
+            version: version.version,
+          })
+          remoteDocument = content
+          version = {
+            md5Checksum: md5(content),
+            headRevisionId: 'revision-2',
+            version: '2',
+          }
+          return true
+        }
+      ),
+    }
+    const store = createTestStore(driveStore)
+
+    const localUri = await store.importTrustedDriveSnapshot(
+      remoteUri,
+      'empty.runme',
+      {
+        expected: {
+          checksum: md5(''),
+          revisionId: 'revision-1',
+          version: '1',
+        },
+      }
+    )
+
+    expect(parseOperationLog(remoteDocument).operations).toEqual([])
+    expect(await store.loadContent(localUri)).toBe(remoteDocument)
+    expect(await store.files.get(localUri)).toMatchObject({
+      remoteId: remoteUri,
+      lastRemoteChecksum: md5(remoteDocument),
+      lastSyncError: undefined,
+    })
+  })
+
+  it('rejects an empty trusted .runme import if its validated revision changes', async () => {
+    const remoteUri = 'https://drive.google.com/file/d/empty-racing/view'
+    const emptyVersion = {
+      md5Checksum: md5(''),
+      headRevisionId: 'revision-1',
+      version: '1',
+    }
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => emptyVersion),
+      loadContent: vi.fn(async () => ''),
+      saveContentIfVersion: vi.fn(async () => false),
+    }
+    const store = createTestStore(driveStore)
+
+    await expect(
+      store.importTrustedDriveSnapshot(remoteUri, 'empty.runme', {
+        expected: {
+          checksum: md5(''),
+          revisionId: 'revision-1',
+          version: '1',
+        },
+      })
+    ).rejects.toBeInstanceOf(DriveSnapshotChangedError)
+
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledWith(
+      remoteUri,
+      expect.stringMatching(/\n$/),
+      'application/vnd.runme.notebook+jsonl',
+      {
+        checksum: md5(''),
+        revisionId: 'revision-1',
+        version: '1',
+      }
+    )
+    const [record] = await store.files.toArray()
+    expect(record).toMatchObject({
+      remoteId: remoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+    })
+    expect(record?.operationLogRef).toBeUndefined()
+  })
+
+  it('rejects an empty trusted .runme import if its validated Drive version changes', async () => {
+    const remoteUri =
+      'https://drive.google.com/file/d/empty-version-racing/view'
+    let remoteVersion = '1'
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => ({ version: remoteVersion })),
+      loadContent: vi.fn(async () => ''),
+      saveContentIfVersion: vi.fn(
+        async (
+          _uri: string,
+          _content: string,
+          _mimeType: string,
+          expected: { version?: string }
+        ) => {
+          remoteVersion = '2'
+          return expected.version === remoteVersion
+        }
+      ),
+    }
+    const store = createTestStore(driveStore)
+
+    await expect(
+      store.importTrustedDriveSnapshot(remoteUri, 'empty.runme', {
+        expected: { version: '1' },
+      })
+    ).rejects.toBeInstanceOf(DriveSnapshotChangedError)
+
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledWith(
+      remoteUri,
+      expect.stringMatching(/\n$/),
+      'application/vnd.runme.notebook+jsonl',
+      { checksum: undefined, revisionId: undefined, version: '1' }
+    )
+    const [record] = await store.files.toArray()
+    expect(record?.operationLogRef).toBeUndefined()
   })
 })
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -489,6 +489,43 @@ export class LocalNotebooks extends Dexie {
       throw new DriveSnapshotChangedError(remoteUri)
     }
 
+    if (
+      content === '' &&
+      detectNotebookFileFormat(record.name) === 'runme-operation-log'
+    ) {
+      // Preserve the validated trust boundary: claim exactly the Drive
+      // revision checked above rather than starting an unconstrained refresh.
+      const initialDocument = createInitialNotebookFile(record.name)
+      const saved = await this.driveStore.saveContentIfVersion(
+        remoteUri,
+        initialDocument,
+        RUNME_OPERATION_LOG_MIME_TYPE,
+        {
+          checksum: after?.md5Checksum,
+          revisionId: after?.headRevisionId,
+          version: after?.version,
+        }
+      )
+      if (!saved) {
+        throw new DriveSnapshotChangedError(remoteUri)
+      }
+      const initializedSnapshot =
+        await this.loadConsistentDriveOperationLogSnapshot(remoteUri)
+      if (
+        !initializedSnapshot ||
+        initializedSnapshot.content !== initialDocument
+      ) {
+        throw new DriveSnapshotChangedError(remoteUri)
+      }
+      await this.initializeUploadedDriveNotebook(
+        localUri,
+        create(parser_pb.NotebookSchema, { cells: [] }),
+        initialDocument,
+        driveMetadataToUpstreamVersion(initializedSnapshot.version)
+      )
+      return localUri
+    }
+
     const decoded = decodeNotebookFile(content, name)
     await this.initializeUploadedDriveNotebook(
       localUri,
@@ -3517,44 +3554,71 @@ export class LocalNotebooks extends Dexie {
     record: LocalFileRecord
   ): Promise<void> {
     if (!record.operationLogRef) {
-      let snapshot: {
-        content: string
-        version: DriveVersionMetadata | null
-      } | null = null
+      // An empty Drive file has no operation-log identity yet. Generate one
+      // seed once, then claim the empty revision with CAS so concurrent
+      // initializers cannot create competing notebook IDs.
+      const initialDocument = createInitialNotebookFile(record.name)
       for (
         let attempt = 0;
-        attempt < DRIVE_OPERATION_LOG_MERGE_ATTEMPTS && !snapshot;
+        attempt < DRIVE_OPERATION_LOG_MERGE_ATTEMPTS;
         attempt += 1
       ) {
-        snapshot = await this.loadConsistentDriveOperationLogSnapshot(
+        const snapshot = await this.loadConsistentDriveOperationLogSnapshot(
           record.remoteId
         )
-      }
-      if (!snapshot) {
-        throw new Error(
-          `Drive operation log changed during ${DRIVE_OPERATION_LOG_MERGE_ATTEMPTS} merge attempts for ${localUri}`
+        if (!snapshot) continue
+
+        let remoteContent = snapshot.content
+        let remoteVersion = snapshot.version
+        if (remoteContent === '') {
+          appLogger.info('Initializing zero-byte Drive operation log', {
+            attrs: {
+              scope: 'storage.drive.sync',
+              code: 'DRIVE_OPERATION_LOG_INITIALIZE_EMPTY',
+              localUri,
+              remoteUri: record.remoteId,
+              source: 'new-mirror',
+            },
+          })
+          const saved = await this.driveStore.saveContentIfVersion(
+            record.remoteId,
+            initialDocument,
+            RUNME_OPERATION_LOG_MIME_TYPE,
+            {
+              checksum: snapshot.version?.md5Checksum,
+              revisionId: snapshot.version?.headRevisionId,
+              version: snapshot.version?.version,
+            }
+          )
+          if (!saved) continue
+          remoteContent = initialDocument
+          remoteVersion = await this.driveStore.getVersionMetadata(
+            record.remoteId
+          )
+        }
+
+        const remote = parseOperationLog(remoteContent)
+        const stored = await this.operationLogStorage.initialize(
+          localUri,
+          serializeOperationLog(remote.header, remote.operations, {
+            canonicalOrder: true,
+          })
         )
-      }
-      const remote = parseOperationLog(snapshot.content)
-      const stored = await this.operationLogStorage.initialize(
-        localUri,
-        serializeOperationLog(remote.header, remote.operations, {
-          canonicalOrder: true,
+        const version = driveMetadataToUpstreamVersion(remoteVersion)
+        await this.files.update(localUri, {
+          doc: '',
+          operationLogRef: stored.ref,
+          md5Checksum: stored.checksum,
+          lastRemoteChecksum: version.checksum ?? md5(remoteContent),
+          lastUpstreamVersion: version,
+          lastSynced: nowIsoString(),
+          lastSyncError: undefined,
         })
+        return
+      }
+      throw new Error(
+        `Drive operation log changed during ${DRIVE_OPERATION_LOG_MERGE_ATTEMPTS} merge attempts for ${localUri}`
       )
-      const version = driveMetadataToUpstreamVersion(
-        snapshot.version
-      )
-      await this.files.update(localUri, {
-        doc: '',
-        operationLogRef: stored.ref,
-        md5Checksum: stored.checksum,
-        lastRemoteChecksum: version.checksum ?? md5(snapshot.content),
-        lastUpstreamVersion: version,
-        lastSynced: nowIsoString(),
-        lastSyncError: undefined,
-      })
-      return
     }
 
     for (
@@ -3570,7 +3634,24 @@ export class LocalNotebooks extends Dexie {
       const remoteContent = snapshot.content
 
       const localLog = parseOperationLog(local.document)
-      const remoteLog = parseOperationLog(remoteContent)
+      // A zero-byte Drive file is an uninitialized upstream, not a malformed
+      // operation log. Use the local header as its identity and force a CAS
+      // upload below. Non-empty malformed content remains a hard error.
+      const remoteWasEmpty = remoteContent === ''
+      const remoteLog: ParsedOperationLog = remoteWasEmpty
+        ? { header: localLog.header, operations: [] }
+        : parseOperationLog(remoteContent)
+      if (remoteWasEmpty) {
+        appLogger.info('Initializing zero-byte Drive operation log', {
+          attrs: {
+            scope: 'storage.drive.sync',
+            code: 'DRIVE_OPERATION_LOG_INITIALIZE_EMPTY',
+            localUri,
+            remoteUri: record.remoteId,
+            source: 'local-operation-log',
+          },
+        })
+      }
       if (localLog.header.notebook_id !== remoteLog.header.notebook_id) {
         throw new Error(
           `Cannot merge different operation-log notebooks for ${localUri}`
@@ -3612,6 +3693,7 @@ export class LocalNotebooks extends Dexie {
         { canonicalOrder: true }
       )
       if (
+        remoteWasEmpty ||
         mergedOperations.some((operation) => !remoteIds.has(operation.op_id))
       ) {
         const saved = await this.driveStore.saveContentIfVersion(
@@ -3621,6 +3703,7 @@ export class LocalNotebooks extends Dexie {
           {
             checksum: snapshot.version?.md5Checksum,
             revisionId: snapshot.version?.headRevisionId,
+            version: snapshot.version?.version,
           }
         )
         if (!saved) continue


### PR DESCRIPTION
## Summary
- treat a zero-byte Drive-backed .runme file as an uninitialized upstream
- initialize it with a version-checked CAS write using the local log identity, or create one for a new mirror
- route trusted empty .runme imports through the same safe sync path
- continue rejecting non-empty malformed operation logs without overwriting them

## Root cause
Drive sync passed the zero-byte upstream body directly to parseOperationLog(). The strict parser correctly requires every valid operation log to end in LF, so sync failed before it reached the CAS upload that could initialize the upstream file.

## Tests
- 126 focused tests passed across local storage, Drive transfer, notebook format, and operation-log codec suites
- Prettier check passed for both changed files
- git diff --check passed

Full app typecheck remains red on pre-existing unrelated errors; none point to these changed lines.