### PR TITLE
Add optional automatic Colab copies for .runme notebooks

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1175,6 +1175,18 @@ describe('Actions tabs', () => {
     ).toBe(`?doc=${encodeURIComponent(source)}`)
     expect(screen.queryByTestId('notebook-readonly-banner')).toBeNull()
     expect(screen.queryByLabelText('Add first cell')).toBeNull()
+    const derivedTab = screen.getByTitle('derived.ipynb')
+    expect(
+      within(derivedTab).getAllByLabelText('Read-only notebook').length
+    ).toBeGreaterThan(0)
+    fireEvent.contextMenu(derivedTab)
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Rename',
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true)
   })
 
   it('requests write access from a read-only notebook banner', () => {

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -1146,6 +1146,37 @@ describe('Actions tabs', () => {
     expect(screen.queryByLabelText('Add first cell')).toBeNull()
   })
 
+  it('explains derived notebooks without offering write access', () => {
+    const uri = 'local://file/derived.ipynb'
+    const source = 'https://drive.google.com/file/d/source/view'
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      { uri, title: 'derived.ipynb', state: 'loaded', readOnly: true },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      readOnly: true,
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {
+          'runme.dev/derivedFrom': JSON.stringify({
+            version: 1,
+            uri: source,
+            notebookId: 'source',
+            generatedAt: '2026-09-05',
+          }),
+        },
+      }),
+    })
+    render(<Actions />)
+    expect(screen.getByRole('note').textContent).toContain('Generated notebook')
+    expect(
+      screen.getByRole('link', { name: 'source notebook' }).getAttribute('href')
+    ).toBe(`?doc=${encodeURIComponent(source)}`)
+    expect(screen.queryByTestId('notebook-readonly-banner')).toBeNull()
+    expect(screen.queryByLabelText('Add first cell')).toBeNull()
+  })
+
   it('requests write access from a read-only notebook banner', () => {
     const uri = 'local://file/reference.runme.md'
     contextMocks.currentDoc = uri

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -475,10 +475,19 @@ function isDriveBackedNotebook(
   )
 }
 
-function ReadOnlyTabIndicator() {
+function ReadOnlyTabIndicator({ uri }: { uri: string }) {
+  const { useNotebookSnapshot } = useNotebookContext()
+  const snapshot = useNotebookSnapshot(uri)
+  const derived = Boolean(
+    parseDerivedSource(snapshot?.notebook.metadata[DERIVED_NOTEBOOK_KEY])
+  )
   return (
     <Tooltip
-      content="Read-only. This notebook is open for editing in another browser tab."
+      content={
+        derived
+          ? 'Read-only generated copy. Edit the source .runme notebook.'
+          : 'Read-only. This notebook is open for editing in another browser tab.'
+      }
       side="bottom"
     >
       <span
@@ -4876,7 +4885,7 @@ export default function Actions() {
                       <span className="max-w-[140px] truncate">
                         {displayName}
                       </span>
-                      {doc.readOnly && <ReadOnlyTabIndicator />}
+                      {doc.readOnly && <ReadOnlyTabIndicator uri={doc.uri} />}
                     </Tabs.Trigger>
                     {isNotebook &&
                       detectNotebookFileFormat(doc.title) ===

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -14,6 +14,12 @@ import {
 import { create } from '@bufbuild/protobuf'
 import { Button, ScrollArea, Tabs, Text, Tooltip } from '@radix-ui/themes'
 
+import { NotebookPropertiesDialog } from '../NotebookPropertiesDialog'
+import {
+  DERIVED_NOTEBOOK_KEY,
+  parseDerivedSource,
+} from '../../lib/derivedNotebook'
+
 import {
   ArrowPathIcon,
   ChatBubbleLeftIcon,
@@ -2244,6 +2250,9 @@ function NotebookTabContent({
     entry.releasePending || notebookSnapshot?.releasePending
   )
   const reviewPending = Boolean(notebookSnapshot?.reviewPending)
+  const derivedSource = parseDerivedSource(
+    notebookSnapshot?.notebook.metadata[DERIVED_NOTEBOOK_KEY]
+  )
   const readOnly = Boolean(
     entry.readOnly ||
       notebookSnapshot?.readOnly ||
@@ -3538,6 +3547,27 @@ function NotebookTabContent({
         {/* Full-width notebook column with horizontal padding for breathing room.
             Cells expand to fill the available width of the tab content area. */}
         <div id="notebook-column" className="w-full py-2 px-8">
+          {derivedSource && (
+            <div
+              id="derived-notebook-notice"
+              role="note"
+              className="mb-3 rounded-nb-sm border border-nb-border bg-nb-surface-2 p-3 text-sm"
+            >
+              <strong>Generated notebook · Read-only</strong>
+              <p>
+                This file is derived from a .runme notebook and will be
+                overwritten on the next source save while automatic export is
+                enabled. Make changes in the{' '}
+                <a
+                  className="text-nb-accent underline"
+                  href={`?doc=${encodeURIComponent(derivedSource.uri)}`}
+                >
+                  source notebook
+                </a>
+                .
+              </p>
+            </div>
+          )}
           {entry.operationLog &&
           !readOnly &&
           !releasePending &&
@@ -3549,7 +3579,7 @@ function NotebookTabContent({
             >
               {entry.refreshErrorMessage}
             </div>
-          ) : reviewPending ? (
+          ) : derivedSource ? null : reviewPending ? (
             <div
               className="mb-3 flex items-center gap-2 rounded-nb-sm border border-nb-border bg-nb-surface-2 px-3 py-2 text-xs text-nb-text-muted"
               data-testid="notebook-suggestion-review-pending-banner"
@@ -4089,6 +4119,7 @@ export default function Actions() {
     readOnly?: boolean
   } | null>(null)
   const tabTriggerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+  const [propertiesUri, setPropertiesUri] = useState<string | null>(null)
   const pendingSelectedTabUriRef = useRef<string | null>(null)
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -4369,7 +4400,7 @@ export default function Actions() {
       return tabContextMenu
     }
     const itemCount =
-      4 +
+      5 +
       (tabContextMenu.googleDriveUri ? 1 : 0) +
       (tabContextMenu.googleDriveUri && tabContextMenu.isIpynb ? 1 : 0) +
       (tabContextMenu.ownerSessionId ? 1 : 0) +
@@ -4712,6 +4743,12 @@ export default function Actions() {
 
   return (
     <div id="documents" className="flex flex-col h-full">
+      {propertiesUri && (
+        <NotebookPropertiesDialog
+          uri={propertiesUri}
+          onClose={() => setPropertiesUri(null)}
+        />
+      )}
       {workspaceDocuments.length === 0 ? (
         <ScrollArea
           type="auto"
@@ -4877,6 +4914,16 @@ export default function Actions() {
               onClick={(event) => event.stopPropagation()}
               onContextMenu={(event) => event.preventDefault()}
             >
+              <button
+                type="button"
+                className="ctx-menu-item"
+                onClick={() => {
+                  setPropertiesUri(adjustedTabContextMenu.docUri)
+                  setTabContextMenu(null)
+                }}
+              >
+                Notebook properties
+              </button>
               <button
                 type="button"
                 className="ctx-menu-item"

--- a/app/src/components/NotebookPropertiesDialog.test.tsx
+++ b/app/src/components/NotebookPropertiesDialog.test.tsx
@@ -1,0 +1,85 @@
+import { create } from '@bufbuild/protobuf'
+import { Theme } from '@radix-ui/themes'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parser_pb } from '../runme/client'
+import { AUTO_IPYNB_KEY } from '../lib/derivedNotebook'
+import { NotebookPropertiesDialog } from './NotebookPropertiesDialog'
+
+const mocks = vi.hoisted(() => ({
+  snapshot: {} as any,
+  setMetadataProperty: vi.fn(),
+  flushPendingPersist: vi.fn(async () => {}),
+  getIpynbExportState: vi.fn(async () => ({})),
+}))
+vi.mock('../contexts/NotebookContext', () => ({
+  useNotebookContext: () => ({
+    useNotebookSnapshot: () => mocks.snapshot,
+    getNotebookData: () => mocks,
+  }),
+}))
+vi.mock('../contexts/NotebookStoreContext', () => ({
+  useNotebookStore: () => ({
+    store: {
+      getIpynbExportState: mocks.getIpynbExportState,
+      subscribeSync: () => () => {},
+    },
+  }),
+}))
+
+describe('Notebook properties', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.snapshot = {
+      loaded: true,
+      readOnly: false,
+      name: 'test.runme',
+      notebook: create(parser_pb.NotebookSchema),
+    }
+  })
+  it('sets and unsets automatic export through a persisted model mutation', async () => {
+    const view = render(
+      <Theme>
+        <NotebookPropertiesDialog uri="local://file/test" onClose={() => {}} />
+      </Theme>
+    )
+    fireEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() =>
+      expect(mocks.flushPendingPersist).toHaveBeenCalledTimes(1)
+    )
+    expect(mocks.setMetadataProperty).toHaveBeenLastCalledWith(
+      AUTO_IPYNB_KEY,
+      'true'
+    )
+    mocks.snapshot.notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+    view.rerender(
+      <Theme>
+        <NotebookPropertiesDialog uri="local://file/test" onClose={() => {}} />
+      </Theme>
+    )
+    await waitFor(() =>
+      expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
+        false
+      )
+    )
+    fireEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() =>
+      expect(mocks.setMetadataProperty).toHaveBeenLastCalledWith(
+        AUTO_IPYNB_KEY,
+        'false'
+      )
+    )
+  })
+  it('prevents changing a read-only notebook', async () => {
+    mocks.snapshot.readOnly = true
+    render(
+      <Theme>
+        <NotebookPropertiesDialog uri="local://file/test" onClose={() => {}} />
+      </Theme>
+    )
+    await waitFor(() => expect(mocks.getIpynbExportState).toHaveBeenCalled())
+    expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
+      true
+    )
+  })
+})

--- a/app/src/components/NotebookPropertiesDialog.test.tsx
+++ b/app/src/components/NotebookPropertiesDialog.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   setMetadataProperty: vi.fn(),
   flushPendingPersist: vi.fn(async () => {}),
   getIpynbExportState: vi.fn(async () => ({})),
+  retryUnconfirmedIpynbCreation: vi.fn(async () => {}),
 }))
 vi.mock('../contexts/NotebookContext', () => ({
   useNotebookContext: () => ({
@@ -22,6 +23,7 @@ vi.mock('../contexts/NotebookStoreContext', () => ({
   useNotebookStore: () => ({
     store: {
       getIpynbExportState: mocks.getIpynbExportState,
+      retryUnconfirmedIpynbCreation: mocks.retryUnconfirmedIpynbCreation,
       subscribeSync: () => () => {},
     },
   }),
@@ -81,5 +83,28 @@ describe('Notebook properties', () => {
     expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
       true
     )
+  })
+  it('requires confirmation before retrying an unconfirmed creation', async () => {
+    mocks.snapshot.notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+    mocks.getIpynbExportState.mockResolvedValue({ needsCreateRecovery: true })
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    render(
+      <Theme>
+        <NotebookPropertiesDialog uri="local://file/test" onClose={() => {}} />
+      </Theme>
+    )
+    const retry = await screen.findByRole('button', {
+      name: 'Retry unconfirmed creation',
+    })
+    fireEvent.click(retry)
+    expect(mocks.retryUnconfirmedIpynbCreation).not.toHaveBeenCalled()
+    confirm.mockReturnValue(true)
+    fireEvent.click(retry)
+    await waitFor(() =>
+      expect(mocks.retryUnconfirmedIpynbCreation).toHaveBeenCalledWith(
+        'local://file/test'
+      )
+    )
+    confirm.mockRestore()
   })
 })

--- a/app/src/components/NotebookPropertiesDialog.tsx
+++ b/app/src/components/NotebookPropertiesDialog.tsx
@@ -20,6 +20,7 @@ export function NotebookPropertiesDialog({
     uri?: string
     error?: string
     exportedAt?: string
+    needsCreateRecovery?: boolean
   }>({})
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
@@ -113,6 +114,27 @@ export function NotebookPropertiesDialog({
                   updated: {status.error}. Export retries on the next save or
                   Drive sync.
                 </p>
+              )}
+              {enabled && status.needsCreateRecovery && !snapshot?.readOnly && (
+                <Button
+                  disabled={saving}
+                  onClick={() => {
+                    if (
+                      !window.confirm(
+                        'Check Google Drive for an existing copy first. Retrying an unconfirmed creation can leave an extra copy if the earlier request is still in flight. Retry anyway?'
+                      )
+                    )
+                      return
+                    setSaving(true)
+                    setError('')
+                    void store
+                      ?.retryUnconfirmedIpynbCreation(uri)
+                      .catch((err) => setError(String(err)))
+                      .finally(() => setSaving(false))
+                  }}
+                >
+                  Retry unconfirmed creation
+                </Button>
               )}
               {enabled && !status.uri && (
                 <p className="text-nb-text-muted">

--- a/app/src/components/NotebookPropertiesDialog.tsx
+++ b/app/src/components/NotebookPropertiesDialog.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { Button, Dialog } from '@radix-ui/themes'
+import { useNotebookContext } from '../contexts/NotebookContext'
+import { useNotebookStore } from '../contexts/NotebookStoreContext'
+import { AUTO_IPYNB_KEY } from '../lib/derivedNotebook'
+import { detectNotebookFileFormat } from '../lib/notebookFormat'
+
+/** Properties edit the shared model; export status is separate from source saves. */
+export function NotebookPropertiesDialog({
+  uri,
+  onClose,
+}: {
+  uri: string
+  onClose: () => void
+}) {
+  const { useNotebookSnapshot, getNotebookData } = useNotebookContext()
+  const snapshot = useNotebookSnapshot(uri)
+  const { store } = useNotebookStore()
+  const [status, setStatus] = useState<{
+    uri?: string
+    error?: string
+    exportedAt?: string
+  }>({})
+  const [error, setError] = useState('')
+  const [saving, setSaving] = useState(false)
+  useEffect(() => {
+    let active = true
+    const refresh = () => {
+      void store
+        ?.getIpynbExportState(uri)
+        .then((next) => {
+          if (active) setStatus(next)
+        })
+        .catch((err) => {
+          if (active) setError(String(err))
+        })
+    }
+    refresh()
+    const unsubscribe = store?.subscribeSync(uri, refresh)
+    return () => {
+      active = false
+      unsubscribe?.()
+    }
+  }, [store, uri])
+  const enabled = snapshot?.notebook.metadata[AUTO_IPYNB_KEY] === 'true'
+  const canConfigure =
+    detectNotebookFileFormat(snapshot?.name ?? '') === 'runme-operation-log'
+  const update = async (value: boolean) => {
+    setSaving(true)
+    setError('')
+    try {
+      const model = getNotebookData(uri)
+      if (!model || !snapshot?.loaded)
+        throw new Error('Wait for the notebook to load.')
+      model.setMetadataProperty(AUTO_IPYNB_KEY, String(value))
+      await model.flushPendingPersist()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <Dialog.Content maxWidth="520px">
+        <Dialog.Title>Notebook properties</Dialog.Title>
+        <Dialog.Description size="2">
+          {snapshot?.name ?? 'Notebook'}
+        </Dialog.Description>
+        <div id="notebook-export-properties" className="my-4 space-y-3 text-sm">
+          {canConfigure ? (
+            <>
+              <label className="flex items-start gap-2">
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  disabled={!snapshot?.loaded || snapshot.readOnly || saving}
+                  onChange={(event) => void update(event.target.checked)}
+                />
+                Automatically save a Colab copy (.ipynb)
+              </label>
+              <p className="text-nb-text-muted">
+                Creates a generated copy next to this notebook in Google Drive.
+                Changes and outputs are exported in the background after saving.
+                For local notebooks, export starts once linked to Drive.
+              </p>
+              <p className="text-nb-text-muted">
+                Turning this off keeps the last copy and stops updating it.
+              </p>
+              {status.uri && (
+                <a
+                  href={status.uri
+                    .replace(
+                      'https://drive.google.com/file/d/',
+                      'https://colab.research.google.com/drive/'
+                    )
+                    .replace(/\/view$/, '')}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-nb-accent underline"
+                >
+                  Open Colab copy
+                </a>
+              )}
+              {enabled && status.error && (
+                <p role="alert">
+                  Your notebook is saved, but the Colab copy could not be
+                  updated: {status.error}. Export retries on the next save or
+                  Drive sync.
+                </p>
+              )}
+              {enabled && !status.uri && (
+                <p className="text-nb-text-muted">
+                  Waiting for the next background export and a Google Drive
+                  connection.
+                </p>
+              )}
+            </>
+          ) : (
+            <p>Automatic Colab copies are available for .runme notebooks.</p>
+          )}
+          {error && <p role="alert">Could not save properties: {error}</p>}
+        </div>
+        <Button onClick={onClose}>Done</Button>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/app/src/lib/derivedIpynb.test.ts
+++ b/app/src/lib/derivedIpynb.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import { parser_pb } from '../runme/client'
+import { encodeDerivedIpynb } from './derivedIpynb'
+import {
+  AUTO_IPYNB_KEY,
+  DERIVED_NOTEBOOK_KEY,
+  parseDerivedSource,
+} from './derivedNotebook'
+import { decodeIpynb } from './ipynb'
+
+describe('derived Colab copy', () => {
+  it('preserves notebook cells and outputs, adds portable provenance and a notice', () => {
+    const notebook = create(parser_pb.NotebookSchema, {
+      metadata: { [AUTO_IPYNB_KEY]: 'true' },
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'python-cell',
+          kind: parser_pb.CellKind.CODE,
+          languageId: 'python',
+          value: 'print(42)',
+          outputs: [
+            create(parser_pb.CellOutputSchema, {
+              items: [
+                create(parser_pb.CellOutputItemSchema, {
+                  mime: 'text/plain',
+                  data: new TextEncoder().encode('42'),
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+    const source = {
+      version: 1 as const,
+      uri: 'https://drive.google.com/file/d/source/view',
+      notebookId: 'source-id',
+      generatedAt: '2026-09-05T00:00:00Z',
+    }
+    const text = encodeDerivedIpynb(notebook, source)
+    const exported = JSON.parse(text)
+    expect(exported.metadata.runme.derivedFrom).toEqual(source)
+    expect(exported.cells[0].source).toContain('will be overwritten')
+    expect(exported.cells[1].source).toBe('print(42)')
+    expect(exported.cells[1].outputs).toHaveLength(1)
+    const decoded = decodeIpynb(text).notebook
+    expect(parseDerivedSource(decoded.metadata[DERIVED_NOTEBOOK_KEY])).toEqual(
+      source
+    )
+    expect(decoded.metadata[AUTO_IPYNB_KEY]).toBeUndefined()
+    expect(notebook.metadata[AUTO_IPYNB_KEY]).toBe('true')
+    expect(notebook.cells).toHaveLength(1)
+  })
+  it('rejects unsafe source links', () => {
+    expect(
+      parseDerivedSource({
+        version: 1,
+        uri: 'javascript:alert(1)',
+        notebookId: 'a',
+        generatedAt: '',
+      })
+    ).toBeNull()
+  })
+})

--- a/app/src/lib/derivedIpynb.ts
+++ b/app/src/lib/derivedIpynb.ts
@@ -1,0 +1,33 @@
+import { clone } from '@bufbuild/protobuf'
+
+import { parser_pb } from '../runme/client'
+import {
+  AUTO_IPYNB_KEY,
+  DERIVED_NOTEBOOK_KEY,
+  type DerivedNotebookSource,
+} from './derivedNotebook'
+import { type IpynbNotebook, encodeIpynb } from './ipynb'
+
+/** Export a full materialized snapshot with a notice visible in Colab too. */
+export function encodeDerivedIpynb(
+  notebook: parser_pb.Notebook,
+  source: DerivedNotebookSource
+): string {
+  const copy = clone(parser_pb.NotebookSchema, notebook)
+  delete copy.metadata[AUTO_IPYNB_KEY]
+  copy.metadata[DERIVED_NOTEBOOK_KEY] = JSON.stringify(source)
+  const result = JSON.parse(encodeIpynb(copy).text) as IpynbNotebook
+  result.metadata.runme = {
+    ...(result.metadata.runme as object),
+    derivedFrom: source,
+  }
+  let noticeId = 'runme-derived-notice'
+  while (result.cells.some((cell) => cell.id === noticeId)) noticeId += '-copy'
+  result.cells.unshift({
+    cell_type: 'markdown',
+    id: noticeId,
+    metadata: {},
+    source: `> **Generated notebook — treat as read-only.** This is a derived copy of a [.runme notebook](${source.uri}). It will be overwritten on the next source save while automatic export is enabled. Make durable changes in the source notebook.`,
+  })
+  return `${JSON.stringify(result, null, 2)}\n`
+}

--- a/app/src/lib/derivedNotebook.ts
+++ b/app/src/lib/derivedNotebook.ts
@@ -7,6 +7,8 @@ export interface DerivedNotebookSource {
   uri: string
   notebookId: string
   generatedAt: string
+  /** Causal coverage prevents an older mirror from replacing a newer export. */
+  operationIds?: string[]
 }
 
 /** Accept only supported provenance with a safe, navigable source URI. */

--- a/app/src/lib/derivedNotebook.ts
+++ b/app/src/lib/derivedNotebook.ts
@@ -1,0 +1,39 @@
+/** Portable notebook metadata shared by the exporter, model and views. */
+export const AUTO_IPYNB_KEY = 'runme.dev/autoIpynb'
+export const DERIVED_NOTEBOOK_KEY = 'runme.dev/derivedFrom'
+
+export interface DerivedNotebookSource {
+  version: 1
+  uri: string
+  notebookId: string
+  generatedAt: string
+}
+
+/** Accept only supported provenance with a safe, navigable source URI. */
+export function parseDerivedSource(
+  value: unknown
+): DerivedNotebookSource | null {
+  try {
+    const source = typeof value === 'string' ? JSON.parse(value) : value
+    if (
+      !source ||
+      source.version !== 1 ||
+      typeof source.uri !== 'string' ||
+      typeof source.notebookId !== 'string' ||
+      typeof source.generatedAt !== 'string'
+    )
+      return null
+    const url = new URL(source.uri)
+    if (
+      !(
+        url.protocol === 'https:' &&
+        url.hostname === 'drive.google.com' &&
+        url.pathname.startsWith('/file/d/')
+      )
+    )
+      return null
+    return source as DerivedNotebookSource
+  } catch {
+    return null
+  }
+}

--- a/app/src/lib/derivedNotebookModel.test.ts
+++ b/app/src/lib/derivedNotebookModel.test.ts
@@ -1,0 +1,36 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it, vi } from 'vitest'
+
+import { parser_pb } from '../runme/client'
+import { DERIVED_NOTEBOOK_KEY } from './derivedNotebook'
+import { NotebookData } from './notebookData'
+
+describe('derived notebook model', () => {
+  it('cannot be edited or saved even after requesting writable state', async () => {
+    const save = vi.fn(async () => {})
+    const model = new NotebookData({
+      uri: 'local://file/copy',
+      name: 'copy.ipynb',
+      loaded: true,
+      notebookStore: { save },
+      notebook: create(parser_pb.NotebookSchema, {
+        metadata: {
+          [DERIVED_NOTEBOOK_KEY]: JSON.stringify({
+            version: 1,
+            uri: 'https://drive.google.com/file/d/source/view',
+            notebookId: 'source',
+            generatedAt: '2026-09-05T00:00:00Z',
+          }),
+        },
+      }),
+    })
+    model.setReadOnly(false)
+    expect(model.isReadOnly()).toBe(true)
+    expect(model.getSnapshot().readOnly).toBe(true)
+    expect(() => model.setMetadataProperty('description', 'edit')).toThrow(
+      'read-only'
+    )
+    await model.flushPendingPersist()
+    expect(save).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/lib/ipynb.ts
+++ b/app/src/lib/ipynb.ts
@@ -7,6 +7,7 @@ import {
   assertCanonicalNotebookCellIds,
   uniqueCanonicalCellId,
 } from './cellIdentity'
+import { DERIVED_NOTEBOOK_KEY, parseDerivedSource } from './derivedNotebook'
 
 export const IPYNB_MIME_TYPE = 'application/x-ipynb+json'
 export const IPYNB_RAW_CELL_METADATA_KEY = 'runme.dev/ipynbRawCell'
@@ -430,10 +431,7 @@ function validateNotebook(value: unknown): IpynbNotebook {
   if (!Array.isArray(document.cells)) {
     throw new Error('Jupyter notebook cells must be an array')
   }
-  document.metadata = asObject(
-    document.metadata,
-    'Jupyter notebook metadata'
-  )
+  document.metadata = asObject(document.metadata, 'Jupyter notebook metadata')
   return document as unknown as IpynbNotebook
 }
 
@@ -456,6 +454,9 @@ export function decodeIpynb(text: string): DecodedIpynb {
   const source = validateNotebook(parsed)
   const languageId = languageIdForNotebook(source.metadata)
   const preservedNotebook = embeddedRunmeNotebook(source.metadata)
+  const derivedFrom = parseDerivedSource(
+    optionalObject(source.metadata.runme)?.derivedFrom
+  )
   const usedIds = new Set<string>()
   const jupyterIdByRunmeRefId: Record<string, string> = {}
   const baselineCellHashes: Record<string, string> = {}
@@ -536,6 +537,9 @@ export function decodeIpynb(text: string): DecodedIpynb {
       metadata: {
         ...(preservedNotebook?.metadata ?? {}),
         'runme.dev/ipynb': 'true',
+        ...(derivedFrom
+          ? { [DERIVED_NOTEBOOK_KEY]: JSON.stringify(derivedFrom) }
+          : {}),
       },
       frontmatter: preservedNotebook?.frontmatter,
     }),

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -15,6 +15,7 @@ import {
   parser_pb,
 } from '../contexts/CellContext'
 import { isHtmlLanguageId } from './cellContent'
+import { DERIVED_NOTEBOOK_KEY, parseDerivedSource } from './derivedNotebook'
 import { googleAnalytics } from './googleAnalytics'
 import {
   IOPUB_INCOMPLETE_METADATA_KEY,
@@ -793,6 +794,15 @@ export class NotebookData {
     this.schedulePersist()
   }
 
+  /** Apply portable document properties through the normal journal save path. */
+  setMetadataProperty(key: string, value: string): void {
+    this.assertWritable()
+    this.notebook.metadata[key] = value
+    this.snapshotCache = this.buildSnapshot()
+    this.emit()
+    this.schedulePersist()
+  }
+
   setName(name: string): void {
     this.assertWritable()
     this.name = name
@@ -823,7 +833,10 @@ export class NotebookData {
   }
 
   isReadOnly(): boolean {
-    return this.readOnly
+    return (
+      this.readOnly ||
+      Boolean(parseDerivedSource(this.notebook.metadata[DERIVED_NOTEBOOK_KEY]))
+    )
   }
 
   setReleasePending(releasePending: boolean): void {
@@ -1209,7 +1222,7 @@ export class NotebookData {
         `Notebook ${this.uri} is releasing its write lock for another session.`
       )
     }
-    if (this.readOnly) {
+    if (this.isReadOnly()) {
       throw new Error(
         `Notebook ${this.uri} is open read-only in this browser tab.`
       )
@@ -2034,7 +2047,7 @@ export class NotebookData {
       uri: this.uri,
       name: this.name,
       loaded: this.loaded,
-      readOnly: this.readOnly,
+      readOnly: this.isReadOnly(),
       releasePending: this.releasePending,
       reviewPending: this.reviewPending,
       reviewReloadRequired: this.reviewReloadRequired,
@@ -2055,7 +2068,7 @@ export class NotebookData {
   private async persist({
     throwOnError = false,
   }: { throwOnError?: boolean } = {}): Promise<void> {
-    if (this.readOnly || !this.notebookStore) {
+    if (this.isReadOnly() || !this.notebookStore) {
       return
     }
     const store = this.notebookStore
@@ -2078,7 +2091,7 @@ export class NotebookData {
   }
 
   private schedulePersist(): void {
-    if (this.readOnly || !this.notebookStore) {
+    if (this.isReadOnly() || !this.notebookStore) {
       return
     }
     if (this.persistTimer) {

--- a/app/src/lib/notebookDataController.test.ts
+++ b/app/src/lib/notebookDataController.test.ts
@@ -198,6 +198,34 @@ describe('NotebookDataController', () => {
     )
   })
 
+  it('propagates a derived notebook model restriction to the first tab entry', async () => {
+    const localStore = createFakeLocalNotebooks()
+    const uri = 'local://file/derived'
+    const notebook = createNotebook('Generated content')
+    notebook.metadata['runme.dev/derivedFrom'] = JSON.stringify({
+      version: 1,
+      uri: 'https://drive.google.com/file/d/source/view',
+      notebookId: 'source',
+      generatedAt: '2026-09-05',
+    })
+    localStore.records.set(uri, {
+      id: uri,
+      name: 'derived.ipynb',
+      remoteId: uri,
+      notebook,
+    })
+    const controller = getNotebookDataController()
+    controller.configureOwnershipManager(createFakeOwnershipManager())
+    controller.configureStores({
+      localNotebooks: localStore as unknown as LocalNotebooks,
+    })
+    const result = await controller.openNotebook(uri)
+    expect(result.entry.readOnly).toBe(true)
+    expect(controller.getOpenNotebooks()[0].readOnly).toBe(true)
+    controller.getNotebookData(uri)?.setReadOnly(false)
+    expect(controller.getOpenNotebooks()[0].readOnly).toBe(true)
+  })
+
   it('opens .runme notebooks writable without acquiring a lifetime lease', async () => {
     const localStore = createFakeLocalNotebooks()
     localStore.records.set('local://file/shared', {
@@ -272,10 +300,7 @@ describe('NotebookDataController', () => {
     })
     await controller.openNotebook(uri)
     const notebookData = controller.getNotebookData(uri)!
-    const flushPendingPersist = vi.spyOn(
-      notebookData,
-      'flushPendingPersist'
-    )
+    const flushPendingPersist = vi.spyOn(notebookData, 'flushPendingPersist')
 
     await controller.refreshReadOnlyNotebook(uri)
 

--- a/app/src/lib/notebookDataController.ts
+++ b/app/src/lib/notebookDataController.ts
@@ -749,6 +749,12 @@ export class NotebookDataController {
     })
     const unsubscribe = data.subscribe(() => {
       this.updateOpenEntryName(data.getUri(), data.getName())
+      // Model-level restrictions (including generated assets) also govern tabs.
+      this.openNotebooks = this.openNotebooks.map((entry) =>
+        entry.uri === data.getUri() && entry.readOnly !== data.isReadOnly()
+          ? { ...entry, readOnly: data.isReadOnly() }
+          : entry
+      )
       this.emit()
     })
     const handle = { data, unsubscribe, loaded }
@@ -824,6 +830,10 @@ export class NotebookDataController {
   }
 
   private upsertOpenEntry(entry: OpenNotebookEntry): OpenNotebookEntry {
+    const model = this.notebooks.get(entry.uri)?.data
+    if (entry.state === 'loaded' && model?.getSnapshot().loaded) {
+      entry = { ...entry, readOnly: model.isReadOnly() }
+    }
     let changed = false
     const next = this.openNotebooks.map((item) => {
       if (item.uri !== entry.uri) {

--- a/app/src/storage/derivedCopy.test.ts
+++ b/app/src/storage/derivedCopy.test.ts
@@ -29,7 +29,12 @@ function remote(reserved: boolean) {
         return true
       }
     ),
-    waitForCreateOperation: vi.fn(async () => null), // Deliberately stale index.
+    waitForCreateOperation: vi.fn(
+      async (
+        _parent: string | null,
+        _operation: string
+      ): Promise<NotebookStoreItem | null> => null
+    ), // Deliberately stale index.
     getDerivedCopyTarget: vi.fn(async (uri: string) => files.get(uri) ?? null),
     canUsePreGeneratedFileId: vi.fn(async () => reserved),
     generateFileId: vi.fn(async () => `reserved-${++state.sequence}`),
@@ -62,6 +67,71 @@ function remote(reserved: boolean) {
 }
 
 describe('source-coordinated derived copies', () => {
+  it.each(['f', 'r', 'p'])(
+    're-elects an inherited %s claim for a copied source',
+    async (kind) => {
+      const server = remote(true)
+      const client = server.client()
+      const original = await ensureDerivedCopy(
+        client as unknown as DriveNotebookStore,
+        source,
+        parent,
+        'original.ipynb',
+        async () => '{}'
+      )
+      server.state.claim = kind + server.state.claim!.slice(1)
+      client.getDerivedCopyTarget.mockClear()
+      const copied = await ensureDerivedCopy(
+        client as unknown as DriveNotebookStore,
+        driveFileUrl('copied-source'),
+        parent,
+        'copy.ipynb',
+        async () => '{}'
+      )
+      expect(copied?.uri).not.toBe(original?.uri)
+      expect(server.files.get(original!.uri)?.name).toBe('original.ipynb')
+      expect(client.getDerivedCopyTarget).not.toHaveBeenCalledWith(
+        original!.uri,
+        expect.anything()
+      )
+      expect(server.state.creates).toBe(2)
+    }
+  )
+
+  it('recovers an unconfirmed copy in its old folder after the source moves', async () => {
+    const server = remote(false)
+    const client = server.client()
+    const create = client.createContent.getMockImplementation()!
+    client.createContent.mockImplementationOnce(async (...args) => {
+      await create(...args)
+      throw new Error('response lost')
+    })
+    await expect(
+      ensureDerivedCopy(
+        client as unknown as DriveNotebookStore,
+        source,
+        parent,
+        'source.ipynb',
+        async () => '{}'
+      )
+    ).rejects.toBeInstanceOf(UnconfirmedDerivedCopyError)
+    const original = [...server.files.values()][0]
+    client.waitForCreateOperation.mockResolvedValue(original)
+    const recovered = await ensureDerivedCopy(
+      client as unknown as DriveNotebookStore,
+      source,
+      'https://drive.google.com/drive/folders/new-parent',
+      'source.ipynb',
+      async () => '{}'
+    )
+    expect(recovered?.uri).toBe(original.uri)
+    expect(client.waitForCreateOperation).toHaveBeenLastCalledWith(
+      null,
+      expect.stringMatching(/^runme-ipynb-/)
+    )
+    expect(server.state.creates).toBe(1)
+  })
+
   it.each([true, false])(
     'elects one identity across concurrent profiles (reserved=%s)',
     async (reserved) => {

--- a/app/src/storage/derivedCopy.test.ts
+++ b/app/src/storage/derivedCopy.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+
+import { UnconfirmedDerivedCopyError, ensureDerivedCopy } from './derivedCopy'
+import { type DriveNotebookStore, driveFileUrl } from './drive'
+import { type NotebookStoreItem, NotebookStoreItemType } from './notebook'
+
+const source = driveFileUrl('source')
+const parent = 'https://drive.google.com/drive/folders/parent'
+
+/** Separate clients share only remote CAS state, never a local lock or cache. */
+function remote(reserved: boolean) {
+  const state = {
+    claim: undefined as string | undefined,
+    sequence: 0,
+    creates: 0,
+  }
+  const files = new Map<string, NotebookStoreItem>()
+  const client = () => ({
+    getDerivedCopyClaim: vi.fn(async () => state.claim),
+    compareAndSetDerivedCopyClaim: vi.fn(
+      async (
+        _uri: string,
+        expected: string | undefined,
+        next: string | null
+      ) => {
+        if (state.claim !== expected) return false
+        state.claim = next ?? undefined
+        return true
+      }
+    ),
+    waitForCreateOperation: vi.fn(async () => null), // Deliberately stale index.
+    getDerivedCopyTarget: vi.fn(async (uri: string) => files.get(uri) ?? null),
+    canUsePreGeneratedFileId: vi.fn(async () => reserved),
+    generateFileId: vi.fn(async () => `reserved-${++state.sequence}`),
+    createContent: vi.fn(
+      async (
+        _parent: string,
+        name: string,
+        _content: string,
+        _mime: string,
+        options: { fileId?: string }
+      ) => {
+        const uri = driveFileUrl(
+          options.fileId ?? `created-${++state.sequence}`
+        )
+        if (!files.has(uri)) {
+          state.creates += 1
+          files.set(uri, {
+            uri,
+            name,
+            type: NotebookStoreItemType.File,
+            children: [],
+            parents: [parent],
+          })
+        }
+        return files.get(uri)!
+      }
+    ),
+  })
+  return { state, files, client }
+}
+
+describe('source-coordinated derived copies', () => {
+  it.each([true, false])(
+    'elects one identity across concurrent profiles (reserved=%s)',
+    async (reserved) => {
+      const server = remote(reserved)
+      const a = server.client()
+      const b = server.client()
+      const run = (client: typeof a) =>
+        ensureDerivedCopy(
+          client as unknown as DriveNotebookStore,
+          source,
+          parent,
+          'source.ipynb',
+          async () => '{}'
+        )
+      const results = await Promise.allSettled([run(a), run(b)])
+      expect(results.some((result) => result.status === 'fulfilled')).toBe(true)
+      expect(server.state.creates).toBe(1)
+      const first = await run(a)
+      const second = await run(b)
+      expect(first?.uri).toBe(second?.uri)
+      expect(server.state.creates).toBe(1)
+    }
+  )
+
+  it('allows explicit recovery when an unconfirmed Shared Drive POST never arrived', async () => {
+    const server = remote(false)
+    const client = server.client()
+    client.createContent.mockRejectedValueOnce(
+      new Error('connection lost before POST')
+    )
+    const run = () =>
+      ensureDerivedCopy(
+        client as unknown as DriveNotebookStore,
+        source,
+        parent,
+        'source.ipynb',
+        async () => '{}'
+      )
+    await expect(run()).rejects.toBeInstanceOf(UnconfirmedDerivedCopyError)
+    const pending = server.state.claim
+    await expect(run()).rejects.toBeInstanceOf(UnconfirmedDerivedCopyError)
+    expect(client.createContent).toHaveBeenCalledTimes(1)
+    expect(
+      await client.compareAndSetDerivedCopyClaim(source, pending, null)
+    ).toBe(true)
+    expect((await run())?.uri).toBeDefined()
+    expect(server.state.creates).toBe(1)
+  })
+
+  it('does not clear a confirmed file using a stale recovery claim', async () => {
+    const server = remote(false)
+    const client = server.client()
+    server.state.claim = 'f:already-confirmed'
+    expect(
+      await client.compareAndSetDerivedCopyClaim(source, 'p:old', null)
+    ).toBe(false)
+    expect(server.state.claim).toBe('f:already-confirmed')
+  })
+})

--- a/app/src/storage/derivedCopy.ts
+++ b/app/src/storage/derivedCopy.ts
@@ -22,7 +22,8 @@ export class UnconfirmedDerivedCopyError extends Error {
 /**
  * All profiles elect one identity using the source file's conditional public
  * property update. r = reserved ID, f = confirmed ID, p = unconfirmed Shared
- * Drive POST. Only the call that wins a p claim may issue that POST.
+ * Drive POST. Claims include the source hash so copied metadata is re-elected.
+ * Only the call that wins a p claim may issue that POST.
  */
 export async function ensureDerivedCopy(
   drive: DriveNotebookStore,
@@ -31,28 +32,37 @@ export async function ensureDerivedCopy(
   name: string,
   content: () => Promise<string | null>
 ): Promise<NotebookStoreItem | null> {
-  const operationId = `runme-ipynb-${md5(driveFileUrl(parseDriveItem(sourceUri).id))}`
+  const sourceHash = md5(driveFileUrl(parseDriveItem(sourceUri).id))
+  const operationId = `runme-ipynb-${sourceHash}`
   let ownedPending: string | undefined
   for (let attempt = 0; attempt < 8; attempt += 1) {
     const claim = await drive.getDerivedCopyClaim(sourceUri)
-    if (claim && !/^[rfp]:[A-Za-z0-9_-]+$/.test(claim)) {
+    if (claim && !/^[rfp]:[a-f0-9]{32}:[A-Za-z0-9_-]+$/.test(claim)) {
       throw new Error(
         'Invalid Colab copy coordination property on the source notebook.'
       )
     }
+    if (claim && claim.split(':')[1] !== sourceHash) {
+      // Drive copies custom properties. Detach the inherited identity without
+      // touching the original notebook's copy (including pending reservations).
+      await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, null)
+      continue
+    }
     let target: NotebookStoreItem | null = null
     if (claim?.startsWith('r:') || claim?.startsWith('f:')) {
       target = await drive.getDerivedCopyTarget(
-        driveFileUrl(claim.slice(2)),
+        driveFileUrl(claim.split(':')[2]),
         operationId
       )
     } else {
-      const found = await drive.waitForCreateOperation(parentUri, operationId)
+      // A source can move while its create is unconfirmed. Search by its
+      // source-scoped identity across folders, then move the recovered target.
+      const found = await drive.waitForCreateOperation(null, operationId)
       if (found)
         target = await drive.getDerivedCopyTarget(found.uri, operationId)
     }
     if (target) {
-      const confirmed = `f:${parseDriveItem(target.uri).id}`
+      const confirmed = `f:${sourceHash}:${parseDriveItem(target.uri).id}`
       if (
         claim === confirmed ||
         (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, confirmed))
@@ -62,8 +72,8 @@ export async function ensureDerivedCopy(
     }
     if (!claim || claim.startsWith('f:')) {
       const next = (await drive.canUsePreGeneratedFileId(parentUri))
-        ? `r:${await drive.generateFileId()}`
-        : `p:${uuidv4()}`
+        ? `r:${sourceHash}:${await drive.generateFileId()}`
+        : `p:${sourceHash}:${uuidv4()}`
       if (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, next)) {
         if (next.startsWith('p:')) ownedPending = next
       }
@@ -86,7 +96,7 @@ export async function ensureDerivedCopy(
         IPYNB_MIME_TYPE,
         {
           createOperationId: operationId,
-          ...(claim.startsWith('r:') ? { fileId: claim.slice(2) } : {}),
+          ...(claim.startsWith('r:') ? { fileId: claim.split(':')[2] } : {}),
         }
       )
     } catch (error) {
@@ -97,7 +107,7 @@ export async function ensureDerivedCopy(
       }
       throw error
     }
-    const confirmed = `f:${parseDriveItem(target.uri).id}`
+    const confirmed = `f:${sourceHash}:${parseDriveItem(target.uri).id}`
     if (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, confirmed))
       return target
     // Another source save can change its ETag. Reread before further actions.

--- a/app/src/storage/derivedCopy.ts
+++ b/app/src/storage/derivedCopy.ts
@@ -1,0 +1,108 @@
+import md5 from 'md5'
+import { v4 as uuidv4 } from 'uuid'
+
+import { IPYNB_MIME_TYPE } from '../lib/ipynb'
+import {
+  DriveCreateNotCommittedError,
+  type DriveNotebookStore,
+  driveFileUrl,
+  parseDriveItem,
+} from './drive'
+import type { NotebookStoreItem } from './notebook'
+
+/** Shared Drive POSTs cannot be safely retried without an explicit recovery decision. */
+export class UnconfirmedDerivedCopyError extends Error {
+  constructor(readonly claim: string) {
+    super(
+      'Colab copy creation is awaiting Drive confirmation. If it persists, check Drive and use Retry unconfirmed creation in Notebook properties.'
+    )
+  }
+}
+
+/**
+ * All profiles elect one identity using the source file's conditional public
+ * property update. r = reserved ID, f = confirmed ID, p = unconfirmed Shared
+ * Drive POST. Only the call that wins a p claim may issue that POST.
+ */
+export async function ensureDerivedCopy(
+  drive: DriveNotebookStore,
+  sourceUri: string,
+  parentUri: string,
+  name: string,
+  content: () => Promise<string | null>
+): Promise<NotebookStoreItem | null> {
+  const operationId = `runme-ipynb-${md5(driveFileUrl(parseDriveItem(sourceUri).id))}`
+  let ownedPending: string | undefined
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const claim = await drive.getDerivedCopyClaim(sourceUri)
+    if (claim && !/^[rfp]:[A-Za-z0-9_-]+$/.test(claim)) {
+      throw new Error(
+        'Invalid Colab copy coordination property on the source notebook.'
+      )
+    }
+    let target: NotebookStoreItem | null = null
+    if (claim?.startsWith('r:') || claim?.startsWith('f:')) {
+      target = await drive.getDerivedCopyTarget(
+        driveFileUrl(claim.slice(2)),
+        operationId
+      )
+    } else {
+      const found = await drive.waitForCreateOperation(parentUri, operationId)
+      if (found)
+        target = await drive.getDerivedCopyTarget(found.uri, operationId)
+    }
+    if (target) {
+      const confirmed = `f:${parseDriveItem(target.uri).id}`
+      if (
+        claim === confirmed ||
+        (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, confirmed))
+      )
+        return target
+      continue
+    }
+    if (!claim || claim.startsWith('f:')) {
+      const next = (await drive.canUsePreGeneratedFileId(parentUri))
+        ? `r:${await drive.generateFileId()}`
+        : `p:${uuidv4()}`
+      if (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, next)) {
+        if (next.startsWith('p:')) ownedPending = next
+      }
+      continue
+    }
+    if (claim.startsWith('p:') && ownedPending !== claim) {
+      throw new UnconfirmedDerivedCopyError(claim)
+    }
+    const bytes = await content()
+    if (bytes === null) {
+      if (ownedPending === claim)
+        await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, null)
+      return null
+    }
+    try {
+      target = await drive.createContent(
+        parentUri,
+        name,
+        bytes,
+        IPYNB_MIME_TYPE,
+        {
+          createOperationId: operationId,
+          ...(claim.startsWith('r:') ? { fileId: claim.slice(2) } : {}),
+        }
+      )
+    } catch (error) {
+      if (error instanceof DriveCreateNotCommittedError) {
+        await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, null)
+      } else if (claim.startsWith('p:')) {
+        throw new UnconfirmedDerivedCopyError(claim)
+      }
+      throw error
+    }
+    const confirmed = `f:${parseDriveItem(target.uri).id}`
+    if (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, confirmed))
+      return target
+    // Another source save can change its ETag. Reread before further actions.
+  }
+  throw new Error(
+    'Colab copy coordination changed repeatedly; retry Drive sync.'
+  )
+}

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -262,6 +262,77 @@ describe("DriveNotebookStore", () => {
     ).toBe(true);
   });
 
+  it.each(["gapi", "fetch"])(
+    "conditionally publishes copy placement and content together via %s",
+    async (transport) => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input, init) => {
+          const url = new URL(String(input));
+          if (init?.method === "GET")
+            return new Response(
+              JSON.stringify({ md5Checksum: "old", version: "1" }),
+              {
+                headers: {
+                  "Content-Type": "application/json",
+                  ETag: '"copy-etag"',
+                },
+              }
+            );
+          expect(init?.method).toBe("PATCH");
+          expect(url.pathname).toBe("/upload/drive/v3/files/copy");
+          expect(url.searchParams.get("uploadType")).toBe("multipart");
+          expect(url.searchParams.get("addParents")).toBe("new");
+          expect(url.searchParams.get("removeParents")).toBe("old");
+          expect(init?.headers).toMatchObject({
+            "If-Match": '"copy-etag"',
+            "Content-Type": expect.stringContaining(
+              "multipart/related; boundary="
+            ),
+          });
+          expect(init?.body).toContain('"name":"new.ipynb"');
+          expect(init?.body).toContain('{"cells":[]}');
+          return new Response("", { status: 412 });
+        });
+      const placement = {
+        name: "new.ipynb",
+        parentUri: "https://drive.google.com/drive/folders/new",
+        previousParentUri: "https://drive.google.com/drive/folders/old",
+      };
+      if (transport === "gapi") {
+        const client = new GapiDriveFilesClient({
+          client: {
+            getToken: () => ({ access_token: "access-token" }),
+            drive: { files: {}, drives: {}, revisions: {} },
+          },
+        } as never);
+        await expect(
+          client.setContentIfMatch(
+            "copy",
+            '{"cells":[]}',
+            "application/x-ipynb+json",
+            '"copy-etag"',
+            undefined,
+            placement
+          )
+        ).resolves.toBe(false);
+      } else {
+        setGoogleDriveBaseUrl("https://drive.example.test");
+        const store = new DriveNotebookStore(async () => "access-token");
+        await expect(
+          store.saveContentIfVersion(
+            "https://drive.google.com/file/d/copy/view",
+            '{"cells":[]}',
+            "application/x-ipynb+json",
+            { checksum: "old", version: "1" },
+            placement
+          )
+        ).resolves.toBe(false);
+      }
+      expect(fetchMock).toHaveBeenCalled();
+    }
+  );
+
   it("reads a Drive v2 ETag and applies it to the CORS-capable v3 upload", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -154,6 +154,101 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it.each([200, 412])(
+    "conditionally updates only the copy property (HTTP %s)",
+    async (status) => {
+      setGoogleDriveBaseUrl("https://drive.example.test");
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/drive/v3/files/source");
+        if (init?.method === "GET")
+          return new Response(
+            JSON.stringify({
+              properties: { runmeIpynbCopy: "p:claim", unrelated: "keep" },
+            }),
+            {
+              headers: {
+                "Content-Type": "application/json",
+                ETag: '"current"',
+              },
+            }
+          );
+        expect(init?.method).toBe("PATCH");
+        expect(init?.headers).toMatchObject({ "If-Match": '"current"' });
+        expect(JSON.parse(String(init?.body))).toEqual({
+          properties: { runmeIpynbCopy: null },
+        });
+        return new Response("", { status });
+      });
+      const store = new DriveNotebookStore(async () => "access-token");
+      expect(
+        await store.compareAndSetDerivedCopyClaim(
+          driveFileUrl("source"),
+          "p:claim",
+          null
+        )
+      ).toBe(status === 200);
+    }
+  );
+
+  it("rejects a forged copy reference without writing its content", async () => {
+    const store = new DriveNotebookStore(async () => "access-token");
+    vi.spyOn(store, "getMetadataIfExists").mockResolvedValue({
+      uri: driveFileUrl("unrelated"),
+      name: "private.ipynb",
+      type: NotebookStoreItemType.File,
+      children: [],
+      parents: [],
+    });
+    vi.spyOn(store, "getVersionMetadata").mockResolvedValue({
+      appProperties: { runmeCreateOperationId: "different-source" },
+    });
+    await expect(
+      store.getDerivedCopyTarget(driveFileUrl("unrelated"), "intended-source")
+    ).rejects.toThrow("refusing to overwrite");
+  });
+
+  it("normalizes public v2 properties and uses their ETag for a v3 claim update", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "GET") {
+        expect(url.pathname).toBe("/drive/v2/files/source");
+        return new Response(
+          JSON.stringify({
+            etag: '"v2"',
+            properties: [
+              { key: "runmeIpynbCopy", value: "r:copy", visibility: "PUBLIC" },
+              { key: "private", value: "hidden", visibility: "PRIVATE" },
+            ],
+          }),
+          { headers: { "Content-Type": "application/json" } }
+        );
+      }
+      expect(url.pathname).toBe("/drive/v3/files/source");
+      expect(init?.headers).toMatchObject({ "If-Match": '"v2"' });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        properties: { runmeIpynbCopy: "f:copy" },
+      });
+      return new Response("", { status: 200 });
+    });
+    const client = new GapiDriveFilesClient({
+      client: {
+        getToken: () => ({ access_token: "token" }),
+        drive: { files: {}, drives: {}, revisions: {} },
+      },
+    } as never);
+    const version = await client.getVersionMetadataWithEtag("source");
+    expect(version.metadata?.properties).toEqual({ runmeIpynbCopy: "r:copy" });
+    expect(
+      await client.setPublicPropertyIfMatch(
+        "source",
+        "runmeIpynbCopy",
+        "f:copy",
+        version.etag!
+      )
+    ).toBe(true);
+  });
+
   it("reads a Drive v2 ETag and applies it to the CORS-capable v3 upload", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -163,7 +258,7 @@ describe("DriveNotebookStore", () => {
           expect(url.pathname).toBe("/drive/v2/files/file123");
           expect(url.searchParams.get("supportsAllDrives")).toBe("true");
           expect(url.searchParams.get("fields")).toBe(
-            "etag,md5Checksum,headRevisionId,version",
+            "etag,md5Checksum,headRevisionId,version,properties",
           );
           expect(init?.headers).toMatchObject({
             Authorization: "Bearer access-token",
@@ -213,6 +308,7 @@ describe("DriveNotebookStore", () => {
         md5Checksum: "checksum-1",
         headRevisionId: "revision-1",
         version: "1",
+        properties: {},
       },
       etag: '\"drive-etag-1\"',
     });

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -154,6 +154,19 @@ describe("isDriveItemUri", () => {
 });
 
 describe("DriveNotebookStore", () => {
+  it("recovers a source-scoped create across folders without a parent filter", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const query = new URL(String(input)).searchParams.get("q");
+      expect(query).toContain("runmeCreateOperationId");
+      expect(query).toContain("source-operation");
+      expect(query).not.toContain("in parents");
+      return new Response(JSON.stringify({ files: [{ id: "copy", name: "source.ipynb", parents: ["old-parent"] }] }), { headers: { "Content-Type": "application/json" } });
+    });
+    const store = new DriveNotebookStore(async () => "access-token");
+    expect((await store.findByCreateOperation(null, "source-operation"))?.parents).toEqual([driveFolderUrl("old-parent")]);
+  });
+
   it.each([200, 412])(
     "conditionally updates only the copy property (HTTP %s)",
     async (status) => {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -23,13 +23,16 @@ const GAPI_SCRIPT_SRC = 'https://apis.google.com/js/api.js'
 
 // VERSION_FIELDS is the fields we want to return when fetching metadata to determine the file content version.
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
-const VERSION_FIELDS = 'md5Checksum,headRevisionId,version,appProperties'
-const DRIVE_V2_VERSION_FIELDS = 'etag,md5Checksum,headRevisionId,version'
+const VERSION_FIELDS =
+  'md5Checksum,headRevisionId,version,appProperties,properties'
+const DRIVE_V2_VERSION_FIELDS =
+  'etag,md5Checksum,headRevisionId,version,properties'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
 const DRIVE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
-const DRIVE_CREATE_OPERATION_PROPERTY = 'runmeCreateOperationId'
+export const DRIVE_CREATE_OPERATION_PROPERTY = 'runmeCreateOperationId'
+const DERIVED_COPY_PROPERTY = 'runmeIpynbCopy'
 export const DRIVE_CREATE_EXPECTED_CHECKSUM_PROPERTY =
   'runmeCreateExpectedChecksum'
 export const DRIVE_CREATE_EXPECTED_REQUEST_PROPERTY =
@@ -381,6 +384,13 @@ type DriveRevisionListResponse = {
 }
 
 interface DriveFilesClient {
+  setPublicPropertyIfMatch(
+    fileId: string,
+    key: string,
+    value: string | null,
+    etag: string,
+    resourceKey?: string
+  ): Promise<boolean>
   generateFileId(): Promise<string>
   create(
     doc: DriveDoc,
@@ -883,12 +893,7 @@ export class GapiDriveFilesClient implements DriveFilesClient {
     }
 
     if (doc.content !== undefined && file.id) {
-      await this.setContent(
-        file.id,
-        doc.content,
-        doc.mimeType,
-        doc.resourceKey
-      )
+      await this.setContent(file.id, doc.content, doc.mimeType, doc.resourceKey)
     }
 
     return file
@@ -966,8 +971,55 @@ export class GapiDriveFilesClient implements DriveFilesClient {
         | (DriveVersionMetadata & { etag?: string })
         | undefined) ?? null
     return {
-      metadata,
+      metadata: metadata
+        ? {
+            ...metadata,
+            properties: Object.fromEntries(
+              (
+                (
+                  metadata as unknown as {
+                    properties?: {
+                      key: string
+                      value: string
+                      visibility: string
+                    }[]
+                  }
+                ).properties ?? []
+              )
+                .filter((property) => property.visibility === 'PUBLIC')
+                .map((property) => [property.key, property.value])
+            ),
+          }
+        : null,
       etag: metadata?.etag ?? response.etag,
+    }
+  }
+
+  /** CAS one public property without changing media or unrelated properties. */
+  async setPublicPropertyIfMatch(
+    fileId: string,
+    key: string,
+    value: string | null,
+    etag: string,
+    resourceKey?: string
+  ): Promise<boolean> {
+    try {
+      await this.request(
+        'PATCH',
+        `/drive/v3/files/${encodeURIComponent(fileId)}`,
+        {
+          params: { supportsAllDrives: true },
+          body: JSON.stringify({ properties: { [key]: value } }),
+          headers: {
+            ...driveResourceKeyHeaders({ id: fileId, resourceKey }),
+            'If-Match': etag,
+          },
+        }
+      )
+      return true
+    } catch (error) {
+      if (error instanceof DrivePreconditionFailedError) return false
+      throw error
     }
   }
 
@@ -1371,12 +1423,7 @@ class FetchDriveFilesClient implements DriveFilesClient {
     }
 
     if (doc.content !== undefined) {
-      await this.setContent(
-        doc.id,
-        doc.content,
-        doc.mimeType,
-        doc.resourceKey
-      )
+      await this.setContent(doc.id, doc.content, doc.mimeType, doc.resourceKey)
     }
 
     return file.id ? file : { ...doc }
@@ -1441,6 +1488,31 @@ class FetchDriveFilesClient implements DriveFilesClient {
     return {
       metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
       etag: response.etag,
+    }
+  }
+
+  /** Use the same source-file CAS contract as the browser transport. */
+  async setPublicPropertyIfMatch(
+    fileId: string,
+    key: string,
+    value: string | null,
+    etag: string,
+    resourceKey?: string
+  ): Promise<boolean> {
+    try {
+      await this.request(
+        'PATCH',
+        `/drive/v3/files/${encodeURIComponent(fileId)}`,
+        {
+          params: { supportsAllDrives: true, resourceKey },
+          body: JSON.stringify({ properties: { [key]: value } }),
+          headers: { 'If-Match': etag },
+        }
+      )
+      return true
+    } catch (error) {
+      if (error instanceof DrivePreconditionFailedError) return false
+      throw error
     }
   }
 
@@ -1868,6 +1940,7 @@ export interface SharedNotebookPreflight {
 }
 
 export interface DriveVersionMetadata {
+  properties?: Record<string, string>
   md5Checksum?: string
   headRevisionId?: string
   version?: string
@@ -2443,6 +2516,59 @@ export class DriveNotebookStore {
       )
     }
     return driveFolderUrl(folder.id)
+  }
+
+  /** Read the shared copy identity from the source, not a profile-local cache. */
+  async getDerivedCopyClaim(uri: string): Promise<string | undefined> {
+    const { id, resourceKey } = parseDriveItem(uri)
+    const { metadata } = await (
+      await this.getFilesClient()
+    ).getVersionMetadataWithEtag(id, resourceKey)
+    return metadata?.properties?.[DERIVED_COPY_PROPERTY]
+  }
+
+  /** Compare-and-set the source property; media edits also invalidate its ETag. */
+  async compareAndSetDerivedCopyClaim(
+    uri: string,
+    expected: string | undefined,
+    next: string | null
+  ): Promise<boolean> {
+    const { id, resourceKey } = parseDriveItem(uri)
+    const client = await this.getFilesClient()
+    const { metadata, etag } = await client.getVersionMetadataWithEtag(
+      id,
+      resourceKey
+    )
+    if (metadata?.properties?.[DERIVED_COPY_PROPERTY] !== expected) return false
+    if (!etag)
+      throw new Error(
+        'Drive did not expose a validator for Colab copy coordination.'
+      )
+    return client.setPublicPropertyIfMatch(
+      id,
+      DERIVED_COPY_PROPERTY,
+      next,
+      etag,
+      resourceKey
+    )
+  }
+
+  /** A source property alone never authorizes overwriting an unrelated file. */
+  async getDerivedCopyTarget(
+    uri: string,
+    operationId: string
+  ): Promise<NotebookStoreItem | null> {
+    const target = await this.getMetadataIfExists(uri)
+    if (!target) return null
+    const version = await this.getVersionMetadata(uri)
+    if (
+      version?.appProperties?.[DRIVE_CREATE_OPERATION_PROPERTY] !== operationId
+    ) {
+      throw new Error(
+        'The Colab copy does not belong to this source notebook; refusing to overwrite it.'
+      )
+    }
+    return target
   }
 
   /** Reserve a Drive file id so retries can target one stable identity. */

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -383,6 +383,44 @@ type DriveRevisionListResponse = {
   result?: { revisions?: DriveRevision[]; nextPageToken?: string }
 }
 
+/** Metadata and content are replaced in one conditional Drive request. */
+export interface DerivedCopyPlacement {
+  name: string
+  parentUri: string
+  previousParentUri?: string
+}
+
+function conditionalUpload(
+  content: string,
+  mimeType: string,
+  placement?: DerivedCopyPlacement
+) {
+  if (!placement)
+    return {
+      body: content,
+      contentType: mimeType,
+      params: { uploadType: 'media' },
+    }
+  const boundary = `runme_${crypto.randomUUID()}`
+  return {
+    body: `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify({ name: placement.name, mimeType })}\r\n--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n${content}\r\n--${boundary}--`,
+    contentType: `multipart/related; boundary=${boundary}`,
+    params: {
+      uploadType: 'multipart',
+      ...(placement.parentUri !== placement.previousParentUri
+        ? {
+            addParents: parseDriveItem(placement.parentUri).id,
+            ...(placement.previousParentUri
+              ? {
+                  removeParents: parseDriveItem(placement.previousParentUri).id,
+                }
+              : {}),
+          }
+        : {}),
+    },
+  }
+}
+
 interface DriveFilesClient {
   setPublicPropertyIfMatch(
     fileId: string,
@@ -419,7 +457,8 @@ interface DriveFilesClient {
     content: string,
     mimeType: string,
     etag: string,
-    resourceKey?: string
+    resourceKey?: string,
+    placement?: DerivedCopyPlacement
   ): Promise<boolean>
   getDrive(request: Record<string, unknown>): Promise<DriveGetResponse>
   list(
@@ -1028,8 +1067,10 @@ export class GapiDriveFilesClient implements DriveFilesClient {
     content: string,
     mimeType: string,
     etag: string,
-    resourceKey?: string
+    resourceKey?: string,
+    placement?: DerivedCopyPlacement
   ): Promise<boolean> {
+    const upload = conditionalUpload(content, mimeType, placement)
     try {
       // Read the validator from Drive v2 because its JSON body exposes the
       // ETag to browser JavaScript, but write through Drive v3. The v2 upload
@@ -1042,11 +1083,11 @@ export class GapiDriveFilesClient implements DriveFilesClient {
         `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
         {
           params: {
-            uploadType: 'media',
+            ...upload.params,
             supportsAllDrives: true,
           },
-          body: content,
-          contentType: mimeType,
+          body: upload.body,
+          contentType: upload.contentType,
           headers: {
             ...driveResourceKeyHeaders({ id: fileId, resourceKey }),
             'If-Match': etag,
@@ -1521,20 +1562,22 @@ class FetchDriveFilesClient implements DriveFilesClient {
     content: string,
     mimeType: string,
     etag: string,
-    resourceKey?: string
+    resourceKey?: string,
+    placement?: DerivedCopyPlacement
   ): Promise<boolean> {
+    const upload = conditionalUpload(content, mimeType, placement)
     try {
       await this.request(
         'PATCH',
         `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
         {
           params: {
-            uploadType: 'media',
+            ...upload.params,
             supportsAllDrives: true,
             resourceKey,
           },
-          body: content,
-          contentType: mimeType,
+          body: upload.body,
+          contentType: upload.contentType,
           headers: { 'If-Match': etag },
         }
       )
@@ -3580,7 +3623,8 @@ export class DriveNotebookStore {
     uri: string,
     content: string,
     mimeType: string,
-    expected: { checksum?: string; revisionId?: string; version?: string }
+    expected: { checksum?: string; revisionId?: string; version?: string },
+    placement?: DerivedCopyPlacement
   ): Promise<boolean> {
     const { id, type, resourceKey } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
@@ -3613,7 +3657,8 @@ export class DriveNotebookStore {
       content,
       mimeType,
       etag,
-      resourceKey
+      resourceKey,
+      placement
     )
     if (saved) {
       this.ipynbState.delete(uri)

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -2762,11 +2762,11 @@ export class DriveNotebookStore {
   }
 
   async findByCreateOperation(
-    parentUri: string,
+    parentUri: string | null,
     createOperationId: string
   ): Promise<NotebookStoreItem | null> {
-    const parent = parseDriveItem(parentUri)
-    if (parent.type !== NotebookStoreItemType.Folder) {
+    const parent = parentUri === null ? null : parseDriveItem(parentUri)
+    if (parent && parent.type !== NotebookStoreItemType.Folder) {
       throw new Error(
         'DriveNotebookStore.findByCreateOperation expects a folder URI'
       )
@@ -2777,12 +2777,14 @@ export class DriveNotebookStore {
       )
     }
 
-    const escapedParentId = escapeDriveQueryValue(parent.id)
+    const parentFilter = parent
+      ? `'${escapeDriveQueryValue(parent.id)}' in parents and `
+      : ''
     const escapedOperationId = escapeDriveQueryValue(createOperationId)
     const result = await this.search(
       {
         q:
-          `'${escapedParentId}' in parents and trashed = false and ` +
+          `${parentFilter}trashed = false and ` +
           `appProperties has { key='${DRIVE_CREATE_OPERATION_PROPERTY}' and ` +
           `value='${escapedOperationId}' }`,
         includeItemsFromAllDrives: true,
@@ -2791,7 +2793,7 @@ export class DriveNotebookStore {
         pageSize: 2,
         fields: 'files(id,name,mimeType,parents,createdTime,appProperties)',
       },
-      driveResourceKeyHeaders(parent)
+      parent ? driveResourceKeyHeaders(parent) : {}
     )
 
     if (result.files.length > 1) {
@@ -2814,7 +2816,9 @@ export class DriveNotebookStore {
       children: [],
       remoteUri: isFolder ? driveFolderUrl(file.id) : driveFileUrl(file.id),
       mimeType: file.mimeType,
-      parents: [parentUri],
+      parents: parentUri
+        ? [parentUri]
+        : (file.parents ?? []).map(driveFolderUrl),
     }
   }
 
@@ -2824,7 +2828,7 @@ export class DriveNotebookStore {
    * browser context has time to become visible.
    */
   async waitForCreateOperation(
-    parentUri: string,
+    parentUri: string | null,
     createOperationId: string,
     initialDelayMs: number = 0
   ): Promise<NotebookStoreItem | null> {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -2818,7 +2818,7 @@ export class DriveNotebookStore {
       mimeType: file.mimeType,
       parents: parentUri
         ? [parentUri]
-        : (file.parents ?? []).map(driveFolderUrl),
+        : (file.parents ?? []).map((id) => driveFolderUrl(id)),
     }
   }
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -177,6 +177,38 @@ function notebookJson(value: string): string {
 }
 
 describe('LocalNotebooks operation-log storage', () => {
+  it('queues a debounced export after a journal save without awaiting it', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({})
+      store.syncIpynbFile = vi.fn(async () => {})
+      store.syncMarkdownFile = vi.fn(async () => {})
+      store.syncFile = vi.fn(async () => {})
+      await store.folders.put({
+        id: LOCAL_FOLDER_URI,
+        name: 'Local',
+        remoteId: '',
+        children: [],
+        lastSynced: '',
+      })
+      const created = await store.create(LOCAL_FOLDER_URI, 'queued.runme')
+      const journal = await store.createOperationLogSaveStore(created.uri, {
+        actorId: 'export-test',
+      })
+      const notebook = await store.load(created.uri)
+      notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+      await journal.save(created.uri, notebook)
+      expect(store.syncIpynbFile).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(19_999)
+      expect(store.syncIpynbFile).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(store.syncIpynbFile).toHaveBeenCalledTimes(1)
+      expect(store.syncIpynbFile).toHaveBeenCalledWith(created.uri)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('exports committed .runme changes, reuses its sibling, and stops when disabled', async () => {
     const parent = 'https://drive.google.com/drive/folders/parent'
     const remote = 'https://drive.google.com/file/d/source/view'

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -280,72 +280,80 @@ describe('LocalNotebooks operation-log storage', () => {
     }
   })
 
-  it('exports committed .runme changes, reuses its sibling, and stops when disabled', async () => {
-    const parent = 'https://drive.google.com/drive/folders/parent'
-    const remote = 'https://drive.google.com/file/d/source/view'
-    const target = {
-      uri: 'https://drive.google.com/file/d/copy/view',
-      name: 'source.ipynb',
-      parents: [parent],
+  it.each(['{}', '', '{', 'null'])(
+    'exports committed .runme changes, repairs/reuses its sibling, and stops when disabled (prior bytes: %s)',
+    async (previousContent) => {
+      const parent = 'https://drive.google.com/drive/folders/parent'
+      const remote = 'https://drive.google.com/file/d/source/view'
+      const target = {
+        uri: 'https://drive.google.com/file/d/copy/view',
+        name: 'source.ipynb',
+        parents: [parent],
+      }
+      const drive = {
+        getMetadata: vi.fn(async (uri: string) =>
+          uri === remote
+            ? { uri, name: 'source.runme', parents: [parent] }
+            : target
+        ),
+        create: vi.fn(async () => target),
+        loadContent: vi.fn(async (uri: string) =>
+          uri === target.uri ? previousContent : ''
+        ),
+        saveContent: vi.fn(
+          async (_uri: string, _content: string, _mime: string) => {}
+        ),
+      }
+      const store = createTestStore(drive)
+      const getMetadataIfExists = vi.fn(drive.getMetadata)
+      Object.assign(drive, { getMetadataIfExists })
+      await store.folders.put({
+        id: LOCAL_FOLDER_URI,
+        name: 'Local',
+        remoteId: '',
+        children: [],
+        lastSynced: '',
+      })
+      const created = await store.create(LOCAL_FOLDER_URI, 'source.runme')
+      await store.files.update(created.uri, { remoteId: remote })
+      const journal = await store.createOperationLogSaveStore(created.uri, {
+        actorId: 'export-test',
+      })
+      const notebook = await store.load(created.uri)
+      notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+      await journal.save(created.uri, notebook)
+      expect((await store.load(created.uri)).metadata[AUTO_IPYNB_KEY]).toBe(
+        'true'
+      )
+      expect(drive.saveContent).not.toHaveBeenCalled()
+      await store.syncIpynbFile(created.uri)
+      await store.syncIpynbFile(created.uri)
+      expect(drive.create).toHaveBeenCalledTimes(1)
+      expect(drive.saveContent).toHaveBeenCalledTimes(2)
+      const exported = JSON.parse(drive.saveContent.mock.calls[0][1])
+      expect(exported.metadata.runme.derivedFrom.uri).toBe(remote)
+      expect(exported.cells[0].source).toContain('read-only')
+      // A deleted copy is recreated; a relinked source never reuses the old target.
+      getMetadataIfExists.mockResolvedValueOnce(null as any)
+      await store.syncIpynbFile(created.uri)
+      expect(drive.create).toHaveBeenCalledTimes(2)
+      await store.files.update(created.uri, {
+        remoteId: 'https://drive.google.com/file/d/relinked/view',
+      })
+      drive.getMetadata.mockResolvedValue({ ...target, name: 'source.runme' })
+      const lookupsBeforeRelink = getMetadataIfExists.mock.calls.length
+      await store.syncIpynbFile(created.uri)
+      expect(drive.create).toHaveBeenCalledTimes(3)
+      expect(getMetadataIfExists).toHaveBeenCalledTimes(lookupsBeforeRelink)
+      notebook.metadata[AUTO_IPYNB_KEY] = 'false'
+      await journal.save(created.uri, notebook)
+      await store.syncIpynbFile(created.uri)
+      expect(drive.saveContent).toHaveBeenCalledTimes(4)
+      expect((await store.getIpynbExportState(created.uri)).uri).toBe(
+        target.uri
+      )
     }
-    const drive = {
-      getMetadata: vi.fn(async (uri: string) =>
-        uri === remote
-          ? { uri, name: 'source.runme', parents: [parent] }
-          : target
-      ),
-      create: vi.fn(async () => target),
-      saveContent: vi.fn(
-        async (_uri: string, _content: string, _mime: string) => {}
-      ),
-    }
-    const store = createTestStore(drive)
-    const getMetadataIfExists = vi.fn(drive.getMetadata)
-    Object.assign(drive, { getMetadataIfExists })
-    await store.folders.put({
-      id: LOCAL_FOLDER_URI,
-      name: 'Local',
-      remoteId: '',
-      children: [],
-      lastSynced: '',
-    })
-    const created = await store.create(LOCAL_FOLDER_URI, 'source.runme')
-    await store.files.update(created.uri, { remoteId: remote })
-    const journal = await store.createOperationLogSaveStore(created.uri, {
-      actorId: 'export-test',
-    })
-    const notebook = await store.load(created.uri)
-    notebook.metadata[AUTO_IPYNB_KEY] = 'true'
-    await journal.save(created.uri, notebook)
-    expect((await store.load(created.uri)).metadata[AUTO_IPYNB_KEY]).toBe(
-      'true'
-    )
-    expect(drive.saveContent).not.toHaveBeenCalled()
-    await store.syncIpynbFile(created.uri)
-    await store.syncIpynbFile(created.uri)
-    expect(drive.create).toHaveBeenCalledTimes(1)
-    expect(drive.saveContent).toHaveBeenCalledTimes(2)
-    const exported = JSON.parse(drive.saveContent.mock.calls[0][1])
-    expect(exported.metadata.runme.derivedFrom.uri).toBe(remote)
-    expect(exported.cells[0].source).toContain('read-only')
-    // A deleted copy is recreated; a relinked source never reuses the old target.
-    getMetadataIfExists.mockResolvedValueOnce(null as any)
-    await store.syncIpynbFile(created.uri)
-    expect(drive.create).toHaveBeenCalledTimes(2)
-    await store.files.update(created.uri, {
-      remoteId: 'https://drive.google.com/file/d/relinked/view',
-    })
-    drive.getMetadata.mockResolvedValue({ ...target, name: 'source.runme' })
-    const lookupsBeforeRelink = getMetadataIfExists.mock.calls.length
-    await store.syncIpynbFile(created.uri)
-    expect(drive.create).toHaveBeenCalledTimes(3)
-    expect(getMetadataIfExists).toHaveBeenCalledTimes(lookupsBeforeRelink)
-    notebook.metadata[AUTO_IPYNB_KEY] = 'false'
-    await journal.save(created.uri, notebook)
-    await store.syncIpynbFile(created.uri)
-    expect(drive.saveContent).toHaveBeenCalledTimes(4)
-    expect((await store.getIpynbExportState(created.uri)).uri).toBe(target.uri)
-  })
+  )
 
   it.each([true, false])(
     'rereads committed state before upload (enabled=%s)',

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -138,6 +138,12 @@ function createTestStore(
     })
   }
   localStore.driveStore = driveStore
+  if (driveStore && typeof driveStore === 'object') {
+    const drive = driveStore as any
+    drive.waitForCreateOperation ??= drive.findByCreateOperation
+    drive.canUsePreGeneratedFileId ??= vi.fn(async () => false)
+    drive.createContent ??= drive.create
+  }
   localStore.driveSyncCoordinator =
     options.driveSyncCoordinator ?? createTestDriveSyncCoordinator()
   localStore.filesystemStore = null
@@ -183,7 +189,7 @@ describe('LocalNotebooks operation-log storage', () => {
       const store = createTestStore({})
       store.syncIpynbFile = vi.fn(async () => {})
       store.syncMarkdownFile = vi.fn(async () => {})
-      store.syncFile = vi.fn(async () => {})
+      Object.assign(store, { syncFile: vi.fn(async () => {}) })
       await store.folders.put({
         id: LOCAL_FOLDER_URI,
         name: 'Local',
@@ -328,6 +334,80 @@ describe('LocalNotebooks operation-log storage', () => {
         expect(drive.saveContent.mock.calls[0][1]).toContain(
           'Latest committed version'
         )
+    }
+  )
+
+  it.each([true, false])(
+    'settles a lost create response before retrying (reserved IDs=%s)',
+    async (reserved) => {
+      const remote = 'https://drive.google.com/file/d/uncertain/view'
+      const parent = 'https://drive.google.com/drive/folders/parent'
+      const target = {
+        uri: 'https://drive.google.com/file/d/reserved-copy/view',
+        name: 'source.ipynb',
+        parents: [parent],
+      }
+      const drive = {
+        getMetadata: vi.fn(async () => ({
+          name: 'source.runme',
+          parents: [parent],
+        })),
+        getMetadataIfExists: vi.fn(async () => null),
+        waitForCreateOperation: vi.fn(
+          async (): Promise<typeof target | null> => null
+        ),
+        canUsePreGeneratedFileId: vi.fn(async () => reserved),
+        generateFileId: vi.fn(async () => 'reserved-copy'),
+        createContent: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('response lost'))
+          .mockResolvedValue(target),
+        saveContent: vi.fn(async () => {}),
+      }
+      const store = createTestStore(drive)
+      await store.folders.put({
+        id: LOCAL_FOLDER_URI,
+        name: 'Local',
+        remoteId: '',
+        children: [],
+        lastSynced: '',
+      })
+      const created = await store.create(LOCAL_FOLDER_URI, 'source.runme')
+      await store.files.update(created.uri, { remoteId: remote })
+      const journal = await store.createOperationLogSaveStore(created.uri, {
+        actorId: 'export-test',
+      })
+      const notebook = await store.load(created.uri)
+      notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+      await journal.save(created.uri, notebook)
+      await expect(store.syncIpynbFile(created.uri)).rejects.toThrow(
+        'response lost'
+      )
+      expect(
+        (await store.files.get(created.uri))?.ipynbExportCreatePending
+      ).toBeDefined()
+      if (reserved) {
+        await store.syncIpynbFile(created.uri)
+        expect(drive.generateFileId).toHaveBeenCalledTimes(1)
+        expect(drive.createContent).toHaveBeenCalledTimes(2)
+        for (const call of drive.createContent.mock.calls)
+          expect(call[4].fileId).toBe('reserved-copy')
+      } else {
+        await expect(store.syncIpynbFile(created.uri)).rejects.toThrow(
+          'awaiting Drive confirmation'
+        )
+        expect(drive.createContent).toHaveBeenCalledTimes(1)
+        drive.waitForCreateOperation.mockResolvedValue(target)
+        await store.syncIpynbFile(created.uri)
+        expect(drive.createContent).toHaveBeenCalledTimes(1)
+      }
+      expect(drive.waitForCreateOperation).toHaveBeenCalled()
+      expect(
+        (await store.files.get(created.uri))?.ipynbExportCreatePending
+      ).toBeUndefined()
+      expect((await store.getIpynbExportState(created.uri)).uri).toBe(
+        target.uri
+      )
     }
   )
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -4,6 +4,7 @@ import { create, toJsonString } from '@bufbuild/protobuf'
 import md5 from 'md5'
 import { describe, expect, it, vi } from 'vitest'
 
+import { AUTO_IPYNB_KEY } from '../lib/derivedNotebook'
 import {
   clearGoogleDriveRuntime,
   setGoogleDriveBaseUrl,
@@ -144,6 +145,7 @@ function createTestStore(
   localStore.syncListeners = new Map()
   localStore.syncSubjects = new Map()
   localStore.markdownSyncSubjects = new Map()
+  localStore.ipynbSyncSubjects = new Map()
   localStore.conflictDocStorage = new MemoryConflictDocStorage()
   localStore.revisionDocStorage = new MemoryRevisionDocStorage()
   localStore.ipynbShadowStorage =
@@ -175,6 +177,189 @@ function notebookJson(value: string): string {
 }
 
 describe('LocalNotebooks operation-log storage', () => {
+  it('exports committed .runme changes, reuses its sibling, and stops when disabled', async () => {
+    const parent = 'https://drive.google.com/drive/folders/parent'
+    const remote = 'https://drive.google.com/file/d/source/view'
+    const target = {
+      uri: 'https://drive.google.com/file/d/copy/view',
+      name: 'source.ipynb',
+      parents: [parent],
+    }
+    const drive = {
+      getMetadata: vi.fn(async (uri: string) =>
+        uri === remote
+          ? { uri, name: 'source.runme', parents: [parent] }
+          : target
+      ),
+      create: vi.fn(async () => target),
+      saveContent: vi.fn(
+        async (_uri: string, _content: string, _mime: string) => {}
+      ),
+    }
+    const store = createTestStore(drive)
+    const getMetadataIfExists = vi.fn(drive.getMetadata)
+    Object.assign(drive, { getMetadataIfExists })
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    const created = await store.create(LOCAL_FOLDER_URI, 'source.runme')
+    await store.files.update(created.uri, { remoteId: remote })
+    const journal = await store.createOperationLogSaveStore(created.uri, {
+      actorId: 'export-test',
+    })
+    const notebook = await store.load(created.uri)
+    notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+    await journal.save(created.uri, notebook)
+    expect((await store.load(created.uri)).metadata[AUTO_IPYNB_KEY]).toBe(
+      'true'
+    )
+    expect(drive.saveContent).not.toHaveBeenCalled()
+    await store.syncIpynbFile(created.uri)
+    await store.syncIpynbFile(created.uri)
+    expect(drive.create).toHaveBeenCalledTimes(1)
+    expect(drive.saveContent).toHaveBeenCalledTimes(2)
+    const exported = JSON.parse(drive.saveContent.mock.calls[0][1])
+    expect(exported.metadata.runme.derivedFrom.uri).toBe(remote)
+    expect(exported.cells[0].source).toContain('read-only')
+    // A deleted copy is recreated; a relinked source never reuses the old target.
+    getMetadataIfExists.mockResolvedValueOnce(null as any)
+    await store.syncIpynbFile(created.uri)
+    expect(drive.create).toHaveBeenCalledTimes(2)
+    await store.files.update(created.uri, {
+      remoteId: 'https://drive.google.com/file/d/relinked/view',
+    })
+    drive.getMetadata.mockResolvedValue({ ...target, name: 'source.runme' })
+    const lookupsBeforeRelink = getMetadataIfExists.mock.calls.length
+    await store.syncIpynbFile(created.uri)
+    expect(drive.create).toHaveBeenCalledTimes(3)
+    expect(getMetadataIfExists).toHaveBeenCalledTimes(lookupsBeforeRelink)
+    notebook.metadata[AUTO_IPYNB_KEY] = 'false'
+    await journal.save(created.uri, notebook)
+    await store.syncIpynbFile(created.uri)
+    expect(drive.saveContent).toHaveBeenCalledTimes(4)
+    expect((await store.getIpynbExportState(created.uri)).uri).toBe(target.uri)
+  })
+
+  it.each([true, false])(
+    'rereads committed state before upload (enabled=%s)',
+    async (enabled) => {
+      const remote = 'https://drive.google.com/file/d/latest/view'
+      const parent = 'https://drive.google.com/drive/folders/parent'
+      let releaseMetadata!: () => void
+      const ready = new Promise<void>((resolve) => {
+        releaseMetadata = resolve
+      })
+      const target = {
+        uri: 'https://drive.google.com/file/d/copy/view',
+        name: 'source.ipynb',
+        parents: [parent],
+      }
+      const drive = {
+        getMetadata: vi.fn(async () => {
+          await ready
+          return { name: 'source.runme', parents: [parent] }
+        }),
+        create: vi.fn(async () => target),
+        saveContent: vi.fn(
+          async (_uri: string, _content: string, _mime: string) => {}
+        ),
+      }
+      const store = createTestStore(drive)
+      await store.folders.put({
+        id: LOCAL_FOLDER_URI,
+        name: 'Local',
+        remoteId: '',
+        children: [],
+        lastSynced: '',
+      })
+      const created = await store.create(LOCAL_FOLDER_URI, 'source.runme')
+      await store.files.update(created.uri, { remoteId: remote })
+      const journal = await store.createOperationLogSaveStore(created.uri, {
+        actorId: 'export-test',
+      })
+      const notebook = await store.load(created.uri)
+      notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+      await journal.save(created.uri, notebook)
+      const exporting = store.syncIpynbFile(created.uri)
+      await vi.waitFor(() => expect(drive.getMetadata).toHaveBeenCalled())
+      notebook.metadata[AUTO_IPYNB_KEY] = String(enabled)
+      notebook.metadata.description = 'Latest committed version'
+      await journal.save(created.uri, notebook)
+      releaseMetadata()
+      await exporting
+      expect(drive.saveContent).toHaveBeenCalledTimes(enabled ? 1 : 0)
+      if (enabled)
+        expect(drive.saveContent.mock.calls[0][1]).toContain(
+          'Latest committed version'
+        )
+    }
+  )
+
+  it('keeps source saves independent of slow and failed derived uploads', async () => {
+    const remote = 'https://drive.google.com/file/d/independent/view'
+    const parent = 'https://drive.google.com/drive/folders/parent'
+    let rejectUpload!: (error: Error) => void
+    const upload = new Promise<void>((_, reject) => {
+      rejectUpload = reject
+    })
+    const drive = {
+      getMetadata: vi.fn(async () => ({
+        name: 'source.runme',
+        parents: [parent],
+      })),
+      create: vi.fn(async () => ({
+        uri: 'https://drive.google.com/file/d/copy/view',
+        name: 'source.ipynb',
+        parents: [parent],
+      })),
+      saveContent: vi.fn(() => upload),
+    }
+    const store = createTestStore(drive)
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    const created = await store.create(LOCAL_FOLDER_URI, 'source.runme')
+    await store.files.update(created.uri, { remoteId: remote })
+    const journal = await store.createOperationLogSaveStore(created.uri, {
+      actorId: 'export-test',
+    })
+    const notebook = await store.load(created.uri)
+    notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+    await journal.save(created.uri, notebook)
+    const exporting = store.syncIpynbFile(created.uri)
+    const failure = expect(exporting).rejects.toThrow('offline')
+    await vi.waitFor(() => expect(drive.saveContent).toHaveBeenCalled())
+    notebook.metadata.description = 'Saved while upload is pending'
+    await journal.save(created.uri, notebook)
+    expect((await store.load(created.uri)).metadata.description).toBe(
+      notebook.metadata.description
+    )
+    rejectUpload(new Error('offline'))
+    await failure
+    expect((await store.getIpynbExportState(created.uri)).error).toContain(
+      'offline'
+    )
+    Object.assign(drive, {
+      getMetadataIfExists: vi.fn(async () => ({
+        uri: 'https://drive.google.com/file/d/copy/view',
+        name: 'source.ipynb',
+        parents: [parent],
+      })),
+    })
+    drive.saveContent.mockResolvedValue(undefined)
+    await store.syncIpynbFile(created.uri)
+    expect((await store.getIpynbExportState(created.uri)).error).toBeUndefined()
+    expect(drive.create).toHaveBeenCalledTimes(1)
+  })
+
   it('initializes a Drive mirror with authoritative OPFS bytes', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const store = createTestStore({}, { operationLogStorage })
@@ -4329,10 +4514,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
     })
     const coordinator: DriveSyncCoordinator = {
       runExclusive: (key, operation) => {
-        if (
-          key ===
-          'legacy-conversion:drive:transitioning-drive-source'
-        ) {
+        if (key === 'legacy-conversion:drive:transitioning-drive-source') {
           canonicalLockRequests += 1
           if (canonicalLockRequests === 2) notifyFirstRekeyRequested()
         }
@@ -4419,10 +4601,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       }
     )
 
-    const first = firstStore.convertLegacyNotebookToRunme(
-      sourceUri,
-      parentUri
-    )
+    const first = firstStore.convertLegacyNotebookToRunme(sourceUri, parentUri)
     await sourceAssigned
     const second = secondStore.convertLegacyNotebookToRunme(
       sourceUri,
@@ -4656,8 +4835,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
       store.convertLegacyNotebookToRunme(sourceUri, parentUri)
     ).rejects.toThrow('transient folder attachment failure')
     expect(
-      (await store.files.get(pendingUri))?.legacyConversionAttempt
-        ?.completedAt
+      (await store.files.get(pendingUri))?.legacyConversionAttempt?.completedAt
     ).toBeUndefined()
 
     const result = await store.convertLegacyNotebookToRunme(

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -160,6 +160,25 @@ function createTestStore(
     drive.getDerivedCopyTarget ??= vi.fn(
       async (uri: string) => drive.getMetadataIfExists?.(uri) ?? null
     )
+    if (drive.saveContent && !drive.saveContentIfVersion) {
+      drive.getVersionMetadata ??= vi.fn(async () => ({
+        md5Checksum: 'copy-checksum',
+        version: '1',
+      }))
+      drive.loadContent ??= vi.fn(async (uri: string) =>
+        [...claims.values()].some((claim) =>
+          uri.endsWith(`/${claim.split(':')[2]}/view`)
+        )
+          ? '{}'
+          : ''
+      )
+      drive.saveContentIfVersion = vi.fn(
+        async (uri: string, content: string, mime: string) => {
+          await drive.saveContent(uri, content, mime)
+          return true
+        }
+      )
+    }
   }
   localStore.driveSyncCoordinator =
     options.driveSyncCoordinator ?? createTestDriveSyncCoordinator()
@@ -520,6 +539,128 @@ describe('LocalNotebooks operation-log storage', () => {
     expect((await store.getIpynbExportState(created.uri)).error).toBeUndefined()
     expect(drive.create).toHaveBeenCalledTimes(1)
   })
+
+  it.each(['discovery', 'upload'])(
+    'protects newer cross-profile exports when the old profile pauses at %s',
+    async (pauseAt) => {
+      const remote = 'https://drive.google.com/file/d/race-source/view'
+      const copy = 'https://drive.google.com/file/d/race-copy/view'
+      let sourceName = 'old.runme'
+      let parent = 'https://drive.google.com/drive/folders/old'
+      let targetName = 'old.ipynb'
+      let targetParent = parent
+      let content = '{}'
+      let upstream = ''
+      let version = 1
+      let paused = false
+      let resume!: () => void
+      const gate = new Promise<void>((resolve) => {
+        resume = resolve
+      })
+      const target = () => ({
+        uri: copy,
+        name: targetName,
+        parents: [targetParent],
+      })
+      const drive = {
+        getDerivedCopyClaim: vi.fn(async () => `f:${md5(remote)}:race-copy`),
+        getDerivedCopyTarget: vi.fn(async () => {
+          if (pauseAt === 'discovery' && !paused) {
+            paused = true
+            await gate
+          }
+          return target()
+        }),
+        getVersionMetadata: vi.fn(async () => ({
+          md5Checksum: md5(content),
+          version: String(version),
+        })),
+        getMetadata: vi.fn(async (uri: string) =>
+          uri === copy ? target() : { uri, name: sourceName, parents: [parent] }
+        ),
+        loadContent: vi.fn(async (uri: string) =>
+          uri === copy ? content : upstream
+        ),
+        saveContentIfVersion: vi.fn(
+          async (
+            _uri: string,
+            bytes: string,
+            _mime: string,
+            expected: { version: string },
+            placement: { name: string; parentUri: string }
+          ) => {
+            if (pauseAt === 'upload' && !paused) {
+              paused = true
+              await gate
+            }
+            if (expected.version !== String(version)) return false
+            content = bytes
+            targetName = placement.name
+            targetParent = placement.parentUri
+            version += 1
+            return true
+          }
+        ),
+      }
+      const firstStorage = new MemoryOperationLogStorage()
+      const first = createTestStore(drive, {
+        operationLogStorage: firstStorage,
+      })
+      await first.folders.put({
+        id: LOCAL_FOLDER_URI,
+        name: 'Local',
+        remoteId: '',
+        children: [],
+        lastSynced: '',
+      })
+      const created = await first.create(LOCAL_FOLDER_URI, 'old.runme')
+      await first.files.update(created.uri, { remoteId: remote })
+      const firstJournal = await first.createOperationLogSaveStore(
+        created.uri,
+        { actorId: 'first' }
+      )
+      const notebook = await first.load(created.uri)
+      notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+      await firstJournal.save(created.uri, notebook)
+      const record = (await first.files.get(created.uri))!
+      const initial = await firstStorage.read(record.operationLogRef!)
+      const storage = new MemoryOperationLogStorage()
+      const snapshot = await storage.initialize(created.uri, initial.document)
+      const second = createTestStore(drive, { operationLogStorage: storage })
+      await second.files.put({ ...record, operationLogRef: snapshot.ref })
+      const oldExport = first.syncIpynbFile(created.uri)
+      const oldResult = oldExport.catch((error) => error)
+      await vi.waitFor(() => expect(paused).toBe(true))
+      sourceName = 'new.runme'
+      parent = 'https://drive.google.com/drive/folders/new'
+      const secondJournal = await second.createOperationLogSaveStore(
+        created.uri,
+        { actorId: 'second' }
+      )
+      const newer = await second.load(created.uri)
+      newer.metadata.description = 'newer profile content'
+      await secondJournal.save(created.uri, newer)
+      upstream = (
+        await storage.read(
+          (await second.files.get(created.uri))!.operationLogRef!
+        )
+      ).document
+      await second.syncIpynbFile(created.uri)
+      resume()
+      const result = await oldResult
+      if (pauseAt === 'upload')
+        expect(String(result)).toContain('fresh export is queued')
+      expect(targetName).toBe('new.ipynb')
+      expect(targetParent).toBe(parent)
+      expect(content).toContain('newer profile content')
+      // Even a subsequent stale mirror must not overwrite causal coverage if
+      // the newer source changes have not yet reached the upstream journal.
+      upstream = ''
+      await expect(first.syncIpynbFile(created.uri)).rejects.toThrow(
+        'contains newer changes'
+      )
+    }
+  )
 
   it('initializes a Drive mirror with authoritative OPFS bytes', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -143,6 +143,23 @@ function createTestStore(
     drive.waitForCreateOperation ??= drive.findByCreateOperation
     drive.canUsePreGeneratedFileId ??= vi.fn(async () => false)
     drive.createContent ??= drive.create
+    const claims = new Map<string, string>()
+    drive.getDerivedCopyClaim ??= vi.fn(async (uri: string) => claims.get(uri))
+    drive.compareAndSetDerivedCopyClaim ??= vi.fn(
+      async (
+        uri: string,
+        expected: string | undefined,
+        next: string | null
+      ) => {
+        if (claims.get(uri) !== expected) return false
+        if (next === null) claims.delete(uri)
+        else claims.set(uri, next)
+        return true
+      }
+    )
+    drive.getDerivedCopyTarget ??= vi.fn(
+      async (uri: string) => drive.getMetadataIfExists?.(uri) ?? null
+    )
   }
   localStore.driveSyncCoordinator =
     options.driveSyncCoordinator ?? createTestDriveSyncCoordinator()
@@ -183,6 +200,35 @@ function notebookJson(value: string): string {
 }
 
 describe('LocalNotebooks operation-log storage', () => {
+  it('clears only the recorded unconfirmed claim before an explicit retry', async () => {
+    const source = 'https://drive.google.com/file/d/source/view'
+    const compareAndSetDerivedCopyClaim = vi.fn(async () => false)
+    const store = createTestStore({ compareAndSetDerivedCopyClaim })
+    const sync = vi.spyOn(store, 'syncIpynbFile').mockResolvedValue()
+    await store.files.put({
+      id: 'local://file/recover',
+      name: 'source.runme',
+      remoteId: source,
+      doc: '',
+      lastSynced: '',
+      md5Checksum: '',
+      lastRemoteChecksum: '',
+      ipynbExportPendingClaim: 'p:old',
+      ipynbExportError: 'unconfirmed',
+    })
+    await store.retryUnconfirmedIpynbCreation('local://file/recover')
+    expect(compareAndSetDerivedCopyClaim).toHaveBeenCalledWith(
+      source,
+      'p:old',
+      null
+    )
+    expect(sync).toHaveBeenCalledWith('local://file/recover')
+    expect(
+      (await store.getIpynbExportState('local://file/recover'))
+        .needsCreateRecovery
+    ).toBe(false)
+  })
+
   it('queues a debounced export after a journal save without awaiting it', async () => {
     vi.useFakeTimers()
     try {
@@ -352,7 +398,9 @@ describe('LocalNotebooks operation-log storage', () => {
           name: 'source.runme',
           parents: [parent],
         })),
-        getMetadataIfExists: vi.fn(async () => null),
+        getMetadataIfExists: vi.fn(
+          async (): Promise<typeof target | null> => null
+        ),
         waitForCreateOperation: vi.fn(
           async (): Promise<typeof target | null> => null
         ),
@@ -381,11 +429,11 @@ describe('LocalNotebooks operation-log storage', () => {
       notebook.metadata[AUTO_IPYNB_KEY] = 'true'
       await journal.save(created.uri, notebook)
       await expect(store.syncIpynbFile(created.uri)).rejects.toThrow(
-        'response lost'
+        reserved ? 'response lost' : 'awaiting Drive confirmation'
       )
       expect(
-        (await store.files.get(created.uri))?.ipynbExportCreatePending
-      ).toBeDefined()
+        (await store.getIpynbExportState(created.uri)).needsCreateRecovery
+      ).toBe(!reserved)
       if (reserved) {
         await store.syncIpynbFile(created.uri)
         expect(drive.generateFileId).toHaveBeenCalledTimes(1)
@@ -398,12 +446,13 @@ describe('LocalNotebooks operation-log storage', () => {
         )
         expect(drive.createContent).toHaveBeenCalledTimes(1)
         drive.waitForCreateOperation.mockResolvedValue(target)
+        drive.getMetadataIfExists.mockResolvedValue(target)
         await store.syncIpynbFile(created.uri)
         expect(drive.createContent).toHaveBeenCalledTimes(1)
       }
       expect(drive.waitForCreateOperation).toHaveBeenCalled()
       expect(
-        (await store.files.get(created.uri))?.ipynbExportCreatePending
+        (await store.files.get(created.uri))?.ipynbExportPendingClaim
       ).toBeUndefined()
       expect((await store.getIpynbExportState(created.uri)).uri).toBe(
         target.uri

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -3530,6 +3530,7 @@ export class LocalNotebooks extends Dexie {
               uri: record.remoteId,
               notebookId: currentLog.header.notebook_id,
               generatedAt: new Date().toISOString(),
+              operationIds: currentLog.operations.map((op) => op.op_id),
             })
           }
         )
@@ -3539,10 +3540,22 @@ export class LocalNotebooks extends Dexie {
           ipynbExportSourceUri: sourceUri,
           ipynbExportPendingClaim: undefined,
         })
-        if (target.name !== name) await driveStore.rename(target.uri, name)
-        if (target.parents?.[0] && target.parents[0] !== parentUri) {
-          await driveStore.move(target.uri, target.parents[0], parentUri)
-        }
+        // Capture the target version BEFORE reading inputs. Metadata and media
+        // publish atomically with If-Match, so a delayed profile cannot undo a
+        // newer profile's placement or contents. Never retry stale bytes.
+        const targetVersion = await driveStore.getVersionMetadata(target.uri)
+        if (!targetVersion)
+          throw new Error('Colab copy disappeared; retry sync.')
+        const currentTarget = await driveStore.getMetadata(target.uri)
+        const previousCopy = JSON.parse(
+          await driveStore.loadContent(target.uri)
+        )
+        const sourceMetadata = await driveStore.getMetadata(record.remoteId)
+        const currentParent = sourceMetadata?.parents?.[0]
+        if (!currentParent)
+          throw new Error('Source notebook has no Drive parent.')
+        const currentName = `${(sourceMetadata.name || record.name).replace(/\.runme$/i, '')}.ipynb`
+        const upstreamContent = await driveStore.loadContent(record.remoteId)
         // Re-read after network work so a disabled option cancels a queued export
         // and a newer local save supersedes the initially observed snapshot.
         const latest = await this.files.get(uri)
@@ -3555,21 +3568,58 @@ export class LocalNotebooks extends Dexie {
         const latestLog = parseOperationLog(
           (await this.operationLogStorage.read(latest.operationLogRef)).document
         )
+        if (upstreamContent !== '') {
+          const upstreamLog = parseOperationLog(upstreamContent)
+          if (upstreamLog.header.notebook_id !== latestLog.header.notebook_id)
+            throw new Error('Source notebook identity changed during export.')
+          latestLog.operations = mergeOperationSets(
+            latestLog.operations,
+            upstreamLog.operations
+          )
+        }
+        const operationIds = latestLog.operations.map((op) => op.op_id)
+        const covered = new Set(operationIds)
+        const previousIds =
+          previousCopy.metadata?.runme?.derivedFrom?.operationIds
+        if (
+          Array.isArray(previousIds) &&
+          previousIds.some((id: string) => !covered.has(id))
+        )
+          throw new Error(
+            'Colab copy contains newer changes. Sync the source notebook before exporting again.'
+          )
         const latestNotebook = materializedLogToNotebook(
           materializeOperationLog(latestLog.operations)
         )
         if (latestNotebook.metadata[AUTO_IPYNB_KEY] !== 'true') return
         const generatedAt = new Date().toISOString()
-        await driveStore.saveContent(
+        const published = await driveStore.saveContentIfVersion(
           target.uri,
           encodeDerivedIpynb(latestNotebook, {
             version: 1,
             uri: record.remoteId,
             notebookId: latestLog.header.notebook_id,
             generatedAt,
+            operationIds,
           }),
-          'application/x-ipynb+json'
+          'application/x-ipynb+json',
+          {
+            checksum: targetVersion.md5Checksum,
+            revisionId: targetVersion.headRevisionId,
+            version: targetVersion.version,
+          },
+          {
+            name: currentName,
+            parentUri: currentParent,
+            previousParentUri: currentTarget?.parents?.[0],
+          }
         )
+        if (!published) {
+          this.enqueueIpynbSync(uri)
+          throw new Error(
+            'Colab copy changed during export; a fresh export is queued.'
+          )
+        }
         await this.files.update(uri, {
           ipynbExportError: undefined,
           ipynbExportedAt: generatedAt,
@@ -3597,9 +3647,7 @@ export class LocalNotebooks extends Dexie {
   }
 
   /** Read export status separately from the primary notebook sync indicator. */
-  async getIpynbExportState(
-    uri: string
-  ): Promise<{
+  async getIpynbExportState(uri: string): Promise<{
     uri?: string
     error?: string
     exportedAt?: string

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -49,9 +49,9 @@ import {
   type ConflictDocumentRef,
   createDefaultConflictDocStorage,
 } from './conflictDocs'
+import { UnconfirmedDerivedCopyError, ensureDerivedCopy } from './derivedCopy'
 import {
   type DriveComment,
-  DriveCreateNotCommittedError,
   DriveNotebookStore,
   type DriveRevision,
   type DriveVersionMetadata,
@@ -136,12 +136,8 @@ export interface LocalFileRecord {
   /** Derived Colab copy identity and last export outcome; source option lives in the journal. */
   ipynbExportUri?: string
   ipynbExportSourceUri?: string
-  /** Durable reservation/uncertain-create marker, written before any remote create. */
-  ipynbExportCreatePending?: {
-    sourceUri: string
-    parentUri: string
-    remoteUri?: string
-  }
+  /** The exact upstream claim that an explicit recovery action may clear. */
+  ipynbExportPendingClaim?: string
   ipynbExportError?: string
   ipynbExportedAt?: string
   /** Stable idempotency key for creating the Markdown sidecar. */
@@ -3505,91 +3501,43 @@ export class LocalNotebooks extends Dexie {
         // A source-scoped identity survives retries and independent local mirrors.
         // Never select an unrelated user file merely because its name matches.
         const sourceUri = driveFileUrl(parseDriveItem(record.remoteId).id)
-        const createOperationId = `runme-ipynb-${md5(sourceUri)}`
-        let pending =
-          record.ipynbExportCreatePending?.sourceUri === sourceUri
-            ? record.ipynbExportCreatePending
-            : undefined
-        let target =
-          record.ipynbExportUri && record.ipynbExportSourceUri === sourceUri
-            ? await driveStore.getMetadataIfExists(record.ipynbExportUri)
-            : pending?.remoteUri
-              ? await driveStore.getMetadataIfExists(pending.remoteUri)
-              : null
-        if (!target) {
-          target = await driveStore.waitForCreateOperation(
-            pending?.parentUri ?? parentUri,
-            createOperationId
-          )
-        }
-        if (!target) {
-          const beforeCreate = await this.files.get(uri)
-          if (
-            !beforeCreate?.operationLogRef ||
-            beforeCreate.conflict ||
-            beforeCreate.remoteId !== record.remoteId
-          )
-            return
-          const creationNotebook = materializedLogToNotebook(
-            materializeOperationLog(
-              parseOperationLog(
-                (
-                  await this.operationLogStorage.read(
-                    beforeCreate.operationLogRef
-                  )
-                ).document
-              ).operations
+        const target = await ensureDerivedCopy(
+          driveStore,
+          record.remoteId,
+          parentUri,
+          name,
+          async () => {
+            const beforeCreate = await this.files.get(uri)
+            if (
+              !beforeCreate?.operationLogRef ||
+              beforeCreate.conflict ||
+              beforeCreate.remoteId !== record.remoteId
             )
-          )
-          if (creationNotebook.metadata[AUTO_IPYNB_KEY] !== 'true') return
-          // Shared Drives cannot reserve IDs. An uncertain request there must
-          // settle in search before retrying; never issue a second blind create.
-          if (pending && !pending.remoteUri) {
-            throw new Error(
-              'Colab copy creation is awaiting Drive confirmation; retry sync later.'
+              return null
+            const currentLog = parseOperationLog(
+              (
+                await this.operationLogStorage.read(
+                  beforeCreate.operationLogRef
+                )
+              ).document
             )
-          }
-          if (!pending) {
-            pending = {
-              sourceUri,
-              parentUri,
-              ...((await driveStore.canUsePreGeneratedFileId(parentUri))
-                ? { remoteUri: driveFileUrl(await driveStore.generateFileId()) }
-                : {}),
-            }
-            await this.files.update(uri, { ipynbExportCreatePending: pending })
-          }
-          try {
-            target = await driveStore.createContent(
-              parentUri,
-              name,
-              encodeDerivedIpynb(creationNotebook, {
-                version: 1,
-                uri: record.remoteId,
-                notebookId: log.header.notebook_id,
-                generatedAt: new Date().toISOString(),
-              }),
-              IPYNB_MIME_TYPE,
-              {
-                createOperationId,
-                ...(pending.remoteUri
-                  ? { fileId: parseDriveItem(pending.remoteUri).id }
-                  : {}),
-              }
+            const currentNotebook = materializedLogToNotebook(
+              materializeOperationLog(currentLog.operations)
             )
-          } catch (error) {
-            if (error instanceof DriveCreateNotCommittedError) {
-              await this.files.update(uri, {
-                ipynbExportCreatePending: undefined,
-              })
-            }
-            throw error
+            if (currentNotebook.metadata[AUTO_IPYNB_KEY] !== 'true') return null
+            return encodeDerivedIpynb(currentNotebook, {
+              version: 1,
+              uri: record.remoteId,
+              notebookId: currentLog.header.notebook_id,
+              generatedAt: new Date().toISOString(),
+            })
           }
-        }
+        )
+        if (!target) return
         await this.files.update(uri, {
           ipynbExportUri: target.uri,
           ipynbExportSourceUri: sourceUri,
-          ipynbExportCreatePending: undefined,
+          ipynbExportPendingClaim: undefined,
         })
         if (target.name !== name) await driveStore.rename(target.uri, name)
         if (target.parents?.[0] && target.parents[0] !== parentUri) {
@@ -3627,7 +3575,13 @@ export class LocalNotebooks extends Dexie {
           ipynbExportedAt: generatedAt,
         })
       } catch (error) {
-        await this.files.update(uri, { ipynbExportError: String(error) })
+        await this.files.update(uri, {
+          ipynbExportError: String(error),
+          ipynbExportPendingClaim:
+            error instanceof UnconfirmedDerivedCopyError
+              ? error.claim
+              : undefined,
+        })
         appLogger.warn('Could not export Colab copy', {
           attrs: {
             scope: 'storage.local.ipynb-export',
@@ -3645,13 +3599,39 @@ export class LocalNotebooks extends Dexie {
   /** Read export status separately from the primary notebook sync indicator. */
   async getIpynbExportState(
     uri: string
-  ): Promise<{ uri?: string; error?: string; exportedAt?: string }> {
+  ): Promise<{
+    uri?: string
+    error?: string
+    exportedAt?: string
+    needsCreateRecovery?: boolean
+  }> {
     const record = await this.files.get(uri)
     return {
       uri: record?.ipynbExportUri,
       error: record?.ipynbExportError,
       exportedAt: record?.ipynbExportedAt,
+      needsCreateRecovery: Boolean(record?.ipynbExportPendingClaim),
     }
+  }
+
+  /** Explicit user recovery: never clear a newer claim or a confirmed copy. */
+  async retryUnconfirmedIpynbCreation(uri: string): Promise<void> {
+    await this.driveSyncCoordinator.runExclusive(uri, async () => {
+      const record = await this.files.get(uri)
+      if (!record?.ipynbExportPendingClaim || !isDriveUri(record.remoteId))
+        return
+      const drive = appState.driveNotebookStore ?? this.driveStore
+      await drive.compareAndSetDerivedCopyClaim(
+        record.remoteId,
+        record.ipynbExportPendingClaim,
+        null
+      )
+      await this.files.update(uri, {
+        ipynbExportPendingClaim: undefined,
+        ipynbExportError: undefined,
+      })
+    })
+    await this.syncIpynbFile(uri)
   }
 
   private async getOrBackfillLocalChecksum(

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -3547,9 +3547,16 @@ export class LocalNotebooks extends Dexie {
         if (!targetVersion)
           throw new Error('Colab copy disappeared; retry sync.')
         const currentTarget = await driveStore.getMetadata(target.uri)
-        const previousCopy = JSON.parse(
-          await driveStore.loadContent(target.uri)
-        )
+        const previousContent = await driveStore.loadContent(target.uri)
+        let previousCopy
+        try {
+          previousCopy = JSON.parse(previousContent)
+        } catch {
+          // A create can commit metadata before its media upload fails. The
+          // source marker was verified by ensureDerivedCopy; repair those bytes
+          // under the captured version rather than strand the owned target.
+          previousCopy = undefined
+        }
         const sourceMetadata = await driveStore.getMetadata(record.remoteId)
         const currentParent = sourceMetadata?.parents?.[0]
         if (!currentParent)
@@ -3580,7 +3587,7 @@ export class LocalNotebooks extends Dexie {
         const operationIds = latestLog.operations.map((op) => op.op_id)
         const covered = new Set(operationIds)
         const previousIds =
-          previousCopy.metadata?.runme?.derivedFrom?.operationIds
+          previousCopy?.metadata?.runme?.derivedFrom?.operationIds
         if (
           Array.isArray(previousIds) &&
           previousIds.some((id: string) => !covered.has(id))

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -51,6 +51,7 @@ import {
 } from './conflictDocs'
 import {
   type DriveComment,
+  DriveCreateNotCommittedError,
   DriveNotebookStore,
   type DriveRevision,
   type DriveVersionMetadata,
@@ -135,6 +136,12 @@ export interface LocalFileRecord {
   /** Derived Colab copy identity and last export outcome; source option lives in the journal. */
   ipynbExportUri?: string
   ipynbExportSourceUri?: string
+  /** Durable reservation/uncertain-create marker, written before any remote create. */
+  ipynbExportCreatePending?: {
+    sourceUri: string
+    parentUri: string
+    remoteUri?: string
+  }
   ipynbExportError?: string
   ipynbExportedAt?: string
   /** Stable idempotency key for creating the Markdown sidecar. */
@@ -3499,24 +3506,90 @@ export class LocalNotebooks extends Dexie {
         // Never select an unrelated user file merely because its name matches.
         const sourceUri = driveFileUrl(parseDriveItem(record.remoteId).id)
         const createOperationId = `runme-ipynb-${md5(sourceUri)}`
+        let pending =
+          record.ipynbExportCreatePending?.sourceUri === sourceUri
+            ? record.ipynbExportCreatePending
+            : undefined
         let target =
           record.ipynbExportUri && record.ipynbExportSourceUri === sourceUri
             ? await driveStore.getMetadataIfExists(record.ipynbExportUri)
-            : null
+            : pending?.remoteUri
+              ? await driveStore.getMetadataIfExists(pending.remoteUri)
+              : null
         if (!target) {
-          target = await driveStore.findByCreateOperation(
-            parentUri,
+          target = await driveStore.waitForCreateOperation(
+            pending?.parentUri ?? parentUri,
             createOperationId
           )
         }
         if (!target) {
-          target = await driveStore.create(parentUri, name, {
-            createOperationId,
-          })
+          const beforeCreate = await this.files.get(uri)
+          if (
+            !beforeCreate?.operationLogRef ||
+            beforeCreate.conflict ||
+            beforeCreate.remoteId !== record.remoteId
+          )
+            return
+          const creationNotebook = materializedLogToNotebook(
+            materializeOperationLog(
+              parseOperationLog(
+                (
+                  await this.operationLogStorage.read(
+                    beforeCreate.operationLogRef
+                  )
+                ).document
+              ).operations
+            )
+          )
+          if (creationNotebook.metadata[AUTO_IPYNB_KEY] !== 'true') return
+          // Shared Drives cannot reserve IDs. An uncertain request there must
+          // settle in search before retrying; never issue a second blind create.
+          if (pending && !pending.remoteUri) {
+            throw new Error(
+              'Colab copy creation is awaiting Drive confirmation; retry sync later.'
+            )
+          }
+          if (!pending) {
+            pending = {
+              sourceUri,
+              parentUri,
+              ...((await driveStore.canUsePreGeneratedFileId(parentUri))
+                ? { remoteUri: driveFileUrl(await driveStore.generateFileId()) }
+                : {}),
+            }
+            await this.files.update(uri, { ipynbExportCreatePending: pending })
+          }
+          try {
+            target = await driveStore.createContent(
+              parentUri,
+              name,
+              encodeDerivedIpynb(creationNotebook, {
+                version: 1,
+                uri: record.remoteId,
+                notebookId: log.header.notebook_id,
+                generatedAt: new Date().toISOString(),
+              }),
+              IPYNB_MIME_TYPE,
+              {
+                createOperationId,
+                ...(pending.remoteUri
+                  ? { fileId: parseDriveItem(pending.remoteUri).id }
+                  : {}),
+              }
+            )
+          } catch (error) {
+            if (error instanceof DriveCreateNotCommittedError) {
+              await this.files.update(uri, {
+                ipynbExportCreatePending: undefined,
+              })
+            }
+            throw error
+          }
         }
         await this.files.update(uri, {
           ipynbExportUri: target.uri,
           ipynbExportSourceUri: sourceUri,
+          ipynbExportCreatePending: undefined,
         })
         if (target.name !== name) await driveStore.rename(target.uri, name)
         if (target.parents?.[0] && target.parents[0] !== parentUri) {

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -5,6 +5,8 @@ import { Subject, debounceTime } from 'rxjs'
 import { v4 as uuidv4 } from 'uuid'
 
 import { migrateNotebookCellIds } from '../lib/cellIdentity'
+import { encodeDerivedIpynb } from '../lib/derivedIpynb'
+import { AUTO_IPYNB_KEY } from '../lib/derivedNotebook'
 import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { appLogger } from '../lib/logging/runtime'
 import { serializeNotebookToMarkdown } from '../lib/markdown/serializeNotebookToMarkdown'
@@ -130,6 +132,11 @@ export interface LocalFileRecord {
   }
   /** Remote Drive URI of the Markdown sidecar (e.g. *.index.md) if present. */
   markdownUri?: string
+  /** Derived Colab copy identity and last export outcome; source option lives in the journal. */
+  ipynbExportUri?: string
+  ipynbExportSourceUri?: string
+  ipynbExportError?: string
+  ipynbExportedAt?: string
   /** Stable idempotency key for creating the Markdown sidecar. */
   markdownCreateOperationId?: string
   /**
@@ -336,6 +343,7 @@ export class LocalNotebooks extends Dexie {
 
   private readonly syncSubjects = new Map<string, Subject<void>>()
   private readonly markdownSyncSubjects = new Map<string, Subject<void>>()
+  private readonly ipynbSyncSubjects = new Map<string, Subject<void>>()
   private readonly inFlightSyncs = new Map<string, Promise<void>>()
   private readonly syncListeners = new Map<string, Set<() => void>>()
 
@@ -2269,15 +2277,13 @@ export class LocalNotebooks extends Dexie {
         ? `drive:${parseDriveItem(sourceRecord.remoteId).id}`
         : sourceUri
     const sourceLockKey = `legacy-conversion:${sourceLockIdentity}`
-    return this.driveSyncCoordinator.runExclusive(
-      sourceLockKey,
-      () =>
-        this.convertLegacyNotebookToRunmeExclusive(
-          sourceUri,
-          parentUri,
-          invokedAt,
-          sourceLockKey
-        )
+    return this.driveSyncCoordinator.runExclusive(sourceLockKey, () =>
+      this.convertLegacyNotebookToRunmeExclusive(
+        sourceUri,
+        parentUri,
+        invokedAt,
+        sourceLockKey
+      )
     )
   }
 
@@ -2439,8 +2445,7 @@ export class LocalNotebooks extends Dexie {
             attempt &&
               (!attempt.completedAt || attempt.completedAt >= invokedAt) &&
               attempt.originalGoogleDriveId === originalGoogleDriveId &&
-              detectNotebookFileFormat(record.name) ===
-                'runme-operation-log'
+              detectNotebookFileFormat(record.name) === 'runme-operation-log'
           )
         })
         .toArray()
@@ -2573,9 +2578,7 @@ export class LocalNotebooks extends Dexie {
         }
 
         if (!isDriveUri(child.remoteId)) {
-          if (
-            child.parentRemoteIdWhenCreated !== destinationParent.remoteId
-          ) {
+          if (child.parentRemoteIdWhenCreated !== destinationParent.remoteId) {
             await this.files.update(childUri, {
               parentRemoteIdWhenCreated: destinationParent.remoteId,
             })
@@ -2600,8 +2603,7 @@ export class LocalNotebooks extends Dexie {
             )
           }
           if (
-            parseDriveItem(currentRemoteParent).id !==
-            destinationDriveFolder.id
+            parseDriveItem(currentRemoteParent).id !== destinationDriveFolder.id
           ) {
             if (currentParent) {
               await this.move(childUri, destinationParentUri)
@@ -2660,10 +2662,7 @@ export class LocalNotebooks extends Dexie {
           this.notifySync(childUri)
         }
 
-        await this.attachDriveFileToFolder(
-          destinationParent.remoteId,
-          childUri
-        )
+        await this.attachDriveFileToFolder(destinationParent.remoteId, childUri)
         await this.syncFile(childUri)
         await this.attachDriveFileToFolder(
           destinationParent.remoteId,
@@ -3033,6 +3032,7 @@ export class LocalNotebooks extends Dexie {
     }
 
     await this.files.update(uri, { name: nextName, remoteId: nextRemoteId })
+    if (record.operationLogRef) this.enqueueIpynbSync(uri)
 
     const parentFolder = await this.findParentFolder(uri)
 
@@ -3152,6 +3152,7 @@ export class LocalNotebooks extends Dexie {
       children.includes(uri) ? children : [...children, uri]
     )
 
+    if (file?.operationLogRef) this.enqueueIpynbSync(uri)
     if (clearMarkdownUri && file) {
       try {
         await this.syncMarkdownFile(uri)
@@ -3437,6 +3438,7 @@ export class LocalNotebooks extends Dexie {
   }
 
   private enqueueMarkdownSync(uri: string): void {
+    this.enqueueIpynbSync(uri)
     let mdSubject = this.markdownSyncSubjects.get(uri)
     if (!mdSubject) {
       mdSubject = new Subject<void>()
@@ -3451,6 +3453,132 @@ export class LocalNotebooks extends Dexie {
       this.markdownSyncSubjects.set(uri, mdSubject)
     }
     mdSubject.next()
+  }
+
+  /** Queue derived work independently: export failure cannot reject a source save. */
+  private enqueueIpynbSync(uri: string): void {
+    let subject = this.ipynbSyncSubjects.get(uri)
+    if (!subject) {
+      subject = new Subject<void>()
+      subject.pipe(debounceTime(20_000)).subscribe(() => {
+        void this.syncIpynbFile(uri).catch(() => undefined)
+      })
+      this.ipynbSyncSubjects.set(uri, subject)
+    }
+    subject.next()
+  }
+
+  /** Publish the latest committed .runme snapshot as an optional Drive sibling. */
+  async syncIpynbFile(uri: string): Promise<void> {
+    await this.driveSyncCoordinator.runExclusive(uri, async () => {
+      try {
+        const record = await this.files.get(uri)
+        if (
+          !record?.operationLogRef ||
+          record.conflict ||
+          !isDriveUri(record.remoteId)
+        )
+          return
+        const document = (
+          await this.operationLogStorage.read(record.operationLogRef)
+        ).document
+        const log = parseOperationLog(document)
+        const notebook = materializedLogToNotebook(
+          materializeOperationLog(log.operations)
+        )
+        if (notebook.metadata[AUTO_IPYNB_KEY] !== 'true') return
+        const driveStore = appState.driveNotebookStore ?? this.driveStore
+        const metadata = await driveStore.getMetadata(record.remoteId)
+        const parentUri = metadata?.parents?.[0]
+        if (!parentUri)
+          throw new Error(
+            'The source notebook needs a Drive parent folder to export a Colab copy.'
+          )
+        const name = `${(metadata.name || record.name).replace(/\.runme$/i, '')}.ipynb`
+        // A source-scoped identity survives retries and independent local mirrors.
+        // Never select an unrelated user file merely because its name matches.
+        const sourceUri = driveFileUrl(parseDriveItem(record.remoteId).id)
+        const createOperationId = `runme-ipynb-${md5(sourceUri)}`
+        let target =
+          record.ipynbExportUri && record.ipynbExportSourceUri === sourceUri
+            ? await driveStore.getMetadataIfExists(record.ipynbExportUri)
+            : null
+        if (!target) {
+          target = await driveStore.findByCreateOperation(
+            parentUri,
+            createOperationId
+          )
+        }
+        if (!target) {
+          target = await driveStore.create(parentUri, name, {
+            createOperationId,
+          })
+        }
+        await this.files.update(uri, {
+          ipynbExportUri: target.uri,
+          ipynbExportSourceUri: sourceUri,
+        })
+        if (target.name !== name) await driveStore.rename(target.uri, name)
+        if (target.parents?.[0] && target.parents[0] !== parentUri) {
+          await driveStore.move(target.uri, target.parents[0], parentUri)
+        }
+        // Re-read after network work so a disabled option cancels a queued export
+        // and a newer local save supersedes the initially observed snapshot.
+        const latest = await this.files.get(uri)
+        if (
+          !latest?.operationLogRef ||
+          latest.conflict ||
+          latest.remoteId !== record.remoteId
+        )
+          return
+        const latestLog = parseOperationLog(
+          (await this.operationLogStorage.read(latest.operationLogRef)).document
+        )
+        const latestNotebook = materializedLogToNotebook(
+          materializeOperationLog(latestLog.operations)
+        )
+        if (latestNotebook.metadata[AUTO_IPYNB_KEY] !== 'true') return
+        const generatedAt = new Date().toISOString()
+        await driveStore.saveContent(
+          target.uri,
+          encodeDerivedIpynb(latestNotebook, {
+            version: 1,
+            uri: record.remoteId,
+            notebookId: latestLog.header.notebook_id,
+            generatedAt,
+          }),
+          'application/x-ipynb+json'
+        )
+        await this.files.update(uri, {
+          ipynbExportError: undefined,
+          ipynbExportedAt: generatedAt,
+        })
+      } catch (error) {
+        await this.files.update(uri, { ipynbExportError: String(error) })
+        appLogger.warn('Could not export Colab copy', {
+          attrs: {
+            scope: 'storage.local.ipynb-export',
+            localUri: uri,
+            error: String(error),
+          },
+        })
+        throw error
+      } finally {
+        this.notifySync(uri)
+      }
+    })
+  }
+
+  /** Read export status separately from the primary notebook sync indicator. */
+  async getIpynbExportState(
+    uri: string
+  ): Promise<{ uri?: string; error?: string; exportedAt?: string }> {
+    const record = await this.files.get(uri)
+    return {
+      uri: record?.ipynbExportUri,
+      error: record?.ipynbExportError,
+      exportedAt: record?.ipynbExportedAt,
+    }
   }
 
   private async getOrBackfillLocalChecksum(
@@ -3635,6 +3763,7 @@ export class LocalNotebooks extends Dexie {
           // Another tab may have completed the pending create while we waited.
           await this.syncFileInner(localUri)
           await this.files.update(localUri, { lastSyncError: undefined })
+          this.enqueueIpynbSync(localUri)
         } catch (error) {
           await this.files.update(localUri, { lastSyncError: String(error) })
           throw error

--- a/docs-dev/CUJs/automatic-colab-copy.md
+++ b/docs-dev/CUJs/automatic-colab-copy.md
@@ -1,0 +1,23 @@
+# Automatically publish a Colab copy
+
+1. Open a Drive-backed `.runme` notebook with text, code, and saved output.
+2. Right-click its tab, open **Notebook properties**, and enable
+   **Automatically save a Colab copy (.ipynb)**. Close and reopen properties;
+   verify the checkbox remains enabled.
+3. Allow the background export to finish. Open **Open Colab copy** and verify
+   the cells and outputs match the source and the first cell warns that this
+   generated file will be overwritten.
+4. Open the generated `.ipynb` in Runme. Verify its header links to the source,
+   editing and execution controls are disabled, and there is no request-write
+   access button for the generated notebook.
+5. Edit the source and save. Verify the same Drive copy ID receives the update.
+6. Disable automatic export, edit and save again. Verify the source changes
+   and the last generated copy remains unchanged.
+7. Re-enable export. Simulate an upload failure and verify the source save still
+   completes, properties reports the copy error, and a later successful sync
+   retries the export.
+
+Automated coverage: `derivedIpynb.test.ts`, `derivedNotebookModel.test.ts`,
+`NotebookPropertiesDialog.test.tsx`, and the operation-log export integration
+cases in `storage/local.test.ts`. The slow-upload test holds a real promise
+pending while another journal save commits and is read back from storage.

--- a/docs-dev/CUJs/automatic-colab-copy.md
+++ b/docs-dev/CUJs/automatic-colab-copy.md
@@ -16,8 +16,16 @@
 7. Re-enable export. Simulate an upload failure and verify the source save still
    completes, properties reports the copy error, and a later successful sync
    retries the export.
+8. Open the same source in independent browser profiles and trigger concurrent
+   exports. Verify the shared source property selects one copy identity.
+9. Simulate a Shared Drive create whose response is lost. Verify subsequent
+   sync waits for confirmation. If no file was created, use the warning-gated
+   recovery action in properties and verify export can resume.
 
 Automated coverage: `derivedIpynb.test.ts`, `derivedNotebookModel.test.ts`,
 `NotebookPropertiesDialog.test.tsx`, and the operation-log export integration
 cases in `storage/local.test.ts`. The slow-upload test holds a real promise
 pending while another journal save commits and is read back from storage.
+`storage/derivedCopy.test.ts` exercises independent clients with only shared
+remote CAS state (no shared local lock), and `storage/drive.test.ts` verifies
+the conditional property update for both browser and token transports.

--- a/docs-dev/CUJs/automatic-colab-copy.md
+++ b/docs-dev/CUJs/automatic-colab-copy.md
@@ -21,6 +21,11 @@
 9. Simulate a Shared Drive create whose response is lost. Verify subsequent
    sync waits for confirmation. If no file was created, use the warning-gated
    recovery action in properties and verify export can resume.
+10. Pause one profile during discovery or upload. In another profile, move and
+    rename the source, add content, and finish exporting. Resume the old profile;
+    verify it cannot revert the copy's name, folder, or newer content. A rejected
+    version check queues fresh work; a mirror missing previously exported
+    operations reports that the source must be synced first.
 
 Automated coverage: `derivedIpynb.test.ts`, `derivedNotebookModel.test.ts`,
 `NotebookPropertiesDialog.test.tsx`, and the operation-log export integration
@@ -29,3 +34,5 @@ pending while another journal save commits and is read back from storage.
 `storage/derivedCopy.test.ts` exercises independent clients with only shared
 remote CAS state (no shared local lock), and `storage/drive.test.ts` verifies
 the conditional property update for both browser and token transports.
+Out-of-order profile tests verify content and placement together. Both transports
+are checked for atomic multipart updates with If-Match and HTTP 412 rejection.

--- a/docs/17-ipynb-notebooks.md
+++ b/docs/17-ipynb-notebooks.md
@@ -97,6 +97,29 @@ Runme Web instead.
 
 ## Synchronization and concurrent edits
 
+### Automatically publish a Colab copy of a .runme notebook
+
+Right-click a `.runme` notebook tab and choose **Notebook properties**. Enable
+**Automatically save a Colab copy (.ipynb)**. The option is saved in the notebook
+and defaults to off. Once the notebook is linked to Google Drive, Runme creates
+a sibling `.ipynb` in the same folder and updates it in the background after
+source saves. Notebook cells and outputs are included. Use **Open Colab copy**
+in properties once the copy has been created.
+
+The `.runme` save completes independently of the export. Properties shows export
+errors; the next source save or successful Drive sync retries the copy. Keep
+Runme open and signed in while background uploads complete. Turning the option
+off keeps the last copy and stops updating it.
+
+Generated copies contain provenance metadata and a leading notice visible in
+Colab. Runme also shows a source link and renders them read-only. Make durable
+edits in the source `.runme` notebook: any changes made to the generated copy in
+Colab will be overwritten by a later export. Drive permissions still determine
+who can open the copy, and runtime compatibility remains subject to the
+limitations below.
+
+### Editing ordinary .ipynb notebooks
+
 Edits made in Colab update the same Drive file. Runme's Drive synchronization
 will detect the upstream change. If the notebook was also edited locally,
 Runme may report a conflict instead of silently overwriting either version.

--- a/docs/17-ipynb-notebooks.md
+++ b/docs/17-ipynb-notebooks.md
@@ -111,6 +111,12 @@ errors; the next source save or successful Drive sync retries the copy. Keep
 Runme open and signed in while background uploads complete. Turning the option
 off keeps the last copy and stops updating it.
 
+If creation in a Shared Drive cannot be confirmed, Runme stops issuing new
+creates to avoid duplicates. Check Drive for an existing copy and sync again.
+If the request never arrived, use **Retry unconfirmed creation** in properties.
+This requires confirmation: an earlier request that is still in flight can
+leave an extra copy. Retrying cannot clear a newer or already-confirmed copy.
+
 Generated copies contain provenance metadata and a leading notice visible in
 Colab. Runme also shows a source link and renders them read-only. Make durable
 edits in the source `.runme` notebook: any changes made to the generated copy in


### PR DESCRIPTION
## Summary

Add an opt-in automatic `.ipynb` copy for `.runme` notebooks so readers can view them in Google Colab.

- Right-click a notebook tab → **Notebook properties** → **Automatically save a Colab copy (.ipynb)**. The property is persisted in the operation log, defaults off, and is disabled for read-only/unloaded notebooks.
- Source journal saves enqueue a debounced background export. Drive copy errors are reported independently and cannot fail or hold up the local source save. Later saves or successful Drive sync retry export.
- Update a stable Drive sibling, never a file selected only by filename. Handle deleted copies and source relinking; preserve the target ID across rename/move.
- Elect the copy identity in a public source-file property using Drive ETag CAS, so independent profiles share one reservation/creation owner. The property contains only an ID/claim. Verify source-scoped provenance before using its target. Unconfirmed Shared Drive creates have an explicit warning-gated recovery action that clears only the observed pending claim.
- Export all materialized cells/outputs, portable provenance metadata, and a leading generated/read-only notice. Runme also renders a source-link header and enforces read-only behavior in the notebook model.
- Turning the option off retains the last copy. Local-only notebooks wait until linked to Drive; Runme must remain open and signed in for background export. This is best-effort derived output, not a transactional cross-device replication guarantee.

## Design

[Runme design notebook in the requested Drive folder](https://runme.gateway.unified-0.internal.api.openai.org/?doc=https%3A%2F%2Fdrive.google.com%2Ffile%2Fd%2F1qjSXkiEYzXcOB9vruVagkCxnAMf3Xrg1%2Fview)

User documentation and the manual CUJ are included.

## Verification and review

- `runme run build test`: passed (all packages built; console tests passed).
- Final post-review app Vitest suite: 116 files / 1,228 tests passed, including source-coordinated concurrent-client tests, both conditional-write transports, explicit unconfirmed-create recovery, source move/copy recovery, incomplete target-media repair, and the debounced scheduling regression.
- Integration cases cover committed property readback, stable target reuse, disable, source relink, deleted target recreation, latest snapshot reread, upload failure/retry, and source saves completing while the derived upload remains pending.
- Encoder/model/UI tests cover provenance and output roundtrip, no source mutation, read-only enforcement, properties on/off, and generated header with no write-access request.
- Independent review found uncertain-create recovery, cross-profile coordination, tab read-only propagation, source move/copy lifecycle, out-of-order export, and incomplete target-media gaps. All nine findings are addressed, replied to, and resolved with regression coverage. Recovery searches across folders; source-bound claims let copied notebooks elect a new target without modifying the original copy. Final self-review verified that media repair retains source ownership validation and the target version guard.
- Content and placement publish atomically with target-version/If-Match protection. The exporter rereads source placement and merges upstream operations. Provenance records operation coverage; a stale mirror cannot replace a copy containing operations it lacks. Reversed profile completion and both multipart transports are covered.
- In-app browser: manually verified the local tab context menu and properties dialog. Drive upload behavior uses the real exporter with mocked Drive calls; a full live Colab journey has not been claimed.
- Reviewed against root/app instructions and docs-dev/style.md. `docs-dev/architecture.md` referenced by app instructions is absent. CUJ updated.
- Separate `pnpm -C app run typecheck` still fails on errors in existing code (e.g. pending comment narrowing and renderer/protobuf types). Verified against an archived base revision: identical diagnostics after normalizing line positions and the union-method-count display. Build does not run this separate check.
