### PR TITLE
Fix browser Drive operation-log CAS

### DIFF
--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -16,6 +16,7 @@ import {
   DriveCreateNotCommittedError,
   DriveFileCreatedError,
   DriveNotebookStore,
+  GapiDriveFilesClient,
   driveFileUrl,
   driveFolderUrl,
   isDriveItemUri,
@@ -153,6 +154,80 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("uses one Drive v2 ETag for the browser CAS read and write", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        if (init?.method === "GET") {
+          expect(url.pathname).toBe("/drive/v2/files/file123");
+          expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+          expect(url.searchParams.get("fields")).toBe(
+            "etag,md5Checksum,headRevisionId,version",
+          );
+          expect(init?.headers).toMatchObject({
+            Authorization: "Bearer access-token",
+            "X-Goog-Drive-Resource-Keys": "file123/file-key",
+          });
+          return new Response(
+            JSON.stringify({
+              etag: '\"drive-etag-1\"',
+              md5Checksum: "checksum-1",
+              headRevisionId: "revision-1",
+              version: "1",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        expect(init?.method).toBe("PATCH");
+        expect(url.pathname).toBe("/upload/drive/v2/files/file123");
+        expect(url.searchParams.get("uploadType")).toBe("media");
+        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        expect(init?.headers).toMatchObject({
+          Authorization: "Bearer access-token",
+          "X-Goog-Drive-Resource-Keys": "file123/file-key",
+          "If-Match": '\"drive-etag-1\"',
+          "Content-Type": "application/vnd.runme.notebook+jsonl",
+        });
+        expect(init?.body).toBe('{"record_type":"runme.notebook"}\n');
+        return new Response("", { status: 200 });
+      });
+    const gapi = {
+      client: {
+        getToken: () => ({ access_token: "access-token" }),
+        drive: { files: {}, drives: {}, revisions: {} },
+      },
+    };
+    const client = new GapiDriveFilesClient(gapi as never);
+
+    const version = await client.getVersionMetadataWithEtag(
+      "file123",
+      "file-key",
+    );
+    expect(version).toEqual({
+      metadata: {
+        etag: '\"drive-etag-1\"',
+        md5Checksum: "checksum-1",
+        headRevisionId: "revision-1",
+        version: "1",
+      },
+      etag: '\"drive-etag-1\"',
+    });
+    await expect(
+      client.setContentIfMatch(
+        "file123",
+        '{"record_type":"runme.notebook"}\n',
+        "application/vnd.runme.notebook+jsonl",
+        version.etag!,
+        "file-key",
+      ),
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("forwards native Drive files.list search parameters and returns paging metadata", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -24,6 +24,7 @@ const GAPI_SCRIPT_SRC = 'https://apis.google.com/js/api.js'
 // VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file content version.
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
 const VERSION_FIELDS = 'md5Checksum,headRevisionId,version,appProperties'
+const DRIVE_V2_VERSION_FIELDS = 'etag,md5Checksum,headRevisionId,version'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
@@ -634,7 +635,7 @@ const DRIVE_COMMENT_FIELDS =
   'id,createdTime,modifiedTime,resolved,anchor,author(displayName,photoLink,me),deleted,htmlContent,content,quotedFileContent(mimeType,value),replies(id,createdTime,modifiedTime,action,author(displayName,photoLink,me),deleted,htmlContent,content)'
 const DRIVE_COMMENT_LIST_FIELDS = `nextPageToken,comments(${DRIVE_COMMENT_FIELDS})`
 
-class GapiDriveFilesClient implements DriveFilesClient {
+export class GapiDriveFilesClient implements DriveFilesClient {
   private readonly files: GapiDriveFileMethods
   private readonly drives: GapiDriveMethods
   private readonly revisions: GapiDriveRevisionMethods
@@ -944,20 +945,29 @@ class GapiDriveFilesClient implements DriveFilesClient {
     metadata: DriveVersionMetadata | null
     etag?: string
   }> {
+    // Drive v3 returns the ETag as an HTTP response header, but Google does
+    // not expose that header to cross-origin browser JavaScript. Drive v2
+    // exposes the same file validator in its JSON body, which lets browser
+    // clients keep using a real If-Match precondition instead of weakening
+    // the operation-log CAS.
     const response = await this.request(
       'GET',
-      `/drive/v3/files/${encodeURIComponent(fileId)}`,
+      `/drive/v2/files/${encodeURIComponent(fileId)}`,
       {
         params: {
           supportsAllDrives: true,
-          fields: VERSION_FIELDS,
-          resourceKey,
+          fields: DRIVE_V2_VERSION_FIELDS,
         },
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
     )
+    const metadata =
+      (response.result as
+        | (DriveVersionMetadata & { etag?: string })
+        | undefined) ?? null
     return {
-      metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
-      etag: response.etag,
+      metadata,
+      etag: metadata?.etag ?? response.etag,
     }
   }
 
@@ -971,16 +981,18 @@ class GapiDriveFilesClient implements DriveFilesClient {
     try {
       await this.request(
         'PATCH',
-        `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
+        `/upload/drive/v2/files/${encodeURIComponent(fileId)}`,
         {
           params: {
             uploadType: 'media',
             supportsAllDrives: true,
-            resourceKey,
           },
           body: content,
           contentType: mimeType,
-          headers: { 'If-Match': etag },
+          headers: {
+            ...driveResourceKeyHeaders({ id: fileId, resourceKey }),
+            'If-Match': etag,
+          },
         }
       )
       return true


### PR DESCRIPTION
## Summary
- read the Drive file ETag from the v2 JSON resource in browser OAuth sessions
- perform the conditional media upload through Drive v2 with that same ETag
- preserve checksum/revision/version checks, Shared Drive support, and resource-key access

## Root cause
Google Drive v3 returns the file ETag as an HTTP header, but its CORS response does not expose that header to browser JavaScript. `saveContentIfVersion` therefore saw no ETag and returned `false` for all eight operation-log merge attempts. The fake Drive server exposed ETag, masking the production-only behavior.

## Validation
- focused Drive/operation-log suite: 5 files, 184 tests passed
- official Drive v2 discovery schema confirms `etag`, `md5Checksum`, `headRevisionId`, and `version` are returned in the File JSON resource
- official Drive v2 schema and CORS preflight confirm Shared Drive and resource-key-header support