### PR TITLE
Show .runme comments as notebook-backed

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -18,6 +18,8 @@ import {
   APPKERNEL_SANDBOX_RUNNER_NAME,
 } from '../../lib/runtime/appKernel'
 import { driveLinkCoordinator } from '../../lib/driveLinkCoordinator'
+import { appState } from '../../lib/runtime/AppState'
+import { createCellCommentAnchor } from '../../lib/notebookComments'
 
 import { parser_pb, RunmeMetadataKey } from '../../runme/client'
 import type { CellData } from '../../lib/notebookData'
@@ -92,8 +94,11 @@ const contextMocks = vi.hoisted(() => ({
     refreshConflictWithLatestUpstream?: ReturnType<typeof vi.fn>
     resolveConflictWithLocal?: ReturnType<typeof vi.fn>
     sync?: ReturnType<typeof vi.fn>
-    listOperationLogComments?: ReturnType<typeof vi.fn>
     subscribeSync: ReturnType<typeof vi.fn>
+    listOperationLogComments?: ReturnType<typeof vi.fn>
+    addOperationLogComment?: ReturnType<typeof vi.fn>
+    replyToOperationLogComment?: ReturnType<typeof vi.fn>
+    setOperationLogCommentResolved?: ReturnType<typeof vi.fn>
   },
 }))
 
@@ -150,6 +155,12 @@ const runnerContextMocks = vi.hoisted(() => ({
     interceptors: []
   }>,
   defaultRunnerName: '<default>' as string | null,
+}))
+
+const commentsPanelMocks = vi.hoisted(() => ({
+  commentsPanelOpen: false,
+  setCommentsPanelOpen: vi.fn(),
+  openCommentsPanel: vi.fn(),
 }))
 
 // Minimal mocks for contexts Action consumes
@@ -220,9 +231,9 @@ vi.mock('../../contexts/CurrentDocContext', () => ({
 
 vi.mock('../../contexts/CommentsPanelContext', () => ({
   useCommentsPanel: () => ({
-    commentsPanelOpen: false,
-    setCommentsPanelOpen: vi.fn(),
-    openCommentsPanel: vi.fn(),
+    commentsPanelOpen: commentsPanelMocks.commentsPanelOpen,
+    setCommentsPanelOpen: commentsPanelMocks.setCommentsPanelOpen,
+    openCommentsPanel: commentsPanelMocks.openCommentsPanel,
   }),
 }))
 
@@ -431,6 +442,11 @@ beforeEach(() => {
   contextMocks.refreshReadOnlyNotebook.mockResolvedValue(undefined)
   contextMocks.notebookSnapshots.clear()
   contextMocks.notebookStore = null
+  commentsPanelMocks.commentsPanelOpen = false
+  commentsPanelMocks.setCommentsPanelOpen.mockReset()
+  commentsPanelMocks.openCommentsPanel.mockReset()
+  appState.setDriveNotebookStore(null)
+  appState.setLocalComments(null)
   conflictMocks.openNotebookConflictDiff.mockReset()
   conflictMocks.openNotebookConflictDiff.mockResolvedValue(undefined)
   conflictMocks.openNotebookUpstreamDiff.mockReset()
@@ -538,6 +554,161 @@ describe('Actions tabs', () => {
       suggestionUri
     )
     expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(uri)
+  })
+
+  it('keeps the complete .runme comment lifecycle in the operation log', async () => {
+    const uri = 'local://file/comments.runme'
+    const cells = ['cell-open', 'cell-resolved', 'cell-new'].map((refId) =>
+      create(parser_pb.CellSchema, {
+        refId,
+        kind: parser_pb.CellKind.MARKUP,
+        languageId: 'markdown',
+        value: `Content for ${refId}`,
+      })
+    )
+    const cellData = new Map(
+      cells.map((cell) => [cell.refId, new StubCellData(cell)])
+    )
+    const comments = [
+      {
+        id: 'comment-open',
+        content: 'Open operation-log comment',
+        anchor: createCellCommentAnchor('cell-open'),
+        resolved: false,
+        replies: [],
+      },
+      {
+        id: 'comment-resolved',
+        content: 'Resolved operation-log comment',
+        anchor: createCellCommentAnchor('cell-resolved'),
+        resolved: true,
+        replies: [],
+      },
+    ]
+    const store = {
+      getMetadata: vi.fn(async () => ({
+        remoteUri: 'https://drive.google.com/file/d/drive-copy/view',
+      })),
+      getSyncState: vi.fn(async () => ({
+        status: 'synced',
+        localUri: uri,
+        remoteId: 'https://drive.google.com/file/d/drive-copy/view',
+      })),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => undefined),
+      listOperationLogComments: vi.fn(async () => comments),
+      addOperationLogComment: vi.fn(async () => comments[0]),
+      replyToOperationLogComment: vi.fn(async () => comments[0]),
+      setOperationLogCommentResolved: vi.fn(async () => comments[0]),
+    }
+    const localComments = {
+      list: vi.fn(),
+      listPendingRecords: vi.fn(),
+      saveDesiredComment: vi.fn(),
+      saveDesiredReply: vi.fn(),
+      setThreadIntent: vi.fn(),
+      reconcile: vi.fn(),
+    }
+    const driveStore = { listComments: vi.fn() }
+
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      {
+        uri,
+        title: 'comments.runme',
+        requestedUri:
+          'https://drive.google.com/file/d/drive-copy/view?resourcekey=key',
+        state: 'loaded',
+      },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      notebook: create(parser_pb.NotebookSchema, { cells }),
+    })
+    contextMocks.getNotebookData.mockReturnValue({
+      getCell: (refId: string) => cellData.get(refId),
+      appendCell: vi.fn(),
+    })
+    contextMocks.notebookStore = store
+    commentsPanelMocks.commentsPanelOpen = true
+    appState.setLocalComments(localComments as never)
+    appState.setDriveNotebookStore(driveStore as never)
+
+    render(<Actions />)
+
+    await waitFor(() => {
+      expect(store.listOperationLogComments).toHaveBeenCalledWith(uri)
+      expect(screen.getByText('Stored in this .runme notebook')).toBeTruthy()
+    })
+    expect(screen.queryByText('Google Drive comment threads')).toBeNull()
+
+    const reply = screen.getByPlaceholderText('Reply or add others with @')
+    fireEvent.change(reply, { target: { value: 'Operation-log reply' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }))
+    await waitFor(() => {
+      expect(store.replyToOperationLogComment).toHaveBeenCalledWith(
+        uri,
+        'comment-open',
+        'Operation-log reply'
+      )
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }))
+    await waitFor(() => {
+      expect(store.setOperationLogCommentResolved).toHaveBeenCalledWith(
+        uri,
+        'comment-open',
+        true
+      )
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /resolved 1/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Reopen' })).toBeTruthy()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen' }))
+    await waitFor(() => {
+      expect(store.setOperationLogCommentResolved).toHaveBeenCalledWith(
+        uri,
+        'comment-resolved',
+        false
+      )
+    })
+
+    const newCell = document.querySelector<HTMLElement>(
+      '[data-cell-ref-id="cell-new"]'
+    )
+    expect(newCell).not.toBeNull()
+    fireEvent.click(
+      within(newCell as HTMLElement).getByRole('button', {
+        name: 'Add comment',
+      })
+    )
+    const draft = await screen.findByText('New comment on Cell 3')
+    const draftArticle = draft.closest('article') as HTMLElement
+    fireEvent.change(within(draftArticle).getByRole('textbox'), {
+      target: { value: 'New operation-log comment' },
+    })
+    fireEvent.click(
+      within(draftArticle).getByRole('button', { name: 'Comment' })
+    )
+    await waitFor(() => {
+      expect(store.addOperationLogComment).toHaveBeenCalledWith(
+        uri,
+        expect.objectContaining({
+          content: 'New operation-log comment',
+          anchor: expect.stringContaining('cell-new'),
+        })
+      )
+    })
+
+    expect(localComments.list).not.toHaveBeenCalled()
+    expect(localComments.saveDesiredComment).not.toHaveBeenCalled()
+    expect(localComments.saveDesiredReply).not.toHaveBeenCalled()
+    expect(localComments.setThreadIntent).not.toHaveBeenCalled()
+    expect(localComments.reconcile).not.toHaveBeenCalled()
+    expect(driveStore.listComments).not.toHaveBeenCalled()
   })
 
   it('embeds an image selected from the button beside Add cell', async () => {
@@ -1138,7 +1309,8 @@ describe('Actions tabs', () => {
         title: 'shared.runme',
         requestedUri: remoteId,
         state: 'loaded',
-        refreshErrorMessage: 'Could not refresh operation log: OPFS unavailable',
+        refreshErrorMessage:
+          'Could not refresh operation log: OPFS unavailable',
       },
     ]
     contextMocks.notebookSnapshots.set(uri, {
@@ -1171,7 +1343,8 @@ describe('Actions tabs', () => {
     })
 
     expect(
-      refresh.compareDocumentPosition(driveSync) & Node.DOCUMENT_POSITION_FOLLOWING
+      refresh.compareDocumentPosition(driveSync) &
+        Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
     fireEvent.click(refresh)
     expect(contextMocks.refreshReadOnlyNotebook).toHaveBeenCalledWith(uri)
@@ -1232,9 +1405,7 @@ describe('Actions tabs', () => {
     fireEvent.click(filesystemStatus)
 
     expect(sync).not.toHaveBeenCalled()
-    expect(
-      screen.queryByLabelText(/Click to sync now/)
-    ).toBeNull()
+    expect(screen.queryByLabelText(/Click to sync now/)).toBeNull()
   })
 
   it('defers rendering inactive read-only notebook cells', () => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -3789,6 +3789,9 @@ function NotebookTabContent({
       </ScrollArea>
       {commentsPanelOpen && (
         <NotebookCommentsPanel
+          storage={
+            operationLogComments ? 'runme-operation-log' : 'google-drive'
+          }
           status={commentsStatus}
           errorMessage={commentsErrorMessage}
           threads={commentThreads}

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -20,6 +20,7 @@ const noop = vi.fn()
 
 function renderPanel(overrides = {}) {
   const props = {
+    storage: 'google-drive' as const,
     status: 'available' as const,
     threads: [],
     cellLabels: new Map<string, string>(),
@@ -48,6 +49,18 @@ function renderPanel(overrides = {}) {
 }
 
 describe('NotebookCommentsPanel', () => {
+  it('describes where comments are stored for each notebook format', () => {
+    const view = renderPanel({ storage: 'runme-operation-log' })
+
+    expect(screen.getByText('Stored in this .runme notebook')).toBeTruthy()
+    expect(screen.queryByText('Google Drive comment threads')).toBeNull()
+
+    view.rerender(<NotebookCommentsPanel {...view} storage="google-drive" />)
+
+    expect(screen.getByText('Google Drive comment threads')).toBeTruthy()
+    expect(screen.queryByText('Stored in this .runme notebook')).toBeNull()
+  })
+
   it('calls onHide from the header hide button', () => {
     const onHide = vi.fn()
 

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -8,6 +8,7 @@ import type {
 
 type CommentsStatus = 'loading' | 'available' | 'unavailable' | 'error'
 type CommentsFilter = 'open' | 'resolved' | 'all'
+export type CommentsStorage = 'google-drive' | 'runme-operation-log'
 type CommentsPanelItem = {
   type: 'thread'
   key: string
@@ -18,6 +19,7 @@ type CommentsPanelItem = {
 }
 
 export function NotebookCommentsPanel({
+  storage,
   status,
   errorMessage,
   threads,
@@ -40,6 +42,7 @@ export function NotebookCommentsPanel({
   onHide,
   onSelectTarget,
 }: {
+  storage: CommentsStorage
   status: CommentsStatus
   errorMessage?: string
   threads: CellCommentThread[]
@@ -196,7 +199,9 @@ export function NotebookCommentsPanel({
           <div>
             <h2 className="text-sm font-semibold text-nb-text">Comments</h2>
             <p className="text-xs text-nb-text-muted">
-              Google Drive comment threads
+              {storage === 'runme-operation-log'
+                ? 'Stored in this .runme notebook'
+                : 'Google Drive comment threads'}
             </p>
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- label `.runme` comment panels as stored in the notebook instead of as Google Drive comment threads
- preserve the Google Drive label for legacy Drive-backed notebook formats
- cover the complete `.runme` UI comment lifecycle and prove list, create, reply, resolve, and reopen use the operation-log store even when a Drive copy is linked

## Root cause

The `.runme` implementation already routes comment operations to `LocalNotebooks` and appends them to the notebook operation log. The comments panel subtitle was static and always described the source as Google Drive, so the UI misrepresented the actual storage path.

## Verification

- `pnpm -C app exec vitest run` (112 files, 1,187 tests)
- `pnpm -C app run build`
- `git diff --check`
