### PR TITLE
Remove public OAuth secret and preserve Google browser login

### DIFF
--- a/app/assets/configs/app-configs.yaml
+++ b/app/assets/configs/app-configs.yaml
@@ -1,5 +1,6 @@
 # app-configs.yaml is a file that will be served by the server as a static asset.
 # It will be used by the frontend to configure itself.
+# This file is public: never include OAuth client secrets or private keys.
 # This is the configuration for local development.
 agent:
   endpoint: 'http://localhost:5191'
@@ -12,7 +13,6 @@ oidc:
   # Use google as the OIDC provider
   google:
     clientID: '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com'
-    clientSecret: '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'
 
 googleDrive:
   clientID: '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com'

--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
     "d3": "^7.9.0",
     "dexie": "3.2.4",
     "dexie-react-hooks": "4.2.0",
+    "jose": "^6.2.10",
     "jwt-decode": "^4.0.0",
     "md5": "2.3.0",
     "oauth4webapi": "^2.4.0",

--- a/app/src/auth/googleImplicitLogin.test.ts
+++ b/app/src/auth/googleImplicitLogin.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { SignJWT, base64url, exportJWK, generateKeyPair } from 'jose'
+import { webcrypto } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import localAppConfigYaml from '../../assets/configs/app-configs.yaml?raw'
+
+describe('secret-free Google OIDC login', () => {
+  let login: typeof import('./googleImplicitLogin')
+  let adapter: import('../browserAdapter.client').BrowserAuthAdapter
+  let config: import('./oidcConfig').OidcConfig
+  let privateKey: CryptoKey
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.stubGlobal('crypto', webcrypto)
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    window.history.replaceState(null, '', '/')
+    const keys = await generateKeyPair('RS256')
+    privateKey = keys.privateKey
+    const jwk = { ...(await exportJWK(keys.publicKey)), kid: 'google-test-key' }
+    fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url) !== 'https://www.googleapis.com/oauth2/v3/certs') {
+        throw new Error('Unexpected network request')
+      }
+      return new Response(JSON.stringify({ keys: [jwk] }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { setAppConfigFromYaml } = await import('../lib/appConfig')
+    config = setAppConfigFromYaml(
+      localAppConfigYaml,
+      'http://localhost/configs/app-configs.yaml'
+    ).oidc!
+    login = await import('./googleImplicitLogin')
+    adapter = new (
+      await import('../browserAdapter.client')
+    ).BrowserAuthAdapter()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  /** Sign a realistic front-channel response; only Google's public-key fetch is mocked. */
+  async function callback(
+    claims: Record<string, unknown> = {},
+    parameters: Record<string, string> = {}
+  ) {
+    const request = new URL(login.beginGoogleImplicitLogin(config))
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode('access-token')
+    )
+    const now = Math.floor(Date.now() / 1000)
+    const token = await new SignJWT({
+      iss: 'https://accounts.google.com',
+      sub: 'test-user',
+      aud: config.clientId,
+      iat: now,
+      exp: now + 1800,
+      nonce: request.searchParams.get('nonce'),
+      at_hash: base64url.encode(new Uint8Array(digest).slice(0, 16)),
+      ...claims,
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'google-test-key' })
+      .sign(privateKey)
+    const params = new URLSearchParams({
+      state: request.searchParams.get('state')!,
+      id_token: token,
+      access_token: 'access-token',
+      token_type: 'Bearer',
+      expires_in: '3600',
+      ...parameters,
+    })
+    window.history.replaceState(
+      null,
+      '',
+      new URL(config.redirectUri).pathname + '#' + params
+    )
+    return token
+  }
+
+  it('routes the shipped configuration to a secret-free Google browser login', async () => {
+    let authorizationUrl = ''
+    const begin = login.beginGoogleImplicitLogin
+    vi.spyOn(login, 'beginGoogleImplicitLogin').mockImplementation(
+      (c, hint) => {
+        authorizationUrl = begin(c, hint)
+        return window.location.href // Avoid navigating jsdom away from the test.
+      }
+    )
+    await adapter.loginWithRedirect({ loginHint: 'user@example.com' })
+    const request = new URL(authorizationUrl)
+    expect(request.origin).toBe('https://accounts.google.com')
+    expect(request.searchParams.get('response_type')).toBe('id_token token')
+    expect(request.searchParams.get('access_type')).toBe('online')
+    expect(request.searchParams.get('login_hint')).toBe('user@example.com')
+    expect(request.searchParams.has('code_challenge')).toBe(false)
+    expect(request.searchParams.has('client_secret')).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(
+      login.usesGoogleImplicitLogin({
+        ...config,
+        discoveryUrl: 'https://issuer.example/discovery',
+      })
+    ).toBe(false)
+    expect(
+      login.usesGoogleImplicitLogin({
+        ...config,
+        clientSecret: 'private-config',
+      })
+    ).toBe(false)
+  })
+
+  it('verifies and persists tokens without a code exchange or an old refresh token', async () => {
+    window.localStorage.setItem(
+      'oidc-auth',
+      JSON.stringify({ access_token: 'old', refresh_token: 'old-refresh' })
+    )
+    const idToken = await callback()
+    await Promise.all([adapter.handleCallback(), adapter.handleCallback()])
+    expect(adapter.simpleAuth).toMatchObject({
+      accessToken: 'access-token',
+      idToken,
+      tokenType: 'Bearer',
+    })
+    expect(adapter.simpleAuth?.refreshToken).toBeUndefined()
+    expect(adapter.simpleAuth?.expiresAt).toBeLessThanOrEqual(
+      Date.now() + 1800_000
+    )
+    expect(window.location.hash).toBe('')
+    expect(login.hasGoogleImplicitLogin()).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await adapter.refresh()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await expect(adapter.handleCallback()).rejects.toThrow()
+  })
+
+  it.each([
+    ['issuer', { iss: 'https://attacker.example' }],
+    ['audience', { aud: 'other-client' }],
+    ['expiry', { exp: 1 }],
+    ['nonce', { nonce: 'other-login' }],
+    ['access-token hash', { at_hash: 'wrong' }],
+    ['authorized party', { azp: 'other-client' }],
+    [
+      'multiple audiences without authorized party',
+      { aud: ['current-client', 'other-client'] },
+    ],
+  ])(
+    'rejects an invalid %s without persisting credentials',
+    async (_name, claims) => {
+      // Resolve the current client at test time for the multi-audience case.
+      if ('aud' in claims && Array.isArray(claims.aud))
+        claims = { aud: [config.clientId, 'other-client'] }
+      await callback(claims)
+      await expect(adapter.handleCallback()).rejects.toThrow()
+      expect(adapter.simpleAuth).toBeNull()
+      expect(window.location.hash).toBe('')
+      expect(login.hasGoogleImplicitLogin()).toBe(false)
+    }
+  )
+
+  it.each([
+    ['state', { state: 'wrong-state' }],
+    ['missing ID token', { id_token: '' }],
+    ['access-token substitution', { access_token: 'other-token' }],
+    ['expiry', { expires_in: 'NaN' }],
+    ['OAuth denial', { error: 'access_denied' }],
+  ])('rejects a callback with invalid %s', async (_name, parameters) => {
+    await callback({}, parameters)
+    await expect(adapter.handleCallback()).rejects.toThrow()
+    expect(adapter.simpleAuth).toBeNull()
+    expect(window.location.hash).toBe('')
+  })
+
+  it('rejects a token signed by a different key', async () => {
+    privateKey = (await generateKeyPair('RS256')).privateKey
+    await callback()
+    await expect(adapter.handleCallback()).rejects.toThrow()
+    expect(adapter.simpleAuth).toBeNull()
+  })
+
+  it('rejects stale transactions', async () => {
+    await callback()
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now + 11 * 60_000)
+    await expect(adapter.handleCallback()).rejects.toThrow('expired')
+    expect(adapter.simpleAuth).toBeNull()
+  })
+
+  it('does not restore credentials if the user logs out during verification', async () => {
+    await callback()
+    const pending = adapter.handleCallback()
+    adapter.logout()
+    await expect(pending).rejects.toThrow('superseded')
+    expect(adapter.simpleAuth).toBeNull()
+  })
+
+  it('rejects duplicate callback state and consumes the transaction', async () => {
+    await callback()
+    window.history.replaceState(null, '', window.location.href + '&state=other')
+    await expect(adapter.handleCallback()).rejects.toThrow('Duplicate')
+    expect(login.hasGoogleImplicitLogin()).toBe(false)
+    expect(adapter.simpleAuth).toBeNull()
+  })
+
+  it('rejects a callback at a different redirect path', async () => {
+    await callback()
+    window.history.replaceState(
+      null,
+      '',
+      '/other-callback' + window.location.hash
+    )
+    await expect(adapter.handleCallback()).rejects.toThrow(
+      'configuration changed'
+    )
+    expect(adapter.simpleAuth).toBeNull()
+  })
+})

--- a/app/src/auth/googleImplicitLogin.test.ts
+++ b/app/src/auth/googleImplicitLogin.test.ts
@@ -34,9 +34,7 @@ describe('secret-free Google OIDC login', () => {
       'http://localhost/configs/app-configs.yaml'
     ).oidc!
     login = await import('./googleImplicitLogin')
-    adapter = new (
-      await import('../browserAdapter.client')
-    ).BrowserAuthAdapter()
+    adapter = (await import('../browserAdapter.client')).getBrowserAdapter()
   })
 
   afterEach(() => {
@@ -190,6 +188,22 @@ describe('secret-free Google OIDC login', () => {
     vi.spyOn(Date, 'now').mockReturnValue(now + 11 * 60_000)
     await expect(adapter.handleCallback()).rejects.toThrow('expired')
     expect(adapter.simpleAuth).toBeNull()
+  })
+
+  it('clears and notifies expired implicit auth before returning request credentials', async () => {
+    await callback()
+    await adapter.handleCallback()
+    const listener = vi.fn()
+    const unsubscribe = adapter.onAuthChange(listener)
+    const expiresAt = adapter.simpleAuth!.expiresAt!
+    vi.spyOn(Date, 'now').mockReturnValue(expiresAt + 1)
+    const { getAuthData } = await import('../token')
+    expect(await getAuthData()).toBeNull()
+    expect(adapter.simpleAuth).toBeNull()
+    expect(window.localStorage.getItem('oidc-auth')).toBeNull()
+    expect(listener).toHaveBeenCalledWith(null)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    unsubscribe()
   })
 
   it('does not restore credentials if the user logs out during verification', async () => {

--- a/app/src/auth/googleImplicitLogin.ts
+++ b/app/src/auth/googleImplicitLogin.ts
@@ -1,0 +1,162 @@
+import { base64url, createRemoteJWKSet, jwtVerify } from 'jose'
+
+import type { OidcConfig } from './oidcConfig'
+import type { OAuthTokenEndpointResponse } from './types'
+
+const TRANSACTION_KEY = 'google_oidc_transaction'
+const DISCOVERY_URL =
+  'https://accounts.google.com/.well-known/openid-configuration'
+const googleKeys = createRemoteJWKSet(
+  new URL('https://www.googleapis.com/oauth2/v3/certs')
+)
+const MAX_LOGIN_AGE_MS = 10 * 60 * 1000
+
+type LoginTransaction = {
+  state: string
+  nonce: string
+  clientId: string
+  redirectUri: string
+  createdAt: number
+}
+
+/** Google web clients cannot exchange authorization codes without a secret. */
+export function usesGoogleImplicitLogin(config: OidcConfig): boolean {
+  return config.discoveryUrl === DISCOVERY_URL && !config.clientSecret?.trim()
+}
+
+/** Keep this login attempt in the initiating tab, separate from Drive OAuth. */
+export function beginGoogleImplicitLogin(
+  config: OidcConfig,
+  loginHint?: string
+): string {
+  const transaction: LoginTransaction = {
+    state: crypto.randomUUID(),
+    nonce: crypto.randomUUID(),
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+    createdAt: Date.now(),
+  }
+  const url = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+  for (const [key, value] of Object.entries(config.extraAuthParams ?? {})) {
+    url.searchParams.set(key, value)
+  }
+  // These protocol parameters cannot be overridden by custom auth parameters.
+  url.searchParams.set('client_id', transaction.clientId)
+  url.searchParams.set('redirect_uri', transaction.redirectUri)
+  url.searchParams.set('response_type', 'id_token token')
+  url.searchParams.set('response_mode', 'fragment')
+  url.searchParams.set('scope', config.scope)
+  url.searchParams.set('state', transaction.state)
+  url.searchParams.set('nonce', transaction.nonce)
+  url.searchParams.set('access_type', 'online')
+  url.searchParams.delete('code_challenge')
+  url.searchParams.delete('code_challenge_method')
+  url.searchParams.delete('client_secret')
+  if (loginHint?.trim()) url.searchParams.set('login_hint', loginHint.trim())
+  window.sessionStorage.setItem(TRANSACTION_KEY, JSON.stringify(transaction))
+  return url.toString()
+}
+
+/** Clear pending login state on logout or when selecting another login flow. */
+export function clearGoogleImplicitLogin(): void {
+  window.sessionStorage.removeItem(TRANSACTION_KEY)
+}
+
+/** Only a login initiated in this tab may consume an implicit callback. */
+export function hasGoogleImplicitLogin(): boolean {
+  return window.sessionStorage.getItem(TRANSACTION_KEY) !== null
+}
+
+/** Validate a front-channel response before any token enters persistent storage. */
+export async function finishGoogleImplicitLogin(
+  callbackUrl: URL,
+  config: OidcConfig
+): Promise<OAuthTokenEndpointResponse> {
+  const raw = window.sessionStorage.getItem(TRANSACTION_KEY)
+  clearGoogleImplicitLogin()
+  // Remove tokens even when validation fails, before the route logs or navigates.
+  window.history.replaceState(
+    null,
+    '',
+    callbackUrl.pathname + callbackUrl.search
+  )
+  if (!raw) throw new Error('No pending Google login')
+  const transaction = JSON.parse(raw) as LoginTransaction
+  const age = Date.now() - transaction.createdAt
+  if (
+    !usesGoogleImplicitLogin(config) ||
+    !transaction.state ||
+    !transaction.nonce ||
+    !Number.isFinite(age) ||
+    age < 0 ||
+    age > MAX_LOGIN_AGE_MS ||
+    transaction.clientId !== config.clientId ||
+    transaction.redirectUri !== config.redirectUri ||
+    callbackUrl.origin + callbackUrl.pathname !== config.redirectUri
+  )
+    throw new Error('Google login transaction expired or configuration changed')
+
+  const params = new URLSearchParams(callbackUrl.hash.slice(1))
+  for (const key of [
+    'state',
+    'id_token',
+    'access_token',
+    'token_type',
+    'expires_in',
+    'error',
+  ]) {
+    if (params.getAll(key).length > 1)
+      throw new Error('Duplicate Google callback parameter')
+  }
+  if (params.get('state') !== transaction.state)
+    throw new Error('Google login state mismatch')
+  if (params.has('error')) throw new Error('Google login was denied or failed')
+  const idToken = params.get('id_token')
+  const accessToken = params.get('access_token')
+  const expiresIn = Number(params.get('expires_in'))
+  if (
+    !idToken ||
+    !accessToken ||
+    params.get('token_type')?.toLowerCase() !== 'bearer' ||
+    !Number.isFinite(expiresIn) ||
+    expiresIn <= 0
+  ) {
+    throw new Error('Google callback is missing valid tokens or expiry')
+  }
+  // Unlike a token-endpoint response, a URL fragment requires signature validation.
+  const { payload } = await jwtVerify(idToken, googleKeys, {
+    algorithms: ['RS256'],
+    issuer: ['https://accounts.google.com', 'accounts.google.com'],
+    audience: transaction.clientId,
+    requiredClaims: ['iss', 'sub', 'aud', 'exp', 'iat', 'nonce', 'at_hash'],
+    maxTokenAge: '10m',
+  })
+  if (typeof payload.sub !== 'string' || !payload.sub)
+    throw new Error('Google ID token subject is missing')
+  if (payload.nonce !== transaction.nonce)
+    throw new Error('Google login nonce mismatch')
+  if (
+    (payload.azp !== undefined && payload.azp !== transaction.clientId) ||
+    (Array.isArray(payload.aud) &&
+      payload.aud.length > 1 &&
+      payload.azp !== transaction.clientId)
+  ) {
+    throw new Error('Google ID token authorized party mismatch')
+  }
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(accessToken)
+  )
+  if (
+    payload.at_hash !== base64url.encode(new Uint8Array(digest).slice(0, 16))
+  ) {
+    throw new Error('Google access token hash mismatch')
+  }
+  return {
+    access_token: accessToken,
+    id_token: idToken,
+    token_type: 'Bearer',
+    scope: params.get('scope') ?? config.scope,
+    expires_in: Math.min(expiresIn, payload.exp! - Date.now() / 1000),
+  }
+}

--- a/app/src/auth/oidcConfig.ts
+++ b/app/src/auth/oidcConfig.ts
@@ -21,6 +21,9 @@ type StoredOidcConfig = {
 
 export const OIDC_STORAGE_KEY = "oidcConfig";
 const STORAGE_KEY = OIDC_STORAGE_KEY;
+// This shared development client is now used as a public browser client.
+const PUBLIC_DEVELOPMENT_CLIENT_ID =
+  "554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com";
 
 function sanitizeString(value?: string): string | undefined {
   const trimmed = value?.trim();
@@ -168,6 +171,18 @@ export class OidcConfigManager {
         return null;
       }
       const parsed = JSON.parse(raw) as StoredOidcConfig | null;
+      if (
+        parsed?.clientId === PUBLIC_DEVELOPMENT_CLIENT_ID &&
+        parsed.discoveryUrl ===
+          "https://accounts.google.com/.well-known/openid-configuration" &&
+        parsed.clientSecret
+      ) {
+        // Migrate before config-precedence logic can preserve the old shipped
+        // credential. Other client IDs and custom OIDC providers are untouched.
+        delete parsed.clientSecret;
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+        window.localStorage.removeItem("oidc-auth");
+      }
       return parsed ?? null;
     } catch (error) {
       console.warn("Failed to read OIDC config from storage", error);

--- a/app/src/browserAdapter.client.ts
+++ b/app/src/browserAdapter.client.ts
@@ -3,13 +3,20 @@ import { useEffect, useState } from 'react'
 import * as oauth from 'oauth4webapi'
 import pkceChallenge from 'pkce-challenge'
 
+import { readAppLoginConfiguration } from './auth/appLoginConfiguration'
+import {
+  beginGoogleImplicitLogin,
+  clearGoogleImplicitLogin,
+  finishGoogleImplicitLogin,
+  hasGoogleImplicitLogin,
+  usesGoogleImplicitLogin,
+} from './auth/googleImplicitLogin'
 import {
   IMPERSONATED_SERVICE_ACCOUNT_CREDENTIAL_CHANGED_EVENT,
   IMPERSONATED_SERVICE_ACCOUNT_CREDENTIAL_STORAGE_KEY,
   clearImpersonatedServiceAccountCredential,
   readImpersonatedServiceAccountCredential,
 } from './auth/impersonatedServiceAccountCredentialStore'
-import { readAppLoginConfiguration } from './auth/appLoginConfiguration'
 import { getOidcConfig } from './auth/oidcConfig'
 import type {
   OAuthTokenEndpointResponse,
@@ -199,6 +206,8 @@ async function loadDiscovery(): Promise<DiscoveryDocument> {
 
 export class BrowserAuthAdapter {
   private readonly listeners = new Set<AuthListener>()
+  private callbackInFlight: Promise<void> | null = null
+  private authOperationVersion = 0
   // The adapter keeps a current-tab copy for immediate subscribers. The
   // canonical, short-lived service-account token is stored in the versioned
   // impersonated-credential bundle; human OAuth credentials are never copied
@@ -206,11 +215,34 @@ export class BrowserAuthAdapter {
   private ephemeralTokenResponse: StoredTokenResponse | null = null
 
   /**
-   * Handles the OAuth callback by exchanging the authorization code for tokens,
-   * removing PKCE state from localStorage, and persisting the token response.
+   * Share callback processing across repeated route effects so one-time login
+   * state is consumed once, including while Google's signing keys are loading.
    */
-  handleCallback = async () => {
+  handleCallback = (): Promise<void> => {
+    if (!this.callbackInFlight) {
+      this.callbackInFlight = this.processCallback().finally(() => {
+        this.callbackInFlight = null
+      })
+    }
+    return this.callbackInFlight
+  }
+
+  /** Validate the selected OAuth flow and persist only its verified credentials. */
+  private processCallback = async () => {
+    const operationVersion = this.authOperationVersion
     const callbackUrl = new URL(window.location.href)
+    if (hasGoogleImplicitLogin()) {
+      const token = await finishGoogleImplicitLogin(
+        callbackUrl,
+        getOidcConfig()
+      )
+      if (operationVersion !== this.authOperationVersion) {
+        throw new Error('Login was superseded by another authentication action')
+      }
+      // Implicit login cannot refresh; discard any previous identity's refresh token.
+      this.persist(token, true)
+      return
+    }
     const callbackParams = callbackUrl.searchParams
     const codeVerifier = window.localStorage.getItem(PKCE_CODE_VERIFIER_KEY)
     const storedState = window.localStorage.getItem(PKCE_STATE_KEY)
@@ -380,6 +412,9 @@ export class BrowserAuthAdapter {
         scopeCount: summarizeScope(result.scope ?? '').length,
       },
     })
+    if (operationVersion !== this.authOperationVersion) {
+      throw new Error('Login was superseded by another authentication action')
+    }
     this.persist(result)
   }
 
@@ -388,7 +423,16 @@ export class BrowserAuthAdapter {
    * Stores PKCE code verifier and state in localStorage.
    */
   loginWithRedirect = async (options?: { loginHint?: string }) => {
+    this.authOperationVersion += 1
     const config = getOidcConfig()
+    if (usesGoogleImplicitLogin(config)) {
+      window.location.href = beginGoogleImplicitLogin(
+        config,
+        options?.loginHint
+      )
+      return
+    }
+    clearGoogleImplicitLogin()
     const discovery = await loadDiscovery()
     const { code_verifier, code_challenge } = await pkceChallenge()
     const state = crypto.randomUUID()
@@ -444,6 +488,8 @@ export class BrowserAuthAdapter {
    * Logs out the user by removing the token from localStorage and notifying listeners.
    */
   logout = () => {
+    this.authOperationVersion += 1
+    clearGoogleImplicitLogin()
     this.ephemeralTokenResponse = null
     window.localStorage.removeItem(STORAGE_KEY)
     clearImpersonatedServiceAccountCredential(['app'])
@@ -472,6 +518,8 @@ export class BrowserAuthAdapter {
     }
     // Switching effective identity must also remove any persisted human OIDC
     // refresh token so expiry cannot silently fall back to the human account.
+    this.authOperationVersion += 1
+    clearGoogleImplicitLogin()
     window.localStorage.removeItem(STORAGE_KEY)
     this.ephemeralTokenResponse = {
       access_token: normalizedToken,
@@ -669,11 +717,14 @@ export class BrowserAuthAdapter {
     return authData ? (JSON.parse(authData) as StoredTokenResponse) : null
   }
 
-  private persist(tokenResponse: OAuthTokenEndpointResponse) {
+  private persist(
+    tokenResponse: OAuthTokenEndpointResponse,
+    replaceExisting = false
+  ) {
     this.ephemeralTokenResponse = null
     const stored = normalizeTokenResponse(
       tokenResponse,
-      this.getPersistedTokenResponse()
+      replaceExisting ? null : this.getPersistedTokenResponse()
     )
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
     const simpleAuth = this.simpleAuth

--- a/app/src/browserAdapter.client.ts
+++ b/app/src/browserAdapter.client.ts
@@ -563,6 +563,11 @@ export class BrowserAuthAdapter {
   refresh = async () => {
     const tokenResponse = this.getTokenResponse()
     if (!tokenResponse?.refresh_token) {
+      if (tokenResponse && buildSimpleAuth(tokenResponse).isExpired()) {
+        // Implicit credentials cannot renew; notify the UI to offer sign-in again.
+        this.logout()
+        return
+      }
       appLogger.warn(
         'OIDC refresh skipped because no refresh token is available',
         {

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -96,15 +96,22 @@ describe('appConfig OIDC Google shorthand', () => {
     expect(getGoogleDriveBaseUrl()).toBe('http://127.0.0.1:9090')
   })
 
-  it('configures local development to use the fetch-based Drive client', async () => {
+  it('configures local development with secret-free implicit Drive auth', async () => {
     const { setAppConfigFromYaml } = await loadModules()
     const { getGoogleDriveBaseUrl } = await import('./googleDriveRuntime')
 
-    setAppConfigFromYaml(
+    const result = setAppConfigFromYaml(
       localAppConfigYaml,
       'http://localhost/configs/app-configs.yaml'
     )
 
+    expect(result.warnings).toEqual([])
+    expect(result.oidc?.clientId).toBeTruthy()
+    // Keep an accidentally reintroduced credential out of test failure output.
+    expect(Boolean(result.oidc?.clientSecret)).toBe(false)
+    expect(result.googleOAuth?.clientId).toBeTruthy()
+    expect(Boolean(result.googleOAuth?.clientSecret)).toBe(false)
+    expect(result.googleOAuth?.authFlow).toBe('implicit')
     expect(getGoogleDriveBaseUrl()).toBe('https://www.googleapis.com')
   })
 

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -167,6 +167,76 @@ describe('appConfig OIDC Google shorthand', () => {
     })
   })
 
+  it.each([true, false])(
+    'migrates the old development OIDC secret with local precedence %s',
+    async (preserveLocalConfiguration) => {
+      window.localStorage.setItem(
+        'oidcConfig',
+        JSON.stringify({
+          clientId:
+            '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com',
+          discoveryUrl:
+            'https://accounts.google.com/.well-known/openid-configuration',
+          clientSecret: 'previously-shipped-secret-fixture',
+          scope: 'openid email',
+          redirectUri: `${window.location.origin}/callback`,
+        })
+      )
+      window.localStorage.setItem(
+        'oidc-auth',
+        JSON.stringify({
+          access_token: 'old-access-token',
+          refresh_token: 'old-refresh-token',
+        })
+      )
+      const { setAppConfigFromYaml, getOidcConfig } = await loadModules()
+      setAppConfigFromYaml(
+        localAppConfigYaml,
+        'http://localhost/configs/app-configs.yaml',
+        {
+          preserveLocalConfiguration,
+        }
+      )
+      const { usesGoogleImplicitLogin } = await import(
+        '../auth/googleImplicitLogin'
+      )
+      expect(usesGoogleImplicitLogin(getOidcConfig())).toBe(true)
+      expect(Boolean(getOidcConfig().clientSecret)).toBe(false)
+      expect(
+        Boolean(
+          JSON.parse(window.localStorage.getItem('oidcConfig')!).clientSecret
+        )
+      ).toBe(false)
+      expect(window.localStorage.getItem('oidc-auth')).toBeNull()
+    }
+  )
+
+  it.each([
+    [
+      'custom-client',
+      'https://accounts.google.com/.well-known/openid-configuration',
+    ],
+    [
+      '554943104515-bdt3on71kvc489nvi3l37gialolcnk0a.apps.googleusercontent.com',
+      'https://issuer.example/discovery',
+    ],
+  ])(
+    'preserves privately configured credentials for %s at %s',
+    async (clientId, discoveryUrl) => {
+      window.localStorage.setItem(
+        'oidcConfig',
+        JSON.stringify({
+          clientId,
+          discoveryUrl,
+          clientSecret: 'custom-secret-fixture',
+          scope: 'openid email',
+        })
+      )
+      const { getOidcConfig } = await loadModules()
+      expect(getOidcConfig().clientSecret).toBe('custom-secret-fixture')
+    }
+  )
+
   it('defaults Google Drive auth UX mode to new_tab when not configured', async () => {
     const { applyAppConfig } = await loadModules()
     const { googleClientManager } = await import('./googleClientManager')
@@ -236,7 +306,7 @@ describe('appConfig OIDC Google shorthand', () => {
         googleDrive: {
           clientID: 'client-id.apps.googleusercontent.com',
           clientSecret: 'ignored-client-secret',
-          clientMaterial: ['GOCSPX-3N-', 'FPEy4XWoKz', 'cVwSyt3yDz_Xwzo'],
+          clientMaterial: ['test-', 'client-', 'secret'],
         },
       },
       'http://localhost/configs/app-configs.yaml'
@@ -244,7 +314,7 @@ describe('appConfig OIDC Google shorthand', () => {
 
     expect(googleClientManager.getOAuthClient()).toMatchObject({
       clientId: 'client-id.apps.googleusercontent.com',
-      clientSecret: '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',
+      clientSecret: 'test-client-secret',
     })
   })
 

--- a/docs/14-authentication-and-app-configuration.md
+++ b/docs/14-authentication-and-app-configuration.md
@@ -35,6 +35,18 @@ oidc.getStatus()
 
 ## Application login UI
 
+For Google OIDC with no client secret, browser login uses Google's implicit
+`id_token token` response. Runme verifies the signed ID token and callback before
+storing credentials. This flow has no refresh token; sign in again when the
+tokens expire. Other OIDC providers and configurations with a client secret
+continue to use authorization code with PKCE.
+
+Google Drive authentication is configured separately. Never put client secrets
+or private keys in an app-config YAML served as a public asset. Deleting a secret
+from the current file does not revoke copies in Git history.
+
+See [Google's OIDC flow documentation](https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters).
+
 Open **Authentication Settings** from the key icon in the left navigation. The
 panel groups the settings and actions for:
 

--- a/docs/14-authentication-and-app-configuration.md
+++ b/docs/14-authentication-and-app-configuration.md
@@ -41,6 +41,11 @@ storing credentials. This flow has no refresh token; sign in again when the
 tokens expire. Other OIDC providers and configurations with a client secret
 continue to use authorization code with PKCE.
 
+Returning users of the shared development client are signed out once while
+Runme removes its previously stored client secret and credentials. Sign in
+again to use the browser flow. Custom OIDC providers and other client IDs keep
+their saved configuration.
+
 Google Drive authentication is configured separately. Never put client secrets
 or private keys in an app-config YAML served as a public asset. Deleting a secret
 from the current file does not revoke copies in Git history.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       dexie-react-hooks:
         specifier: 4.2.0
         version: 4.2.0(@types/react@19.2.2)(dexie@3.2.4)(react@19.2.0)
+      jose:
+        specifier: ^6.2.10
+        version: 6.2.10
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4001,6 +4004,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   jotai-scope@0.7.2:
     resolution: {integrity: sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg==}
@@ -9233,6 +9239,8 @@ snapshots:
   javascript-natural-sort@0.7.1: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.10: {}
 
   jotai-scope@0.7.2(jotai@2.11.0(@types/react@19.2.2)(react@19.2.0))(react@19.2.0):
     dependencies:


### PR DESCRIPTION
The public local-development YAML included an OAuth client secret for app login. Removing it alone breaks Google's authorization-code token exchange. Remove the secret and use Google's supported `id_token token` browser flow when Google OIDC is configured without a secret. Drive keeps its separate implicit OAuth configuration.

The callback verifies Google's RS256 signature, issuer, audience, authorized party, expiry, nonce, state, and access-token hash before storing credentials. Login state belongs to the initiating tab and expires after ten minutes. Tokens are removed from the URL, repeated route effects share one callback, and logout or an identity switch prevents an in-flight callback from restoring credentials. A successful implicit login discards any old refresh token; users sign in again after expiration. Other providers and configurations with a secret retain PKCE.

Returning profiles migrate the shared development client's stored secret and credentials before config-precedence logic runs. Other client IDs and providers retain their saved configuration. Expired credentials without a refresh token are cleared and auth subscribers notified when credentials are requested. The same secret was also removed from a test fixture and replaced with synthetic data.

Tests cover the real shipped YAML, pre-populated local configuration, a signed successful callback through BrowserAuthAdapter, rejected callbacks, replay, duplicate parameters, expiry, and callback lifecycle behavior. The only network fixture in the new tests is Google's public-key response; no token exchange is mocked as successful.

Validation:
- `runme run build test` passed (production build and 7 console tests).
- 72 focused tests passed across Google implicit login, BrowserAuthAdapter, app config, and GoogleAuthContext.
- `git diff --check` passed.
- App type-checking still reports existing errors, including the unchanged oauth4webapi result casts; no errors were reported in the new authentication module or its tests.

Live Google consent/login was not exercised. Removing the value does not revoke historical copies; credential revocation remains a provider-side action.

References: [Google OIDC browser flow](https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters), [JOSE token verification](https://github.com/panva/jose).

Fixes #364
