### PR TITLE
Convert legacy notebooks to .runme

### DIFF
--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -730,6 +730,56 @@ describe('WorkspaceExplorer current document handling', () => {
     })
   })
 
+  it('shows actionable conflict guidance when conversion is blocked', async () => {
+    const folderUri = 'local://folder/drive'
+    const fileUri = 'local://file/conflicted-notebook'
+    const message =
+      'Resolve the sync conflict before converting conflicted.ipynb'
+    mocks.workspaceItems = [folderUri]
+    mocks.isDriveItemUri.mockImplementation((uri: string) =>
+      uri.startsWith('https://drive.google.com')
+    )
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === folderUri) {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [fileUri],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === fileUri) {
+        return {
+          uri,
+          name: 'conflicted.ipynb',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/conflicted/view',
+          parents: [folderUri],
+        }
+      }
+      return null
+    })
+    mocks.store.convertLegacyNotebookToRunme.mockRejectedValueOnce(
+      new Error(message)
+    )
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('conflicted.ipynb'))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    )
+
+    expect(await screen.findByText(message)).toBeTruthy()
+  })
+
   it('prompts for Drive auth when the legacy source create is pending', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     mocks.isDriveItemUri.mockImplementation((uri: string) =>

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -730,6 +730,43 @@ describe('WorkspaceExplorer current document handling', () => {
     })
   })
 
+  it('does not offer legacy notebook conversion for Excalidraw JSON files', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/diagram'],
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/diagram') {
+        return {
+          uri,
+          name: 'diagram.excalidraw.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('diagram.excalidraw.json'))
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    ).toBeNull()
+  })
+
   it.each([
     'Google Drive authorization is required.',
     'Google Drive service-account authorization is required.',

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -780,6 +780,58 @@ describe('WorkspaceExplorer current document handling', () => {
     expect(await screen.findByText(message)).toBeTruthy()
   })
 
+  it.each([
+    'Invalid Jupyter notebook JSON: SyntaxError',
+    'Unsupported Jupyter nbformat major version: 3',
+    'Jupyter notebook cells must be an array',
+  ])('shows actionable IPYNB validation guidance: %s', async (message) => {
+    const folderUri = 'local://folder/drive'
+    const fileUri = 'local://file/invalid-notebook'
+    mocks.workspaceItems = [folderUri]
+    mocks.isDriveItemUri.mockImplementation((uri: string) =>
+      uri.startsWith('https://drive.google.com')
+    )
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === folderUri) {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [fileUri],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === fileUri) {
+        return {
+          uri,
+          name: 'invalid.ipynb',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/invalid/view',
+          parents: [folderUri],
+        }
+      }
+      return null
+    })
+    mocks.store.convertLegacyNotebookToRunme.mockRejectedValueOnce(
+      new Error(message)
+    )
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('invalid.ipynb'))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    )
+
+    expect(await screen.findByText(message)).toBeTruthy()
+  })
+
   it('prompts for Drive auth when the legacy source create is pending', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     mocks.isDriveItemUri.mockImplementation((uri: string) =>

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   addItem: vi.fn(),
   removeItem: vi.fn(),
   ensureAccessToken: vi.fn(),
+  fsStore: null as any,
   store: {
     getMetadata: vi.fn(),
     create: vi.fn(),
@@ -102,7 +103,7 @@ vi.mock('../../contexts/NotebookStoreContext', () => ({
 
 vi.mock('../../contexts/FilesystemStoreContext', () => ({
   useFilesystemStore: () => ({
-    fsStore: null,
+    fsStore: mocks.fsStore,
   }),
 }))
 
@@ -167,6 +168,7 @@ describe('WorkspaceExplorer current document handling', () => {
     mocks.removeItem.mockReset()
     mocks.ensureAccessToken.mockReset()
     mocks.ensureAccessToken.mockResolvedValue('access-token')
+    mocks.fsStore = null
     mocks.workspaceItems = []
     mocks.store.getMetadata.mockReset()
     mocks.store.getMetadata.mockResolvedValue({
@@ -776,6 +778,48 @@ describe('WorkspaceExplorer current document handling', () => {
         'local://file/notebook',
         'local://folder/drive'
       )
+    })
+  })
+
+  it('rejects a non-notebook JSON file from a filesystem workspace', async () => {
+    const rootUri = 'fs://workspace/test/dir/'
+    const fileUri = 'fs://workspace/test/file/unrelated.json'
+    mocks.workspaceItems = [rootUri]
+    mocks.fsStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: rootUri,
+        name: 'Filesystem Root',
+        type: NotebookStoreItemType.Folder,
+        children: [],
+        parents: [],
+      })),
+      list: vi.fn(async () => [
+        {
+          uri: fileUri,
+          name: 'unrelated.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: [rootUri],
+        },
+      ]),
+      loadContent: vi.fn(async () => JSON.stringify({ unrelated: 'document' })),
+      createContent: vi.fn(),
+    }
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Filesystem Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('unrelated.json'))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.fsStore.loadContent).toHaveBeenCalledWith(fileUri)
+      expect(mocks.fsStore.createContent).not.toHaveBeenCalled()
     })
   })
 

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     create: vi.fn(),
     createContent: vi.fn(),
     createFolder: vi.fn(),
+    convertLegacyNotebookToRunme: vi.fn(),
     move: vi.fn(),
     moveToTrash: vi.fn(),
     rename: vi.fn(),
@@ -202,6 +203,15 @@ describe('WorkspaceExplorer current document handling', () => {
       children: [],
       remoteUri: undefined,
       mimeType: 'application/vnd.excalidraw+json',
+      parents: ['local://folder/drive'],
+    })
+    mocks.store.convertLegacyNotebookToRunme.mockReset()
+    mocks.store.convertLegacyNotebookToRunme.mockResolvedValue({
+      uri: 'local://file/converted',
+      name: 'direct.runme',
+      type: NotebookStoreItemType.File,
+      children: [],
+      remoteUri: 'https://drive.google.com/file/d/converted/view',
       parents: ['local://folder/drive'],
     })
     mocks.store.moveToTrash.mockReset()
@@ -665,6 +675,94 @@ describe('WorkspaceExplorer current document handling', () => {
         expect.stringMatching(/^untitled-\d{8}-\d{4}\.runme$/)
       )
     })
+  })
+
+  it('saves a legacy Drive notebook as a sibling .runme file', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.isDriveItemUri.mockImplementation((uri: string) =>
+      uri.startsWith('https://drive.google.com')
+    )
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/notebook'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/notebook') {
+        return {
+          uri,
+          name: 'direct.ipynb',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/direct/view',
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('direct.ipynb'))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.ensureAccessToken).toHaveBeenCalledWith({
+        interactive: true,
+      })
+      expect(mocks.store.convertLegacyNotebookToRunme).toHaveBeenCalledWith(
+        'local://file/notebook',
+        'local://folder/drive'
+      )
+    })
+  })
+
+  it('does not offer conversion for an existing .runme notebook', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/notebook'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/notebook') {
+        return {
+          uri,
+          name: 'direct.runme',
+          type: NotebookStoreItemType.File,
+          children: [],
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('direct.runme'))
+    expect(
+      screen.queryByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    ).toBeNull()
   })
 
   it('creates a Jupyter notebook from a folder context menu', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -871,6 +871,9 @@ describe('WorkspaceExplorer current document handling', () => {
       expect(mocks.fsStore.loadContent).toHaveBeenCalledWith(fileUri)
       expect(mocks.fsStore.createContent).not.toHaveBeenCalled()
     })
+    expect(
+      await screen.findByText('Legacy .json file is not a Runme notebook')
+    ).toBeTruthy()
   })
 
   it('does not offer conversion for an existing .runme notebook', async () => {

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -767,6 +767,48 @@ describe('WorkspaceExplorer current document handling', () => {
     ).toBeNull()
   })
 
+  it.each(['.json', '.ipynb'])(
+    'does not offer conversion for a titleless legacy file named %s',
+    async (name) => {
+      mocks.workspaceItems = ['local://folder/drive']
+      mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+        if (uri === 'local://folder/drive') {
+          return {
+            uri,
+            name: 'Drive Root',
+            type: NotebookStoreItemType.Folder,
+            children: ['local://file/titleless'],
+            parents: [],
+          }
+        }
+        if (uri === 'local://file/titleless') {
+          return {
+            uri,
+            name,
+            type: NotebookStoreItemType.File,
+            children: [],
+            parents: ['local://folder/drive'],
+          }
+        }
+        return null
+      })
+
+      render(<WorkspaceExplorer />)
+
+      await screen.findByText('Drive Root')
+      fireEvent.click(
+        screen.getAllByRole('button', { name: 'Collapse folder' })[0]
+      )
+      fireEvent.contextMenu(await screen.findByText(name))
+
+      expect(
+        screen.queryByRole('button', {
+          name: 'Save as Runme Notebook (.runme)',
+        })
+      ).toBeNull()
+    }
+  )
+
   it.each([
     'Google Drive authorization is required.',
     'Google Drive service-account authorization is required.',

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -730,6 +730,62 @@ describe('WorkspaceExplorer current document handling', () => {
     })
   })
 
+  it.each([
+    'Google Drive authorization is required.',
+    'Google Drive service-account authorization is required.',
+    'Google service-account authorization opened in a new tab.',
+    'Redirecting to Google OAuth for Drive authorization.',
+  ])('shows actionable conversion authorization guidance: %s', async (message) => {
+    const folderUri = 'local://folder/drive'
+    const fileUri = 'local://file/notebook'
+    mocks.workspaceItems = [folderUri]
+    mocks.isDriveItemUri.mockImplementation((uri: string) =>
+      uri.startsWith('https://drive.google.com')
+    )
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === folderUri) {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: [fileUri],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === fileUri) {
+        return {
+          uri,
+          name: 'direct.ipynb',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: 'https://drive.google.com/file/d/direct/view',
+          parents: [folderUri],
+        }
+      }
+      return null
+    })
+    mocks.ensureAccessToken.mockRejectedValueOnce(new Error(message))
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('direct.ipynb'))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    )
+
+    expect(mocks.store.convertLegacyNotebookToRunme).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText(
+        `${message} Complete Google Drive authorization, then retry the conversion.`
+      )
+    ).toBeTruthy()
+  })
+
   it('shows actionable conflict guidance when conversion is blocked', async () => {
     const folderUri = 'local://folder/drive'
     const fileUri = 'local://file/conflicted-notebook'

--- a/app/src/components/Workspace/WorkspaceExplorer.test.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.test.tsx
@@ -728,6 +728,57 @@ describe('WorkspaceExplorer current document handling', () => {
     })
   })
 
+  it('prompts for Drive auth when the legacy source create is pending', async () => {
+    mocks.workspaceItems = ['local://folder/drive']
+    mocks.isDriveItemUri.mockImplementation((uri: string) =>
+      uri.startsWith('https://drive.google.com')
+    )
+    mocks.store.getMetadata.mockImplementation(async (uri: string) => {
+      if (uri === 'local://folder/drive') {
+        return {
+          uri,
+          name: 'Drive Root',
+          type: NotebookStoreItemType.Folder,
+          children: ['local://file/notebook'],
+          remoteUri: 'https://drive.google.com/drive/folders/drive-root',
+          parents: [],
+        }
+      }
+      if (uri === 'local://file/notebook') {
+        return {
+          uri,
+          name: 'pending.json',
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: undefined,
+          parents: ['local://folder/drive'],
+        }
+      }
+      return null
+    })
+
+    render(<WorkspaceExplorer />)
+
+    await screen.findByText('Drive Root')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Collapse folder' })[0])
+    fireEvent.contextMenu(await screen.findByText('pending.json'))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save as Runme Notebook (.runme)',
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.ensureAccessToken).toHaveBeenCalledWith({
+        interactive: true,
+      })
+      expect(mocks.store.convertLegacyNotebookToRunme).toHaveBeenCalledWith(
+        'local://file/notebook',
+        'local://folder/drive'
+      )
+    })
+  })
+
   it('does not offer conversion for an existing .runme notebook', async () => {
     mocks.workspaceItems = ['local://folder/drive']
     mocks.store.getMetadata.mockImplementation(async (uri: string) => {

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -32,6 +32,7 @@ import {
   isLegacyNotebookFileName,
   isNotebookFileName,
   notebookFileExtension,
+  runmeFileNameForLegacyNotebook,
   validateNotebookRenameFormat,
 } from '../../lib/notebookFormat'
 import {
@@ -206,7 +207,15 @@ function isVisibleDocumentFile(name: string): boolean {
 }
 
 function isConvertibleLegacyNotebookFileName(name: string): boolean {
-  return isLegacyNotebookFileName(name) && !isExcalidrawFileName(name)
+  if (!isLegacyNotebookFileName(name) || isExcalidrawFileName(name)) {
+    return false
+  }
+  try {
+    runmeFileNameForLegacyNotebook(name)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -113,6 +113,20 @@ function driveCreateErrorMessage(error: unknown, fallback: string): string {
     : fallback;
 }
 
+/** Preserve conversion failures that tell the user how to unblock the action. */
+function legacyConversionErrorMessage(error: unknown): string {
+  const fallback =
+    'Unable to save this notebook as a .runme file. Please try again.'
+  const storageMessage = driveCreateErrorMessage(error, fallback)
+  if (storageMessage !== fallback) {
+    return storageMessage
+  }
+  const message = error instanceof Error ? error.message.trim() : ''
+  return message.startsWith('Resolve the sync conflict before converting')
+    ? message
+    : fallback
+}
+
 /**
  * Preserves actionable authorization and filename-validation errors while
  * hiding unexpected storage failures behind a stable user-facing fallback.
@@ -1150,10 +1164,7 @@ export function WorkspaceExplorer() {
             error: String(error),
           },
         })
-        const message = driveCreateErrorMessage(
-          error,
-          'Unable to save this notebook as a .runme file. Please try again.'
-        )
+        const message = legacyConversionErrorMessage(error)
         setErrorMessage(message)
         showToast({ message, tone: 'error' })
       }

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -122,7 +122,11 @@ function legacyConversionErrorMessage(error: unknown): string {
     return storageMessage
   }
   const message = error instanceof Error ? error.message.trim() : ''
-  return message.startsWith('Resolve the sync conflict before converting')
+  const actionablePrefixes = [
+    'Resolve the sync conflict before converting',
+    'Legacy .json file is not a Runme notebook',
+  ]
+  return actionablePrefixes.some((prefix) => message.startsWith(prefix))
     ? message
     : fallback
 }

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -205,6 +205,10 @@ function isVisibleDocumentFile(name: string): boolean {
   return isNotebookFileName(name) || isExcalidrawFileName(name)
 }
 
+function isConvertibleLegacyNotebookFileName(name: string): boolean {
+  return isLegacyNotebookFileName(name) && !isExcalidrawFileName(name)
+}
+
 /**
  * Record that a workspace root outlived its separately persisted local
  * metadata. The local URI is opaque and safe to include in diagnostics.
@@ -337,7 +341,7 @@ function getContextMenuItemCount(menu: ContextMenuState): number {
     return (
       (menu.uri.startsWith('fs://') ? 0 : 1) +
       4 +
-      (isLegacyNotebookFileName(menu.name) ? 1 : 0) +
+      (isConvertibleLegacyNotebookFileName(menu.name) ? 1 : 0) +
       (menu.remoteUri ? 5 : 0)
     )
   }
@@ -1116,7 +1120,7 @@ export function WorkspaceExplorer() {
 
   const handleConvertLegacyNotebook = useCallback(
     async (menu: ContextMenuState) => {
-      if (!menu.parentUri || !isLegacyNotebookFileName(menu.name)) {
+      if (!menu.parentUri || !isConvertibleLegacyNotebookFileName(menu.name)) {
         return
       }
 
@@ -1808,7 +1812,9 @@ function formatShortTimestamp(date: Date): string {
               >
                 Rename
               </button>
-              {isLegacyNotebookFileName(adjustedContextMenu.name) && (
+              {isConvertibleLegacyNotebookFileName(
+                adjustedContextMenu.name
+              ) && (
                 <button
                   type="button"
                   className="ctx-menu-item"

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -44,7 +44,10 @@ import {
   NotebookStoreItemType,
 } from "../../storage/notebook";
 import type { StorageBrowser } from "../../storage/browser";
-import { isFileSystemAccessSupported } from "../../storage/fs";
+import {
+  FilesystemEntryAlreadyExistsError,
+  isFileSystemAccessSupported,
+} from "../../storage/fs";
 import {
   DriveCreateNotCommittedError,
   fetchDriveItemWithParents,
@@ -102,6 +105,9 @@ function createPlaceholderNode(uri: string, label: string): TreeNode {
 }
 
 function driveCreateErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof FilesystemEntryAlreadyExistsError) {
+    return error.message
+  }
   return error instanceof DriveCreateNotCommittedError
     ? error.message
     : fallback;

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -125,6 +125,9 @@ function legacyConversionErrorMessage(error: unknown): string {
   const actionablePrefixes = [
     'Resolve the sync conflict before converting',
     'Legacy .json file is not a Runme notebook',
+    'Invalid Jupyter notebook JSON',
+    'Unsupported Jupyter ',
+    'Jupyter ',
   ]
   return actionablePrefixes.some((prefix) => message.startsWith(prefix))
     ? message

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -28,7 +28,7 @@ import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
 import { appLogger } from "../../lib/logging/runtime";
 import {
   type NotebookFileFormat,
-  convertLegacyNotebookToRunme,
+  convertLegacyNotebookFileToRunme,
   isLegacyNotebookFileName,
   isNotebookFileName,
   notebookFileExtension,
@@ -1113,8 +1113,11 @@ export function WorkspaceExplorer() {
           if (!fsStore) {
             throw new Error('Filesystem notebook storage is not initialized')
           }
-          const notebook = await fsStore.load(menu.uri)
-          const file = await convertLegacyNotebookToRunme(notebook, menu.name)
+          const content = await fsStore.loadContent(menu.uri)
+          const file = await convertLegacyNotebookFileToRunme(
+            content,
+            menu.name
+          )
           converted = await fsStore.createContent(
             menu.parentUri,
             file.fileName,

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -28,6 +28,8 @@ import { useFilesystemStore } from "../../contexts/FilesystemStoreContext";
 import { appLogger } from "../../lib/logging/runtime";
 import {
   type NotebookFileFormat,
+  convertLegacyNotebookToRunme,
+  isLegacyNotebookFileName,
   isNotebookFileName,
   notebookFileExtension,
   validateNotebookRenameFormat,
@@ -298,7 +300,12 @@ const DEFAULT_DRIVE_FOLDER_NAME = "New Folder";
 
 function getContextMenuItemCount(menu: ContextMenuState): number {
   if (menu.type === NotebookStoreItemType.File) {
-    return (menu.uri.startsWith('fs://') ? 0 : 1) + 4 + (menu.remoteUri ? 5 : 0)
+    return (
+      (menu.uri.startsWith('fs://') ? 0 : 1) +
+      4 +
+      (isLegacyNotebookFileName(menu.name) ? 1 : 0) +
+      (menu.remoteUri ? 5 : 0)
+    )
   }
 
   if (menu.type === NotebookStoreItemType.Folder) {
@@ -1073,6 +1080,64 @@ export function WorkspaceExplorer() {
     [fetchChildren, store],
   );
 
+  const handleConvertLegacyNotebook = useCallback(
+    async (menu: ContextMenuState) => {
+      if (!menu.parentUri || !isLegacyNotebookFileName(menu.name)) {
+        return
+      }
+
+      try {
+        if (menu.remoteUri && isDriveItemUri(menu.remoteUri)) {
+          await ensureAccessToken({ interactive: true })
+        }
+
+        let converted: NotebookStoreItem
+        if (menu.uri.startsWith('fs://')) {
+          if (!fsStore) {
+            throw new Error('Filesystem notebook storage is not initialized')
+          }
+          const notebook = await fsStore.load(menu.uri)
+          const file = await convertLegacyNotebookToRunme(notebook, menu.name)
+          converted = await fsStore.create(menu.parentUri, file.fileName)
+          await fsStore.saveContent(converted.uri, file.content)
+        } else {
+          if (!store) {
+            throw new Error('Notebook storage is not initialized')
+          }
+          converted = await store.convertLegacyNotebookToRunme(
+            menu.uri,
+            menu.parentUri
+          )
+        }
+
+        treeRef.current?.open(menu.parentUri)
+        await fetchChildren(menu.parentUri)
+        setErrorMessage(null)
+        showToast({
+          message: `Saved "${converted.name}"`,
+          tone: 'success',
+        })
+      } catch (error) {
+        appLogger.error('Failed to convert legacy notebook to .runme', {
+          attrs: {
+            scope: 'notebook.convert',
+            code: 'EXPLORER_LEGACY_NOTEBOOK_CONVERSION_FAILED',
+            uri: menu.uri,
+            remoteUri: menu.remoteUri,
+            error: String(error),
+          },
+        })
+        const message = driveCreateErrorMessage(
+          error,
+          'Unable to save this notebook as a .runme file. Please try again.'
+        )
+        setErrorMessage(message)
+        showToast({ message, tone: 'error' })
+      }
+    },
+    [ensureAccessToken, fetchChildren, fsStore, store]
+  )
+
   const handleStartRename = useCallback((uri: string) => {
     setContextMenu(null);
     setPendingEditId(uri);
@@ -1695,6 +1760,21 @@ function formatShortTimestamp(date: Date): string {
               >
                 Rename
               </button>
+              {isLegacyNotebookFileName(adjustedContextMenu.name) && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    const menu = adjustedContextMenu
+                    setContextMenu(null)
+                    void handleConvertLegacyNotebook(menu)
+                  }}
+                >
+                  Save as Runme Notebook (.runme)
+                </button>
+              )}
               <button
                 type="button"
                 className="ctx-menu-item"

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -113,6 +113,15 @@ function driveCreateErrorMessage(error: unknown, fallback: string): string {
     : fallback;
 }
 
+function isDriveAuthorizationMessage(message: string): boolean {
+  return [
+    'Google Drive authorization is required',
+    'Google Drive service-account authorization is required',
+    'Google service-account authorization opened in a new tab',
+    'Redirecting to Google OAuth for Drive authorization',
+  ].some((prefix) => message.startsWith(prefix))
+}
+
 /** Preserve conversion failures that tell the user how to unblock the action. */
 function legacyConversionErrorMessage(error: unknown): string {
   const fallback =
@@ -122,6 +131,9 @@ function legacyConversionErrorMessage(error: unknown): string {
     return storageMessage
   }
   const message = error instanceof Error ? error.message.trim() : ''
+  if (isDriveAuthorizationMessage(message)) {
+    return `${message} Complete Google Drive authorization, then retry the conversion.`
+  }
   const actionablePrefixes = [
     'Resolve the sync conflict before converting',
     'Legacy .json file is not a Runme notebook',
@@ -142,12 +154,7 @@ function legacyConversionErrorMessage(error: unknown): string {
  */
 function renameErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message.trim() : "";
-  if (
-    message.startsWith("Google Drive authorization is required") ||
-    message.startsWith("Google Drive service-account authorization is required") ||
-    message.startsWith("Google service-account authorization opened in a new tab") ||
-    message.startsWith("Redirecting to Google OAuth for Drive authorization")
-  ) {
+  if (isDriveAuthorizationMessage(message)) {
     return `${message} Complete Google Drive authorization, then retry the rename.`;
   }
   if (

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -1093,7 +1093,18 @@ export function WorkspaceExplorer() {
       }
 
       try {
-        if (menu.remoteUri && isDriveItemUri(menu.remoteUri)) {
+        const sourceRemoteUri = menu.remoteUri
+        let isDriveBacked = sourceRemoteUri
+          ? isDriveItemUri(sourceRemoteUri)
+          : false
+        if (!isDriveBacked && !menu.uri.startsWith('fs://') && store) {
+          const parent = await store.getMetadata(menu.parentUri)
+          const parentRemoteUri = parent?.remoteUri
+          isDriveBacked = parentRemoteUri
+            ? isDriveItemUri(parentRemoteUri)
+            : false
+        }
+        if (isDriveBacked) {
           await ensureAccessToken({ interactive: true })
         }
 

--- a/app/src/components/Workspace/WorkspaceExplorer.tsx
+++ b/app/src/components/Workspace/WorkspaceExplorer.tsx
@@ -1104,8 +1104,11 @@ export function WorkspaceExplorer() {
           }
           const notebook = await fsStore.load(menu.uri)
           const file = await convertLegacyNotebookToRunme(notebook, menu.name)
-          converted = await fsStore.create(menu.parentUri, file.fileName)
-          await fsStore.saveContent(converted.uri, file.content)
+          converted = await fsStore.createContent(
+            menu.parentUri,
+            file.fileName,
+            file.content
+          )
         } else {
           if (!store) {
             throw new Error('Notebook storage is not initialized')

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -24,12 +24,8 @@ import {
   detectNotebookFileFormat,
   encodeIpynbNotebook,
   encodeRunmeNotebook,
+  encodeRunmeOperationLogSnapshot,
 } from './notebookFormat'
-import {
-  type NotebookLogHeader,
-  buildOperationLogDiff,
-  serializeOperationLog,
-} from './operationLog'
 import { appState } from './runtime/AppState'
 
 function ensureDriveStore() {
@@ -511,34 +507,6 @@ async function hashCreateOperationId(value: string): Promise<string> {
   ).join('')
 }
 
-async function encodeOperationLogSnapshot(
-  notebook: parser_pb.Notebook,
-  stableIdentity?: string
-): Promise<string> {
-  const seed = stableIdentity
-    ? await hashCreateOperationId(`${stableIdentity}\u0000runme`)
-    : crypto.randomUUID().replace(/-/g, '')
-  const createdAt = stableIdentity
-    ? '1970-01-01T00:00:00.000Z'
-    : new Date().toISOString()
-  const header: NotebookLogHeader = {
-    record_type: 'runme.notebook',
-    format_version: 1,
-    notebook_id: `notebook_${seed}`,
-    created_by: `actor_${seed}`,
-    created_at: createdAt,
-  }
-  const operations = await buildOperationLogDiff({
-    previous: create(parser_pb.NotebookSchema, { cells: [] }),
-    next: notebook,
-    observedOperations: [],
-    actorId: header.created_by,
-    firstActorSequence: 1,
-    createdAt: () => createdAt,
-  })
-  return serializeOperationLog(header, operations)
-}
-
 export async function saveNotebookAsDriveCopy(
   notebook: parser_pb.Notebook,
   folder: string,
@@ -573,7 +541,10 @@ export async function saveNotebookAsDriveCopy(
   let notebookJson: string
   let mimeType: string
   if (format === 'runme-operation-log') {
-    notebookJson = await encodeOperationLogSnapshot(notebook, createOperationId)
+    notebookJson = await encodeRunmeOperationLogSnapshot(
+      notebook,
+      createOperationId
+    )
     mimeType = RUNME_OPERATION_LOG_MIME_TYPE
   } else {
     notebookJson =
@@ -1180,7 +1151,7 @@ export async function copyDriveNotebookFile(
       const content =
         sourceFormat === 'runme-operation-log' && sourceRawContent
           ? sourceRawContent
-          : await encodeOperationLogSnapshot(sourceNotebook)
+          : await encodeRunmeOperationLogSnapshot(sourceNotebook)
       created = await store.createContent(
         targetFolderRef,
         fileName,

--- a/app/src/lib/notebookFormat.test.ts
+++ b/app/src/lib/notebookFormat.test.ts
@@ -3,14 +3,18 @@
 import { create } from '@bufbuild/protobuf'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { MimeType, parser_pb } from '../runme/client'
+import { MimeType, RunmeMetadataKey, parser_pb } from '../runme/client'
 import { appLogger } from './logging/runtime'
 import {
+  convertLegacyNotebookFileToRunme,
+  convertLegacyNotebookToRunme,
   createInitialNotebookFile,
   decodeNotebookFile,
   detectNotebookFileFormat,
   encodeRunmeNotebook,
   inspectRunmeNotebookJsonShape,
+  isLegacyNotebookFileName,
+  runmeFileNameForLegacyNotebook,
 } from './notebookFormat'
 import {
   type NotebookLogHeader,
@@ -228,5 +232,67 @@ describe('Runme operation-log format', () => {
       metadata: { trusted: 'true' },
     })
     expect(decoded.operationLog?.operations).toEqual([operation])
+  })
+})
+
+describe('legacy notebook conversion', () => {
+  it('converts legacy Runme JSON bytes into .runme bytes', async () => {
+    const source = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'cell-json',
+          kind: parser_pb.CellKind.MARKUP,
+          value: '# Legacy JSON',
+        }),
+      ],
+    })
+
+    const converted = await convertLegacyNotebookFileToRunme(
+      encodeRunmeNotebook(source),
+      'legacy.json'
+    )
+    const decoded = decodeNotebookFile(converted.content, converted.fileName)
+
+    expect(converted.fileName).toBe('legacy.runme')
+    expect(decoded.notebook.cells[0]?.value).toBe('# Legacy JSON')
+  })
+
+  it('creates a .runme operation log and preserves the source notebook', async () => {
+    const source = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: 'print(42)',
+        }),
+      ],
+      metadata: { owner: 'runme' },
+    })
+
+    const converted = await convertLegacyNotebookToRunme(source, 'demo.ipynb', {
+      originalGoogleDriveId: 'drive-source-123',
+    })
+    const decoded = decodeNotebookFile(converted.content, converted.fileName)
+
+    expect(converted.fileName).toBe('demo.runme')
+    expect(decoded.format).toBe('runme-operation-log')
+    expect(decoded.notebook.cells).toHaveLength(1)
+    expect(decoded.notebook.cells[0]?.value).toBe('print(42)')
+    expect(decoded.notebook.metadata).toMatchObject({
+      owner: 'runme',
+      [RunmeMetadataKey.OriginalGoogleDriveID]: 'drive-source-123',
+    })
+    expect(
+      source.metadata[RunmeMetadataKey.OriginalGoogleDriveID]
+    ).toBeUndefined()
+  })
+
+  it('recognizes both legacy extensions and replaces only the extension', () => {
+    expect(isLegacyNotebookFileName('report.json')).toBe(true)
+    expect(isLegacyNotebookFileName('report.ipynb')).toBe(true)
+    expect(isLegacyNotebookFileName('report.runme')).toBe(false)
+    expect(runmeFileNameForLegacyNotebook('report.v2.json')).toBe(
+      'report.v2.runme'
+    )
   })
 })

--- a/app/src/lib/notebookFormat.test.ts
+++ b/app/src/lib/notebookFormat.test.ts
@@ -266,6 +266,15 @@ describe('legacy notebook conversion', () => {
     ).rejects.toThrow('Legacy .json file is not a Runme notebook')
   })
 
+  it('classifies invalid protobuf values as invalid legacy notebooks', async () => {
+    await expect(
+      convertLegacyNotebookFileToRunme(
+        JSON.stringify({ cells: [{ kind: 'NOT_A_KIND' }] }),
+        'invalid.json'
+      )
+    ).rejects.toThrow('Legacy .json file is not a Runme notebook')
+  })
+
   it('creates a .runme operation log and preserves the source notebook', async () => {
     const source = create(parser_pb.NotebookSchema, {
       cells: [

--- a/app/src/lib/notebookFormat.test.ts
+++ b/app/src/lib/notebookFormat.test.ts
@@ -257,6 +257,15 @@ describe('legacy notebook conversion', () => {
     expect(decoded.notebook.cells[0]?.value).toBe('# Legacy JSON')
   })
 
+  it('rejects valid JSON that is not a Runme notebook', async () => {
+    await expect(
+      convertLegacyNotebookFileToRunme(
+        JSON.stringify({ unrelated: 'document' }),
+        'unrelated.json'
+      )
+    ).rejects.toThrow('Legacy .json file is not a Runme notebook')
+  })
+
   it('creates a .runme operation log and preserves the source notebook', async () => {
     const source = create(parser_pb.NotebookSchema, {
       cells: [

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -173,6 +173,15 @@ function decodeRunmeNotebook(text: string): parser_pb.Notebook {
   return notebook
 }
 
+function decodeLegacyRunmeNotebookStrict(text: string): parser_pb.Notebook {
+  if (!inspectRunmeNotebookJsonShape(text)) {
+    throw new Error('Legacy .json file is not a Runme notebook')
+  }
+  const notebook = fromJsonString(parser_pb.NotebookSchema, text)
+  migrateNotebookCellIds(notebook)
+  return notebook
+}
+
 export function detectNotebookFileFormat(
   fileName: string
 ): NotebookFileFormat | null {
@@ -303,6 +312,13 @@ export async function convertLegacyNotebookFileToRunme(
   sourceFileName: string,
   options: { originalGoogleDriveId?: string } = {}
 ): Promise<ConvertedRunmeNotebookFile> {
+  if (detectNotebookFileFormat(sourceFileName) === 'runme-json') {
+    return convertLegacyNotebookToRunme(
+      decodeLegacyRunmeNotebookStrict(text),
+      sourceFileName,
+      options
+    )
+  }
   const decoded = decodeNotebookFile(text, sourceFileName)
   if (decoded.format === 'runme-operation-log') {
     throw new Error('Only .json and .ipynb notebooks can be converted')

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -272,14 +272,6 @@ export async function encodeRunmeOperationLogSnapshot(
     created_by: `actor_${seed}`,
     created_at: createdAt,
   }
-  return encodeRunmeOperationLogSnapshotWithHeader(notebook, header)
-}
-
-/** Rebuild a snapshot while retaining an existing .runme document identity. */
-export async function encodeRunmeOperationLogSnapshotWithHeader(
-  notebook: parser_pb.Notebook,
-  header: NotebookLogHeader
-): Promise<string> {
   const operations = await buildOperationLogDiff({
     previous: create(parser_pb.NotebookSchema, { cells: [] }),
     next: notebook,

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -272,13 +272,21 @@ export async function encodeRunmeOperationLogSnapshot(
     created_by: `actor_${seed}`,
     created_at: createdAt,
   }
+  return encodeRunmeOperationLogSnapshotWithHeader(notebook, header)
+}
+
+/** Rebuild a snapshot while retaining an existing .runme document identity. */
+export async function encodeRunmeOperationLogSnapshotWithHeader(
+  notebook: parser_pb.Notebook,
+  header: NotebookLogHeader
+): Promise<string> {
   const operations = await buildOperationLogDiff({
     previous: create(parser_pb.NotebookSchema, { cells: [] }),
     next: notebook,
     observedOperations: [],
     actorId: header.created_by,
     firstActorSequence: 1,
-    createdAt: () => createdAt,
+    createdAt: () => header.created_at,
   })
   return serializeOperationLog(header, operations)
 }

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -177,9 +177,13 @@ function decodeLegacyRunmeNotebookStrict(text: string): parser_pb.Notebook {
   if (!inspectRunmeNotebookJsonShape(text)) {
     throw new Error('Legacy .json file is not a Runme notebook')
   }
-  const notebook = fromJsonString(parser_pb.NotebookSchema, text)
-  migrateNotebookCellIds(notebook)
-  return notebook
+  try {
+    const notebook = fromJsonString(parser_pb.NotebookSchema, text)
+    migrateNotebookCellIds(notebook)
+    return notebook
+  } catch {
+    throw new Error('Legacy .json file is not a Runme notebook')
+  }
 }
 
 export function detectNotebookFileFormat(

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -1,6 +1,6 @@
-import { create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
+import { clone, create, fromJsonString, toJsonString } from '@bufbuild/protobuf'
 
-import { parser_pb } from '../runme/client'
+import { RunmeMetadataKey, parser_pb } from '../runme/client'
 import { migrateNotebookCellIds } from './cellIdentity'
 import {
   type DecodedIpynb,
@@ -13,6 +13,7 @@ import { appLogger } from './logging/runtime'
 import {
   type NotebookLogHeader,
   type ParsedOperationLog,
+  buildOperationLogDiff,
   materializeOperationLog,
   materializedLogToNotebook,
   parseOperationLog,
@@ -27,6 +28,12 @@ export const RUNME_OPERATION_LOG_MIME_TYPE =
   'application/vnd.runme.notebook+jsonl'
 
 export type NotebookFileFormat = 'runme-json' | 'ipynb' | 'runme-operation-log'
+
+export interface ConvertedRunmeNotebookFile {
+  fileName: string
+  notebook: parser_pb.Notebook
+  content: string
+}
 
 export function notebookFileExtension(format: NotebookFileFormat): string {
   switch (format) {
@@ -205,6 +212,102 @@ export function validateNotebookRenameFormat(
 
 export function isNotebookFileName(fileName: string): boolean {
   return detectNotebookFileFormat(fileName) !== null
+}
+
+export function isLegacyNotebookFileName(fileName: string): boolean {
+  const format = detectNotebookFileFormat(fileName)
+  return format === 'runme-json' || format === 'ipynb'
+}
+
+export function runmeFileNameForLegacyNotebook(fileName: string): string {
+  const trimmed = fileName.trim()
+  const format = detectNotebookFileFormat(trimmed)
+  if (format !== 'runme-json' && format !== 'ipynb') {
+    throw new Error(
+      `Legacy notebook file name must end in .json or .ipynb: ${fileName}`
+    )
+  }
+  const extension = notebookFileExtension(format)
+  const title = trimmed.slice(0, -extension.length)
+  if (!title) {
+    throw new Error('Legacy notebook file name must include a title')
+  }
+  return `${title}.runme`
+}
+
+async function hashOperationLogIdentity(value: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(value)
+  )
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')
+}
+
+/** Encode a materialized notebook as a self-contained .runme operation log. */
+export async function encodeRunmeOperationLogSnapshot(
+  notebook: parser_pb.Notebook,
+  stableIdentity?: string
+): Promise<string> {
+  const seed = stableIdentity
+    ? await hashOperationLogIdentity(`${stableIdentity}\u0000runme`)
+    : globalThis.crypto.randomUUID().replace(/-/g, '')
+  const createdAt = stableIdentity
+    ? '1970-01-01T00:00:00.000Z'
+    : new Date().toISOString()
+  const header: NotebookLogHeader = {
+    record_type: 'runme.notebook',
+    format_version: 1,
+    notebook_id: `notebook_${seed}`,
+    created_by: `actor_${seed}`,
+    created_at: createdAt,
+  }
+  const operations = await buildOperationLogDiff({
+    previous: create(parser_pb.NotebookSchema, { cells: [] }),
+    next: notebook,
+    observedOperations: [],
+    actorId: header.created_by,
+    firstActorSequence: 1,
+    createdAt: () => createdAt,
+  })
+  return serializeOperationLog(header, operations)
+}
+
+/**
+ * Convert a parsed legacy notebook into a new .runme document without
+ * carrying over external comments. The input notebook is never mutated.
+ */
+export async function convertLegacyNotebookToRunme(
+  notebook: parser_pb.Notebook,
+  sourceFileName: string,
+  options: { originalGoogleDriveId?: string } = {}
+): Promise<ConvertedRunmeNotebookFile> {
+  const converted = clone(parser_pb.NotebookSchema, notebook)
+  migrateNotebookCellIds(converted)
+  converted.metadata = { ...converted.metadata }
+  if (options.originalGoogleDriveId) {
+    converted.metadata[RunmeMetadataKey.OriginalGoogleDriveID] =
+      options.originalGoogleDriveId
+  }
+  return {
+    fileName: runmeFileNameForLegacyNotebook(sourceFileName),
+    notebook: converted,
+    content: await encodeRunmeOperationLogSnapshot(converted),
+  }
+}
+
+/** Convert raw legacy notebook bytes into a new .runme document. */
+export async function convertLegacyNotebookFileToRunme(
+  text: string,
+  sourceFileName: string,
+  options: { originalGoogleDriveId?: string } = {}
+): Promise<ConvertedRunmeNotebookFile> {
+  const decoded = decodeNotebookFile(text, sourceFileName)
+  if (decoded.format === 'runme-operation-log') {
+    throw new Error('Only .json and .ipynb notebooks can be converted')
+  }
+  return convertLegacyNotebookToRunme(decoded.notebook, sourceFileName, options)
 }
 
 export function decodeNotebookFile(

--- a/app/src/runme/client.ts
+++ b/app/src/runme/client.ts
@@ -29,6 +29,7 @@ export enum RunmeMetadataKey {
   JupyterServerName = 'runme.dev/jupyterServerName',
   JupyterKernelName = 'runme.dev/jupyterKernelName',
   JupyterKernelID = 'runme.dev/jupyterKernelID',
+  OriginalGoogleDriveID = 'runme.dev/originalGoogleDriveID',
 }
 
 export enum RunmeExecutionState {

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -838,6 +838,28 @@ describe("FilesystemNotebookStore", () => {
       expect(existing.createWritable).not.toHaveBeenCalled()
     })
 
+    it('refuses a file created externally between the probe and create', async () => {
+      const externalContent = 'content written by another process'
+      const external = createMockFileHandle('shared.runme', externalContent)
+      vi.mocked(rootHandle.getFileHandle).mockImplementation(
+        async (fileName: string, options?: FileSystemGetFileOptions) => {
+          if (!options?.create) {
+            throw new DOMException('File not found', 'NotFoundError')
+          }
+          rootEntries.set(fileName, external)
+          return external
+        }
+      )
+
+      await expect(store.create(ROOT_URI, 'shared.runme')).rejects.toThrow(
+        'A file named "shared.runme" already exists in this folder.'
+      )
+      const preserved = await external.getFile()
+      await expect(preserved.text()).resolves.toBe(externalContent)
+      expect(external.createWritable).not.toHaveBeenCalled()
+      expect(rootHandle.removeEntry).not.toHaveBeenCalled()
+    })
+
     it('serializes case aliases on a case-insensitive filesystem', async () => {
       vi.mocked(rootHandle.getFileHandle).mockImplementation(
         async (fileName: string, options?: FileSystemGetFileOptions) => {

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -773,6 +773,20 @@ describe("FilesystemNotebookStore", () => {
       })
     })
 
+    it('refuses to overwrite an existing notebook', async () => {
+      const original = 'original runme content'
+      const existing = createMockFileHandle('shared.runme', original)
+      rootEntries.set('shared.runme', existing)
+
+      await expect(store.create(ROOT_URI, 'shared.runme')).rejects.toThrow(
+        'A file named "shared.runme" already exists in this folder.'
+      )
+      await expect(existing.getFile().then((file) => file.text())).resolves.toBe(
+        original
+      )
+      expect(existing.createWritable).not.toHaveBeenCalled()
+    })
+
     it('calls getFileHandle with create: true', async () => {
       await store.create(ROOT_URI, 'new-notebook.json')
       expect(rootHandle.getFileHandle).toHaveBeenCalledWith(

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -838,6 +838,43 @@ describe("FilesystemNotebookStore", () => {
       expect(existing.createWritable).not.toHaveBeenCalled()
     })
 
+    it('serializes case aliases on a case-insensitive filesystem', async () => {
+      vi.mocked(rootHandle.getFileHandle).mockImplementation(
+        async (fileName: string, options?: FileSystemGetFileOptions) => {
+          const physicalName = fileName.normalize('NFC').toLowerCase()
+          if (rootEntries.has(physicalName)) {
+            return rootEntries.get(physicalName)
+          }
+          if (options?.create) {
+            const handle = createMockFileHandle(fileName, '')
+            rootEntries.set(physicalName, handle)
+            return handle
+          }
+          throw new DOMException('File not found', 'NotFoundError')
+        }
+      )
+      const upperContent = createInitialNotebookFile('Report.runme')
+      const lowerContent = createInitialNotebookFile('report.runme')
+
+      const results = await Promise.allSettled([
+        store.createContent(ROOT_URI, 'Report.runme', upperContent),
+        store.createContent(ROOT_URI, 'report.runme', lowerContent),
+      ])
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled')
+      ).toHaveLength(1)
+      const rejection = results.find((result) => result.status === 'rejected')
+      expect(rejection).toMatchObject({
+        reason: expect.any(FilesystemEntryAlreadyExistsError),
+      })
+      const savedContent = await rootEntries
+        .get('report.runme')
+        .getFile()
+        .then((file) => file.text())
+      expect([upperContent, lowerContent]).toContain(savedContent)
+    })
+
     it('serializes concurrent creates through aliases of the same directory', async () => {
       const firstContent = createInitialNotebookFile('shared.runme')
       const secondContent = createInitialNotebookFile('shared.runme')

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -882,6 +882,65 @@ describe("FilesystemNotebookStore", () => {
       expect([firstContent, secondContent]).toContain(savedContent)
     })
 
+    it('serializes concurrent creates through overlapping workspace roots', async () => {
+      const firstContent = createInitialNotebookFile('shared.runme')
+      const secondContent = createInitialNotebookFile('shared.runme')
+      const nestedWorkspaceId = 'nested-workspace-id'
+      const nestedEntries = new Map<string, any>()
+      const nestedRootHandle = createMockDirectoryHandle(
+        'subdir',
+        nestedEntries
+      )
+      rootEntries.set('subdir', nestedRootHandle)
+      ;(rootHandle as any).isSameEntry = vi.fn(async () => false)
+      ;(nestedRootHandle as any).isSameEntry = vi.fn(async () => false)
+      ;(rootHandle as any).resolve = vi.fn(
+        async (other: FileSystemHandle) =>
+          other === nestedRootHandle ? ['subdir'] : null
+      )
+      ;(nestedRootHandle as any).resolve = vi.fn(async () => null)
+      ;(db.workspaces as any)._store.set(nestedWorkspaceId, {
+        id: nestedWorkspaceId,
+        name: 'subdir',
+        rootHandle: nestedRootHandle,
+        lastOpened: Date.now(),
+        permissionState: 'granted',
+      })
+      ;(db.entries as any)._store.set(`${nestedWorkspaceId}:`, {
+        id: `${nestedWorkspaceId}:`,
+        workspaceId: nestedWorkspaceId,
+        relativePath: '',
+        kind: 'directory',
+        handle: nestedRootHandle,
+        lastKnownMtime: 0,
+        lastKnownSize: 0,
+      })
+      const outerSubdirectoryUri = `fs://workspace/${WORKSPACE_ID}/dir/${encodeURIComponent('subdir')}`
+      const nestedRootUri = `fs://workspace/${nestedWorkspaceId}/dir/${encodeURIComponent('')}`
+
+      const results = await Promise.allSettled([
+        store.createContent(
+          outerSubdirectoryUri,
+          'shared.runme',
+          firstContent
+        ),
+        store.createContent(nestedRootUri, 'shared.runme', secondContent),
+      ])
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled')
+      ).toHaveLength(1)
+      const rejection = results.find((result) => result.status === 'rejected')
+      expect(rejection).toMatchObject({
+        reason: expect.any(FilesystemEntryAlreadyExistsError),
+      })
+      const savedContent = await nestedEntries
+        .get('shared.runme')
+        .getFile()
+        .then((file) => file.text())
+      expect([firstContent, secondContent]).toContain(savedContent)
+    })
+
     it('calls getFileHandle with create: true', async () => {
       await store.create(ROOT_URI, 'new-notebook.json')
       expect(rootHandle.getFileHandle).toHaveBeenCalledWith(

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -10,7 +10,11 @@ import {
 } from '../lib/notebookFormat'
 import { parseOperationLog } from '../lib/operationLog'
 import { parser_pb } from '../runme/client'
-import { FilesystemNotebookStore, isFileSystemAccessSupported } from './fs'
+import {
+  FilesystemEntryAlreadyExistsError,
+  FilesystemNotebookStore,
+  isFileSystemAccessSupported,
+} from './fs'
 import type { FsDatabase, FsEntryRecord, WorkspaceRecord } from './fsdb'
 import { NotebookStoreItemType } from './notebook'
 
@@ -831,6 +835,29 @@ describe("FilesystemNotebookStore", () => {
         original
       )
       expect(existing.createWritable).not.toHaveBeenCalled()
+    })
+
+    it('serializes concurrent creates for the same destination', async () => {
+      const firstContent = createInitialNotebookFile('shared.runme')
+      const secondContent = createInitialNotebookFile('shared.runme')
+
+      const results = await Promise.allSettled([
+        store.createContent(ROOT_URI, 'shared.runme', firstContent),
+        store.createContent(ROOT_URI, 'shared.runme', secondContent),
+      ])
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled')
+      ).toHaveLength(1)
+      const rejection = results.find((result) => result.status === 'rejected')
+      expect(rejection).toMatchObject({
+        reason: expect.any(FilesystemEntryAlreadyExistsError),
+      })
+      const savedContent = await rootEntries
+        .get('shared.runme')
+        .getFile()
+        .then((file) => file.text())
+      expect([firstContent, secondContent]).toContain(savedContent)
     })
 
     it('calls getFileHandle with create: true', async () => {

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   RUNME_OPERATION_LOG_MIME_TYPE,
+  createInitialNotebookFile,
   encodeRunmeNotebook,
 } from '../lib/notebookFormat'
 import { parseOperationLog } from '../lib/operationLog'
@@ -771,6 +772,51 @@ describe("FilesystemNotebookStore", () => {
         },
         operations: [],
       })
+    })
+
+    it('creates a notebook with the supplied content in one operation', async () => {
+      const content = createInitialNotebookFile('converted.runme')
+
+      const item = await store.createContent(
+        ROOT_URI,
+        'converted.runme',
+        content
+      )
+
+      expect(item.name).toBe('converted.runme')
+      await expect(
+        rootEntries.get('converted.runme').getFile().then((file) => file.text())
+      ).resolves.toBe(content)
+    })
+
+    it('removes a newly created target when writing its content fails', async () => {
+      const failingHandle = createMockFileHandle('converted.runme', '')
+      vi.mocked(failingHandle.createWritable).mockResolvedValue({
+        write: vi.fn(async () => {
+          throw new Error('write failed')
+        }),
+        close: vi.fn(async () => {}),
+      } as FileSystemWritableFileStream)
+      vi.mocked(rootHandle.getFileHandle).mockImplementation(
+        async (fileName: string, options?: FileSystemGetFileOptions) => {
+          if (!options?.create) {
+            throw new DOMException('File not found', 'NotFoundError')
+          }
+          rootEntries.set(fileName, failingHandle)
+          return failingHandle
+        }
+      )
+
+      await expect(
+        store.createContent(
+          ROOT_URI,
+          'converted.runme',
+          createInitialNotebookFile('converted.runme')
+        )
+      ).rejects.toThrow('write failed')
+
+      expect(rootHandle.removeEntry).toHaveBeenCalledWith('converted.runme')
+      expect(rootEntries.has('converted.runme')).toBe(false)
     })
 
     it('refuses to overwrite an existing notebook', async () => {

--- a/app/src/storage/fs.test.ts
+++ b/app/src/storage/fs.test.ts
@@ -136,6 +136,7 @@ function createMockTable<T extends { id?: string }>() {
     delete: vi.fn(async (id: string) => {
       store.delete(id);
     }),
+    toArray: vi.fn(async () => [...store.values()]),
     orderBy: vi.fn((field: string) => ({
       reverse: vi.fn(() => ({
         toArray: vi.fn(async () => {
@@ -837,13 +838,34 @@ describe("FilesystemNotebookStore", () => {
       expect(existing.createWritable).not.toHaveBeenCalled()
     })
 
-    it('serializes concurrent creates for the same destination', async () => {
+    it('serializes concurrent creates through aliases of the same directory', async () => {
       const firstContent = createInitialNotebookFile('shared.runme')
       const secondContent = createInitialNotebookFile('shared.runme')
+      const aliasWorkspaceId = 'alias-workspace-id'
+      const aliasRootUri = `fs://workspace/${aliasWorkspaceId}/dir/${encodeURIComponent('')}`
+      ;(rootHandle as any).isSameEntry = vi.fn(
+        async (other: FileSystemHandle) => other === rootHandle
+      )
+      ;(db.workspaces as any)._store.set(aliasWorkspaceId, {
+        id: aliasWorkspaceId,
+        name: 'my-project-alias',
+        rootHandle,
+        lastOpened: Date.now(),
+        permissionState: 'granted',
+      })
+      ;(db.entries as any)._store.set(`${aliasWorkspaceId}:`, {
+        id: `${aliasWorkspaceId}:`,
+        workspaceId: aliasWorkspaceId,
+        relativePath: '',
+        kind: 'directory',
+        handle: rootHandle,
+        lastKnownMtime: 0,
+        lastKnownSize: 0,
+      })
 
       const results = await Promise.allSettled([
         store.createContent(ROOT_URI, 'shared.runme', firstContent),
-        store.createContent(ROOT_URI, 'shared.runme', secondContent),
+        store.createContent(aliasRootUri, 'shared.runme', secondContent),
       ])
 
       expect(

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -128,6 +128,18 @@ function entryRecordId(workspaceId: string, relativePath: string): string {
   return `${workspaceId}:${relativePath}`;
 }
 
+/**
+ * Canonicalize only the coordination key, never the actual filesystem path.
+ * This safely over-serializes case-distinct creates on case-sensitive volumes
+ * while preventing overwrite races where the underlying volume ignores case.
+ */
+function physicalEntryLockId(
+  workspaceId: string,
+  relativePath: string
+): string {
+  return entryRecordId(workspaceId, relativePath.normalize('NFC').toLowerCase())
+}
+
 // ---------------------------------------------------------------------------
 // Notebook helpers
 // ---------------------------------------------------------------------------
@@ -639,14 +651,16 @@ export class FilesystemNotebookStore {
     relativePath: string
   ): Promise<string> {
     const workspace = await this.db.workspaces.get(workspaceId)
-    if (!workspace) return entryRecordId(workspaceId, relativePath)
+    if (!workspace) return physicalEntryLockId(workspaceId, relativePath)
 
-    const equivalentEntryIds = [entryRecordId(workspaceId, relativePath)]
+    const equivalentEntryIds = [physicalEntryLockId(workspaceId, relativePath)]
     for (const candidate of await this.db.workspaces.toArray()) {
       if (candidate.id === workspaceId) continue
       try {
         if (await workspace.rootHandle.isSameEntry(candidate.rootHandle)) {
-          equivalentEntryIds.push(entryRecordId(candidate.id, relativePath))
+          equivalentEntryIds.push(
+            physicalEntryLockId(candidate.id, relativePath)
+          )
           continue
         }
 
@@ -656,10 +670,10 @@ export class FilesystemNotebookStore {
         if (candidateBelowWorkspace) {
           const candidatePrefix = candidateBelowWorkspace.join('/')
           if (relativePath === candidatePrefix) {
-            equivalentEntryIds.push(entryRecordId(candidate.id, ''))
+            equivalentEntryIds.push(physicalEntryLockId(candidate.id, ''))
           } else if (relativePath.startsWith(`${candidatePrefix}/`)) {
             equivalentEntryIds.push(
-              entryRecordId(
+              physicalEntryLockId(
                 candidate.id,
                 relativePath.slice(candidatePrefix.length + 1)
               )
@@ -673,7 +687,7 @@ export class FilesystemNotebookStore {
         )
         if (workspaceBelowCandidate) {
           equivalentEntryIds.push(
-            entryRecordId(
+            physicalEntryLockId(
               candidate.id,
               [...workspaceBelowCandidate, relativePath]
                 .filter(Boolean)

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -193,6 +193,39 @@ function isNotFoundError(error: unknown): boolean {
   )
 }
 
+const FILE_CREATE_LOCK_PREFIX = 'runme:filesystem-create:'
+const fallbackCreateTails = new Map<string, Promise<void>>()
+
+async function runFilesystemCreateExclusive<T>(
+  key: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const lockName = `${FILE_CREATE_LOCK_PREFIX}${key}`
+  if (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.locks?.request === 'function'
+  ) {
+    return navigator.locks.request(lockName, operation)
+  }
+
+  const previous = fallbackCreateTails.get(lockName) ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const tail = previous.then(() => current)
+  fallbackCreateTails.set(lockName, tail)
+  await previous
+  try {
+    return await operation()
+  } finally {
+    release()
+    if (fallbackCreateTails.get(lockName) === tail) {
+      fallbackCreateTails.delete(lockName)
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // FilesystemNotebookStore
 // ---------------------------------------------------------------------------
@@ -523,68 +556,71 @@ export class FilesystemNotebookStore {
         `FilesystemNotebookStore.${operation} expects a directory URI`,
       );
     }
+    const relPath = parsed.relativePath
+      ? `${parsed.relativePath}/${safeName}`
+      : safeName
+    const recId = entryRecordId(parsed.workspaceId, relPath)
 
-    const dirHandle = await this.resolveDirectoryHandle(
-      parsed.workspaceId,
-      parsed.relativePath,
-    );
+    return runFilesystemCreateExclusive(recId, async () => {
+      const dirHandle = await this.resolveDirectoryHandle(
+        parsed.workspaceId,
+        parsed.relativePath,
+      );
 
-    try {
-      await dirHandle.getFileHandle(safeName)
-      throw new FilesystemEntryAlreadyExistsError(safeName)
-    } catch (error) {
-      if (!isNotFoundError(error)) {
+      try {
+        await dirHandle.getFileHandle(safeName)
+        throw new FilesystemEntryAlreadyExistsError(safeName)
+      } catch (error) {
+        if (!isNotFoundError(error)) {
+          throw error
+        }
+      }
+
+      const fileHandle = await dirHandle.getFileHandle(safeName, {
+        create: true,
+      })
+      try {
+        const writable = await fileHandle.createWritable()
+        await writable.write(content)
+        await writable.close()
+
+        const fileUri = buildFsUri(parsed.workspaceId, relPath, "file");
+        const file = await fileHandle.getFile();
+
+        await this.db.entries.put({
+          id: recId,
+          workspaceId: parsed.workspaceId,
+          relativePath: relPath,
+          kind: "file",
+          handle: fileHandle,
+          lastKnownMtime: file.lastModified,
+          lastKnownSize: file.size,
+          cachedDoc: content,
+        });
+
+        this.baseRevisions.set(recId, {
+          lastModified: file.lastModified,
+          size: file.size,
+        });
+
+        return {
+          uri: fileUri,
+          name: safeName,
+          type: NotebookStoreItemType.File,
+          children: [],
+          mimeType:
+            detectNotebookFileFormat(safeName) === 'ipynb'
+              ? IPYNB_MIME_TYPE
+              : detectNotebookFileFormat(safeName) === 'runme-operation-log'
+                ? RUNME_OPERATION_LOG_MIME_TYPE
+                : 'application/json',
+          parents: [parentUri],
+        };
+      } catch (error) {
+        await dirHandle.removeEntry(safeName).catch(() => {})
         throw error
       }
-    }
-
-    const fileHandle = await dirHandle.getFileHandle(safeName, { create: true })
-    try {
-      const writable = await fileHandle.createWritable()
-      await writable.write(content)
-      await writable.close()
-
-      const relPath = parsed.relativePath
-        ? `${parsed.relativePath}/${safeName}`
-        : safeName;
-      const fileUri = buildFsUri(parsed.workspaceId, relPath, "file");
-
-      const file = await fileHandle.getFile();
-      const recId = entryRecordId(parsed.workspaceId, relPath);
-
-      await this.db.entries.put({
-        id: recId,
-        workspaceId: parsed.workspaceId,
-        relativePath: relPath,
-        kind: "file",
-        handle: fileHandle,
-        lastKnownMtime: file.lastModified,
-        lastKnownSize: file.size,
-        cachedDoc: content,
-      });
-
-      this.baseRevisions.set(recId, {
-        lastModified: file.lastModified,
-        size: file.size,
-      });
-
-      return {
-        uri: fileUri,
-        name: safeName,
-        type: NotebookStoreItemType.File,
-        children: [],
-        mimeType:
-          detectNotebookFileFormat(safeName) === 'ipynb'
-            ? IPYNB_MIME_TYPE
-            : detectNotebookFileFormat(safeName) === 'runme-operation-log'
-              ? RUNME_OPERATION_LOG_MIME_TYPE
-              : 'application/json',
-        parents: [parentUri],
-      };
-    } catch (error) {
-      await dirHandle.removeEntry(safeName).catch(() => {})
-      throw error
-    }
+    })
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -627,7 +627,13 @@ export class FilesystemNotebookStore {
     })
   }
 
-  /** Use the same create lock for workspace aliases of one physical root. */
+  /**
+   * Use the same create lock for every workspace path that names one physical
+   * entry. Besides identical root aliases, mounted roots can overlap (for
+   * example, one workspace may open a subdirectory of another workspace).
+   * Express the target relative to every registered ancestor/descendant root
+   * and choose the same stable key from that equivalent set.
+   */
   private async physicalEntryLockKey(
     workspaceId: string,
     relativePath: string
@@ -635,19 +641,52 @@ export class FilesystemNotebookStore {
     const workspace = await this.db.workspaces.get(workspaceId)
     if (!workspace) return entryRecordId(workspaceId, relativePath)
 
-    const equivalentIds = [workspaceId]
+    const equivalentEntryIds = [entryRecordId(workspaceId, relativePath)]
     for (const candidate of await this.db.workspaces.toArray()) {
       if (candidate.id === workspaceId) continue
       try {
         if (await workspace.rootHandle.isSameEntry(candidate.rootHandle)) {
-          equivalentIds.push(candidate.id)
+          equivalentEntryIds.push(entryRecordId(candidate.id, relativePath))
+          continue
+        }
+
+        const candidateBelowWorkspace = await workspace.rootHandle.resolve(
+          candidate.rootHandle
+        )
+        if (candidateBelowWorkspace) {
+          const candidatePrefix = candidateBelowWorkspace.join('/')
+          if (relativePath === candidatePrefix) {
+            equivalentEntryIds.push(entryRecordId(candidate.id, ''))
+          } else if (relativePath.startsWith(`${candidatePrefix}/`)) {
+            equivalentEntryIds.push(
+              entryRecordId(
+                candidate.id,
+                relativePath.slice(candidatePrefix.length + 1)
+              )
+            )
+          }
+          continue
+        }
+
+        const workspaceBelowCandidate = await candidate.rootHandle.resolve(
+          workspace.rootHandle
+        )
+        if (workspaceBelowCandidate) {
+          equivalentEntryIds.push(
+            entryRecordId(
+              candidate.id,
+              [...workspaceBelowCandidate, relativePath]
+                .filter(Boolean)
+                .join('/')
+            )
+          )
         }
       } catch {
-        // A stale or revoked alias cannot provide a reliable shared identity.
+        // A stale or revoked overlapping root cannot provide shared identity.
       }
     }
-    equivalentIds.sort()
-    return entryRecordId(equivalentIds[0], relativePath)
+    equivalentEntryIds.sort()
+    return equivalentEntryIds[0]
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -560,8 +560,12 @@ export class FilesystemNotebookStore {
       ? `${parsed.relativePath}/${safeName}`
       : safeName
     const recId = entryRecordId(parsed.workspaceId, relPath)
+    const createLockKey = await this.physicalEntryLockKey(
+      parsed.workspaceId,
+      relPath
+    )
 
-    return runFilesystemCreateExclusive(recId, async () => {
+    return runFilesystemCreateExclusive(createLockKey, async () => {
       const dirHandle = await this.resolveDirectoryHandle(
         parsed.workspaceId,
         parsed.relativePath,
@@ -621,6 +625,29 @@ export class FilesystemNotebookStore {
         throw error
       }
     })
+  }
+
+  /** Use the same create lock for workspace aliases of one physical root. */
+  private async physicalEntryLockKey(
+    workspaceId: string,
+    relativePath: string
+  ): Promise<string> {
+    const workspace = await this.db.workspaces.get(workspaceId)
+    if (!workspace) return entryRecordId(workspaceId, relativePath)
+
+    const equivalentIds = [workspaceId]
+    for (const candidate of await this.db.workspaces.toArray()) {
+      if (candidate.id === workspaceId) continue
+      try {
+        if (await workspace.rootHandle.isSameEntry(candidate.rootHandle)) {
+          equivalentIds.push(candidate.id)
+        }
+      } catch {
+        // A stale or revoked alias cannot provide a reliable shared identity.
+      }
+    }
+    equivalentIds.sort()
+    return entryRecordId(equivalentIds[0], relativePath)
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -595,6 +595,15 @@ export class FilesystemNotebookStore {
       const fileHandle = await dirHandle.getFileHandle(safeName, {
         create: true,
       })
+      // The File System Access API has no exclusive-create flag. A process
+      // outside this origin can therefore create the target after the probe
+      // above but before getFileHandle resolves. A newly created file is
+      // empty, so refuse a returned handle that already contains data rather
+      // than overwriting the external file.
+      const initialFile = await fileHandle.getFile()
+      if (initialFile.size !== 0) {
+        throw new FilesystemEntryAlreadyExistsError(safeName)
+      }
       try {
         const writable = await fileHandle.createWritable()
         await writable.write(content)
@@ -633,7 +642,12 @@ export class FilesystemNotebookStore {
           parents: [parentUri],
         };
       } catch (error) {
-        await dirHandle.removeEntry(safeName).catch(() => {})
+        // Only remove an empty target. A failed writer or another process may
+        // have populated the path after our check; deleting it would lose data.
+        const failedFile = await fileHandle.getFile().catch(() => undefined)
+        if (failedFile?.size === 0) {
+          await dirHandle.removeEntry(safeName).catch(() => {})
+        }
         throw error
       }
     })

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -177,6 +177,22 @@ export function isFileSystemAccessSupported(): boolean {
   );
 }
 
+export class FilesystemEntryAlreadyExistsError extends Error {
+  constructor(readonly fileName: string) {
+    super(`A file named "${fileName}" already exists in this folder.`)
+    this.name = 'FilesystemEntryAlreadyExistsError'
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'NotFoundError'
+  )
+}
+
 // ---------------------------------------------------------------------------
 // FilesystemNotebookStore
 // ---------------------------------------------------------------------------
@@ -484,6 +500,15 @@ export class FilesystemNotebookStore {
       parsed.workspaceId,
       parsed.relativePath,
     );
+
+    try {
+      await dirHandle.getFileHandle(safeName)
+      throw new FilesystemEntryAlreadyExistsError(safeName)
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        throw error
+      }
+    }
 
     const fileHandle = await dirHandle.getFileHandle(safeName, { create: true })
 

--- a/app/src/storage/fs.ts
+++ b/app/src/storage/fs.ts
@@ -487,14 +487,42 @@ export class FilesystemNotebookStore {
   }
 
   async create(parentUri: string, name: string): Promise<NotebookStoreItem> {
+    const safeName = notebookNameForCreate(name)
+    return this.createFileWithContent(
+      parentUri,
+      safeName,
+      createInitialNotebookFile(safeName),
+      'create'
+    )
+  }
+
+  async createContent(
+    parentUri: string,
+    name: string,
+    content: string
+  ): Promise<NotebookStoreItem> {
+    const safeName = notebookNameForCreate(name)
+    decodeNotebookFile(content, safeName)
+    return this.createFileWithContent(
+      parentUri,
+      safeName,
+      content,
+      'createContent'
+    )
+  }
+
+  private async createFileWithContent(
+    parentUri: string,
+    safeName: string,
+    content: string,
+    operation: 'create' | 'createContent'
+  ): Promise<NotebookStoreItem> {
     const parsed = parseFsUri(parentUri);
     if (parsed.kind !== "directory") {
       throw new Error(
-        "FilesystemNotebookStore.create expects a directory URI",
+        `FilesystemNotebookStore.${operation} expects a directory URI`,
       );
     }
-
-    const safeName = notebookNameForCreate(name)
 
     const dirHandle = await this.resolveDirectoryHandle(
       parsed.workspaceId,
@@ -511,49 +539,52 @@ export class FilesystemNotebookStore {
     }
 
     const fileHandle = await dirHandle.getFileHandle(safeName, { create: true })
+    try {
+      const writable = await fileHandle.createWritable()
+      await writable.write(content)
+      await writable.close()
 
-    const json = createInitialNotebookFile(safeName)
-    const writable = await fileHandle.createWritable()
-    await writable.write(json)
-    await writable.close()
+      const relPath = parsed.relativePath
+        ? `${parsed.relativePath}/${safeName}`
+        : safeName;
+      const fileUri = buildFsUri(parsed.workspaceId, relPath, "file");
 
-    const relPath = parsed.relativePath
-      ? `${parsed.relativePath}/${safeName}`
-      : safeName;
-    const fileUri = buildFsUri(parsed.workspaceId, relPath, "file");
+      const file = await fileHandle.getFile();
+      const recId = entryRecordId(parsed.workspaceId, relPath);
 
-    const file = await fileHandle.getFile();
-    const recId = entryRecordId(parsed.workspaceId, relPath);
+      await this.db.entries.put({
+        id: recId,
+        workspaceId: parsed.workspaceId,
+        relativePath: relPath,
+        kind: "file",
+        handle: fileHandle,
+        lastKnownMtime: file.lastModified,
+        lastKnownSize: file.size,
+        cachedDoc: content,
+      });
 
-    await this.db.entries.put({
-      id: recId,
-      workspaceId: parsed.workspaceId,
-      relativePath: relPath,
-      kind: "file",
-      handle: fileHandle,
-      lastKnownMtime: file.lastModified,
-      lastKnownSize: file.size,
-      cachedDoc: json,
-    });
+      this.baseRevisions.set(recId, {
+        lastModified: file.lastModified,
+        size: file.size,
+      });
 
-    this.baseRevisions.set(recId, {
-      lastModified: file.lastModified,
-      size: file.size,
-    });
-
-    return {
-      uri: fileUri,
-      name: safeName,
-      type: NotebookStoreItemType.File,
-      children: [],
-      mimeType:
-        detectNotebookFileFormat(safeName) === 'ipynb'
-          ? IPYNB_MIME_TYPE
-          : detectNotebookFileFormat(safeName) === 'runme-operation-log'
-            ? RUNME_OPERATION_LOG_MIME_TYPE
-            : 'application/json',
-      parents: [parentUri],
-    };
+      return {
+        uri: fileUri,
+        name: safeName,
+        type: NotebookStoreItemType.File,
+        children: [],
+        mimeType:
+          detectNotebookFileFormat(safeName) === 'ipynb'
+            ? IPYNB_MIME_TYPE
+            : detectNotebookFileFormat(safeName) === 'runme-operation-log'
+              ? RUNME_OPERATION_LOG_MIME_TYPE
+              : 'application/json',
+        parents: [parentUri],
+      };
+    } catch (error) {
+      await dirHandle.removeEntry(safeName).catch(() => {})
+      throw error
+    }
   }
 
   async rename(uri: string, name: string): Promise<NotebookStoreItem> {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -4406,6 +4406,218 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
+  it('recovers a committed pending conversion before moving it', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/source-drive-pending-move'
+    const conversionUri = 'local://file/conversion-drive-pending-move'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-pending-move/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/conversion-drive-pending-move/view'
+    const oldParentUri = 'local://folder/drive-pending-move-old'
+    const oldParentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-pending-move-old'
+    const newParentUri = 'local://folder/drive-pending-move-new'
+    const newParentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-pending-move-new'
+    const sourceDoc = notebookJson('echo pending move')
+    const conversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-pending-move' }
+    )
+    const conversionSnapshot = await operationLogStorage.initialize(
+      conversionUri,
+      conversion.content
+    )
+    const recoveredFile = {
+      uri: conversionRemoteUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      type: NotebookStoreItemType.File,
+      children: [],
+      parents: [oldParentRemoteUri],
+    }
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceDoc),
+      findByCreateOperation: vi.fn(async () => recoveredFile),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: conversionSnapshot.checksum,
+      })),
+      move: vi.fn(async () => ({
+        ...recoveredFile,
+        parents: [newParentRemoteUri],
+      })),
+      createContent: vi.fn(),
+    }
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.folders.put({
+      id: oldParentUri,
+      name: 'Old Drive folder',
+      remoteId: oldParentRemoteUri,
+      children: [conversionUri],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: newParentUri,
+      name: 'New Drive folder',
+      remoteId: newParentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: '',
+      parentRemoteIdWhenCreated: oldParentRemoteUri,
+      driveCreateOperationId: 'pending-conversion-operation',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-pending-move',
+        sourceChecksum: md5(sourceDoc),
+      },
+      doc: '',
+      md5Checksum: conversionSnapshot.checksum,
+      operationLogRef: conversionSnapshot.ref,
+    })
+    vi.spyOn(store, 'syncFile').mockResolvedValue()
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      newParentUri
+    )
+
+    expect(result).toMatchObject({
+      uri: conversionUri,
+      remoteUri: conversionRemoteUri,
+      parents: [newParentUri],
+    })
+    expect(driveStore.findByCreateOperation).toHaveBeenCalledWith(
+      oldParentRemoteUri,
+      'pending-conversion-operation'
+    )
+    expect(driveStore.createContent).not.toHaveBeenCalled()
+    expect(driveStore.move).toHaveBeenCalledWith(
+      conversionRemoteUri,
+      oldParentRemoteUri,
+      newParentRemoteUri
+    )
+    await expect(store.files.get(conversionUri)).resolves.toMatchObject({
+      remoteId: conversionRemoteUri,
+      parentRemoteIdWhenCreated: undefined,
+      legacyConversionAttempt: { completedAt: expect.any(String) },
+    })
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
+  it('resolves the remote parent when an unfinished conversion has no local membership', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/source-drive-orphaned-move'
+    const conversionUri = 'local://file/conversion-drive-orphaned-move'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-orphaned-move/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/conversion-drive-orphaned-move/view'
+    const oldParentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-orphaned-move-old'
+    const newParentUri = 'local://folder/drive-orphaned-move-new'
+    const newParentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-orphaned-move-new'
+    const sourceDoc = notebookJson('echo orphaned move')
+    const conversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-orphaned-move' }
+    )
+    const conversionSnapshot = await operationLogStorage.initialize(
+      conversionUri,
+      conversion.content
+    )
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceDoc),
+      getMetadata: vi.fn(async () => ({
+        uri: conversionRemoteUri,
+        name: 'source.runme',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [oldParentRemoteUri],
+      })),
+      move: vi.fn(async () => ({
+        uri: conversionRemoteUri,
+        name: 'source.runme',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [newParentRemoteUri],
+      })),
+    }
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.folders.put({
+      id: newParentUri,
+      name: 'New Drive folder',
+      remoteId: newParentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: conversionRemoteUri,
+      lastRemoteChecksum: conversionSnapshot.checksum,
+      lastSynced: '',
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-orphaned-move',
+        sourceChecksum: md5(sourceDoc),
+      },
+      doc: '',
+      md5Checksum: conversionSnapshot.checksum,
+      operationLogRef: conversionSnapshot.ref,
+    })
+    vi.spyOn(store, 'syncFile').mockResolvedValue()
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      newParentUri
+    )
+
+    expect(result).toMatchObject({
+      uri: conversionUri,
+      remoteUri: conversionRemoteUri,
+      parents: [newParentUri],
+    })
+    expect(driveStore.getMetadata).toHaveBeenCalledWith(conversionRemoteUri)
+    expect(driveStore.move).toHaveBeenCalledWith(
+      conversionRemoteUri,
+      oldParentRemoteUri,
+      newParentRemoteUri
+    )
+    expect((await store.folders.get(newParentUri))?.children).toEqual([
+      sourceUri,
+      conversionUri,
+    ])
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
   it('does not reuse an older conversion with an unrelated sync error', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const sourceUri = 'local://file/source-drive-new-attempt'

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3388,6 +3388,46 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(1)
   })
 
+  it('strictly validates raw Drive JSON before normal synchronization', async () => {
+    const sourceUri = 'local://file/unrelated-drive-json'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/unrelated-drive-json/view'
+    const parentUri = 'local://folder/unrelated-drive-json'
+    const rawSource = '{"unrelated":"document"}'
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({ name: 'unrelated.json' })),
+      getVersionMetadata: vi.fn(async () => ({
+        md5Checksum: md5(rawSource),
+      })),
+      load: vi.fn(async () => create(parser_pb.NotebookSchema, { cells: [] })),
+      loadContent: vi.fn(async () => rawSource),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive folder',
+      remoteId: 'https://drive.google.com/drive/folders/unrelated-drive-json',
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'unrelated.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('Legacy .json file is not a Runme notebook')
+    expect(driveStore.load).not.toHaveBeenCalled()
+    expect(driveStore.loadContent).toHaveBeenCalledWith(sourceRemoteUri)
+    await expect(store.files.toArray()).resolves.toHaveLength(1)
+  })
+
   it('rejects a conflicted Drive IPYNB instead of converting its stale shadow', async () => {
     const sourceUri = 'local://file/conflicted-ipynb'
     const sourceRemoteUri =
@@ -3443,7 +3483,6 @@ describe('LocalNotebooks legacy notebook conversion', () => {
   })
 
   it('records the original Drive file ID and waits for the new file sync', async () => {
-    const store = createTestStore({})
     const sourceUri = 'local://file/source-drive'
     const sourceRemoteUri =
       'https://drive.google.com/file/d/original-drive-id/view'
@@ -3451,6 +3490,9 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       'https://drive.google.com/file/d/converted-drive-id/view'
     const parentUri = 'local://folder/drive'
     const sourceDoc = notebookJson('echo drive')
+    const store = createTestStore({
+      loadContent: vi.fn(async () => sourceDoc),
+    })
     await store.folders.put({
       id: parentUri,
       name: 'Drive',
@@ -3495,8 +3537,104 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
   })
 
+  it('deduplicates concurrent Drive conversion requests across stores', async () => {
+    const sourceUri = 'local://file/concurrent-drive-source'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/concurrent-drive-source/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/concurrent-drive-target/view'
+    const parentUri = 'local://folder/concurrent-drive'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/concurrent-drive'
+    const sourceDoc = notebookJson('echo concurrent')
+    const files = createMockTable<LocalFileRecord>()
+    const folders = createMockTable<LocalFolderRecord>()
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const baseCoordinator = createTestDriveSyncCoordinator()
+    let legacyLockRequests = 0
+    let notifySecondLockRequest!: () => void
+    const secondLockRequested = new Promise<void>((resolve) => {
+      notifySecondLockRequest = resolve
+    })
+    const coordinator: DriveSyncCoordinator = {
+      runExclusive: (key, operation) => {
+        if (key === `legacy-conversion:${sourceUri}`) {
+          legacyLockRequests += 1
+          if (legacyLockRequests === 2) notifySecondLockRequest()
+        }
+        return baseCoordinator.runExclusive(key, operation)
+      },
+    }
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceDoc),
+    }
+    const options = {
+      files,
+      folders,
+      driveSyncCoordinator: coordinator,
+      operationLogStorage,
+    }
+    const firstStore = createTestStore(driveStore, options)
+    const secondStore = createTestStore(driveStore, options)
+    await folders.put({
+      id: parentUri,
+      name: 'Concurrent Drive',
+      remoteId: parentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    let releaseFirstTargetSync!: () => void
+    const firstTargetSyncReleased = new Promise<void>((resolve) => {
+      releaseFirstTargetSync = resolve
+    })
+    let notifyFirstTargetSync!: () => void
+    const firstTargetSyncStarted = new Promise<void>((resolve) => {
+      notifyFirstTargetSync = resolve
+    })
+    vi.spyOn(firstStore, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri === sourceUri) return
+      notifyFirstTargetSync()
+      await firstTargetSyncReleased
+      await files.update(uri, {
+        remoteId: destinationRemoteUri,
+        parentRemoteIdWhenCreated: undefined,
+      })
+    })
+    vi.spyOn(secondStore, 'syncFile').mockImplementation(
+      async (uri: string) => {
+        if (uri === sourceUri) return
+        await files.update(uri, {
+          remoteId: destinationRemoteUri,
+          parentRemoteIdWhenCreated: undefined,
+        })
+      }
+    )
+
+    const first = firstStore.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    await firstTargetSyncStarted
+    const second = secondStore.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+    await secondLockRequested
+    releaseFirstTargetSync()
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    expect(secondResult.uri).toBe(firstResult.uri)
+    expect(secondResult.remoteUri).toBe(destinationRemoteUri)
+    await expect(files.toArray()).resolves.toHaveLength(2)
+  })
+
   it('syncs a pending Drive source before recording its original file ID', async () => {
-    const store = createTestStore({})
     const sourceUri = 'local://file/pending-source-drive'
     const sourceRemoteUri =
       'https://drive.google.com/file/d/pending-source-drive-id/view'
@@ -3506,6 +3644,9 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const parentRemoteUri =
       'https://drive.google.com/drive/folders/pending-source-drive'
     const sourceDoc = notebookJson('echo pending source')
+    const store = createTestStore({
+      loadContent: vi.fn(async () => sourceDoc),
+    })
     await store.folders.put({
       id: parentUri,
       name: 'Pending source Drive',
@@ -3570,6 +3711,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
         children: [],
         parents: [remoteParentUri],
       })),
+      loadContent: vi.fn(async () => sourceDoc),
     }
     const store = createTestStore(driveStore)
     const sourceDoc = notebookJson('echo drive')
@@ -3613,7 +3755,6 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
   it('reuses a pending Drive conversion after a transient sync failure', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
-    const store = createTestStore({}, { operationLogStorage })
     const sourceUri = 'local://file/source-drive-retry'
     const pendingUri = 'local://file/pending-drive-retry'
     const sourceRemoteUri =
@@ -3624,6 +3765,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const parentRemoteUri = 'https://drive.google.com/drive/folders/drive-retry'
     const sourceDoc = notebookJson('echo retry')
     const pendingSourceDoc = notebookJson('echo before retry')
+    const store = createTestStore(
+      { loadContent: vi.fn(async () => sourceDoc) },
+      { operationLogStorage }
+    )
     const pendingConversion = await convertLegacyNotebookFileToRunme(
       pendingSourceDoc,
       'source.json',
@@ -3693,7 +3838,11 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     expect((await store.load(pendingUri)).cells[0]?.value).toBe('echo retry')
     expect(
       (await store.files.get(pendingUri))?.legacyConversionAttempt
-    ).toBeUndefined()
+    ).toMatchObject({
+      originalGoogleDriveId: 'original-drive-retry',
+      sourceChecksum: md5(sourceDoc),
+      completedAt: expect.any(String),
+    })
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
@@ -3723,7 +3872,9 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     }
     const driveStore = {
       getVersionMetadata: vi.fn(async () => remoteVersion),
-      loadContent: vi.fn(async () => remoteContent),
+      loadContent: vi.fn(async (uri: string) =>
+        uri === sourceRemoteUri ? sourceDoc : remoteContent
+      ),
       saveContentIfVersion: vi.fn(async (_uri: string, content: string) => {
         remoteContent = content
         remoteVersion = {
@@ -3815,13 +3966,16 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     )
     expect(
       (await store.files.get(conversionUri))?.legacyConversionAttempt
-    ).toBeUndefined()
+    ).toMatchObject({
+      originalGoogleDriveId: 'original-drive-post-create',
+      sourceChecksum: md5(sourceDoc),
+      completedAt: expect.any(String),
+    })
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
   it('does not reuse an older conversion with an unrelated sync error', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
-    const store = createTestStore({}, { operationLogStorage })
     const sourceUri = 'local://file/source-drive-new-attempt'
     const oldConversionUri = 'local://file/old-drive-conversion'
     const sourceRemoteUri =
@@ -3834,6 +3988,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const parentRemoteUri =
       'https://drive.google.com/drive/folders/drive-new-attempt'
     const sourceDoc = notebookJson('echo new attempt')
+    const store = createTestStore(
+      { loadContent: vi.fn(async () => sourceDoc) },
+      { operationLogStorage }
+    )
     const oldConversion = await convertLegacyNotebookFileToRunme(
       sourceDoc,
       'source.json',
@@ -3867,6 +4025,11 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       lastRemoteChecksum: oldSnapshot.checksum,
       lastSynced: new Date().toISOString(),
       lastSyncError: 'unrelated later failure',
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-new-attempt',
+        sourceChecksum: md5(sourceDoc),
+        completedAt: '2026-09-03T00:00:00.000Z',
+      },
       doc: '',
       md5Checksum: oldSnapshot.checksum,
       operationLogRef: oldSnapshot.ref,

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3537,7 +3537,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
   })
 
-  it('preserves a fresh Drive conversion across a lagging folder listing', async () => {
+  it('reattaches a fresh Drive conversion after provisional membership expires', async () => {
     const sourceUri = 'local://file/source-drive-listing-race'
     const sourceRemoteUri =
       'https://drive.google.com/file/d/original-drive-listing-race/view'
@@ -3550,6 +3550,13 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const store = createTestStore({
       loadContent: vi.fn(async () => sourceDoc),
       list: vi.fn(async () => []),
+      getMetadata: vi.fn(async () => ({
+        uri: destinationRemoteUri,
+        name: 'source.runme',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [parentRemoteUri],
+      })),
     })
     await store.folders.put({
       id: parentUri,
@@ -3592,6 +3599,13 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const first = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
     await targetSyncStarted
     const second = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    // Simulate another tab refreshing the folder after the 60-second
+    // provisional-child TTL expires while the first target sync is blocked.
+    await store.folders.update(parentUri, {
+      children: [sourceUri],
+      provisionalChildren: [],
+      provisionalChildrenAttachedAt: {},
+    })
     releaseTargetSync()
     const [firstResult, secondResult] = await Promise.all([first, second])
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3439,6 +3439,64 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
   })
 
+  it('syncs a pending Drive source before recording its original file ID', async () => {
+    const store = createTestStore({})
+    const sourceUri = 'local://file/pending-source-drive'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/pending-source-drive-id/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/pending-source-conversion-id/view'
+    const parentUri = 'local://folder/pending-source-drive'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/pending-source-drive'
+    const sourceDoc = notebookJson('echo pending source')
+    await store.folders.put({
+      id: parentUri,
+      name: 'Pending source Drive',
+      remoteId: parentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: '',
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      driveCreateOperationId: 'pending-source-create-operation',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    const syncFile = vi
+      .spyOn(store, 'syncFile')
+      .mockImplementation(async (uri: string) => {
+        if (uri === sourceUri) {
+          await store.files.update(uri, {
+            remoteId: sourceRemoteUri,
+            parentRemoteIdWhenCreated: undefined,
+          })
+          return
+        }
+        await store.files.update(uri, { remoteId: destinationRemoteUri })
+      })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(syncFile).toHaveBeenNthCalledWith(1, sourceUri)
+    expect(result).toMatchObject({
+      name: 'source.runme',
+      remoteUri: destinationRemoteUri,
+    })
+    const converted = await store.load(result.uri)
+    expect(converted.metadata).toMatchObject({
+      [RunmeMetadataKey.OriginalGoogleDriveID]: 'pending-source-drive-id',
+    })
+  })
+
   it('discovers the Drive parent when one is not supplied', async () => {
     const sourceUri = 'local://file/source-drive'
     const sourceRemoteUri =

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -4167,7 +4167,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
-  it('resumes an uploaded Drive conversion before its completion marker is written', async () => {
+  it('resumes and renames an uploaded unfinished conversion after the source is renamed', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const sourceUri = 'local://file/source-drive-post-create'
     const conversionUri = 'local://file/conversion-drive-post-create'
@@ -4196,6 +4196,14 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       loadContent: vi.fn(async (uri: string) =>
         uri === sourceRemoteUri ? sourceDoc : remoteContent
       ),
+      rename: vi.fn(async () => ({
+        uri: conversionRemoteUri,
+        name: 'renamed.runme',
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri: conversionRemoteUri,
+        parents: [parentRemoteUri],
+      })),
       saveContentIfVersion: vi.fn(async (_uri: string, content: string) => {
         remoteContent = content
         remoteVersion = {
@@ -4220,7 +4228,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
     await store.files.put({
       id: sourceUri,
-      name: 'source.json',
+      name: 'renamed.json',
       remoteId: sourceRemoteUri,
       lastRemoteChecksum: md5(sourceDoc),
       lastSynced: new Date().toISOString(),
@@ -4257,9 +4265,13 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
     expect(result).toMatchObject({
       uri: conversionUri,
-      name: 'source.runme',
+      name: 'renamed.runme',
       remoteUri: conversionRemoteUri,
     })
+    expect(driveStore.rename).toHaveBeenCalledWith(
+      conversionRemoteUri,
+      'renamed.runme'
+    )
     expect(syncFile).toHaveBeenCalledWith(conversionUri)
     const refreshedLog = parseOperationLog(
       await store.loadContent(conversionUri)

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3537,6 +3537,68 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
   })
 
+  it('preserves a fresh Drive conversion across a lagging folder listing', async () => {
+    const sourceUri = 'local://file/source-drive-listing-race'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-listing-race/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/converted-drive-listing-race/view'
+    const parentUri = 'local://folder/drive-listing-race'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-listing-race'
+    const sourceDoc = notebookJson('echo listing race')
+    const store = createTestStore({
+      loadContent: vi.fn(async () => sourceDoc),
+      list: vi.fn(async () => []),
+    })
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive',
+      remoteId: parentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+
+    let notifyTargetSync!: () => void
+    const targetSyncStarted = new Promise<void>((resolve) => {
+      notifyTargetSync = resolve
+    })
+    let releaseTargetSync!: () => void
+    const targetSyncReleased = new Promise<void>((resolve) => {
+      releaseTargetSync = resolve
+    })
+    vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri === sourceUri) return
+      await store.files.update(uri, { remoteId: destinationRemoteUri })
+      await store.updateFolder(parentRemoteUri, 'Drive')
+      notifyTargetSync()
+      await targetSyncReleased
+    })
+
+    const first = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    await targetSyncStarted
+    const second = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    releaseTargetSync()
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    expect(secondResult.uri).toBe(firstResult.uri)
+    expect(secondResult.remoteUri).toBe(destinationRemoteUri)
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+    await expect(store.folders.get(parentUri)).resolves.toMatchObject({
+      children: [firstResult.uri],
+      provisionalChildren: [firstResult.uri],
+    })
+  })
+
   it('deduplicates concurrent Drive conversions across equivalent source URLs and folder mounts', async () => {
     const firstSourceUri = 'local://file/concurrent-drive-source-1'
     const secondSourceUri = 'local://file/concurrent-drive-source-2'

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -10,7 +10,12 @@ import {
 } from '../lib/googleDriveRuntime'
 import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { appLogger } from '../lib/logging/runtime'
-import { encodeIpynbNotebook, encodeRunmeNotebook } from '../lib/notebookFormat'
+import {
+  RUNME_OPERATION_LOG_MIME_TYPE,
+  convertLegacyNotebookFileToRunme,
+  encodeIpynbNotebook,
+  encodeRunmeNotebook,
+} from '../lib/notebookFormat'
 import {
   type NotebookLogHeader,
   createRunmeOperation,
@@ -3493,21 +3498,31 @@ describe('LocalNotebooks legacy notebook conversion', () => {
   })
 
   it('reuses a pending Drive conversion after a transient sync failure', async () => {
-    const store = createTestStore({})
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const store = createTestStore({}, { operationLogStorage })
     const sourceUri = 'local://file/source-drive-retry'
+    const pendingUri = 'local://file/pending-drive-retry'
     const sourceRemoteUri =
       'https://drive.google.com/file/d/original-drive-retry/view'
     const destinationRemoteUri =
       'https://drive.google.com/file/d/converted-drive-retry/view'
     const parentUri = 'local://folder/drive-retry'
-    const parentRemoteUri =
-      'https://drive.google.com/drive/folders/drive-retry'
+    const parentRemoteUri = 'https://drive.google.com/drive/folders/drive-retry'
     const sourceDoc = notebookJson('echo retry')
+    const pendingConversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-retry' }
+    )
+    const pendingSnapshot = await operationLogStorage.initialize(
+      pendingUri,
+      pendingConversion.content
+    )
     await store.folders.put({
       id: parentUri,
       name: 'Drive retry',
       remoteId: parentRemoteUri,
-      children: [sourceUri],
+      children: [sourceUri, pendingUri],
       lastSynced: '',
     })
     await store.files.put({
@@ -3519,32 +3534,31 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       doc: sourceDoc,
       md5Checksum: md5(sourceDoc),
     })
-    let destinationAttempts = 0
-    vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
-      if (uri === sourceUri) {
-        return
-      }
-      destinationAttempts += 1
-      if (destinationAttempts <= 2) {
-        throw new Error('transient Drive failure')
-      }
-      await store.files.update(uri, {
-        remoteId: destinationRemoteUri,
-        parentRemoteIdWhenCreated: undefined,
-      })
-    })
-
-    await expect(
-      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
-    ).rejects.toThrow('transient Drive failure')
-    const pending = (await store.files.toArray()).find(
-      (record) => record.id !== sourceUri
-    )
-    expect(pending).toMatchObject({
+    await store.files.put({
+      id: pendingUri,
       name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
       remoteId: '',
       parentRemoteIdWhenCreated: parentRemoteUri,
+      driveCreateOperationId: 'stable-create-operation',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: pendingSnapshot.checksum,
+      operationLogRef: pendingSnapshot.ref,
     })
+    const syncFile = vi
+      .spyOn(store, 'syncFile')
+      .mockImplementation(async (uri: string) => {
+        if (uri === sourceUri) {
+          return
+        }
+        expect(uri).toBe(pendingUri)
+        await store.files.update(uri, {
+          remoteId: destinationRemoteUri,
+          parentRemoteIdWhenCreated: undefined,
+        })
+      })
 
     const result = await store.convertLegacyNotebookToRunme(
       sourceUri,
@@ -3552,10 +3566,83 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     )
 
     expect(result).toMatchObject({
-      uri: pending?.id,
+      uri: pendingUri,
       name: 'source.runme',
       remoteUri: destinationRemoteUri,
     })
+    expect(syncFile).toHaveBeenCalledWith(pendingUri)
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
+  it('reuses a Drive conversion whose post-create sync failed', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const store = createTestStore({}, { operationLogStorage })
+    const sourceUri = 'local://file/source-drive-post-create'
+    const conversionUri = 'local://file/conversion-drive-post-create'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-post-create/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/conversion-drive-post-create/view'
+    const parentUri = 'local://folder/drive-post-create'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-post-create'
+    const sourceDoc = notebookJson('echo post create')
+    const conversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-post-create' }
+    )
+    const conversionSnapshot = await operationLogStorage.initialize(
+      conversionUri,
+      conversion.content
+    )
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive post-create',
+      remoteId: parentRemoteUri,
+      children: [sourceUri, conversionUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: conversionRemoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      lastSyncError: 'post-create sync failed',
+      doc: '',
+      md5Checksum: conversionSnapshot.checksum,
+      operationLogRef: conversionSnapshot.ref,
+    })
+    const syncFile = vi
+      .spyOn(store, 'syncFile')
+      .mockImplementation(async (uri: string) => {
+        if (uri === conversionUri) {
+          await store.files.update(uri, { lastSyncError: undefined })
+        }
+      })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result).toMatchObject({
+      uri: conversionUri,
+      name: 'source.runme',
+      remoteUri: conversionRemoteUri,
+    })
+    expect(syncFile).toHaveBeenCalledWith(conversionUri)
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 })

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3719,6 +3719,137 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
   })
 
+  it('keeps pending and assigned Drive source conversions under one lock', async () => {
+    const sourceUri = 'local://file/transitioning-drive-source'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/transitioning-drive-source/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/transitioning-drive-target/view'
+    const parentUri = 'local://folder/transitioning-drive'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/transitioning-drive'
+    const sourceDoc = notebookJson('echo transitioning source')
+    const files = createMockTable<LocalFileRecord>()
+    const folders = createMockTable<LocalFolderRecord>()
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const baseCoordinator = createTestDriveSyncCoordinator()
+    let canonicalLockRequests = 0
+    let notifyFirstRekeyRequested!: () => void
+    const firstRekeyRequested = new Promise<void>((resolve) => {
+      notifyFirstRekeyRequested = resolve
+    })
+    const coordinator: DriveSyncCoordinator = {
+      runExclusive: (key, operation) => {
+        if (
+          key ===
+          'legacy-conversion:drive:transitioning-drive-source'
+        ) {
+          canonicalLockRequests += 1
+          if (canonicalLockRequests === 2) notifyFirstRekeyRequested()
+        }
+        return baseCoordinator.runExclusive(key, operation)
+      },
+    }
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceDoc),
+    }
+    const options = {
+      files,
+      folders,
+      driveSyncCoordinator: coordinator,
+      operationLogStorage,
+    }
+    const firstStore = createTestStore(driveStore, options)
+    const secondStore = createTestStore(driveStore, options)
+    await folders.put({
+      id: parentUri,
+      name: 'Transitioning Drive source',
+      remoteId: parentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: '',
+      parentRemoteIdWhenCreated: parentRemoteUri,
+      driveCreateOperationId: 'transitioning-source-create-operation',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+
+    let notifySourceAssigned!: () => void
+    const sourceAssigned = new Promise<void>((resolve) => {
+      notifySourceAssigned = resolve
+    })
+    let releaseFirstSourceSync!: () => void
+    const firstSourceSyncReleased = new Promise<void>((resolve) => {
+      releaseFirstSourceSync = resolve
+    })
+    vi.spyOn(firstStore, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri === sourceUri) {
+        await files.update(uri, {
+          remoteId: sourceRemoteUri,
+          parentRemoteIdWhenCreated: undefined,
+        })
+        notifySourceAssigned()
+        await firstSourceSyncReleased
+        return
+      }
+      await files.update(uri, { remoteId: destinationRemoteUri })
+    })
+    vi.spyOn(secondStore, 'syncFile').mockImplementation(
+      async (uri: string) => {
+        if (uri === sourceUri) return
+        await files.update(uri, { remoteId: destinationRemoteUri })
+      }
+    )
+
+    let notifySecondCreateStarted!: () => void
+    const secondCreateStarted = new Promise<void>((resolve) => {
+      notifySecondCreateStarted = resolve
+    })
+    let releaseSecondCreate!: () => void
+    const secondCreateReleased = new Promise<void>((resolve) => {
+      releaseSecondCreate = resolve
+    })
+    const secondCreateContent = secondStore.createContent.bind(secondStore)
+    vi.spyOn(secondStore, 'createContent').mockImplementation(
+      async (parent, name, content, mimeType, createOptions) => {
+        notifySecondCreateStarted()
+        await secondCreateReleased
+        return secondCreateContent(
+          parent,
+          name,
+          content,
+          mimeType,
+          createOptions
+        )
+      }
+    )
+
+    const first = firstStore.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+    await sourceAssigned
+    const second = secondStore.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+    await secondCreateStarted
+    releaseFirstSourceSync()
+    await firstRekeyRequested
+    releaseSecondCreate()
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    expect(firstResult.uri).toBe(secondResult.uri)
+    expect(firstResult.remoteUri).toBe(destinationRemoteUri)
+    await expect(files.toArray()).resolves.toHaveLength(2)
+  })
+
   it('discovers the Drive parent when one is not supplied', async () => {
     const sourceUri = 'local://file/source-drive'
     const sourceRemoteUri =

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3567,8 +3567,9 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const parentUri = 'local://folder/drive-retry'
     const parentRemoteUri = 'https://drive.google.com/drive/folders/drive-retry'
     const sourceDoc = notebookJson('echo retry')
+    const pendingSourceDoc = notebookJson('echo before retry')
     const pendingConversion = await convertLegacyNotebookFileToRunme(
-      sourceDoc,
+      pendingSourceDoc,
       'source.json',
       { originalGoogleDriveId: 'original-drive-retry' }
     )
@@ -3599,6 +3600,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       remoteId: '',
       parentRemoteIdWhenCreated: parentRemoteUri,
       driveCreateOperationId: 'stable-create-operation',
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-retry',
+        sourceChecksum: md5(pendingSourceDoc),
+      },
       lastRemoteChecksum: '',
       lastSynced: '',
       doc: '',
@@ -3629,6 +3634,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       remoteUri: destinationRemoteUri,
     })
     expect(syncFile).toHaveBeenCalledWith(pendingUri)
+    expect((await store.load(pendingUri)).cells[0]?.value).toBe('echo retry')
+    expect(
+      (await store.files.get(pendingUri))?.legacyConversionAttempt
+    ).toBeUndefined()
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
@@ -3678,6 +3687,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       lastRemoteChecksum: '',
       lastSynced: '',
       lastSyncError: 'post-create sync failed',
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-post-create',
+        sourceChecksum: md5(sourceDoc),
+      },
       doc: '',
       md5Checksum: conversionSnapshot.checksum,
       operationLogRef: conversionSnapshot.ref,
@@ -3701,7 +3714,78 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       remoteUri: conversionRemoteUri,
     })
     expect(syncFile).toHaveBeenCalledWith(conversionUri)
+    expect(
+      (await store.files.get(conversionUri))?.legacyConversionAttempt
+    ).toBeUndefined()
     await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
+  it('does not reuse an older conversion with an unrelated sync error', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const store = createTestStore({}, { operationLogStorage })
+    const sourceUri = 'local://file/source-drive-new-attempt'
+    const oldConversionUri = 'local://file/old-drive-conversion'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-new-attempt/view'
+    const oldConversionRemoteUri =
+      'https://drive.google.com/file/d/old-drive-conversion/view'
+    const newConversionRemoteUri =
+      'https://drive.google.com/file/d/new-drive-conversion/view'
+    const parentUri = 'local://folder/drive-new-attempt'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-new-attempt'
+    const sourceDoc = notebookJson('echo new attempt')
+    const oldConversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-new-attempt' }
+    )
+    const oldSnapshot = await operationLogStorage.initialize(
+      oldConversionUri,
+      oldConversion.content
+    )
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive new attempt',
+      remoteId: parentRemoteUri,
+      children: [sourceUri, oldConversionUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: oldConversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: oldConversionRemoteUri,
+      lastRemoteChecksum: oldSnapshot.checksum,
+      lastSynced: new Date().toISOString(),
+      lastSyncError: 'unrelated later failure',
+      doc: '',
+      md5Checksum: oldSnapshot.checksum,
+      operationLogRef: oldSnapshot.ref,
+    })
+    vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri !== sourceUri) {
+        await store.files.update(uri, { remoteId: newConversionRemoteUri })
+      }
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result.uri).not.toBe(oldConversionUri)
+    expect(result.remoteUri).toBe(newConversionRemoteUri)
+    await expect(store.files.toArray()).resolves.toHaveLength(3)
   })
 })
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3576,8 +3576,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const targetSyncReleased = new Promise<void>((resolve) => {
       releaseTargetSync = resolve
     })
+    let targetSyncCalls = 0
     vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
       if (uri === sourceUri) return
+      targetSyncCalls += 1
       expect(
         (await store.folders.get(parentUri))?.provisionalChildren
       ).toContain(uri)
@@ -3595,6 +3597,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
     expect(secondResult.uri).toBe(firstResult.uri)
     expect(secondResult.remoteUri).toBe(destinationRemoteUri)
+    expect(targetSyncCalls).toBe(2)
     await expect(store.files.toArray()).resolves.toHaveLength(2)
     await expect(store.folders.get(parentUri)).resolves.toMatchObject({
       children: [firstResult.uri],

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3537,15 +3537,21 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
   })
 
-  it('deduplicates concurrent Drive conversion requests across stores', async () => {
-    const sourceUri = 'local://file/concurrent-drive-source'
-    const sourceRemoteUri =
+  it('deduplicates concurrent Drive conversions across equivalent source URLs and folder mounts', async () => {
+    const firstSourceUri = 'local://file/concurrent-drive-source-1'
+    const secondSourceUri = 'local://file/concurrent-drive-source-2'
+    const firstSourceRemoteUri =
       'https://drive.google.com/file/d/concurrent-drive-source/view'
+    const secondSourceRemoteUri =
+      'https://drive.google.com/open?id=concurrent-drive-source'
     const destinationRemoteUri =
       'https://drive.google.com/file/d/concurrent-drive-target/view'
-    const parentUri = 'local://folder/concurrent-drive'
-    const parentRemoteUri =
+    const firstParentUri = 'local://folder/concurrent-drive-1'
+    const secondParentUri = 'local://folder/concurrent-drive-2'
+    const firstParentRemoteUri =
       'https://drive.google.com/drive/folders/concurrent-drive'
+    const secondParentRemoteUri =
+      'https://drive.google.com/drive/folders/concurrent-drive?resourcekey=alias'
     const sourceDoc = notebookJson('echo concurrent')
     const files = createMockTable<LocalFileRecord>()
     const folders = createMockTable<LocalFolderRecord>()
@@ -3558,7 +3564,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
     const coordinator: DriveSyncCoordinator = {
       runExclusive: (key, operation) => {
-        if (key === `legacy-conversion:${sourceUri}`) {
+        if (key === 'legacy-conversion:drive:concurrent-drive-source') {
           legacyLockRequests += 1
           if (legacyLockRequests === 2) notifySecondLockRequest()
         }
@@ -3577,16 +3583,32 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const firstStore = createTestStore(driveStore, options)
     const secondStore = createTestStore(driveStore, options)
     await folders.put({
-      id: parentUri,
-      name: 'Concurrent Drive',
-      remoteId: parentRemoteUri,
-      children: [sourceUri],
+      id: firstParentUri,
+      name: 'Concurrent Drive first mount',
+      remoteId: firstParentRemoteUri,
+      children: [firstSourceUri],
+      lastSynced: '',
+    })
+    await folders.put({
+      id: secondParentUri,
+      name: 'Concurrent Drive alias mount',
+      remoteId: secondParentRemoteUri,
+      children: [secondSourceUri],
       lastSynced: '',
     })
     await files.put({
-      id: sourceUri,
+      id: firstSourceUri,
       name: 'source.json',
-      remoteId: sourceRemoteUri,
+      remoteId: firstSourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await files.put({
+      id: secondSourceUri,
+      name: 'source.json',
+      remoteId: secondSourceRemoteUri,
       lastRemoteChecksum: md5(sourceDoc),
       lastSynced: new Date().toISOString(),
       doc: sourceDoc,
@@ -3601,7 +3623,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       notifyFirstTargetSync = resolve
     })
     vi.spyOn(firstStore, 'syncFile').mockImplementation(async (uri: string) => {
-      if (uri === sourceUri) return
+      if (uri === firstSourceUri || uri === secondSourceUri) return
       notifyFirstTargetSync()
       await firstTargetSyncReleased
       await files.update(uri, {
@@ -3611,7 +3633,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
     vi.spyOn(secondStore, 'syncFile').mockImplementation(
       async (uri: string) => {
-        if (uri === sourceUri) return
+        if (uri === firstSourceUri || uri === secondSourceUri) return
         await files.update(uri, {
           remoteId: destinationRemoteUri,
           parentRemoteIdWhenCreated: undefined,
@@ -3619,11 +3641,14 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       }
     )
 
-    const first = firstStore.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    const first = firstStore.convertLegacyNotebookToRunme(
+      firstSourceUri,
+      firstParentUri
+    )
     await firstTargetSyncStarted
     const second = secondStore.convertLegacyNotebookToRunme(
-      sourceUri,
-      parentUri
+      secondSourceUri,
+      secondParentUri
     )
     await secondLockRequested
     releaseFirstTargetSync()
@@ -3631,7 +3656,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
     expect(secondResult.uri).toBe(firstResult.uri)
     expect(secondResult.remoteUri).toBe(destinationRemoteUri)
-    await expect(files.toArray()).resolves.toHaveLength(2)
+    await expect(files.toArray()).resolves.toHaveLength(3)
   })
 
   it('syncs a pending Drive source before recording its original file ID', async () => {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3397,6 +3397,54 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
+  it('serializes concurrent local conversions that derive the same target name', async () => {
+    const store = createTestStore({})
+    const jsonSourceUri = 'local://file/concurrent-local-json'
+    const ipynbSourceUri = 'local://file/concurrent-local-ipynb'
+    const sourceDoc = notebookJson('echo concurrent local')
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local Notebooks',
+      remoteId: '',
+      children: [jsonSourceUri, ipynbSourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: jsonSourceUri,
+      name: 'report.json',
+      remoteId: jsonSourceUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: ipynbSourceUri,
+      name: 'report.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: ipynbSourceUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+
+    const results = await Promise.allSettled([
+      store.convertLegacyNotebookToRunme(jsonSourceUri, LOCAL_FOLDER_URI),
+      store.convertLegacyNotebookToRunme(ipynbSourceUri, LOCAL_FOLDER_URI),
+    ])
+
+    expect(
+      results.filter((result) => result.status === 'fulfilled')
+    ).toHaveLength(1)
+    expect(
+      results.filter((result) => result.status === 'rejected')
+    ).toHaveLength(1)
+    const files = await store.files.toArray()
+    expect(files.filter((file) => file.name === 'report.runme')).toHaveLength(1)
+    expect(files).toHaveLength(3)
+  })
+
   it('rejects a malformed local source instead of creating an empty notebook', async () => {
     const store = createTestStore({})
     const sourceUri = 'local://file/malformed-json'
@@ -3585,7 +3633,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       'https://drive.google.com/drive/folders/fresh-profile'
     const sourceDoc = notebookJson('echo fresh profile')
     const conversion = await convertLegacyNotebookFileToRunme(
-      sourceDoc,
+      notebookJson('echo target-only edit'),
       'source.json',
       { originalGoogleDriveId: 'fresh-profile-source-id' }
     )
@@ -3649,6 +3697,9 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     )
 
     expect(result.uri).toBe(conversionUri)
+    expect((await store.load(conversionUri)).cells[0]?.value).toBe(
+      'echo target-only edit'
+    )
     await expect(store.files.get(conversionUri)).resolves.toMatchObject({
       legacyConversionAttempt: {
         originalGoogleDriveId: 'fresh-profile-source-id',

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3657,6 +3657,12 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     expect(secondResult.uri).toBe(firstResult.uri)
     expect(secondResult.remoteUri).toBe(destinationRemoteUri)
     await expect(files.toArray()).resolves.toHaveLength(3)
+    expect((await folders.get(firstParentUri))?.children).toContain(
+      firstResult.uri
+    )
+    expect((await folders.get(secondParentUri))?.children).toContain(
+      firstResult.uri
+    )
   })
 
   it('syncs a pending Drive source before recording its original file ID', async () => {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3986,6 +3986,19 @@ describe('LocalNotebooks legacy notebook conversion', () => {
         })
       })
 
+    const attachDriveFileToFolder = store.attachDriveFileToFolder.bind(store)
+    vi.spyOn(store, 'attachDriveFileToFolder')
+      .mockRejectedValueOnce(new Error('transient folder attachment failure'))
+      .mockImplementation(attachDriveFileToFolder)
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('transient folder attachment failure')
+    expect(
+      (await store.files.get(pendingUri))?.legacyConversionAttempt
+        ?.completedAt
+    ).toBeUndefined()
+
     const result = await store.convertLegacyNotebookToRunme(
       sourceUri,
       parentUri

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -4306,6 +4306,106 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
+  it('moves an uploaded unfinished conversion after the source moves folders', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/source-drive-moved'
+    const conversionUri = 'local://file/conversion-drive-moved'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-moved/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/conversion-drive-moved/view'
+    const oldParentUri = 'local://folder/drive-moved-old'
+    const oldParentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-moved-old'
+    const newParentUri = 'local://folder/drive-moved-new'
+    const newParentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-moved-new'
+    const sourceDoc = notebookJson('echo moved source')
+    const conversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-moved' }
+    )
+    const conversionSnapshot = await operationLogStorage.initialize(
+      conversionUri,
+      conversion.content
+    )
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceDoc),
+      move: vi.fn(async () => ({
+        uri: conversionRemoteUri,
+        name: 'source.runme',
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri: conversionRemoteUri,
+        parents: [newParentRemoteUri],
+      })),
+    }
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.folders.put({
+      id: oldParentUri,
+      name: 'Old Drive folder',
+      remoteId: oldParentRemoteUri,
+      children: [conversionUri],
+      lastSynced: '',
+    })
+    await store.folders.put({
+      id: newParentUri,
+      name: 'New Drive folder',
+      remoteId: newParentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: conversionRemoteUri,
+      lastRemoteChecksum: conversionSnapshot.checksum,
+      lastSynced: '',
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-moved',
+        sourceChecksum: md5(sourceDoc),
+      },
+      doc: '',
+      md5Checksum: conversionSnapshot.checksum,
+      operationLogRef: conversionSnapshot.ref,
+    })
+    vi.spyOn(store, 'syncFile').mockResolvedValue()
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      newParentUri
+    )
+
+    expect(result).toMatchObject({
+      uri: conversionUri,
+      name: 'source.runme',
+      remoteUri: conversionRemoteUri,
+      parents: [newParentUri],
+    })
+    expect(driveStore.move).toHaveBeenCalledWith(
+      conversionRemoteUri,
+      oldParentRemoteUri,
+      newParentRemoteUri
+    )
+    expect((await store.folders.get(oldParentUri))?.children).toEqual([])
+    expect((await store.folders.get(newParentUri))?.children).toEqual([
+      sourceUri,
+      conversionUri,
+    ])
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
   it('does not reuse an older conversion with an unrelated sync error', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const sourceUri = 'local://file/source-drive-new-attempt'

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3598,7 +3598,6 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
     const first = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
     await targetSyncStarted
-    const second = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
     // Simulate another tab refreshing the folder after the 60-second
     // provisional-child TTL expires while the first target sync is blocked.
     await store.folders.update(parentUri, {
@@ -3607,7 +3606,15 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       provisionalChildrenAttachedAt: {},
     })
     releaseTargetSync()
-    const [firstResult, secondResult] = await Promise.all([first, second])
+    const firstResult = await first
+    expect((await store.folders.get(parentUri))?.children).toContain(
+      firstResult.uri
+    )
+
+    const secondResult = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
 
     expect(secondResult.uri).toBe(firstResult.uri)
     expect(secondResult.remoteUri).toBe(destinationRemoteUri)
@@ -3655,6 +3662,13 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     }
     const driveStore = {
       loadContent: vi.fn(async () => sourceDoc),
+      rename: vi.fn(async (uri: string, name: string) => ({
+        uri,
+        name,
+        type: NotebookStoreItemType.File,
+        children: [],
+        remoteUri: uri,
+      })),
     }
     const options = {
       files,
@@ -3689,7 +3703,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
     await files.put({
       id: secondSourceUri,
-      name: 'source.json',
+      name: 'renamed.json',
       remoteId: secondSourceRemoteUri,
       lastRemoteChecksum: md5(sourceDoc),
       lastSynced: new Date().toISOString(),
@@ -3737,7 +3751,12 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const [firstResult, secondResult] = await Promise.all([first, second])
 
     expect(secondResult.uri).toBe(firstResult.uri)
+    expect(secondResult.name).toBe('renamed.runme')
     expect(secondResult.remoteUri).toBe(destinationRemoteUri)
+    expect(driveStore.rename).toHaveBeenCalledWith(
+      destinationRemoteUri,
+      'renamed.runme'
+    )
     await expect(files.toArray()).resolves.toHaveLength(3)
     expect((await folders.get(firstParentUri))?.children).toContain(
       firstResult.uri

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3598,15 +3598,17 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
     const first = store.convertLegacyNotebookToRunme(sourceUri, parentUri)
     await targetSyncStarted
-    // Simulate another tab refreshing the folder after the 60-second
-    // provisional-child TTL expires while the first target sync is blocked.
+    // Simulate a sync lasting beyond the provisional-child TTL without a
+    // folder refresh. The post-sync attachment must renew this timestamp.
     await store.folders.update(parentUri, {
-      children: [sourceUri],
-      provisionalChildren: [],
-      provisionalChildrenAttachedAt: {},
+      provisionalChildrenAttachedAt: {
+        [(await store.folders.get(parentUri))!.provisionalChildren![0]]:
+          Date.now() - 120_000,
+      },
     })
     releaseTargetSync()
     const firstResult = await first
+    await store.updateFolder(parentRemoteUri, 'Drive')
     expect((await store.folders.get(parentUri))?.children).toContain(
       firstResult.uri
     )

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3846,7 +3846,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
-  it('reuses a Drive conversion whose post-create sync failed', async () => {
+  it('resumes an uploaded Drive conversion before its completion marker is written', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const sourceUri = 'local://file/source-drive-post-create'
     const conversionUri = 'local://file/conversion-drive-post-create'
@@ -3913,7 +3913,6 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       remoteId: conversionRemoteUri,
       lastRemoteChecksum: '',
       lastSynced: '',
-      lastSyncError: 'post-create sync failed',
       legacyConversionAttempt: {
         originalGoogleDriveId: 'original-drive-post-create',
         sourceChecksum: md5(conversionSourceDoc),

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -19,6 +19,8 @@ import {
 import {
   type NotebookLogHeader,
   createRunmeOperation,
+  materializeOperationLog,
+  materializedLogToNotebook,
   parseOperationLog,
   serializeOperationLog,
 } from '../lib/operationLog'
@@ -3386,6 +3388,60 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(1)
   })
 
+  it('rejects a conflicted Drive IPYNB instead of converting its stale shadow', async () => {
+    const sourceUri = 'local://file/conflicted-ipynb'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/conflicted-ipynb/view'
+    const parentUri = 'local://folder/conflicted-ipynb'
+    const shadowStorage = new MemoryIpynbShadowStorage()
+    const staleNotebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'cell-1',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: 'echo stale shadow',
+        }),
+      ],
+    })
+    const staleIpynb = encodeIpynbNotebook(staleNotebook)
+    const shadowRef = await shadowStorage.write(sourceUri, staleIpynb.text)
+    const localDoc = notebookJson('echo unsynced local edit')
+    const store = createTestStore({}, { ipynbShadowStorage: shadowStorage })
+    await store.folders.put({
+      id: parentUri,
+      name: 'Conflicted Drive folder',
+      remoteId: 'https://drive.google.com/drive/folders/conflicted-ipynb',
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'conflicted.ipynb',
+      mimeType: IPYNB_MIME_TYPE,
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(staleIpynb.text),
+      lastSynced: new Date().toISOString(),
+      conflict: {
+        detectedAt: new Date().toISOString(),
+        upstreamChecksum: 'upstream-conflict-checksum',
+        localChecksumAtDetection: md5(localDoc),
+      },
+      doc: localDoc,
+      md5Checksum: md5(localDoc),
+      ipynbPreservation: {
+        upstreamFingerprint: md5(staleIpynb.text),
+        shadowRef,
+        ...staleIpynb.state,
+      },
+    })
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('Resolve the sync conflict before converting')
+    await expect(store.files.toArray()).resolves.toHaveLength(1)
+  })
+
   it('records the original Drive file ID and waits for the new file sync', async () => {
     const store = createTestStore({})
     const sourceUri = 'local://file/source-drive'
@@ -3643,7 +3699,6 @@ describe('LocalNotebooks legacy notebook conversion', () => {
 
   it('reuses a Drive conversion whose post-create sync failed', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
-    const store = createTestStore({}, { operationLogStorage })
     const sourceUri = 'local://file/source-drive-post-create'
     const conversionUri = 'local://file/conversion-drive-post-create'
     const sourceRemoteUri =
@@ -3660,6 +3715,26 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       'source.json',
       { originalGoogleDriveId: 'original-drive-post-create' }
     )
+    let remoteContent = conversion.content
+    let remoteVersion = {
+      md5Checksum: md5(remoteContent),
+      headRevisionId: 'conversion-revision-1',
+      version: '1',
+    }
+    const driveStore = {
+      getVersionMetadata: vi.fn(async () => remoteVersion),
+      loadContent: vi.fn(async () => remoteContent),
+      saveContentIfVersion: vi.fn(async (_uri: string, content: string) => {
+        remoteContent = content
+        remoteVersion = {
+          md5Checksum: md5(content),
+          headRevisionId: 'conversion-revision-2',
+          version: '2',
+        }
+        return true
+      }),
+    }
+    const store = createTestStore(driveStore, { operationLogStorage })
     const conversionSnapshot = await operationLogStorage.initialize(
       conversionUri,
       conversion.content
@@ -3696,12 +3771,12 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       md5Checksum: conversionSnapshot.checksum,
       operationLogRef: conversionSnapshot.ref,
     })
+    const syncFileImplementation = store.syncFile.bind(store)
     const syncFile = vi
       .spyOn(store, 'syncFile')
       .mockImplementation(async (uri: string) => {
-        if (uri === conversionUri) {
-          await store.files.update(uri, { lastSyncError: undefined })
-        }
+        if (uri === sourceUri) return
+        await syncFileImplementation(uri)
       })
 
     const result = await store.convertLegacyNotebookToRunme(
@@ -3721,6 +3796,20 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     expect(refreshedLog.header).toEqual(
       parseOperationLog(conversion.content).header
     )
+    const uploadedBefore = parseOperationLog(conversion.content)
+    const uploadedAfter = parseOperationLog(remoteContent)
+    expect(
+      uploadedAfter.operations.slice(0, uploadedBefore.operations.length)
+    ).toEqual(uploadedBefore.operations)
+    expect(
+      new Set(uploadedAfter.operations.map((operation) => operation.op_id)).size
+    ).toBe(uploadedAfter.operations.length)
+    expect(
+      materializedLogToNotebook(
+        materializeOperationLog(uploadedAfter.operations)
+      ).cells[0]?.value
+    ).toBe('echo after post create failure')
+    expect(driveStore.saveContentIfVersion).toHaveBeenCalledOnce()
     expect((await store.load(conversionUri)).cells[0]?.value).toBe(
       'echo after post create failure'
     )

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -4728,6 +4728,88 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     expect(result.remoteUri).toBe(newConversionRemoteUri)
     await expect(store.files.toArray()).resolves.toHaveLength(3)
   })
+
+  it('preserves a user-renamed completed Drive conversion', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/source-drive-user-rename'
+    const customConversionUri = 'local://file/custom-drive-conversion'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-user-rename/view'
+    const customConversionRemoteUri =
+      'https://drive.google.com/file/d/custom-drive-conversion/view'
+    const newConversionRemoteUri =
+      'https://drive.google.com/file/d/new-drive-user-rename/view'
+    const parentUri = 'local://folder/drive-user-rename'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-user-rename'
+    const sourceDoc = notebookJson('echo user rename')
+    const customConversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-user-rename' }
+    )
+    const customSnapshot = await operationLogStorage.initialize(
+      customConversionUri,
+      customConversion.content
+    )
+    const driveStore = {
+      loadContent: vi.fn(async () => sourceDoc),
+      rename: vi.fn(),
+    }
+    const store = createTestStore(driveStore, { operationLogStorage })
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive user rename',
+      remoteId: parentRemoteUri,
+      children: [sourceUri, customConversionUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: customConversionUri,
+      name: 'custom.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: customConversionRemoteUri,
+      lastRemoteChecksum: customSnapshot.checksum,
+      lastSynced: new Date().toISOString(),
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-user-rename',
+        sourceChecksum: md5(sourceDoc),
+        completedAt: '2026-09-03T00:00:00.000Z',
+      },
+      doc: '',
+      md5Checksum: customSnapshot.checksum,
+      operationLogRef: customSnapshot.ref,
+    })
+    vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri !== sourceUri) {
+        await store.files.update(uri, { remoteId: newConversionRemoteUri })
+      }
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result.uri).not.toBe(customConversionUri)
+    expect(result.name).toBe('source.runme')
+    expect(result.remoteUri).toBe(newConversionRemoteUri)
+    expect(driveStore.rename).not.toHaveBeenCalled()
+    await expect(store.files.get(customConversionUri)).resolves.toMatchObject({
+      name: 'custom.runme',
+      remoteId: customConversionRemoteUri,
+    })
+    await expect(store.files.toArray()).resolves.toHaveLength(3)
+  })
 })
 
 describe('LocalNotebooks rename', () => {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3578,6 +3578,9 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
     vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
       if (uri === sourceUri) return
+      expect(
+        (await store.folders.get(parentUri))?.provisionalChildren
+      ).toContain(uri)
       await store.files.update(uri, { remoteId: destinationRemoteUri })
       await store.updateFolder(parentRemoteUri, 'Drive')
       notifyTargetSync()
@@ -3975,6 +3978,84 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       name: 'source.runme',
       remoteUri: destinationRemoteUri,
     })
+  })
+
+  it('aborts when an unfinished conversion snapshot cannot be read', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/source-drive-snapshot-retry'
+    const pendingUri = 'local://file/pending-drive-snapshot-retry'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-snapshot-retry/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/converted-drive-snapshot-retry/view'
+    const parentUri = 'local://folder/drive-snapshot-retry'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-snapshot-retry'
+    const sourceDoc = notebookJson('echo snapshot retry')
+    const store = createTestStore(
+      { loadContent: vi.fn(async () => sourceDoc) },
+      { operationLogStorage }
+    )
+    const pendingConversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'original-drive-snapshot-retry' }
+    )
+    const pendingSnapshot = await operationLogStorage.initialize(
+      pendingUri,
+      pendingConversion.content
+    )
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive snapshot retry',
+      remoteId: parentRemoteUri,
+      children: [sourceUri, pendingUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: pendingUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: destinationRemoteUri,
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'original-drive-snapshot-retry',
+        sourceChecksum: md5(sourceDoc),
+      },
+      lastRemoteChecksum: pendingSnapshot.checksum,
+      lastSynced: '',
+      doc: '',
+      md5Checksum: pendingSnapshot.checksum,
+      operationLogRef: pendingSnapshot.ref,
+    })
+    const syncFile = vi.spyOn(store, 'syncFile').mockResolvedValue()
+    vi.spyOn(store, 'loadOperationLogSnapshot').mockRejectedValueOnce(
+      new Error('transient snapshot read failure')
+    )
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('transient snapshot read failure')
+    expect(syncFile).not.toHaveBeenCalledWith(pendingUri)
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result.uri).toBe(pendingUri)
+    expect(result.remoteUri).toBe(destinationRemoteUri)
+    expect(syncFile).toHaveBeenCalledWith(pendingUri)
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
   it('reuses a pending Drive conversion after a transient sync failure', async () => {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3653,9 +3653,10 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     const parentUri = 'local://folder/drive-post-create'
     const parentRemoteUri =
       'https://drive.google.com/drive/folders/drive-post-create'
-    const sourceDoc = notebookJson('echo post create')
+    const sourceDoc = notebookJson('echo after post create failure')
+    const conversionSourceDoc = notebookJson('echo before post create failure')
     const conversion = await convertLegacyNotebookFileToRunme(
-      sourceDoc,
+      conversionSourceDoc,
       'source.json',
       { originalGoogleDriveId: 'original-drive-post-create' }
     )
@@ -3689,7 +3690,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       lastSyncError: 'post-create sync failed',
       legacyConversionAttempt: {
         originalGoogleDriveId: 'original-drive-post-create',
-        sourceChecksum: md5(sourceDoc),
+        sourceChecksum: md5(conversionSourceDoc),
       },
       doc: '',
       md5Checksum: conversionSnapshot.checksum,
@@ -3714,6 +3715,15 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       remoteUri: conversionRemoteUri,
     })
     expect(syncFile).toHaveBeenCalledWith(conversionUri)
+    const refreshedLog = parseOperationLog(
+      await store.loadContent(conversionUri)
+    )
+    expect(refreshedLog.header).toEqual(
+      parseOperationLog(conversion.content).header
+    )
+    expect((await store.load(conversionUri)).cells[0]?.value).toBe(
+      'echo after post create failure'
+    )
     expect(
       (await store.files.get(conversionUri))?.legacyConversionAttempt
     ).toBeUndefined()

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3659,6 +3659,157 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
+  it('propagates a fresh-profile provenance read failure without creating a duplicate', async () => {
+    const sourceUri = 'local://file/provenance-read-source'
+    const conversionUri = 'local://file/provenance-read-conversion'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/provenance-read-source-id/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/provenance-read-conversion-id/view'
+    const parentUri = 'local://folder/provenance-read'
+    const sourceDoc = notebookJson('echo provenance read')
+    const driveStore = {
+      loadContent: vi.fn(async (remoteUri: string) => {
+        if (remoteUri === conversionRemoteUri) {
+          throw new Error('temporary Drive read failure')
+        }
+        return sourceDoc
+      }),
+    }
+    const store = createTestStore(driveStore)
+    await store.folders.put({
+      id: parentUri,
+      name: 'Provenance read Drive folder',
+      remoteId: 'https://drive.google.com/drive/folders/provenance-read',
+      children: [sourceUri, conversionUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: conversionRemoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+    })
+    vi.spyOn(
+      store as unknown as { syncFile(uri: string): Promise<void> },
+      'syncFile'
+    ).mockResolvedValue()
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('temporary Drive read failure')
+
+    expect(
+      (await store.files.get(conversionUri))?.legacyConversionAttempt
+    ).toBeUndefined()
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
+  it('reuses an unfinished reconstructed conversion after target sync fails', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/recovered-retry-source'
+    const conversionUri = 'local://file/recovered-retry-conversion'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/recovered-retry-source-id/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/recovered-retry-conversion-id/view'
+    const parentUri = 'local://folder/recovered-retry'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/recovered-retry'
+    const sourceDoc = notebookJson('echo recovered retry')
+    const conversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'recovered-retry-source-id' }
+    )
+    const conversionSnapshot = await operationLogStorage.initialize(
+      conversionUri,
+      conversion.content
+    )
+    const store = createTestStore(
+      { loadContent: vi.fn(async () => sourceDoc) },
+      { operationLogStorage }
+    )
+    await store.folders.put({
+      id: parentUri,
+      name: 'Recovered retry Drive folder',
+      remoteId: parentRemoteUri,
+      children: [sourceUri, conversionUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: conversionRemoteUri,
+      lastRemoteChecksum: conversionSnapshot.checksum,
+      lastSynced: new Date().toISOString(),
+      doc: '',
+      md5Checksum: conversionSnapshot.checksum,
+      operationLogRef: conversionSnapshot.ref,
+    })
+    let targetSyncCalls = 0
+    vi.spyOn(
+      store as unknown as { syncFile(uri: string): Promise<void> },
+      'syncFile'
+    ).mockImplementation(async (uri: string) => {
+      if (uri !== conversionUri) return
+      targetSyncCalls += 1
+      if (targetSyncCalls === 1) {
+        throw new Error('temporary target sync failure')
+      }
+    })
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('temporary target sync failure')
+    await expect(store.files.get(conversionUri)).resolves.toMatchObject({
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'recovered-retry-source-id',
+        sourceChecksum: md5(sourceDoc),
+        completedAt: undefined,
+      },
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result.uri).toBe(conversionUri)
+    expect(targetSyncCalls).toBe(2)
+    await expect(store.files.get(conversionUri)).resolves.toMatchObject({
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'recovered-retry-source-id',
+        sourceChecksum: md5(sourceDoc),
+        completedAt: expect.any(String),
+      },
+    })
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
   it('reattaches a fresh Drive conversion after provisional membership expires', async () => {
     const sourceUri = 'local://file/source-drive-listing-race'
     const sourceRemoteUri =

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3355,6 +3355,32 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     ).toBeUndefined()
   })
 
+  it('rejects a malformed local source instead of creating an empty notebook', async () => {
+    const store = createTestStore({})
+    const sourceUri = 'local://file/malformed-json'
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local Notebooks',
+      remoteId: '',
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'malformed.json',
+      remoteId: sourceUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '{not valid json',
+      md5Checksum: md5('{not valid json'),
+    })
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, LOCAL_FOLDER_URI)
+    ).rejects.toThrow()
+    await expect(store.files.toArray()).resolves.toHaveLength(1)
+  })
+
   it('records the original Drive file ID and waits for the new file sync', async () => {
     const store = createTestStore({})
     const sourceUri = 'local://file/source-drive'
@@ -3464,6 +3490,73 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       name: 'source.runme',
       remoteUri: destinationRemoteUri,
     })
+  })
+
+  it('reuses a pending Drive conversion after a transient sync failure', async () => {
+    const store = createTestStore({})
+    const sourceUri = 'local://file/source-drive-retry'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-retry/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/converted-drive-retry/view'
+    const parentUri = 'local://folder/drive-retry'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/drive-retry'
+    const sourceDoc = notebookJson('echo retry')
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive retry',
+      remoteId: parentRemoteUri,
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    let destinationAttempts = 0
+    vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri === sourceUri) {
+        return
+      }
+      destinationAttempts += 1
+      if (destinationAttempts <= 2) {
+        throw new Error('transient Drive failure')
+      }
+      await store.files.update(uri, {
+        remoteId: destinationRemoteUri,
+        parentRemoteIdWhenCreated: undefined,
+      })
+    })
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, parentUri)
+    ).rejects.toThrow('transient Drive failure')
+    const pending = (await store.files.toArray()).find(
+      (record) => record.id !== sourceUri
+    )
+    expect(pending).toMatchObject({
+      name: 'source.runme',
+      remoteId: '',
+      parentRemoteIdWhenCreated: parentRemoteUri,
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result).toMatchObject({
+      uri: pending?.id,
+      name: 'source.runme',
+      remoteUri: destinationRemoteUri,
+    })
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 })
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -3362,6 +3362,41 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     ).toBeUndefined()
   })
 
+  it('rejects a repeated conversion in the browser-local folder', async () => {
+    const store = createTestStore({})
+    const sourceUri = 'local://file/repeated-local-source'
+    const sourceDoc = notebookJson('echo local once')
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local Notebooks',
+      remoteId: '',
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'repeated.json',
+      remoteId: sourceUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+
+    const first = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      LOCAL_FOLDER_URI
+    )
+
+    await expect(
+      store.convertLegacyNotebookToRunme(sourceUri, LOCAL_FOLDER_URI)
+    ).rejects.toThrow(
+      'A file named "repeated.runme" already exists in this folder.'
+    )
+    expect(first.name).toBe('repeated.runme')
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
+  })
+
   it('rejects a malformed local source instead of creating an empty notebook', async () => {
     const store = createTestStore({})
     const sourceUri = 'local://file/malformed-json'
@@ -3535,6 +3570,93 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     expect(converted.metadata).toMatchObject({
       [RunmeMetadataKey.OriginalGoogleDriveID]: 'original-drive-id',
     })
+  })
+
+  it('reconstructs conversion retry state from embedded Drive provenance', async () => {
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const sourceUri = 'local://file/fresh-profile-source'
+    const conversionUri = 'local://file/fresh-profile-conversion'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/fresh-profile-source-id/view'
+    const conversionRemoteUri =
+      'https://drive.google.com/file/d/fresh-profile-conversion-id/view'
+    const parentUri = 'local://folder/fresh-profile'
+    const parentRemoteUri =
+      'https://drive.google.com/drive/folders/fresh-profile'
+    const sourceDoc = notebookJson('echo fresh profile')
+    const conversion = await convertLegacyNotebookFileToRunme(
+      sourceDoc,
+      'source.json',
+      { originalGoogleDriveId: 'fresh-profile-source-id' }
+    )
+    const store = createTestStore(
+      {
+        loadContent: vi.fn(async (remoteUri: string) =>
+          remoteUri === conversionRemoteUri ? conversion.content : sourceDoc
+        ),
+      },
+      { operationLogStorage }
+    )
+    await store.folders.put({
+      id: parentUri,
+      name: 'Fresh profile Drive folder',
+      remoteId: parentRemoteUri,
+      children: [sourceUri, conversionUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    await store.files.put({
+      id: conversionUri,
+      name: 'source.runme',
+      mimeType: RUNME_OPERATION_LOG_MIME_TYPE,
+      remoteId: conversionRemoteUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: '',
+      md5Checksum: '',
+      // A fresh profile mirrors the Drive document without the IndexedDB-only
+      // retry marker written by the profile that originally converted it.
+      legacyConversionAttempt: undefined,
+    })
+    vi.spyOn(
+      store as unknown as { syncFile(uri: string): Promise<void> },
+      'syncFile'
+    ).mockImplementation(async (uri: string) => {
+      if (uri !== conversionUri) return
+      const snapshot = await operationLogStorage.initialize(
+        conversionUri,
+        conversion.content
+      )
+      await store.files.update(conversionUri, {
+        lastRemoteChecksum: snapshot.checksum,
+        lastSynced: new Date().toISOString(),
+        md5Checksum: snapshot.checksum,
+        operationLogRef: snapshot.ref,
+      })
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result.uri).toBe(conversionUri)
+    await expect(store.files.get(conversionUri)).resolves.toMatchObject({
+      legacyConversionAttempt: {
+        originalGoogleDriveId: 'fresh-profile-source-id',
+        sourceChecksum: md5(sourceDoc),
+        completedAt: expect.any(String),
+      },
+    })
+    await expect(store.files.toArray()).resolves.toHaveLength(2)
   })
 
   it('reattaches a fresh Drive conversion after provisional membership expires', async () => {

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -17,7 +17,7 @@ import {
   parseOperationLog,
   serializeOperationLog,
 } from '../lib/operationLog'
-import { MimeType, parser_pb } from '../runme/client'
+import { MimeType, RunmeMetadataKey, parser_pb } from '../runme/client'
 import { MemoryConflictDocStorage } from './conflictDocs'
 import { DriveNotebookStore } from './drive'
 import type { DriveSyncCoordinator } from './driveSyncCoordinator'
@@ -3316,6 +3316,154 @@ describe('LocalNotebooks ipynb conversion', () => {
     await expect(
       store.rename('local://file/ipynb', 'shared.json')
     ).rejects.toThrow('Changing notebook formats by rename')
+  })
+})
+
+describe('LocalNotebooks legacy notebook conversion', () => {
+  it('creates a local .runme sibling without modifying the source', async () => {
+    const store = createTestStore({})
+    const sourceUri = 'local://file/source-json'
+    const sourceDoc = notebookJson('echo source')
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local Notebooks',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'migration.plan.json',
+      remoteId: sourceUri,
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      LOCAL_FOLDER_URI
+    )
+
+    expect(result.name).toBe('migration.plan.runme')
+    expect((await store.files.get(sourceUri))?.doc).toBe(sourceDoc)
+    const converted = await store.load(result.uri)
+    expect(converted.cells[0]?.value).toBe('echo source')
+    expect(
+      converted.metadata[RunmeMetadataKey.OriginalGoogleDriveID]
+    ).toBeUndefined()
+  })
+
+  it('records the original Drive file ID and waits for the new file sync', async () => {
+    const store = createTestStore({})
+    const sourceUri = 'local://file/source-drive'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-id/view'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/converted-drive-id/view'
+    const parentUri = 'local://folder/drive'
+    const sourceDoc = notebookJson('echo drive')
+    await store.folders.put({
+      id: parentUri,
+      name: 'Drive',
+      remoteId: 'https://drive.google.com/drive/folders/drive-root',
+      children: [sourceUri],
+      lastSynced: '',
+    })
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    const syncFile = vi
+      .spyOn(
+        store as unknown as { syncFile(uri: string): Promise<void> },
+        'syncFile'
+      )
+      .mockImplementation(async (uri: string) => {
+        if (uri !== sourceUri) {
+          await store.files.update(uri, { remoteId: destinationRemoteUri })
+        }
+      })
+
+    const result = await store.convertLegacyNotebookToRunme(
+      sourceUri,
+      parentUri
+    )
+
+    expect(result).toMatchObject({
+      name: 'source.runme',
+      remoteUri: destinationRemoteUri,
+    })
+    expect(syncFile).toHaveBeenCalledWith(sourceUri)
+    expect(syncFile).toHaveBeenCalledWith(result.uri)
+    const converted = await store.load(result.uri)
+    expect(converted.metadata).toMatchObject({
+      [RunmeMetadataKey.OriginalGoogleDriveID]: 'original-drive-id',
+    })
+  })
+
+  it('discovers the Drive parent when one is not supplied', async () => {
+    const sourceUri = 'local://file/source-drive'
+    const sourceRemoteUri =
+      'https://drive.google.com/file/d/original-drive-id/view'
+    const remoteParentUri =
+      'https://drive.google.com/drive/folders/drive-parent-id'
+    const parentUri = 'local://folder/drive-parent'
+    const destinationRemoteUri =
+      'https://drive.google.com/file/d/converted-drive-id/view'
+    const driveStore = {
+      getMetadata: vi.fn(async () => ({
+        uri: sourceRemoteUri,
+        name: 'source.ipynb',
+        type: NotebookStoreItemType.File,
+        children: [],
+        parents: [remoteParentUri],
+      })),
+    }
+    const store = createTestStore(driveStore)
+    const sourceDoc = notebookJson('echo drive')
+    await store.files.put({
+      id: sourceUri,
+      name: 'source.json',
+      remoteId: sourceRemoteUri,
+      lastRemoteChecksum: md5(sourceDoc),
+      lastSynced: new Date().toISOString(),
+      doc: sourceDoc,
+      md5Checksum: md5(sourceDoc),
+    })
+    const updateFolder = vi
+      .spyOn(store, 'updateFolder')
+      .mockImplementation(async (remoteUri: string) => {
+        expect(remoteUri).toBe(remoteParentUri)
+        await store.folders.put({
+          id: parentUri,
+          name: 'Drive parent',
+          remoteId: remoteParentUri,
+          children: [sourceUri],
+          lastSynced: '',
+        })
+        return parentUri
+      })
+    vi.spyOn(store, 'syncFile').mockImplementation(async (uri: string) => {
+      if (uri !== sourceUri) {
+        await store.files.update(uri, { remoteId: destinationRemoteUri })
+      }
+    })
+
+    const result = await store.convertLegacyNotebookToRunme(sourceUri)
+
+    expect(driveStore.getMetadata).toHaveBeenCalledWith(sourceRemoteUri)
+    expect(updateFolder).toHaveBeenCalledWith(remoteParentUri)
+    expect(result).toMatchObject({
+      name: 'source.runme',
+      remoteUri: destinationRemoteUri,
+    })
   })
 })
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -116,6 +116,11 @@ export interface LocalFileRecord {
   parentRemoteIdWhenCreated?: string
   /** Stable idempotency key for creating the primary Drive file. */
   driveCreateOperationId?: string
+  /** Retry state retained only while a legacy-to-Runme Drive copy is pending. */
+  legacyConversionAttempt?: {
+    originalGoogleDriveId: string
+    sourceChecksum: string
+  }
   /** Remote Drive URI of the Markdown sidecar (e.g. *.index.md) if present. */
   markdownUri?: string
   /** Stable idempotency key for creating the Markdown sidecar. */
@@ -2165,9 +2170,16 @@ export class LocalNotebooks extends Dexie {
     parentUri: string,
     name: string,
     content: string,
-    mimeType: string
+    mimeType: string,
+    options: {
+      legacyConversionAttempt?: LocalFileRecord['legacyConversionAttempt']
+    } = {}
   ): Promise<NotebookStoreItem> {
-    return this.createLocalFile(parentUri, name, { mimeType, content })
+    return this.createLocalFile(parentUri, name, {
+      mimeType,
+      content,
+      legacyConversionAttempt: options.legacyConversionAttempt,
+    })
   }
 
   /**
@@ -2217,6 +2229,7 @@ export class LocalNotebooks extends Dexie {
       sourceRecord.name,
       { originalGoogleDriveId }
     )
+    const sourceChecksum = md5(sourceContent)
 
     let destinationParentUri = parentUri
     if (!destinationParentUri) {
@@ -2256,6 +2269,8 @@ export class LocalNotebooks extends Dexie {
         if (
           child?.name !== converted.fileName ||
           (!isPendingCreate && !isErroredDriveConversion) ||
+          child.legacyConversionAttempt?.originalGoogleDriveId !==
+            originalGoogleDriveId ||
           detectNotebookFileFormat(child.name) !== 'runme-operation-log'
         ) {
           continue
@@ -2272,7 +2287,24 @@ export class LocalNotebooks extends Dexie {
           continue
         }
 
+        if (child.legacyConversionAttempt.sourceChecksum !== sourceChecksum) {
+          await this.saveContent(
+            childUri,
+            converted.content,
+            RUNME_OPERATION_LOG_MIME_TYPE
+          )
+          await this.files.update(childUri, {
+            legacyConversionAttempt: {
+              originalGoogleDriveId,
+              sourceChecksum,
+            },
+          })
+        }
+
         await this.syncFile(childUri)
+        await this.files.update(childUri, {
+          legacyConversionAttempt: undefined,
+        })
         return (
           (await this.getMetadata(childUri)) ?? {
             uri: childUri,
@@ -2291,10 +2323,19 @@ export class LocalNotebooks extends Dexie {
       destinationParentUri,
       converted.fileName,
       converted.content,
-      RUNME_OPERATION_LOG_MIME_TYPE
+      RUNME_OPERATION_LOG_MIME_TYPE,
+      {
+        legacyConversionAttempt:
+          isDriveUri(destinationParent.remoteId) && originalGoogleDriveId
+            ? { originalGoogleDriveId, sourceChecksum }
+            : undefined,
+      }
     )
     if (isDriveUri(destinationParent.remoteId)) {
       await this.syncFile(created.uri)
+      await this.files.update(created.uri, {
+        legacyConversionAttempt: undefined,
+      })
     }
     return (await this.getMetadata(created.uri)) ?? created
   }
@@ -2302,7 +2343,11 @@ export class LocalNotebooks extends Dexie {
   private async createLocalFile(
     parentUri: string,
     name: string,
-    options: { mimeType: string; content: string }
+    options: {
+      mimeType: string
+      content: string
+      legacyConversionAttempt?: LocalFileRecord['legacyConversionAttempt']
+    }
   ): Promise<NotebookStoreItem> {
     if (!parentUri.startsWith('local://folder/')) {
       throw new Error('LocalNotebooks.create expects a folder parent URI')
@@ -2359,6 +2404,7 @@ export class LocalNotebooks extends Dexie {
         ? parent.remoteId
         : undefined,
       driveCreateOperationId: isDriveBackedParent ? uuidv4() : undefined,
+      legacyConversionAttempt: options.legacyConversionAttempt,
       lastRemoteChecksum: '',
       lastSynced: isDriveBackedParent ? '' : nowIsoString(),
       doc: localContent,

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2351,7 +2351,7 @@ export class LocalNotebooks extends Dexie {
           const attempt = record.legacyConversionAttempt
           return Boolean(
             attempt &&
-              !attempt.completedAt &&
+              (!attempt.completedAt || attempt.completedAt >= invokedAt) &&
               attempt.originalGoogleDriveId === originalGoogleDriveId &&
               detectNotebookFileFormat(record.name) ===
                 'runme-operation-log'

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2199,8 +2199,13 @@ export class LocalNotebooks extends Dexie {
       )
     }
     const invokedAt = nowIsoString()
+    const sourceRecord = await this.files.get(sourceUri)
+    const sourceLockIdentity =
+      sourceRecord && isDriveUri(sourceRecord.remoteId)
+        ? `drive:${parseDriveItem(sourceRecord.remoteId).id}`
+        : sourceUri
     return this.driveSyncCoordinator.runExclusive(
-      `legacy-conversion:${sourceUri}`,
+      `legacy-conversion:${sourceLockIdentity}`,
       () =>
         this.convertLegacyNotebookToRunmeExclusive(
           sourceUri,
@@ -2300,7 +2305,24 @@ export class LocalNotebooks extends Dexie {
     }
 
     if (isDriveUri(destinationParent.remoteId) && originalGoogleDriveId) {
-      for (const childUri of destinationParent.children) {
+      const destinationDriveFolder = parseDriveItem(destinationParent.remoteId)
+      const equivalentDestinationParents = await this.folders
+        .filter((record) => {
+          try {
+            const candidate = parseDriveItem(record.remoteId)
+            return (
+              candidate.type === NotebookStoreItemType.Folder &&
+              candidate.id === destinationDriveFolder.id
+            )
+          } catch {
+            return false
+          }
+        })
+        .toArray()
+      const candidateChildUris = new Set(
+        equivalentDestinationParents.flatMap((record) => record.children)
+      )
+      for (const childUri of candidateChildUris) {
         if (!childUri.startsWith('local://file/')) {
           continue
         }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -10,6 +10,7 @@ import { appLogger } from '../lib/logging/runtime'
 import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookToMarkdown'
 import {
   RUNME_OPERATION_LOG_MIME_TYPE,
+  convertLegacyNotebookToRunme,
   createInitialNotebookFile,
   decodeNotebookFile,
   detectNotebookFileFormat,
@@ -2167,6 +2168,78 @@ export class LocalNotebooks extends Dexie {
     mimeType: string
   ): Promise<NotebookStoreItem> {
     return this.createLocalFile(parentUri, name, { mimeType, content })
+  }
+
+  /**
+   * Create a sibling .runme copy of a legacy .json or .ipynb notebook.
+   * Drive-backed sources produce a new Drive file and retain the source Drive
+   * file ID in notebook metadata. Comments remain attached to the source file.
+   */
+  async convertLegacyNotebookToRunme(
+    sourceUri: string,
+    parentUri?: string
+  ): Promise<NotebookStoreItem> {
+    if (!sourceUri.startsWith('local://file/')) {
+      throw new Error(
+        'LocalNotebooks.convertLegacyNotebookToRunme expects a local file URI'
+      )
+    }
+    const sourceRecord = await this.files.get(sourceUri)
+    if (!sourceRecord) {
+      throw new Error(`Local notebook record not found for ${sourceUri}`)
+    }
+    const sourceFormat = detectNotebookFileFormat(sourceRecord.name)
+    if (sourceFormat !== 'runme-json' && sourceFormat !== 'ipynb') {
+      throw new Error('Only .json and .ipynb notebooks can be converted')
+    }
+
+    if (isDriveUri(sourceRecord.remoteId)) {
+      await this.syncFile(sourceUri)
+    }
+    const sourceNotebook = await this.load(sourceUri)
+    const originalGoogleDriveId = isDriveUri(sourceRecord.remoteId)
+      ? parseDriveItem(sourceRecord.remoteId).id
+      : undefined
+    const converted = await convertLegacyNotebookToRunme(
+      sourceNotebook,
+      sourceRecord.name,
+      { originalGoogleDriveId }
+    )
+
+    let destinationParentUri = parentUri
+    if (!destinationParentUri) {
+      destinationParentUri = (await this.findParentFolder(sourceUri))?.id
+    }
+    if (!destinationParentUri && isDriveUri(sourceRecord.remoteId)) {
+      const sourceMetadata = await this.driveStore.getMetadata(
+        sourceRecord.remoteId
+      )
+      const remoteParentUri = sourceMetadata?.parents?.[0]
+      if (!remoteParentUri) {
+        throw new Error(
+          `Google Drive parent folder not found for ${sourceRecord.remoteId}`
+        )
+      }
+      destinationParentUri = await this.updateFolder(remoteParentUri)
+    }
+    if (!destinationParentUri) {
+      destinationParentUri = LOCAL_FOLDER_URI
+    }
+    const destinationParent = await this.folders.get(destinationParentUri)
+    if (!destinationParent) {
+      throw new Error(`Parent folder not found for ${destinationParentUri}`)
+    }
+
+    const created = await this.createContent(
+      destinationParentUri,
+      converted.fileName,
+      converted.content,
+      RUNME_OPERATION_LOG_MIME_TYPE
+    )
+    if (isDriveUri(destinationParent.remoteId)) {
+      await this.syncFile(created.uri)
+    }
+    return (await this.getMetadata(created.uri)) ?? created
   }
 
   private async createLocalFile(

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2461,6 +2461,10 @@ export class LocalNotebooks extends Dexie {
     )
     if (isDriveUri(destinationParent.remoteId)) {
       await this.syncFile(created.uri)
+      await this.attachDriveFileToFolder(
+        destinationParent.remoteId,
+        created.uri
+      )
       await this.files.update(created.uri, {
         legacyConversionAttempt: originalGoogleDriveId
           ? {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2346,6 +2346,21 @@ export class LocalNotebooks extends Dexie {
       const candidateChildUris = new Set(
         equivalentDestinationParents.flatMap((record) => record.children)
       )
+      const unfinishedAttempts = await this.files
+        .filter((record) => {
+          const attempt = record.legacyConversionAttempt
+          return Boolean(
+            attempt &&
+              !attempt.completedAt &&
+              attempt.originalGoogleDriveId === originalGoogleDriveId &&
+              detectNotebookFileFormat(record.name) ===
+                'runme-operation-log'
+          )
+        })
+        .toArray()
+      for (const attempt of unfinishedAttempts) {
+        candidateChildUris.add(attempt.id)
+      }
       for (const childUri of candidateChildUris) {
         if (!childUri.startsWith('local://file/')) {
           continue
@@ -2382,6 +2397,28 @@ export class LocalNotebooks extends Dexie {
             throw new Error(`Local notebook record not found for ${childUri}`)
           }
           child = renamedChild
+        }
+
+        const currentParent = await this.findParentFolder(childUri)
+        if (!isDriveUri(child.remoteId)) {
+          if (
+            child.parentRemoteIdWhenCreated !== destinationParent.remoteId
+          ) {
+            await this.files.update(childUri, {
+              parentRemoteIdWhenCreated: destinationParent.remoteId,
+            })
+            child = {
+              ...child,
+              parentRemoteIdWhenCreated: destinationParent.remoteId,
+            }
+          }
+        } else if (
+          currentParent &&
+          isDriveUri(currentParent.remoteId) &&
+          parseDriveItem(currentParent.remoteId).id !==
+            destinationDriveFolder.id
+        ) {
+          await this.move(childUri, destinationParentUri)
         }
 
         if (attempt.sourceChecksum !== sourceChecksum) {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2400,18 +2400,17 @@ export class LocalNotebooks extends Dexie {
           child.name === converted.fileName &&
           detectNotebookFileFormat(child.name) === 'runme-operation-log'
         ) {
-          try {
-            pendingNotebook = child.operationLogRef
-              ? await this.loadOperationLogSnapshot(childUri)
-              : isDriveUri(child.remoteId)
-                ? decodeNotebookFile(
-                    await this.driveStore.loadContent(child.remoteId),
-                    child.name
-                  ).notebook
-                : undefined
-          } catch {
-            pendingNotebook = undefined
-          }
+          // A read failure is not evidence that the same-named file is
+          // unrelated. Surface it so a retry can inspect the existing Drive
+          // file instead of falling through and creating a duplicate.
+          pendingNotebook = child.operationLogRef
+            ? await this.loadOperationLogSnapshot(childUri)
+            : isDriveUri(child.remoteId)
+              ? decodeNotebookFile(
+                  await this.driveStore.loadContent(child.remoteId),
+                  child.name
+                ).notebook
+              : undefined
           if (
             pendingNotebook?.metadata[
               RunmeMetadataKey.OriginalGoogleDriveID
@@ -2434,7 +2433,9 @@ export class LocalNotebooks extends Dexie {
               // original conversion. The empty sentinel deliberately sends
               // it through the refresh path below.
               sourceChecksum: '',
-              completedAt: nowIsoString(),
+              // Keep the recovered marker unfinished until the final target
+              // sync succeeds, so any failure is reusable by the next retry.
+              completedAt: undefined,
             }
             await this.files.update(childUri, {
               legacyConversionAttempt: attempt,

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2364,15 +2364,11 @@ export class LocalNotebooks extends Dexie {
         ) {
           continue
         }
-        try {
-          const pendingNotebook = await this.loadOperationLogSnapshot(childUri)
-          if (
-            pendingNotebook.metadata[RunmeMetadataKey.OriginalGoogleDriveID] !==
-            originalGoogleDriveId
-          ) {
-            continue
-          }
-        } catch {
+        const pendingNotebook = await this.loadOperationLogSnapshot(childUri)
+        if (
+          pendingNotebook.metadata[RunmeMetadataKey.OriginalGoogleDriveID] !==
+          originalGoogleDriveId
+        ) {
           continue
         }
 
@@ -2421,11 +2417,11 @@ export class LocalNotebooks extends Dexie {
           this.notifySync(childUri)
         }
 
-        await this.syncFile(childUri)
         await this.attachDriveFileToFolder(
           destinationParent.remoteId,
           childUri
         )
+        await this.syncFile(childUri)
         await this.files.update(childUri, {
           legacyConversionAttempt: {
             originalGoogleDriveId,
@@ -2460,11 +2456,11 @@ export class LocalNotebooks extends Dexie {
       }
     )
     if (isDriveUri(destinationParent.remoteId)) {
-      await this.syncFile(created.uri)
       await this.attachDriveFileToFolder(
         destinationParent.remoteId,
         created.uri
       )
+      await this.syncFile(created.uri)
       await this.files.update(created.uri, {
         legacyConversionAttempt: originalGoogleDriveId
           ? {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -609,7 +609,8 @@ export class LocalNotebooks extends Dexie {
    */
   async attachDriveFileToFolder(
     remoteFolderUri: string,
-    localFileUri: string
+    localFileUri: string,
+    options: { renewProvisionalAttachment?: boolean } = {}
   ): Promise<string | null> {
     const target = parseDriveItem(remoteFolderUri)
     if (target.type !== NotebookStoreItemType.Folder) {
@@ -680,9 +681,10 @@ export class LocalNotebooks extends Dexie {
             for (const folder of folders) {
               const attachedAt = {
                 ...(folder.provisionalChildrenAttachedAt ?? {}),
-                [localFileUri]:
-                  folder.provisionalChildrenAttachedAt?.[localFileUri] ??
-                  Date.now(),
+                [localFileUri]: options.renewProvisionalAttachment
+                  ? Date.now()
+                  : (folder.provisionalChildrenAttachedAt?.[localFileUri] ??
+                    Date.now()),
               }
               if (!folder.children.includes(localFileUri)) {
                 await this.folders.update(folder.id, {
@@ -697,14 +699,17 @@ export class LocalNotebooks extends Dexie {
                   lastSynced: nowIsoString(),
                 })
               } else if (
+                options.renewProvisionalAttachment ||
                 !(folder.provisionalChildren ?? []).includes(localFileUri) ||
                 folder.provisionalChildrenAttachedAt?.[localFileUri] ===
                   undefined
               ) {
                 await this.folders.update(folder.id, {
                   provisionalChildren: [
-                    ...(folder.provisionalChildren ?? []),
-                    localFileUri,
+                    ...new Set([
+                      ...(folder.provisionalChildren ?? []),
+                      localFileUri,
+                    ]),
                   ],
                   provisionalChildrenAttachedAt: attachedAt,
                 })
@@ -2519,7 +2524,8 @@ export class LocalNotebooks extends Dexie {
         await this.syncFile(childUri)
         await this.attachDriveFileToFolder(
           destinationParent.remoteId,
-          childUri
+          childUri,
+          { renewProvisionalAttachment: true }
         )
         await this.files.update(childUri, {
           legacyConversionAttempt: {
@@ -2563,7 +2569,8 @@ export class LocalNotebooks extends Dexie {
       await this.syncFile(created.uri)
       await this.attachDriveFileToFolder(
         destinationParent.remoteId,
-        created.uri
+        created.uri,
+        { renewProvisionalAttachment: true }
       )
       await this.files.update(created.uri, {
         legacyConversionAttempt: originalGoogleDriveId

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2389,7 +2389,10 @@ export class LocalNotebooks extends Dexie {
             !completedDuringInvocation &&
             !isCompletedMatchingConversion) ||
           attempt?.originalGoogleDriveId !== originalGoogleDriveId ||
-          detectNotebookFileFormat(child.name) !== 'runme-operation-log'
+          detectNotebookFileFormat(child.name) !== 'runme-operation-log' ||
+          (child.name !== converted.fileName &&
+            !isActiveConversionAttempt &&
+            !completedDuringInvocation)
         ) {
           continue
         }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2204,13 +2204,15 @@ export class LocalNotebooks extends Dexie {
       sourceRecord && isDriveUri(sourceRecord.remoteId)
         ? `drive:${parseDriveItem(sourceRecord.remoteId).id}`
         : sourceUri
+    const sourceLockKey = `legacy-conversion:${sourceLockIdentity}`
     return this.driveSyncCoordinator.runExclusive(
-      `legacy-conversion:${sourceLockIdentity}`,
+      sourceLockKey,
       () =>
         this.convertLegacyNotebookToRunmeExclusive(
           sourceUri,
           parentUri,
-          invokedAt
+          invokedAt,
+          sourceLockKey
         )
     )
   }
@@ -2218,7 +2220,9 @@ export class LocalNotebooks extends Dexie {
   private async convertLegacyNotebookToRunmeExclusive(
     sourceUri: string,
     parentUri: string | undefined,
-    invokedAt: string
+    invokedAt: string,
+    heldLockKey: string,
+    sourceAlreadySynced = false
   ): Promise<NotebookStoreItem> {
     let sourceRecord = await this.files.get(sourceUri)
     if (!sourceRecord) {
@@ -2245,8 +2249,9 @@ export class LocalNotebooks extends Dexie {
     }
 
     if (
-      isDriveUri(sourceRecord.remoteId) ||
-      isDriveUri(sourceRecord.parentRemoteIdWhenCreated)
+      !sourceAlreadySynced &&
+      (isDriveUri(sourceRecord.remoteId) ||
+        isDriveUri(sourceRecord.parentRemoteIdWhenCreated))
     ) {
       await this.syncFile(sourceUri)
       sourceRecord = await this.files.get(sourceUri)
@@ -2263,6 +2268,23 @@ export class LocalNotebooks extends Dexie {
       throw new Error(
         `Resolve the sync conflict before converting ${sourceRecord.name}`
       )
+    }
+    if (isDriveUri(sourceRecord.remoteId)) {
+      const canonicalLockKey = `legacy-conversion:drive:${parseDriveItem(sourceRecord.remoteId).id}`
+      if (canonicalLockKey !== heldLockKey) {
+        // A pending Drive create starts under its local URI. Retain that lock
+        // while joining the stable Drive-ID lock so callers arriving after the
+        // source upload cannot race destination-marker creation.
+        return this.driveSyncCoordinator.runExclusive(canonicalLockKey, () =>
+          this.convertLegacyNotebookToRunmeExclusive(
+            sourceUri,
+            parentUri,
+            invokedAt,
+            canonicalLockKey,
+            true
+          )
+        )
+      }
     }
     // DriveNotebookStore.load normalizes protobuf JSON with unknown fields
     // ignored. Read the raw bytes after sync rather than the normalized cache.

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -15,7 +15,6 @@ import {
   decodeNotebookFile,
   detectNotebookFileFormat,
   encodeIpynbNotebook,
-  encodeRunmeOperationLogSnapshotWithHeader,
   isNotebookFileName,
   notebookFileExtension,
   validateNotebookRenameFormat,
@@ -2221,6 +2220,11 @@ export class LocalNotebooks extends Dexie {
         )
       }
     }
+    if (sourceRecord.conflict) {
+      throw new Error(
+        `Resolve the sync conflict before converting ${sourceRecord.name}`
+      )
+    }
     const sourceContent = await this.loadContent(sourceUri)
     const originalGoogleDriveId = isDriveUri(sourceRecord.remoteId)
       ? parseDriveItem(sourceRecord.remoteId).id
@@ -2289,14 +2293,25 @@ export class LocalNotebooks extends Dexie {
         }
 
         if (child.legacyConversionAttempt.sourceChecksum !== sourceChecksum) {
-          const currentLog = parseOperationLog(
-            await this.loadContent(childUri)
+          const currentLog = parseOperationLog(await this.loadContent(childUri))
+          const currentNotebook = materializedLogToNotebook(
+            materializeOperationLog(currentLog.operations)
           )
-          const refreshedContent =
-            await encodeRunmeOperationLogSnapshotWithHeader(
-              converted.notebook,
-              currentLog.header
-            )
+          const appendedOperations = await buildOperationLogDiff({
+            previous: currentNotebook,
+            next: converted.notebook,
+            observedOperations: currentLog.operations,
+            actorId: currentLog.header.created_by,
+            firstActorSequence:
+              highestActorSequence(
+                currentLog.operations,
+                currentLog.header.created_by
+              ) + 1,
+          })
+          const refreshedContent = serializeOperationLog(currentLog.header, [
+            ...currentLog.operations,
+            ...appendedOperations,
+          ])
           await this.saveContent(
             childUri,
             refreshedContent,

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2429,6 +2429,10 @@ export class LocalNotebooks extends Dexie {
             completedAt: nowIsoString(),
           },
         })
+        await this.attachDriveFileToFolder(
+          destinationParent.remoteId,
+          childUri
+        )
         return (
           (await this.getMetadata(childUri)) ?? {
             uri: childUri,

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2373,12 +2373,18 @@ export class LocalNotebooks extends Dexie {
         const isActiveConversionAttempt = Boolean(
           attempt && !attempt.completedAt
         )
+        const isCompletedMatchingConversion = Boolean(
+          attempt?.completedAt &&
+            attempt.sourceChecksum === sourceChecksum &&
+            !child?.lastSyncError
+        )
         if (
           !child ||
-          (!isActiveConversionAttempt && !completedDuringInvocation) ||
+          (!isActiveConversionAttempt &&
+            !completedDuringInvocation &&
+            !isCompletedMatchingConversion) ||
           attempt?.originalGoogleDriveId !== originalGoogleDriveId ||
-          detectNotebookFileFormat(child.name) !== 'runme-operation-log' ||
-          (child.name !== converted.fileName && !isActiveConversionAttempt)
+          detectNotebookFileFormat(child.name) !== 'runme-operation-log'
         ) {
           continue
         }
@@ -2511,6 +2517,10 @@ export class LocalNotebooks extends Dexie {
           childUri
         )
         await this.syncFile(childUri)
+        await this.attachDriveFileToFolder(
+          destinationParent.remoteId,
+          childUri
+        )
         await this.files.update(childUri, {
           legacyConversionAttempt: {
             originalGoogleDriveId,
@@ -2551,6 +2561,10 @@ export class LocalNotebooks extends Dexie {
         created.uri
       )
       await this.syncFile(created.uri)
+      await this.attachDriveFileToFolder(
+        destinationParent.remoteId,
+        created.uri
+      )
       await this.files.update(created.uri, {
         legacyConversionAttempt: originalGoogleDriveId
           ? {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -60,7 +60,10 @@ import {
   browserDriveSyncCoordinator,
 } from './driveSyncCoordinator'
 import { EXCALIDRAW_MIME_TYPE, isExcalidrawFileName } from './excalidraw'
-import type { FilesystemNotebookStore } from './fs'
+import {
+  FilesystemEntryAlreadyExistsError,
+  type FilesystemNotebookStore,
+} from './fs'
 import {
   type IpynbPreservationState,
   type IpynbShadowStorage,
@@ -2333,6 +2336,17 @@ export class LocalNotebooks extends Dexie {
       throw new Error(`Parent folder not found for ${destinationParentUri}`)
     }
 
+    if (!isDriveUri(destinationParent.remoteId)) {
+      for (const childUri of destinationParent.children) {
+        const child = childUri.startsWith('local://file/')
+          ? await this.files.get(childUri)
+          : undefined
+        if (child?.name === converted.fileName) {
+          throw new FilesystemEntryAlreadyExistsError(converted.fileName)
+        }
+      }
+    }
+
     if (isDriveUri(destinationParent.remoteId) && originalGoogleDriveId) {
       const destinationDriveFolder = parseDriveItem(destinationParent.remoteId)
       const equivalentDestinationParents = await this.folders
@@ -2371,7 +2385,64 @@ export class LocalNotebooks extends Dexie {
           continue
         }
         let child = await this.files.get(childUri)
-        const attempt = child?.legacyConversionAttempt
+        let attempt = child?.legacyConversionAttempt
+        let pendingNotebook: parser_pb.Notebook | undefined
+        let recoveredFromNotebookMetadata = false
+
+        // Conversion provenance lives in the .runme document as well as the
+        // local retry marker. Reconstruct the marker when this Drive sibling
+        // was mirrored by a fresh browser profile or after IndexedDB was
+        // cleared, so retrying conversion does not upload a duplicate.
+        if (
+          child &&
+          !attempt &&
+          !child.lastSyncError &&
+          child.name === converted.fileName &&
+          detectNotebookFileFormat(child.name) === 'runme-operation-log'
+        ) {
+          try {
+            pendingNotebook = child.operationLogRef
+              ? await this.loadOperationLogSnapshot(childUri)
+              : isDriveUri(child.remoteId)
+                ? decodeNotebookFile(
+                    await this.driveStore.loadContent(child.remoteId),
+                    child.name
+                  ).notebook
+                : undefined
+          } catch {
+            pendingNotebook = undefined
+          }
+          if (
+            pendingNotebook?.metadata[
+              RunmeMetadataKey.OriginalGoogleDriveID
+            ] === originalGoogleDriveId
+          ) {
+            if (!child.operationLogRef) {
+              await this.syncFile(childUri)
+              const syncedChild = await this.files.get(childUri)
+              if (!syncedChild?.operationLogRef) {
+                throw new Error(
+                  `Operation-log reference missing for ${childUri} after sync`
+                )
+              }
+              child = syncedChild
+              pendingNotebook = await this.loadOperationLogSnapshot(childUri)
+            }
+            attempt = {
+              originalGoogleDriveId,
+              // A fresh mirror cannot recover the checksum used by the
+              // original conversion. The empty sentinel deliberately sends
+              // it through the refresh path below.
+              sourceChecksum: '',
+              completedAt: nowIsoString(),
+            }
+            await this.files.update(childUri, {
+              legacyConversionAttempt: attempt,
+            })
+            child = { ...child, legacyConversionAttempt: attempt }
+            recoveredFromNotebookMetadata = true
+          }
+        }
         const completedDuringInvocation = Boolean(
           attempt?.completedAt && attempt.completedAt >= invokedAt
         )
@@ -2387,7 +2458,8 @@ export class LocalNotebooks extends Dexie {
           !child ||
           (!isActiveConversionAttempt &&
             !completedDuringInvocation &&
-            !isCompletedMatchingConversion) ||
+            !isCompletedMatchingConversion &&
+            !recoveredFromNotebookMetadata) ||
           attempt?.originalGoogleDriveId !== originalGoogleDriveId ||
           detectNotebookFileFormat(child.name) !== 'runme-operation-log' ||
           (child.name !== converted.fileName &&
@@ -2396,7 +2468,7 @@ export class LocalNotebooks extends Dexie {
         ) {
           continue
         }
-        const pendingNotebook = await this.loadOperationLogSnapshot(childUri)
+        pendingNotebook ??= await this.loadOperationLogSnapshot(childUri)
         if (
           pendingNotebook.metadata[RunmeMetadataKey.OriginalGoogleDriveID] !==
           originalGoogleDriveId

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2236,10 +2236,14 @@ export class LocalNotebooks extends Dexie {
           continue
         }
         const child = await this.files.get(childUri)
+        const isPendingCreate =
+          child?.remoteId === '' &&
+          child.parentRemoteIdWhenCreated === destinationParent.remoteId
+        const isErroredDriveConversion =
+          isDriveUri(child?.remoteId) && Boolean(child?.lastSyncError)
         if (
           child?.name !== converted.fileName ||
-          child.remoteId !== '' ||
-          child.parentRemoteIdWhenCreated !== destinationParent.remoteId ||
+          (!isPendingCreate && !isErroredDriveConversion) ||
           detectNotebookFileFormat(child.name) !== 'runme-operation-log'
         ) {
           continue
@@ -2247,9 +2251,8 @@ export class LocalNotebooks extends Dexie {
         try {
           const pendingNotebook = await this.loadOperationLogSnapshot(childUri)
           if (
-            pendingNotebook.metadata[
-              RunmeMetadataKey.OriginalGoogleDriveID
-            ] !== originalGoogleDriveId
+            pendingNotebook.metadata[RunmeMetadataKey.OriginalGoogleDriveID] !==
+            originalGoogleDriveId
           ) {
             continue
           }
@@ -2258,15 +2261,17 @@ export class LocalNotebooks extends Dexie {
         }
 
         await this.syncFile(childUri)
-        return (await this.getMetadata(childUri)) ?? {
-          uri: childUri,
-          name: child.name,
-          type: NotebookStoreItemType.File,
-          children: [],
-          remoteUri: publicRemoteUri(child),
-          mimeType: child.mimeType,
-          parents: [destinationParentUri],
-        }
+        return (
+          (await this.getMetadata(childUri)) ?? {
+            uri: childUri,
+            name: child.name,
+            type: NotebookStoreItemType.File,
+            children: [],
+            remoteUri: publicRemoteUri(child),
+            mimeType: child.mimeType,
+            parents: [destinationParentUri],
+          }
+        )
       }
     }
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -116,10 +116,12 @@ export interface LocalFileRecord {
   parentRemoteIdWhenCreated?: string
   /** Stable idempotency key for creating the primary Drive file. */
   driveCreateOperationId?: string
-  /** Retry state retained only while a legacy-to-Runme Drive copy is pending. */
+  /** Retry/deduplication state for a legacy-to-Runme Drive copy. */
   legacyConversionAttempt?: {
     originalGoogleDriveId: string
     sourceChecksum: string
+    /** Set after sync so callers already waiting on the same lock reuse it. */
+    completedAt?: string
   }
   /** Remote Drive URI of the Markdown sidecar (e.g. *.index.md) if present. */
   markdownUri?: string
@@ -2196,6 +2198,23 @@ export class LocalNotebooks extends Dexie {
         'LocalNotebooks.convertLegacyNotebookToRunme expects a local file URI'
       )
     }
+    const invokedAt = nowIsoString()
+    return this.driveSyncCoordinator.runExclusive(
+      `legacy-conversion:${sourceUri}`,
+      () =>
+        this.convertLegacyNotebookToRunmeExclusive(
+          sourceUri,
+          parentUri,
+          invokedAt
+        )
+    )
+  }
+
+  private async convertLegacyNotebookToRunmeExclusive(
+    sourceUri: string,
+    parentUri: string | undefined,
+    invokedAt: string
+  ): Promise<NotebookStoreItem> {
     let sourceRecord = await this.files.get(sourceUri)
     if (!sourceRecord) {
       throw new Error(`Local notebook record not found for ${sourceUri}`)
@@ -2203,6 +2222,21 @@ export class LocalNotebooks extends Dexie {
     const sourceFormat = detectNotebookFileFormat(sourceRecord.name)
     if (sourceFormat !== 'runme-json' && sourceFormat !== 'ipynb') {
       throw new Error('Only .json and .ipynb notebooks can be converted')
+    }
+    if (sourceRecord.conflict) {
+      throw new Error(
+        `Resolve the sync conflict before converting ${sourceRecord.name}`
+      )
+    }
+
+    // Validate raw Drive JSON before normal synchronization can decode it into
+    // the protobuf model and discard unknown fields. Conversion below reads it
+    // again after sync so the produced copy still reflects the latest bytes.
+    if (sourceFormat === 'runme-json' && isDriveUri(sourceRecord.remoteId)) {
+      await convertLegacyNotebookFileToRunme(
+        await this.driveStore.loadContent(sourceRecord.remoteId),
+        sourceRecord.name
+      )
     }
 
     if (
@@ -2225,7 +2259,12 @@ export class LocalNotebooks extends Dexie {
         `Resolve the sync conflict before converting ${sourceRecord.name}`
       )
     }
-    const sourceContent = await this.loadContent(sourceUri)
+    // DriveNotebookStore.load normalizes protobuf JSON with unknown fields
+    // ignored. Read the raw bytes after sync rather than the normalized cache.
+    const sourceContent =
+      sourceFormat === 'runme-json' && isDriveUri(sourceRecord.remoteId)
+        ? await this.driveStore.loadContent(sourceRecord.remoteId)
+        : await this.loadContent(sourceUri)
     const originalGoogleDriveId = isDriveUri(sourceRecord.remoteId)
       ? parseDriveItem(sourceRecord.remoteId).id
       : undefined
@@ -2271,11 +2310,16 @@ export class LocalNotebooks extends Dexie {
           child.parentRemoteIdWhenCreated === destinationParent.remoteId
         const isErroredDriveConversion =
           isDriveUri(child?.remoteId) && Boolean(child?.lastSyncError)
+        const attempt = child?.legacyConversionAttempt
+        const completedDuringInvocation = Boolean(
+          attempt?.completedAt && attempt.completedAt >= invokedAt
+        )
+        const isActiveConversionAttempt =
+          !attempt?.completedAt && (isPendingCreate || isErroredDriveConversion)
         if (
           child?.name !== converted.fileName ||
-          (!isPendingCreate && !isErroredDriveConversion) ||
-          child.legacyConversionAttempt?.originalGoogleDriveId !==
-            originalGoogleDriveId ||
+          (!isActiveConversionAttempt && !completedDuringInvocation) ||
+          attempt?.originalGoogleDriveId !== originalGoogleDriveId ||
           detectNotebookFileFormat(child.name) !== 'runme-operation-log'
         ) {
           continue
@@ -2292,7 +2336,7 @@ export class LocalNotebooks extends Dexie {
           continue
         }
 
-        if (child.legacyConversionAttempt.sourceChecksum !== sourceChecksum) {
+        if (attempt.sourceChecksum !== sourceChecksum) {
           if (!child.operationLogRef) {
             continue
           }
@@ -2331,6 +2375,7 @@ export class LocalNotebooks extends Dexie {
             legacyConversionAttempt: {
               originalGoogleDriveId,
               sourceChecksum,
+              completedAt: undefined,
             },
           })
           this.notifySync(childUri)
@@ -2338,7 +2383,11 @@ export class LocalNotebooks extends Dexie {
 
         await this.syncFile(childUri)
         await this.files.update(childUri, {
-          legacyConversionAttempt: undefined,
+          legacyConversionAttempt: {
+            originalGoogleDriveId,
+            sourceChecksum,
+            completedAt: nowIsoString(),
+          },
         })
         return (
           (await this.getMetadata(childUri)) ?? {
@@ -2369,7 +2418,13 @@ export class LocalNotebooks extends Dexie {
     if (isDriveUri(destinationParent.remoteId)) {
       await this.syncFile(created.uri)
       await this.files.update(created.uri, {
-        legacyConversionAttempt: undefined,
+        legacyConversionAttempt: originalGoogleDriveId
+          ? {
+              originalGoogleDriveId,
+              sourceChecksum,
+              completedAt: nowIsoString(),
+            }
+          : undefined,
       })
     }
     return (await this.getMetadata(created.uri)) ?? created

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2175,12 +2175,14 @@ export class LocalNotebooks extends Dexie {
     mimeType: string,
     options: {
       legacyConversionAttempt?: LocalFileRecord['legacyConversionAttempt']
+      autoSync?: boolean
     } = {}
   ): Promise<NotebookStoreItem> {
     return this.createLocalFile(parentUri, name, {
       mimeType,
       content,
       legacyConversionAttempt: options.legacyConversionAttempt,
+      autoSync: options.autoSync,
     })
   }
 
@@ -2453,6 +2455,7 @@ export class LocalNotebooks extends Dexie {
           isDriveUri(destinationParent.remoteId) && originalGoogleDriveId
             ? { originalGoogleDriveId, sourceChecksum }
             : undefined,
+        autoSync: false,
       }
     )
     if (isDriveUri(destinationParent.remoteId)) {
@@ -2481,6 +2484,7 @@ export class LocalNotebooks extends Dexie {
       mimeType: string
       content: string
       legacyConversionAttempt?: LocalFileRecord['legacyConversionAttempt']
+      autoSync?: boolean
     }
   ): Promise<NotebookStoreItem> {
     if (!parentUri.startsWith('local://folder/')) {
@@ -2560,7 +2564,7 @@ export class LocalNotebooks extends Dexie {
       )
     }
 
-    if (isDriveBackedParent) {
+    if (isDriveBackedParent && options.autoSync !== false) {
       void (async () => {
         try {
           await this.syncFile(fileUri)

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -15,6 +15,7 @@ import {
   decodeNotebookFile,
   detectNotebookFileFormat,
   encodeIpynbNotebook,
+  encodeRunmeOperationLogSnapshotWithHeader,
   isNotebookFileName,
   notebookFileExtension,
   validateNotebookRenameFormat,
@@ -2288,9 +2289,17 @@ export class LocalNotebooks extends Dexie {
         }
 
         if (child.legacyConversionAttempt.sourceChecksum !== sourceChecksum) {
+          const currentLog = parseOperationLog(
+            await this.loadContent(childUri)
+          )
+          const refreshedContent =
+            await encodeRunmeOperationLogSnapshotWithHeader(
+              converted.notebook,
+              currentLog.header
+            )
           await this.saveContent(
             childUri,
-            converted.content,
+            refreshedContent,
             RUNME_OPERATION_LOG_MIME_TYPE
           )
           await this.files.update(childUri, {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2390,6 +2390,25 @@ export class LocalNotebooks extends Dexie {
           continue
         }
 
+        const currentParent = await this.findParentFolder(childUri)
+        if (
+          !isDriveUri(child.remoteId) &&
+          child.parentRemoteIdWhenCreated &&
+          parseDriveItem(child.parentRemoteIdWhenCreated).id !==
+            destinationDriveFolder.id
+        ) {
+          // The original create may already have committed before the local
+          // remote ID was persisted. Reconcile it against the original parent
+          // before changing folders, otherwise the retry could create a second
+          // file in the destination folder.
+          await this.completePendingDriveCreate(childUri, child)
+          const recoveredChild = await this.files.get(childUri)
+          if (!recoveredChild) {
+            throw new Error(`Local notebook record not found for ${childUri}`)
+          }
+          child = recoveredChild
+        }
+
         if (child.name !== converted.fileName) {
           await this.rename(childUri, converted.fileName)
           const renamedChild = await this.files.get(childUri)
@@ -2399,7 +2418,6 @@ export class LocalNotebooks extends Dexie {
           child = renamedChild
         }
 
-        const currentParent = await this.findParentFolder(childUri)
         if (!isDriveUri(child.remoteId)) {
           if (
             child.parentRemoteIdWhenCreated !== destinationParent.remoteId
@@ -2412,13 +2430,35 @@ export class LocalNotebooks extends Dexie {
               parentRemoteIdWhenCreated: destinationParent.remoteId,
             }
           }
-        } else if (
-          currentParent &&
-          isDriveUri(currentParent.remoteId) &&
-          parseDriveItem(currentParent.remoteId).id !==
+        } else {
+          let currentRemoteParent =
+            currentParent && isDriveUri(currentParent.remoteId)
+              ? currentParent.remoteId
+              : undefined
+          if (!currentRemoteParent) {
+            currentRemoteParent = (
+              await this.driveStore.getMetadata(child.remoteId)
+            )?.parents?.[0]
+          }
+          if (!currentRemoteParent) {
+            throw new Error(
+              `Google Drive parent folder not found for ${child.remoteId}`
+            )
+          }
+          if (
+            parseDriveItem(currentRemoteParent).id !==
             destinationDriveFolder.id
-        ) {
-          await this.move(childUri, destinationParentUri)
+          ) {
+            if (currentParent) {
+              await this.move(childUri, destinationParentUri)
+            } else {
+              await this.driveStore.move(
+                child.remoteId,
+                currentRemoteParent,
+                destinationParent.remoteId
+              )
+            }
+          }
         }
 
         if (attempt.sourceChecksum !== sourceChecksum) {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2422,6 +2422,10 @@ export class LocalNotebooks extends Dexie {
         }
 
         await this.syncFile(childUri)
+        await this.attachDriveFileToFolder(
+          destinationParent.remoteId,
+          childUri
+        )
         await this.files.update(childUri, {
           legacyConversionAttempt: {
             originalGoogleDriveId,
@@ -2429,10 +2433,6 @@ export class LocalNotebooks extends Dexie {
             completedAt: nowIsoString(),
           },
         })
-        await this.attachDriveFileToFolder(
-          destinationParent.remoteId,
-          childUri
-        )
         return (
           (await this.getMetadata(childUri)) ?? {
             uri: childUri,

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2293,36 +2293,47 @@ export class LocalNotebooks extends Dexie {
         }
 
         if (child.legacyConversionAttempt.sourceChecksum !== sourceChecksum) {
-          const currentLog = parseOperationLog(await this.loadContent(childUri))
-          const currentNotebook = materializedLogToNotebook(
-            materializeOperationLog(currentLog.operations)
-          )
-          const appendedOperations = await buildOperationLogDiff({
-            previous: currentNotebook,
-            next: converted.notebook,
-            observedOperations: currentLog.operations,
-            actorId: currentLog.header.created_by,
-            firstActorSequence:
-              highestActorSequence(
-                currentLog.operations,
-                currentLog.header.created_by
-              ) + 1,
-          })
-          const refreshedContent = serializeOperationLog(currentLog.header, [
-            ...currentLog.operations,
-            ...appendedOperations,
-          ])
-          await this.saveContent(
-            childUri,
-            refreshedContent,
-            RUNME_OPERATION_LOG_MIME_TYPE
+          if (!child.operationLogRef) {
+            continue
+          }
+          const refreshed = await this.operationLogStorage.appendTransaction(
+            child.operationLogRef,
+            async (currentDocument) => {
+              const currentLog = parseOperationLog(currentDocument)
+              const currentNotebook = materializedLogToNotebook(
+                materializeOperationLog(currentLog.operations)
+              )
+              const appendedOperations = await buildOperationLogDiff({
+                previous: currentNotebook,
+                next: converted.notebook,
+                observedOperations: currentLog.operations,
+                actorId: currentLog.header.created_by,
+                firstActorSequence:
+                  highestActorSequence(
+                    currentLog.operations,
+                    currentLog.header.created_by
+                  ) + 1,
+              })
+              return appendedOperations.length === 0
+                ? ''
+                : `${appendedOperations
+                    .map((operation) =>
+                      canonicalJson(operation as unknown as JsonValue)
+                    )
+                    .join('\n')}\n`
+            },
+            { validate: (document) => void parseOperationLog(document) }
           )
           await this.files.update(childUri, {
+            doc: '',
+            md5Checksum: refreshed.checksum,
+            operationLogRef: refreshed.ref,
             legacyConversionAttempt: {
               originalGoogleDriveId,
               sourceChecksum,
             },
           })
+          this.notifySync(childUri)
         }
 
         await this.syncFile(childUri)

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -10,7 +10,7 @@ import { appLogger } from '../lib/logging/runtime'
 import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookToMarkdown'
 import {
   RUNME_OPERATION_LOG_MIME_TYPE,
-  convertLegacyNotebookToRunme,
+  convertLegacyNotebookFileToRunme,
   createInitialNotebookFile,
   decodeNotebookFile,
   detectNotebookFileFormat,
@@ -39,7 +39,7 @@ import {
   serializeOperationLog,
 } from '../lib/operationLog'
 import { appState } from '../lib/runtime/AppState'
-import { parser_pb } from '../runme/client'
+import { RunmeMetadataKey, parser_pb } from '../runme/client'
 import {
   type ConflictDocStorage,
   type ConflictDocumentRef,
@@ -2196,12 +2196,12 @@ export class LocalNotebooks extends Dexie {
     if (isDriveUri(sourceRecord.remoteId)) {
       await this.syncFile(sourceUri)
     }
-    const sourceNotebook = await this.load(sourceUri)
+    const sourceContent = await this.loadContent(sourceUri)
     const originalGoogleDriveId = isDriveUri(sourceRecord.remoteId)
       ? parseDriveItem(sourceRecord.remoteId).id
       : undefined
-    const converted = await convertLegacyNotebookToRunme(
-      sourceNotebook,
+    const converted = await convertLegacyNotebookFileToRunme(
+      sourceContent,
       sourceRecord.name,
       { originalGoogleDriveId }
     )
@@ -2228,6 +2228,46 @@ export class LocalNotebooks extends Dexie {
     const destinationParent = await this.folders.get(destinationParentUri)
     if (!destinationParent) {
       throw new Error(`Parent folder not found for ${destinationParentUri}`)
+    }
+
+    if (isDriveUri(destinationParent.remoteId) && originalGoogleDriveId) {
+      for (const childUri of destinationParent.children) {
+        if (!childUri.startsWith('local://file/')) {
+          continue
+        }
+        const child = await this.files.get(childUri)
+        if (
+          child?.name !== converted.fileName ||
+          child.remoteId !== '' ||
+          child.parentRemoteIdWhenCreated !== destinationParent.remoteId ||
+          detectNotebookFileFormat(child.name) !== 'runme-operation-log'
+        ) {
+          continue
+        }
+        try {
+          const pendingNotebook = await this.loadOperationLogSnapshot(childUri)
+          if (
+            pendingNotebook.metadata[
+              RunmeMetadataKey.OriginalGoogleDriveID
+            ] !== originalGoogleDriveId
+          ) {
+            continue
+          }
+        } catch {
+          continue
+        }
+
+        await this.syncFile(childUri)
+        return (await this.getMetadata(childUri)) ?? {
+          uri: childUri,
+          name: child.name,
+          type: NotebookStoreItemType.File,
+          children: [],
+          remoteUri: publicRemoteUri(child),
+          mimeType: child.mimeType,
+          parents: [destinationParentUri],
+        }
+      }
     }
 
     const created = await this.createContent(

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2305,17 +2305,13 @@ export class LocalNotebooks extends Dexie {
           continue
         }
         const child = await this.files.get(childUri)
-        const isPendingCreate =
-          child?.remoteId === '' &&
-          child.parentRemoteIdWhenCreated === destinationParent.remoteId
-        const isErroredDriveConversion =
-          isDriveUri(child?.remoteId) && Boolean(child?.lastSyncError)
         const attempt = child?.legacyConversionAttempt
         const completedDuringInvocation = Boolean(
           attempt?.completedAt && attempt.completedAt >= invokedAt
         )
-        const isActiveConversionAttempt =
-          !attempt?.completedAt && (isPendingCreate || isErroredDriveConversion)
+        const isActiveConversionAttempt = Boolean(
+          attempt && !attempt.completedAt
+        )
         if (
           child?.name !== converted.fileName ||
           (!isActiveConversionAttempt && !completedDuringInvocation) ||

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2184,7 +2184,7 @@ export class LocalNotebooks extends Dexie {
         'LocalNotebooks.convertLegacyNotebookToRunme expects a local file URI'
       )
     }
-    const sourceRecord = await this.files.get(sourceUri)
+    let sourceRecord = await this.files.get(sourceUri)
     if (!sourceRecord) {
       throw new Error(`Local notebook record not found for ${sourceUri}`)
     }
@@ -2193,8 +2193,20 @@ export class LocalNotebooks extends Dexie {
       throw new Error('Only .json and .ipynb notebooks can be converted')
     }
 
-    if (isDriveUri(sourceRecord.remoteId)) {
+    if (
+      isDriveUri(sourceRecord.remoteId) ||
+      isDriveUri(sourceRecord.parentRemoteIdWhenCreated)
+    ) {
       await this.syncFile(sourceUri)
+      sourceRecord = await this.files.get(sourceUri)
+      if (!sourceRecord) {
+        throw new Error(`Local notebook record not found for ${sourceUri}`)
+      }
+      if (!isDriveUri(sourceRecord.remoteId)) {
+        throw new Error(
+          `Google Drive source did not receive a remote ID after sync: ${sourceUri}`
+        )
+      }
     }
     const sourceContent = await this.loadContent(sourceUri)
     const originalGoogleDriveId = isDriveUri(sourceRecord.remoteId)

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2350,7 +2350,7 @@ export class LocalNotebooks extends Dexie {
         if (!childUri.startsWith('local://file/')) {
           continue
         }
-        const child = await this.files.get(childUri)
+        let child = await this.files.get(childUri)
         const attempt = child?.legacyConversionAttempt
         const completedDuringInvocation = Boolean(
           attempt?.completedAt && attempt.completedAt >= invokedAt
@@ -2359,10 +2359,11 @@ export class LocalNotebooks extends Dexie {
           attempt && !attempt.completedAt
         )
         if (
-          child?.name !== converted.fileName ||
+          !child ||
           (!isActiveConversionAttempt && !completedDuringInvocation) ||
           attempt?.originalGoogleDriveId !== originalGoogleDriveId ||
-          detectNotebookFileFormat(child.name) !== 'runme-operation-log'
+          detectNotebookFileFormat(child.name) !== 'runme-operation-log' ||
+          (child.name !== converted.fileName && !isActiveConversionAttempt)
         ) {
           continue
         }
@@ -2372,6 +2373,15 @@ export class LocalNotebooks extends Dexie {
           originalGoogleDriveId
         ) {
           continue
+        }
+
+        if (child.name !== converted.fileName) {
+          await this.rename(childUri, converted.fileName)
+          const renamedChild = await this.files.get(childUri)
+          if (!renamedChild) {
+            throw new Error(`Local notebook record not found for ${childUri}`)
+          }
+          child = renamedChild
         }
 
         if (attempt.sourceChecksum !== sourceChecksum) {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -2337,14 +2337,27 @@ export class LocalNotebooks extends Dexie {
     }
 
     if (!isDriveUri(destinationParent.remoteId)) {
-      for (const childUri of destinationParent.children) {
-        const child = childUri.startsWith('local://file/')
-          ? await this.files.get(childUri)
-          : undefined
-        if (child?.name === converted.fileName) {
-          throw new FilesystemEntryAlreadyExistsError(converted.fileName)
+      const targetLockKey = `legacy-conversion-target:${destinationParentUri}:${converted.fileName}`
+      return this.driveSyncCoordinator.runExclusive(targetLockKey, async () => {
+        const currentParent = await this.folders.get(destinationParentUri)
+        if (!currentParent) {
+          throw new Error(`Parent folder not found for ${destinationParentUri}`)
         }
-      }
+        for (const childUri of currentParent.children) {
+          const child = childUri.startsWith('local://file/')
+            ? await this.files.get(childUri)
+            : undefined
+          if (child?.name === converted.fileName) {
+            throw new FilesystemEntryAlreadyExistsError(converted.fileName)
+          }
+        }
+        return this.createContent(
+          destinationParentUri,
+          converted.fileName,
+          converted.content,
+          RUNME_OPERATION_LOG_MIME_TYPE
+        )
+      })
     }
 
     if (isDriveUri(destinationParent.remoteId) && originalGoogleDriveId) {
@@ -2429,10 +2442,10 @@ export class LocalNotebooks extends Dexie {
             }
             attempt = {
               originalGoogleDriveId,
-              // A fresh mirror cannot recover the checksum used by the
-              // original conversion. The empty sentinel deliberately sends
-              // it through the refresh path below.
-              sourceChecksum: '',
+              // The original conversion checksum is not embedded in the
+              // document. Treat the recovered copy as current so conversion
+              // never overwrites edits made only in the .runme target.
+              sourceChecksum,
               // Keep the recovered marker unfinished until the final target
               // sync succeeds, so any failure is reusable by the next retry.
               completedAt: undefined,


### PR DESCRIPTION
## Summary
- add reusable conversion for legacy `.json` and `.ipynb` notebooks into `.runme` operation logs
- create sibling Drive-backed files and record the original Google Drive file ID in notebook metadata
- expose conversion from the file explorer context menu for legacy notebook formats

## Review
- verified input notebooks are cloned before metadata and cell-ID migration
- fixed Drive parent discovery when callers omit an explorer parent
- confirmed existing `.runme` notebooks do not show the conversion action

## Tests
- `runme run build test`
- `pnpm -C app exec vitest run src/storage/local.test.ts src/lib/notebookFormat.test.ts src/components/Workspace/WorkspaceExplorer.test.tsx` (111 tests)