### PR TITLE
Fix Drive browser CAS upload CORS

### DIFF
--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -154,7 +154,7 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
-  it("uses one Drive v2 ETag for the browser CAS read and write", async () => {
+  it("reads a Drive v2 ETag and applies it to the CORS-capable v3 upload", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockImplementation(async (input, init) => {
@@ -183,7 +183,7 @@ describe("DriveNotebookStore", () => {
           );
         }
         expect(init?.method).toBe("PATCH");
-        expect(url.pathname).toBe("/upload/drive/v2/files/file123");
+        expect(url.pathname).toBe("/upload/drive/v3/files/file123");
         expect(url.searchParams.get("uploadType")).toBe("media");
         expect(url.searchParams.get("supportsAllDrives")).toBe("true");
         expect(init?.headers).toMatchObject({

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -979,9 +979,15 @@ export class GapiDriveFilesClient implements DriveFilesClient {
     resourceKey?: string
   ): Promise<boolean> {
     try {
+      // Read the validator from Drive v2 because its JSON body exposes the
+      // ETag to browser JavaScript, but write through Drive v3. The v2 upload
+      // endpoint omits Access-Control-Allow-Origin from its actual response,
+      // so a successful preflight still ends as `TypeError: Failed to fetch`
+      // in browsers. Send the v2 file ETag back as the If-Match validator for
+      // the same file through Drive's current v3 media-update endpoint.
       await this.request(
         'PATCH',
-        `/upload/drive/v2/files/${encodeURIComponent(fileId)}`,
+        `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
         {
           params: {
             uploadType: 'media',


### PR DESCRIPTION
## Summary
- keep reading the browser-visible file ETag from Drive v2 metadata
- send the conditional media update through Drive v3, whose actual response is CORS-readable
- retain the same `If-Match` concurrency guard and add a regression assertion for the split v2-read/v3-write path

## Root cause
Drive v2 accepts the upload preflight but omits `Access-Control-Allow-Origin` on the actual media-upload response. Browser fetch therefore rejects the request as `TypeError: Failed to fetch`, even though the preflight succeeded. Drive v3 exposes the actual response correctly.

## Validation
- `pnpm -C app exec vitest run src/storage/drive.test.ts src/storage/local.test.ts src/lib/driveTransfer.test.ts` (167 tests)
- `pnpm run build`
- `go test testing/fake-drive-server.go testing/fake-drive-server_test.go`
- `git diff --check`

## Review notes
- No CUJ text change is needed: the user-visible sync semantics are unchanged.
- The existing fake Drive CAS test already exercises the v3 conditional upload endpoint.