### PR TITLE
Expose suggestion review from notebook tabs

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1534,7 +1534,10 @@ describe('Actions tabs', () => {
       loaded: true,
       notebook: create(parser_pb.NotebookSchema, { metadata: {}, cells: [] }),
     })
-    contextMocks.getNotebookData.mockReturnValue({ appendCell: vi.fn() })
+    contextMocks.getNotebookData.mockReturnValue({
+      appendCell: vi.fn(),
+      getSnapshot: vi.fn(() => ({ loaded: true })),
+    })
 
     render(<Actions />)
 
@@ -1554,6 +1557,42 @@ describe('Actions tabs', () => {
       afterUri: uri,
     })
     expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(suggestionUri)
+  })
+
+  it('omits suggestion review while a .runme notebook is loading', () => {
+    const uri = 'local://file/loading-review'
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(async () => ({
+        uri,
+        name: 'loading-review.runme',
+        type: 'file',
+        children: [],
+        parents: [],
+      })),
+      getSyncState: vi.fn(async () => null),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      { uri, title: 'loading-review.runme', state: 'loading' },
+    ]
+    contextMocks.getNotebookData.mockReturnValue({
+      getSnapshot: vi.fn(() => ({ loaded: false })),
+    })
+
+    render(<Actions />)
+
+    fireEvent.contextMenu(
+      screen.getByRole('tab', { name: /loading-review\.runme/ })
+    )
+    const contextMenu = document.querySelector<HTMLElement>('.ctx-menu')
+    expect(contextMenu).not.toBeNull()
+    expect(
+      within(contextMenu as HTMLElement).queryByRole('button', {
+        name: 'Review suggestions',
+      })
+    ).toBeNull()
   })
 
   it('omits suggestion review from legacy notebook tab context menus', async () => {

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -501,6 +501,7 @@ describe('Actions tabs', () => {
 
     expect(contextMocks.showDocument).toHaveBeenCalledWith(suggestionUri, {
       title: 'Suggestions · suggestions.runme',
+      afterUri: uri,
     })
     expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(suggestionUri)
   })
@@ -1502,6 +1503,97 @@ describe('Actions tabs', () => {
       expect(screen.getByRole('tab', { name: /Getting Started/ })).toBeTruthy()
     })
     expect(contextMocks.setCurrentDoc).not.toHaveBeenCalled()
+  })
+
+  it('opens suggestion review from a .runme tab context menu', async () => {
+    const uri = 'local://file/reviewable'
+    const suggestionUri = getOperationLogSuggestionDocumentUri(uri)
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(async () => ({
+        uri,
+        name: 'reviewable.runme',
+        type: 'file',
+        children: [],
+        parents: [],
+      })),
+      getSyncState: vi.fn(async () => ({
+        status: 'local-only',
+        localUri: uri,
+        remoteId: uri,
+      })),
+      listOperationLogComments: vi.fn(async () => []),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      { uri, title: 'reviewable.runme', state: 'loaded' },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      notebook: create(parser_pb.NotebookSchema, { metadata: {}, cells: [] }),
+    })
+    contextMocks.getNotebookData.mockReturnValue({ appendCell: vi.fn() })
+
+    render(<Actions />)
+
+    fireEvent.contextMenu(
+      screen.getByRole('tab', { name: /reviewable\.runme/ })
+    )
+    const contextMenu = document.querySelector<HTMLElement>('.ctx-menu')
+    expect(contextMenu).not.toBeNull()
+    fireEvent.click(
+      within(contextMenu as HTMLElement).getByRole('button', {
+        name: 'Review suggestions',
+      })
+    )
+
+    expect(contextMocks.showDocument).toHaveBeenCalledWith(suggestionUri, {
+      title: 'Suggestions · reviewable.runme',
+      afterUri: uri,
+    })
+    expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(suggestionUri)
+  })
+
+  it('omits suggestion review from legacy notebook tab context menus', async () => {
+    const uri = 'local://file/legacy'
+    const getMetadata = vi.fn(async () => ({
+      uri,
+      name: 'legacy.json',
+      type: 'file',
+      children: [],
+      parents: [],
+    }))
+    contextMocks.notebookStore = {
+      getMetadata,
+      getSyncState: vi.fn(async () => ({
+        status: 'local-only',
+        localUri: uri,
+        remoteId: uri,
+      })),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      { uri, title: 'legacy.json', state: 'loaded' },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      notebook: create(parser_pb.NotebookSchema, { metadata: {}, cells: [] }),
+    })
+    contextMocks.getNotebookData.mockReturnValue({ appendCell: vi.fn() })
+
+    render(<Actions />)
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /legacy\.json/ }))
+    await waitFor(() => expect(getMetadata).toHaveBeenCalledWith(uri))
+
+    expect(
+      screen.queryByRole('button', { name: 'Review suggestions' })
+    ).toBeNull()
   })
 
   it('renames the notebook from the tab context menu', async () => {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2309,6 +2309,7 @@ function NotebookTabContent({
     const suggestionUri = getOperationLogSuggestionDocumentUri(docUri)
     showDocument(suggestionUri, {
       title: `Suggestions · ${entry.name}`,
+      afterUri: docUri,
     })
     setCurrentDoc(suggestionUri)
   }, [docUri, entry.name, setCurrentDoc, showDocument])
@@ -4084,6 +4085,7 @@ export default function Actions() {
     isIpynb: boolean
     ownerSessionId: string | null
     canOpenUpstreamDiff: boolean
+    canReviewSuggestions: boolean
     readOnly?: boolean
   } | null>(null)
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -4371,7 +4373,8 @@ export default function Actions() {
       (tabContextMenu.googleDriveUri ? 1 : 0) +
       (tabContextMenu.googleDriveUri && tabContextMenu.isIpynb ? 1 : 0) +
       (tabContextMenu.ownerSessionId ? 1 : 0) +
-      (tabContextMenu.canOpenUpstreamDiff ? 1 : 0)
+      (tabContextMenu.canOpenUpstreamDiff ? 1 : 0) +
+      (tabContextMenu.canReviewSuggestions ? 1 : 0)
     const menuWidth = 220
     const menuHeight = itemCount * 36 + 8
     return {
@@ -4396,6 +4399,7 @@ export default function Actions() {
       const title =
         document?.title?.trim() ||
         getNotebookDisplayName(docUri, document?.title ?? docUri)
+      const format = detectNotebookFileFormat(title)
       setTabContextMenu({
         x: event.clientX,
         y: event.clientY,
@@ -4405,10 +4409,12 @@ export default function Actions() {
         googleDriveUri: isGoogleDriveFileUri(docUri)
           ? docUri
           : requestedDriveUri,
-        isIpynb: detectNotebookFileFormat(title) === 'ipynb',
+        isIpynb: format === 'ipynb',
         ownerSessionId: getNotebookOwnerSessionId(document?.owner),
         canOpenUpstreamDiff:
           docUri.startsWith('local://') && Boolean(requestedDriveUri),
+        canReviewSuggestions:
+          Boolean(store) && format === 'runme-operation-log',
         readOnly: document?.readOnly,
       })
 
@@ -4436,6 +4442,9 @@ export default function Actions() {
               canOpenUpstreamDiff:
                 docUri.startsWith('local://') &&
                 isGoogleDriveFileUri(remoteUri),
+              canReviewSuggestions:
+                detectNotebookFileFormat(metadata?.name ?? current.title) ===
+                'runme-operation-log',
             }
           })
         } catch (error) {
@@ -4496,6 +4505,22 @@ export default function Actions() {
       setTabContextMenu(null)
     }
   }, [getNotebookData, showDocument, store, tabContextMenu])
+
+  const handleReviewTabSuggestions = useCallback(() => {
+    if (!tabContextMenu?.canReviewSuggestions) {
+      setTabContextMenu(null)
+      return
+    }
+    const suggestionUri = getOperationLogSuggestionDocumentUri(
+      tabContextMenu.docUri
+    )
+    showDocument(suggestionUri, {
+      title: `Suggestions · ${tabContextMenu.title}`,
+      afterUri: tabContextMenu.docUri,
+    })
+    setCurrentDoc(suggestionUri)
+    setTabContextMenu(null)
+  }, [setCurrentDoc, showDocument, tabContextMenu])
 
   const handleCopyTabShareableLink = useCallback(async () => {
     if (!tabContextMenu) {
@@ -4859,6 +4884,18 @@ export default function Actions() {
               >
                 Rename
               </button>
+              {adjustedTabContextMenu.canReviewSuggestions && (
+                <button
+                  type="button"
+                  className="ctx-menu-item"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    handleReviewTabSuggestions()
+                  }}
+                >
+                  Review suggestions
+                </button>
+              )}
               <button
                 type="button"
                 className="ctx-menu-item"

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -4400,6 +4400,10 @@ export default function Actions() {
         document?.title?.trim() ||
         getNotebookDisplayName(docUri, document?.title ?? docUri)
       const format = detectNotebookFileFormat(title)
+      const suggestionReviewReady =
+        format === 'runme-operation-log' &&
+        document?.state === 'loaded' &&
+        getNotebookData(docUri)?.getSnapshot().loaded === true
       setTabContextMenu({
         x: event.clientX,
         y: event.clientY,
@@ -4413,8 +4417,7 @@ export default function Actions() {
         ownerSessionId: getNotebookOwnerSessionId(document?.owner),
         canOpenUpstreamDiff:
           docUri.startsWith('local://') && Boolean(requestedDriveUri),
-        canReviewSuggestions:
-          Boolean(store) && format === 'runme-operation-log',
+        canReviewSuggestions: Boolean(store) && suggestionReviewReady,
         readOnly: document?.readOnly,
       })
 
@@ -4443,8 +4446,9 @@ export default function Actions() {
                 docUri.startsWith('local://') &&
                 isGoogleDriveFileUri(remoteUri),
               canReviewSuggestions:
+                suggestionReviewReady &&
                 detectNotebookFileFormat(metadata?.name ?? current.title) ===
-                'runme-operation-log',
+                  'runme-operation-log',
             }
           })
         } catch (error) {
@@ -4459,7 +4463,7 @@ export default function Actions() {
         }
       })()
     },
-    [store, workspaceDocuments]
+    [getNotebookData, store, workspaceDocuments]
   )
 
   const handleRenameTab = useCallback(async () => {

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.test.ts
@@ -40,6 +40,45 @@ describe("WorkspaceDocumentController", () => {
     ]);
   });
 
+  it("keeps a suggestion document immediately after its notebook", () => {
+    const controller = new WorkspaceDocumentController(createMemoryPersistence());
+    const notebookUri = "local://file/a";
+    const suggestionUri = getOperationLogSuggestionDocumentUri(notebookUri);
+
+    controller.showDocument(notebookUri, { title: "a.runme" });
+    controller.showDocument("local://file/b", { title: "b.runme" });
+    controller.showDocument(suggestionUri, {
+      title: "Suggestions · a.runme",
+      afterUri: notebookUri,
+    });
+
+    expect(controller.getSnapshot().documents.map((item) => item.uri)).toEqual([
+      notebookUri,
+      suggestionUri,
+      "local://file/b",
+    ]);
+  });
+
+  it("moves an existing suggestion document next to its notebook", () => {
+    const controller = new WorkspaceDocumentController(createMemoryPersistence());
+    const notebookUri = "local://file/a";
+    const suggestionUri = getOperationLogSuggestionDocumentUri(notebookUri);
+
+    controller.showDocument(notebookUri, { title: "a.runme" });
+    controller.showDocument("local://file/b", { title: "b.runme" });
+    controller.showDocument(suggestionUri, { title: "Notebook suggestions" });
+    controller.showDocument(suggestionUri, {
+      title: "Suggestions · a.runme",
+      afterUri: notebookUri,
+    });
+
+    expect(controller.getSnapshot().documents.map((item) => item.uri)).toEqual([
+      notebookUri,
+      suggestionUri,
+      "local://file/b",
+    ]);
+  });
+
   it("closes a document and returns the neighboring fallback", () => {
     const controller = new WorkspaceDocumentController(createMemoryPersistence());
     controller.showDocument("local://file/a", { title: "a.json" });

--- a/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
+++ b/app/src/lib/workspaceDocuments/workspaceDocumentController.ts
@@ -18,7 +18,9 @@ export interface WorkspaceDocumentPersistence {
 export type ShowWorkspaceDocumentOptions = Omit<
   Partial<WorkspaceDocument>,
   'uri'
->
+> & {
+  afterUri?: string
+}
 
 export const WORKSPACE_DOCUMENT_FOCUS_EVENT = 'runme:workspace-document-focus'
 
@@ -167,6 +169,11 @@ export class WorkspaceDocumentController {
     const existingIndex = this.documents.findIndex(
       (item) => item.uri === normalizedUri
     )
+    const afterUri = options?.afterUri?.trim()
+    const isPositionedAfter =
+      Boolean(afterUri) &&
+      existingIndex > 0 &&
+      this.documents[existingIndex - 1]?.uri === afterUri
     if (existingIndex >= 0) {
       const existing = this.documents[existingIndex]
       if (
@@ -182,7 +189,8 @@ export class WorkspaceDocumentController {
           nextDocument.writeAccessErrorMessage &&
         existing?.refreshErrorMessage === nextDocument.refreshErrorMessage &&
         existing?.errorMessage === nextDocument.errorMessage &&
-        existing?.owner === nextDocument.owner
+        existing?.owner === nextDocument.owner &&
+        (!afterUri || isPositionedAfter)
       ) {
         return
       }
@@ -191,6 +199,18 @@ export class WorkspaceDocumentController {
       )
     } else {
       this.documents = [...this.documents, nextDocument]
+    }
+    if (afterUri && afterUri !== normalizedUri) {
+      const documentsWithoutTarget = this.documents.filter(
+        (item) => item.uri !== normalizedUri
+      )
+      const afterIndex = documentsWithoutTarget.findIndex(
+        (item) => item.uri === afterUri
+      )
+      if (afterIndex >= 0) {
+        documentsWithoutTarget.splice(afterIndex + 1, 0, nextDocument)
+        this.documents = documentsWithoutTarget
+      }
     }
     this.emit()
     this.persist()


### PR DESCRIPTION
## Summary
- add Review suggestions to the right-click menu for `.runme` notebook tabs
- keep each suggestion review tab immediately to the right of its edit tab
- reposition an already-open review tab instead of duplicating it
- cover the context-menu visibility and tab-ordering behavior with tests

## Verification
- `pnpm -C app exec vitest run` (112 files, 1,191 tests)
- `pnpm -C app run build`
- `runme run build test`
- `git diff --check`