### PR TITLE
Fix localhost Google Drive client initialization

### DIFF
--- a/app/assets/configs/app-configs.yaml
+++ b/app/assets/configs/app-configs.yaml
@@ -16,6 +16,9 @@ oidc:
 
 googleDrive:
   clientID: '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com'
+  # An explicit base URL selects the fetch-based Drive client, avoiding the GAPI
+  # discovery loader that can remain pending in sandboxed localhost browsers.
+  baseUrl: 'https://www.googleapis.com'
   # Supported values for authFlow: implicit (token), pkce (authorization code).
   authFlow: 'implicit'
   # Supported values for authUxMode: popup, redirect, new_tab.

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import localAppConfigYaml from '../../assets/configs/app-configs.yaml?raw'
+
 async function loadModules() {
   vi.resetModules()
   const appConfig = await import('./appConfig')
@@ -92,6 +94,18 @@ describe('appConfig OIDC Google shorthand', () => {
     )
 
     expect(getGoogleDriveBaseUrl()).toBe('http://127.0.0.1:9090')
+  })
+
+  it('configures local development to use the fetch-based Drive client', async () => {
+    const { setAppConfigFromYaml } = await loadModules()
+    const { getGoogleDriveBaseUrl } = await import('./googleDriveRuntime')
+
+    setAppConfigFromYaml(
+      localAppConfigYaml,
+      'http://localhost/configs/app-configs.yaml'
+    )
+
+    expect(getGoogleDriveBaseUrl()).toBe('https://www.googleapis.com')
   })
 
   it('applies Google Drive PKCE auth flow when configured', async () => {

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -262,6 +262,48 @@ describe("DriveNotebookStore", () => {
     ).toBe(true);
   });
 
+  it("preserves v2 ETags and public properties through the fetch transport", async () => {
+    setGoogleDriveBaseUrl("https://www.googleapis.com");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = new URL(String(input));
+        if (init?.method === "GET") {
+          expect(url.pathname).toBe("/drive/v2/files/source");
+          return new Response(
+            JSON.stringify({
+              etag: '"v2"',
+              properties: [
+                {
+                  key: "runmeIpynbCopy",
+                  value: "r:copy",
+                  visibility: "PUBLIC",
+                },
+                { key: "private", value: "hidden", visibility: "PRIVATE" },
+              ],
+            }),
+            { headers: { "Content-Type": "application/json" } }
+          );
+        }
+        expect(url.pathname).toBe("/drive/v3/files/source");
+        expect(init?.headers).toMatchObject({ "If-Match": '"v2"' });
+        expect(JSON.parse(String(init?.body))).toEqual({
+          properties: { runmeIpynbCopy: "f:copy" },
+        });
+        return new Response("", { status: 200 });
+      });
+    const store = new DriveNotebookStore(async () => "access-token");
+
+    await expect(
+      store.compareAndSetDerivedCopyClaim(
+        driveFileUrl("source"),
+        "r:copy",
+        "f:copy"
+      )
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it.each(["gapi", "fetch"])(
     "conditionally publishes copy placement and content together via %s",
     async (transport) => {

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -1005,33 +1005,7 @@ export class GapiDriveFilesClient implements DriveFilesClient {
         headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
     )
-    const metadata =
-      (response.result as
-        | (DriveVersionMetadata & { etag?: string })
-        | undefined) ?? null
-    return {
-      metadata: metadata
-        ? {
-            ...metadata,
-            properties: Object.fromEntries(
-              (
-                (
-                  metadata as unknown as {
-                    properties?: {
-                      key: string
-                      value: string
-                      visibility: string
-                    }[]
-                  }
-                ).properties ?? []
-              )
-                .filter((property) => property.visibility === 'PUBLIC')
-                .map((property) => [property.key, property.value])
-            ),
-          }
-        : null,
-      etag: metadata?.etag ?? response.etag,
-    }
+    return normalizeDriveV2VersionResponse(response)
   }
 
   /** CAS one public property without changing media or unrelated properties. */
@@ -1515,21 +1489,41 @@ class FetchDriveFilesClient implements DriveFilesClient {
     metadata: DriveVersionMetadata | null
     etag?: string
   }> {
+    // Fake/test servers expose the v3 ETag header through CORS, so preserve
+    // their existing v3 contract instead of requiring them to emulate v2.
+    if (!new URL(this.baseUrl).hostname.endsWith('.googleapis.com')) {
+      const response = await this.request(
+        'GET',
+        `/drive/v3/files/${encodeURIComponent(fileId)}`,
+        {
+          params: {
+            supportsAllDrives: true,
+            fields: VERSION_FIELDS,
+            resourceKey,
+          },
+        }
+      )
+      return {
+        metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
+        etag: response.etag,
+      }
+    }
+
+    // Match the GAPI transport's v2 metadata request. Google does not expose
+    // the v3 ETag response header to cross-origin browser JavaScript, while v2
+    // includes the validator in the JSON body.
     const response = await this.request(
       'GET',
-      `/drive/v3/files/${encodeURIComponent(fileId)}`,
+      `/drive/v2/files/${encodeURIComponent(fileId)}`,
       {
         params: {
           supportsAllDrives: true,
-          fields: VERSION_FIELDS,
-          resourceKey,
+          fields: DRIVE_V2_VERSION_FIELDS,
         },
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
     )
-    return {
-      metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
-      etag: response.etag,
-    }
+    return normalizeDriveV2VersionResponse(response)
   }
 
   /** Use the same source-file CAS contract as the browser transport. */
@@ -1988,6 +1982,40 @@ export interface DriveVersionMetadata {
   headRevisionId?: string
   version?: string
   appProperties?: Record<string, string>
+}
+
+type DriveV2VersionMetadata = Omit<DriveVersionMetadata, 'properties'> & {
+  etag?: string
+  properties?: {
+    key: string
+    value: string
+    visibility: string
+  }[]
+}
+
+/** Normalize Drive v2's public-property array and browser-visible JSON ETag. */
+function normalizeDriveV2VersionResponse(response: {
+  result?: unknown
+  etag?: string
+}): {
+  metadata: DriveVersionMetadata | null
+  etag?: string
+} {
+  const metadata =
+    (response.result as DriveV2VersionMetadata | undefined) ?? null
+  return {
+    metadata: metadata
+      ? {
+          ...metadata,
+          properties: Object.fromEntries(
+            (metadata.properties ?? [])
+              .filter((property) => property.visibility === 'PUBLIC')
+              .map((property) => [property.key, property.value])
+          ),
+        }
+      : null,
+    etag: metadata?.etag ?? response.etag,
+  }
 }
 
 export interface DriveRevision {


### PR DESCRIPTION
## Summary
- configure the localhost app to use the existing fetch-based Google Drive client
- avoid the GAPI discovery initialization path that can remain pending in sandboxed localhost browsers
- preserve conditional Drive writes by reading Google-hosted ETags from the Drive v2 JSON response
- add regression coverage that loads the actual local-development YAML and exercises fetch-transport compare-and-set behavior

## Validation
- runme run build test (passed)
- pnpm exec vitest run src/lib/appConfig.test.ts src/storage/drive.gapi.test.ts src/storage/drive.test.ts src/lib/runtime/driveWorkspaceTools.test.ts (88 tests passed)
- git diff --check (passed)
- End-to-end localhost verification: mounted runme-dev-nbs, opened a Drive-backed notebook, synchronized a temporary cell to Google Drive, and synchronized its removal

## Notes
- pnpm -C app run typecheck still reports the repository's existing unrelated TypeScript errors; this change adds no new typecheck errors.