### PR TITLE
Use Drive v3 checks and recover overwritten .runme revisions

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -189,6 +189,17 @@ jobs:
           CUJ_SCENARIO_CMD_LOG_CHARS: "20000"
           CUJ_MOVIE_WAIT_TIMEOUT_MS: "30000"
           CUJ_RUNME_AGENT_BIN: ${{ github.workspace }}/bin/runme
+          # agent-browser truncates encoder errors before ffmpeg's useful diagnostics.
+          FFREPORT: file=${{ github.workspace }}/app/test/browser/test-output/ffmpeg-%p-%t.log:level=32
         run: |
           set -euo pipefail
           pnpm -C app run cuj:run
+
+      - name: Show recorder diagnostics
+        if: always()
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for report in app/test/browser/test-output/ffmpeg-*.log; do
+            tail -n 30 "$report"
+          done

--- a/app/src/lib/driveTransfer.test.ts
+++ b/app/src/lib/driveTransfer.test.ts
@@ -826,7 +826,7 @@ describe('driveTransfer', () => {
         'metadata-revision'
       )
     })
-    const saveContentIfVersion = vi
+    const saveContentAfterVersionCheck = vi
       .fn()
       .mockImplementation(async (_uri, content) => {
         remoteContent = content
@@ -849,7 +849,7 @@ describe('driveTransfer', () => {
     appState.setDriveNotebookStore({
       findByCreateOperation,
       createContent,
-      saveContentIfVersion,
+      saveContentAfterVersionCheck,
       getVersionMetadata,
       loadContent,
       markCreateOperationComplete,
@@ -871,7 +871,7 @@ describe('driveTransfer', () => {
 
     expect(result.fileId).toBe('partial123')
     expect(createContent).toHaveBeenCalledTimes(1)
-    expect(saveContentIfVersion).toHaveBeenCalledWith(
+    expect(saveContentAfterVersionCheck).toHaveBeenCalledWith(
       remoteFile.uri,
       expect.stringContaining('Recovered'),
       'application/json',
@@ -902,7 +902,7 @@ describe('driveTransfer', () => {
     }
     let metadataCreated = false
     const markCreateOperationComplete = vi.fn()
-    const saveContentIfVersion = vi.fn()
+    const saveContentAfterVersionCheck = vi.fn()
     appState.setDriveNotebookStore({
       findByCreateOperation: vi
         .fn()
@@ -922,7 +922,7 @@ describe('driveTransfer', () => {
         appProperties: {},
       }),
       loadContent: vi.fn().mockResolvedValue(''),
-      saveContentIfVersion,
+      saveContentAfterVersionCheck,
       markCreateOperationComplete,
     } as any)
 
@@ -935,7 +935,7 @@ describe('driveTransfer', () => {
     await expect(createOnce()).rejects.toThrow(
       'changed before creation completed'
     )
-    expect(saveContentIfVersion).not.toHaveBeenCalled()
+    expect(saveContentAfterVersionCheck).not.toHaveBeenCalled()
     expect(markCreateOperationComplete).not.toHaveBeenCalled()
   })
 

--- a/app/src/lib/driveTransfer.ts
+++ b/app/src/lib/driveTransfer.ts
@@ -773,7 +773,7 @@ export async function saveNotebookAsDriveCopy(
               `IDEMPOTENCY_CONFLICT: Drive notebook changed before creation completed: ${remoteUri}`
             )
           }
-          const repaired = await driveStore.saveContentIfVersion(
+          const repaired = await driveStore.saveContentAfterVersionCheck(
             remoteUri,
             notebookJson,
             mimeType,

--- a/app/src/storage/derivedCopy.test.ts
+++ b/app/src/storage/derivedCopy.test.ts
@@ -8,7 +8,7 @@ import { type NotebookStoreItem, NotebookStoreItemType } from './notebook'
 const source = driveFileUrl('source')
 const parent = 'https://drive.google.com/drive/folders/parent'
 
-/** Separate clients share only remote CAS state, never a local lock or cache. */
+/** Separate clients share remote claim state; these fixtures serialize property updates. */
 function remote(reserved: boolean) {
   const state = {
     claim: undefined as string | undefined,
@@ -18,7 +18,7 @@ function remote(reserved: boolean) {
   const files = new Map<string, NotebookStoreItem>()
   const client = () => ({
     getDerivedCopyClaim: vi.fn(async () => state.claim),
-    compareAndSetDerivedCopyClaim: vi.fn(
+    updateDerivedCopyClaimAfterCheck: vi.fn(
       async (
         _uri: string,
         expected: string | undefined,
@@ -175,7 +175,7 @@ describe('source-coordinated derived copies', () => {
     await expect(run()).rejects.toBeInstanceOf(UnconfirmedDerivedCopyError)
     expect(client.createContent).toHaveBeenCalledTimes(1)
     expect(
-      await client.compareAndSetDerivedCopyClaim(source, pending, null)
+      await client.updateDerivedCopyClaimAfterCheck(source, pending, null)
     ).toBe(true)
     expect((await run())?.uri).toBeDefined()
     expect(server.state.creates).toBe(1)
@@ -186,7 +186,7 @@ describe('source-coordinated derived copies', () => {
     const client = server.client()
     server.state.claim = 'f:already-confirmed'
     expect(
-      await client.compareAndSetDerivedCopyClaim(source, 'p:old', null)
+      await client.updateDerivedCopyClaimAfterCheck(source, 'p:old', null)
     ).toBe(false)
     expect(server.state.claim).toBe('f:already-confirmed')
   })

--- a/app/src/storage/derivedCopy.ts
+++ b/app/src/storage/derivedCopy.ts
@@ -20,10 +20,10 @@ export class UnconfirmedDerivedCopyError extends Error {
 }
 
 /**
- * All profiles elect one identity using the source file's conditional public
- * property update. r = reserved ID, f = confirmed ID, p = unconfirmed Shared
- * Drive POST. Claims include the source hash so copied metadata is re-elected.
- * Only the call that wins a p claim may issue that POST.
+ * Profiles coordinate a shared identity with client-side checks of a public
+ * property. This is best-effort coordination, not an atomic election.
+ * r = reserved ID, f = confirmed ID, p = unconfirmed Shared Drive POST. Claims include the source hash so copied metadata is re-elected.
+ * A caller must observe its own p claim before issuing that POST.
  */
 export async function ensureDerivedCopy(
   drive: DriveNotebookStore,
@@ -45,7 +45,7 @@ export async function ensureDerivedCopy(
     if (claim && claim.split(':')[1] !== sourceHash) {
       // Drive copies custom properties. Detach the inherited identity without
       // touching the original notebook's copy (including pending reservations).
-      await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, null)
+      await drive.updateDerivedCopyClaimAfterCheck(sourceUri, claim, null)
       continue
     }
     let target: NotebookStoreItem | null = null
@@ -65,7 +65,11 @@ export async function ensureDerivedCopy(
       const confirmed = `f:${sourceHash}:${parseDriveItem(target.uri).id}`
       if (
         claim === confirmed ||
-        (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, confirmed))
+        (await drive.updateDerivedCopyClaimAfterCheck(
+          sourceUri,
+          claim,
+          confirmed
+        ))
       )
         return target
       continue
@@ -74,7 +78,9 @@ export async function ensureDerivedCopy(
       const next = (await drive.canUsePreGeneratedFileId(parentUri))
         ? `r:${sourceHash}:${await drive.generateFileId()}`
         : `p:${sourceHash}:${uuidv4()}`
-      if (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, next)) {
+      if (
+        await drive.updateDerivedCopyClaimAfterCheck(sourceUri, claim, next)
+      ) {
         if (next.startsWith('p:')) ownedPending = next
       }
       continue
@@ -85,9 +91,12 @@ export async function ensureDerivedCopy(
     const bytes = await content()
     if (bytes === null) {
       if (ownedPending === claim)
-        await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, null)
+        await drive.updateDerivedCopyClaimAfterCheck(sourceUri, claim, null)
       return null
     }
+    // Recheck after asynchronous serialization, as another profile can change
+    // the claim while we prepare bytes. The final read/POST gap still exists.
+    if ((await drive.getDerivedCopyClaim(sourceUri)) !== claim) continue
     try {
       target = await drive.createContent(
         parentUri,
@@ -101,16 +110,18 @@ export async function ensureDerivedCopy(
       )
     } catch (error) {
       if (error instanceof DriveCreateNotCommittedError) {
-        await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, null)
+        await drive.updateDerivedCopyClaimAfterCheck(sourceUri, claim, null)
       } else if (claim.startsWith('p:')) {
         throw new UnconfirmedDerivedCopyError(claim)
       }
       throw error
     }
     const confirmed = `f:${sourceHash}:${parseDriveItem(target.uri).id}`
-    if (await drive.compareAndSetDerivedCopyClaim(sourceUri, claim, confirmed))
+    if (
+      await drive.updateDerivedCopyClaimAfterCheck(sourceUri, claim, confirmed)
+    )
       return target
-    // Another source save can change its ETag. Reread before further actions.
+    // Another profile changed the claim. Reread before further actions.
   }
   throw new Error(
     'Colab copy coordination changed repeatedly; retry Drive sync.'

--- a/app/src/storage/drive.test.ts
+++ b/app/src/storage/drive.test.ts
@@ -161,48 +161,95 @@ describe("DriveNotebookStore", () => {
       expect(query).toContain("runmeCreateOperationId");
       expect(query).toContain("source-operation");
       expect(query).not.toContain("in parents");
-      return new Response(JSON.stringify({ files: [{ id: "copy", name: "source.ipynb", parents: ["old-parent"] }] }), { headers: { "Content-Type": "application/json" } });
+      return new Response(
+        JSON.stringify({
+          files: [
+            { id: "copy", name: "source.ipynb", parents: ["old-parent"] },
+          ],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      );
     });
     const store = new DriveNotebookStore(async () => "access-token");
-    expect((await store.findByCreateOperation(null, "source-operation"))?.parents).toEqual([driveFolderUrl("old-parent")]);
+    expect(
+      (await store.findByCreateOperation(null, "source-operation"))?.parents,
+    ).toEqual([driveFolderUrl("old-parent")]);
   });
 
-  it.each([200, 412])(
-    "conditionally updates only the copy property (HTTP %s)",
-    async (status) => {
+  it.each([
+    ["gapi", false],
+    ["gapi", true],
+    ["fetch", false],
+    ["fetch", true],
+  ] as const)(
+    "rechecks public copy claims and detects a competing readback (%s, %s)",
+    async (transport, race) => {
       setGoogleDriveBaseUrl("https://drive.example.test");
-      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-        const url = new URL(String(input));
-        expect(url.pathname).toBe("/drive/v3/files/source");
-        if (init?.method === "GET")
-          return new Response(
-            JSON.stringify({
-              properties: { runmeIpynbCopy: "p:claim", unrelated: "keep" },
-            }),
-            {
-              headers: {
-                "Content-Type": "application/json",
-                ETag: '"current"',
-              },
-            }
-          );
-        expect(init?.method).toBe("PATCH");
-        expect(init?.headers).toMatchObject({ "If-Match": '"current"' });
-        expect(JSON.parse(String(init?.body))).toEqual({
-          properties: { runmeIpynbCopy: null },
+      let property: string | undefined = "p:claim";
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (_input, init) => {
+          expect(init?.headers).not.toHaveProperty("If-Match");
+          if (init?.method === "GET")
+            return new Response(
+              JSON.stringify({
+                properties: { runmeIpynbCopy: property, unrelated: "keep" },
+              }),
+            );
+          expect(JSON.parse(String(init?.body))).toEqual({
+            properties: { runmeIpynbCopy: null },
+          });
+          property = race ? "p:other" : undefined;
+          return new Response("", { status: 200 });
         });
-        return new Response("", { status });
-      });
       const store = new DriveNotebookStore(async () => "access-token");
+      if (transport === "gapi")
+        vi.spyOn(store as any, "getFilesClient").mockResolvedValue(
+          new GapiDriveFilesClient({
+            client: {
+              getToken: () => ({ access_token: "access-token" }),
+              drive: { files: {}, drives: {}, revisions: {} },
+            },
+          } as never),
+        );
       expect(
-        await store.compareAndSetDerivedCopyClaim(
+        await store.updateDerivedCopyClaimAfterCheck(
           driveFileUrl("source"),
           "p:claim",
-          null
-        )
-      ).toBe(status === 200);
-    }
+          null,
+        ),
+      ).toBe(!race);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    },
   );
+
+  it("does not mutate copy claims when metadata is unavailable", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 200 }));
+    const store = new DriveNotebookStore(async () => "access-token");
+    expect(
+      await store.updateDerivedCopyClaimAfterCheck(
+        driveFileUrl("source"),
+        undefined,
+        "p:claim",
+      ),
+    ).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves recovery pending when Drive refuses to retain a revision", async () => {
+    setGoogleDriveBaseUrl("https://drive.example.test");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("retention limit", { status: 403 }));
+    const store = new DriveNotebookStore(async () => "access-token");
+    await expect(
+      store.loadRevisionForRecovery(driveFileUrl("source"), { id: "hidden" }),
+    ).rejects.toThrow("200 retained-revision limit");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 
   it("rejects a forged copy reference without writing its content", async () => {
     const store = new DriveNotebookStore(async () => "access-token");
@@ -217,130 +264,51 @@ describe("DriveNotebookStore", () => {
       appProperties: { runmeCreateOperationId: "different-source" },
     });
     await expect(
-      store.getDerivedCopyTarget(driveFileUrl("unrelated"), "intended-source")
+      store.getDerivedCopyTarget(driveFileUrl("unrelated"), "intended-source"),
     ).rejects.toThrow("refusing to overwrite");
   });
 
-  it("normalizes public v2 properties and uses their ETag for a v3 claim update", async () => {
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = new URL(String(input));
-      if (init?.method === "GET") {
-        expect(url.pathname).toBe("/drive/v2/files/source");
-        return new Response(
-          JSON.stringify({
-            etag: '"v2"',
-            properties: [
-              { key: "runmeIpynbCopy", value: "r:copy", visibility: "PUBLIC" },
-              { key: "private", value: "hidden", visibility: "PRIVATE" },
-            ],
-          }),
-          { headers: { "Content-Type": "application/json" } }
-        );
-      }
-      expect(url.pathname).toBe("/drive/v3/files/source");
-      expect(init?.headers).toMatchObject({ "If-Match": '"v2"' });
-      expect(JSON.parse(String(init?.body))).toEqual({
-        properties: { runmeIpynbCopy: "f:copy" },
-      });
-      return new Response("", { status: 200 });
-    });
-    const client = new GapiDriveFilesClient({
-      client: {
-        getToken: () => ({ access_token: "token" }),
-        drive: { files: {}, drives: {}, revisions: {} },
-      },
-    } as never);
-    const version = await client.getVersionMetadataWithEtag("source");
-    expect(version.metadata?.properties).toEqual({ runmeIpynbCopy: "r:copy" });
-    expect(
-      await client.setPublicPropertyIfMatch(
-        "source",
-        "runmeIpynbCopy",
-        "f:copy",
-        version.etag!
-      )
-    ).toBe(true);
-  });
-
-  it("preserves v2 ETags and public properties through the fetch transport", async () => {
-    setGoogleDriveBaseUrl("https://www.googleapis.com");
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementation(async (input, init) => {
-        const url = new URL(String(input));
-        if (init?.method === "GET") {
-          expect(url.pathname).toBe("/drive/v2/files/source");
-          return new Response(
-            JSON.stringify({
-              etag: '"v2"',
-              properties: [
-                {
-                  key: "runmeIpynbCopy",
-                  value: "r:copy",
-                  visibility: "PUBLIC",
-                },
-                { key: "private", value: "hidden", visibility: "PRIVATE" },
-              ],
-            }),
-            { headers: { "Content-Type": "application/json" } }
-          );
-        }
-        expect(url.pathname).toBe("/drive/v3/files/source");
-        expect(init?.headers).toMatchObject({ "If-Match": '"v2"' });
-        expect(JSON.parse(String(init?.body))).toEqual({
-          properties: { runmeIpynbCopy: "f:copy" },
-        });
-        return new Response("", { status: 200 });
-      });
-    const store = new DriveNotebookStore(async () => "access-token");
-
-    await expect(
-      store.compareAndSetDerivedCopyClaim(
-        driveFileUrl("source"),
-        "r:copy",
-        "f:copy"
-      )
-    ).resolves.toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
   it.each(["gapi", "fetch"])(
-    "conditionally publishes copy placement and content together via %s",
+    "uses v3 metadata and upload receipts without an ETag via %s",
     async (transport) => {
+      setGoogleDriveBaseUrl("https://www.googleapis.com");
+      const receipt = {
+        md5Checksum: "new",
+        headRevisionId: "opaque-upload",
+        version: "42",
+      };
       const fetchMock = vi
         .spyOn(globalThis, "fetch")
         .mockImplementation(async (input, init) => {
           const url = new URL(String(input));
-          if (init?.method === "GET")
+          expect(url.pathname).not.toContain("/v2/");
+          expect(init?.headers).not.toHaveProperty("If-Match");
+          expect(init?.headers).toMatchObject({
+            "X-Goog-Drive-Resource-Keys": "copy/file-key",
+          });
+          expect(url.searchParams.get("fields")).toBe(
+            "md5Checksum,headRevisionId,version,appProperties,properties",
+          );
+          if (init?.method === "GET") {
+            expect(url.pathname).toBe("/drive/v3/files/copy");
             return new Response(
-              JSON.stringify({ md5Checksum: "old", version: "1" }),
-              {
-                headers: {
-                  "Content-Type": "application/json",
-                  ETag: '"copy-etag"',
-                },
-              }
+              JSON.stringify({
+                md5Checksum: "old",
+                headRevisionId: "opaque-before",
+                version: "40",
+                properties: { runmeIpynbCopy: "r:copy" },
+              }),
             );
-          expect(init?.method).toBe("PATCH");
+          }
           expect(url.pathname).toBe("/upload/drive/v3/files/copy");
           expect(url.searchParams.get("uploadType")).toBe("multipart");
           expect(url.searchParams.get("addParents")).toBe("new");
           expect(url.searchParams.get("removeParents")).toBe("old");
-          expect(init?.headers).toMatchObject({
-            "If-Match": '"copy-etag"',
-            "Content-Type": expect.stringContaining(
-              "multipart/related; boundary="
-            ),
-          });
           expect(init?.body).toContain('"name":"new.ipynb"');
           expect(init?.body).toContain('{"cells":[]}');
-          return new Response("", { status: 412 });
+          return new Response(JSON.stringify(receipt));
         });
-      const placement = {
-        name: "new.ipynb",
-        parentUri: "https://drive.google.com/drive/folders/new",
-        previousParentUri: "https://drive.google.com/drive/folders/old",
-      };
+      const store = new DriveNotebookStore(async () => "access-token");
       if (transport === "gapi") {
         const client = new GapiDriveFilesClient({
           client: {
@@ -348,107 +316,80 @@ describe("DriveNotebookStore", () => {
             drive: { files: {}, drives: {}, revisions: {} },
           },
         } as never);
-        await expect(
-          client.setContentIfMatch(
-            "copy",
-            '{"cells":[]}',
-            "application/x-ipynb+json",
-            '"copy-etag"',
-            undefined,
-            placement
-          )
-        ).resolves.toBe(false);
-      } else {
-        setGoogleDriveBaseUrl("https://drive.example.test");
-        const store = new DriveNotebookStore(async () => "access-token");
-        await expect(
-          store.saveContentIfVersion(
-            "https://drive.google.com/file/d/copy/view",
-            '{"cells":[]}',
-            "application/x-ipynb+json",
-            { checksum: "old", version: "1" },
-            placement
-          )
-        ).resolves.toBe(false);
+        vi.spyOn(store as any, "getFilesClient").mockResolvedValue(client);
       }
-      expect(fetchMock).toHaveBeenCalled();
-    }
+      await expect(
+        store.saveContentAfterVersionCheck(
+          "https://drive.google.com/file/d/copy/view?resourcekey=file-key",
+          '{"cells":[]}',
+          "application/x-ipynb+json",
+          { checksum: "old", revisionId: "opaque-before", version: "40" },
+          {
+            name: "new.ipynb",
+            parentUri: "https://drive.google.com/drive/folders/new",
+            previousParentUri: "https://drive.google.com/drive/folders/old",
+          },
+        ),
+      ).resolves.toEqual(receipt);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
   );
 
-  it("reads a Drive v2 ETag and applies it to the CORS-capable v3 upload", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementation(async (input, init) => {
+  it.each(["gapi", "fetch"])(
+    "paginates, retains and downloads recovery revisions via %s",
+    async (transport) => {
+      setGoogleDriveBaseUrl("https://drive.example.test");
+      const requests: string[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
         const url = new URL(String(input));
-        if (init?.method === "GET") {
-          expect(url.pathname).toBe("/drive/v2/files/file123");
-          expect(url.searchParams.get("supportsAllDrives")).toBe("true");
-          expect(url.searchParams.get("fields")).toBe(
-            "etag,md5Checksum,headRevisionId,version,properties",
-          );
-          expect(init?.headers).toMatchObject({
-            Authorization: "Bearer access-token",
-            "X-Goog-Drive-Resource-Keys": "file123/file-key",
-          });
-          return new Response(
-            JSON.stringify({
-              etag: '\"drive-etag-1\"',
-              md5Checksum: "checksum-1",
-              headRevisionId: "revision-1",
-              version: "1",
-            }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            },
-          );
-        }
-        expect(init?.method).toBe("PATCH");
-        expect(url.pathname).toBe("/upload/drive/v3/files/file123");
-        expect(url.searchParams.get("uploadType")).toBe("media");
-        expect(url.searchParams.get("supportsAllDrives")).toBe("true");
+        requests.push(`${init?.method} ${url.pathname}`);
         expect(init?.headers).toMatchObject({
-          Authorization: "Bearer access-token",
-          "X-Goog-Drive-Resource-Keys": "file123/file-key",
-          "If-Match": '\"drive-etag-1\"',
-          "Content-Type": "application/vnd.runme.notebook+jsonl",
+          "X-Goog-Drive-Resource-Keys": "copy/file-key",
         });
-        expect(init?.body).toBe('{"record_type":"runme.notebook"}\n');
-        return new Response("", { status: 200 });
+        if (url.pathname.endsWith("/revisions"))
+          return new Response(
+            JSON.stringify(
+              url.searchParams.has("pageToken")
+                ? { revisions: [{ id: "head" }] }
+                : {
+                    revisions: [{ id: "intervening", keepForever: false }],
+                    nextPageToken: "second",
+                  },
+            ),
+          );
+        expect(url.pathname).toBe("/drive/v3/files/copy/revisions/intervening");
+        if (init?.method === "PATCH") {
+          expect(JSON.parse(String(init.body))).toEqual({ keepForever: true });
+          return new Response("{}");
+        }
+        expect(url.searchParams.get("alt")).toBe("media");
+        return new Response("historical bytes");
       });
-    const gapi = {
-      client: {
-        getToken: () => ({ access_token: "access-token" }),
-        drive: { files: {}, drives: {}, revisions: {} },
-      },
-    };
-    const client = new GapiDriveFilesClient(gapi as never);
-
-    const version = await client.getVersionMetadataWithEtag(
-      "file123",
-      "file-key",
-    );
-    expect(version).toEqual({
-      metadata: {
-        etag: '\"drive-etag-1\"',
-        md5Checksum: "checksum-1",
-        headRevisionId: "revision-1",
-        version: "1",
-        properties: {},
-      },
-      etag: '\"drive-etag-1\"',
-    });
-    await expect(
-      client.setContentIfMatch(
-        "file123",
-        '{"record_type":"runme.notebook"}\n',
-        "application/vnd.runme.notebook+jsonl",
-        version.etag!,
-        "file-key",
-      ),
-    ).resolves.toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
+      const store = new DriveNotebookStore(async () => "access-token");
+      if (transport === "gapi")
+        vi.spyOn(store as any, "getFilesClient").mockResolvedValue(
+          new GapiDriveFilesClient({
+            client: {
+              getToken: () => ({ access_token: "access-token" }),
+              drive: { files: {}, drives: {}, revisions: {} },
+            },
+          } as never),
+        );
+      const uri =
+        "https://drive.google.com/file/d/copy/view?resourcekey=file-key";
+      const revisions = await store.listRevisions(uri);
+      expect(revisions.map((r) => r.id)).toEqual(["intervening", "head"]);
+      expect(await store.loadRevisionForRecovery(uri, revisions[0]!)).toBe(
+        "historical bytes",
+      );
+      expect(requests).toEqual([
+        "GET /drive/v3/files/copy/revisions",
+        "GET /drive/v3/files/copy/revisions",
+        "PATCH /drive/v3/files/copy/revisions/intervening",
+        "GET /drive/v3/files/copy/revisions/intervening",
+      ]);
+    },
+  );
 
   it("forwards native Drive files.list search parameters and returns paging metadata", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
@@ -1005,7 +946,9 @@ describe("DriveNotebookStore", () => {
       .spyOn(globalThis, "fetch")
       .mockImplementation(async (input, init) => {
         const url = new URL(String(input));
-        expect(url.searchParams.get("resourceKey")).toBe("file-key");
+        expect(init?.headers).toMatchObject({
+          "X-Goog-Drive-Resource-Keys": "file123/file-key",
+        });
         if (init?.method === "GET") {
           expect(url.pathname).toBe("/drive/v3/files/file123");
           return new Response(
@@ -1026,7 +969,6 @@ describe("DriveNotebookStore", () => {
         expect(init?.method).toBe("PATCH");
         expect(init?.headers).toMatchObject({
           "Content-Type": "application/json",
-          "If-Match": '"drive-etag-1"',
         });
         expect(init?.body).toBe('{"cells":[]}');
         return new Response("", { status: 200 });
@@ -1036,13 +978,13 @@ describe("DriveNotebookStore", () => {
     const uri =
       "https://drive.google.com/file/d/file123/view?resourcekey=file-key";
     await expect(
-      store.saveContentIfVersion(
+      store.saveContentAfterVersionCheck(
         uri,
         '{"cells":[]}',
         "application/json",
         { checksum: "empty-checksum", revisionId: "empty-revision" },
       ),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({});
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -1063,7 +1005,7 @@ describe("DriveNotebookStore", () => {
 
     const store = new DriveNotebookStore(async () => "access-token");
     await expect(
-      store.saveContentIfVersion(
+      store.saveContentAfterVersionCheck(
         "https://drive.google.com/file/d/file123/view",
         '{"cells":[]}',
         "application/json",
@@ -1073,7 +1015,7 @@ describe("DriveNotebookStore", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a repair when Drive changes during the conditional upload", async () => {
+  it("propagates an upload failure without reporting a successful preflight", async () => {
     setGoogleDriveBaseUrl("https://drive.example.test");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -1099,13 +1041,13 @@ describe("DriveNotebookStore", () => {
     const store = new DriveNotebookStore(async () => "access-token");
     const uri = "https://drive.google.com/file/d/file123/view";
     await expect(
-      store.saveContentIfVersion(
+      store.saveContentAfterVersionCheck(
         uri,
         '{"cells":[]}',
         "application/json",
         { checksum: "empty-checksum", revisionId: "empty-revision" },
       ),
-    ).resolves.toBe(false);
+    ).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -1307,7 +1249,7 @@ describe("DriveNotebookStore", () => {
 
   it.each([
     "saveContent",
-    "saveContentIfVersion",
+    "saveContentAfterVersionCheck",
     "externalEdit",
   ] as const)(
     "reloads IPYNB preservation state after %s",
@@ -1373,20 +1315,16 @@ describe("DriveNotebookStore", () => {
       const store = new DriveNotebookStore(async () => "access-token");
       const notebook = await store.load(uri);
       if (writeMethod === "saveContent") {
-        await store.saveContent(
-          uri,
-          rawContent,
-          "application/x-ipynb+json",
-        );
-      } else if (writeMethod === "saveContentIfVersion") {
+        await store.saveContent(uri, rawContent, "application/x-ipynb+json");
+      } else if (writeMethod === "saveContentAfterVersionCheck") {
         await expect(
-          store.saveContentIfVersion(
+          store.saveContentAfterVersionCheck(
             uri,
             rawContent,
             "application/x-ipynb+json",
             { checksum: "initial-checksum", revisionId: "revision-1" },
           ),
-        ).resolves.toBe(true);
+        ).resolves.toEqual({});
       } else {
         remoteContent = rawContent;
         checksum = "external-checksum";

--- a/app/src/storage/drive.ts
+++ b/app/src/storage/drive.ts
@@ -25,8 +25,6 @@ const GAPI_SCRIPT_SRC = 'https://apis.google.com/js/api.js'
 // https://developers.google.com/workspace/drive/api/guides/fields-parameter
 const VERSION_FIELDS =
   'md5Checksum,headRevisionId,version,appProperties,properties'
-const DRIVE_V2_VERSION_FIELDS =
-  'etag,md5Checksum,headRevisionId,version,properties'
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
 } as unknown as Parameters<typeof toJsonString>[2]
@@ -383,14 +381,14 @@ type DriveRevisionListResponse = {
   result?: { revisions?: DriveRevision[]; nextPageToken?: string }
 }
 
-/** Metadata and content are replaced in one conditional Drive request. */
+/** Metadata and content are replaced in one Drive request. */
 export interface DerivedCopyPlacement {
   name: string
   parentUri: string
   previousParentUri?: string
 }
 
-function conditionalUpload(
+function contentUpload(
   content: string,
   mimeType: string,
   placement?: DerivedCopyPlacement
@@ -422,11 +420,15 @@ function conditionalUpload(
 }
 
 interface DriveFilesClient {
-  setPublicPropertyIfMatch(
+  keepRevision(
+    fileId: string,
+    revisionId: string,
+    resourceKey?: string
+  ): Promise<void>
+  setPublicProperty(
     fileId: string,
     key: string,
     value: string | null,
-    etag: string,
     resourceKey?: string
   ): Promise<boolean>
   generateFileId(): Promise<string>
@@ -445,21 +447,19 @@ interface DriveFilesClient {
   get(
     request: Record<string, unknown>
   ): Promise<{ body?: string; result?: unknown }>
-  getVersionMetadataWithEtag(
+  readVersionMetadata(
     fileId: string,
     resourceKey?: string
   ): Promise<{
     metadata: DriveVersionMetadata | null
-    etag?: string
   }>
-  setContentIfMatch(
+  uploadContent(
     fileId: string,
     content: string,
     mimeType: string,
-    etag: string,
     resourceKey?: string,
     placement?: DerivedCopyPlacement
-  ): Promise<boolean>
+  ): Promise<DriveVersionMetadata>
   getDrive(request: Record<string, unknown>): Promise<DriveGetResponse>
   list(
     request: Record<string, unknown>,
@@ -716,7 +716,7 @@ export class GapiDriveFilesClient implements DriveFilesClient {
       expectText?: boolean
       headers?: Record<string, string>
     } = {}
-  ): Promise<{ body?: string; result?: unknown; etag?: string }> {
+  ): Promise<{ body?: string; result?: unknown }> {
     const token = this.gapi.client.getToken?.()?.access_token ?? ''
     if (!token) {
       throw new Error('Google Drive request requires an access token')
@@ -751,7 +751,6 @@ export class GapiDriveFilesClient implements DriveFilesClient {
     if (options.expectText) {
       return {
         body: await response.text(),
-        etag: response.headers.get('etag') ?? undefined,
       }
     }
 
@@ -759,12 +758,10 @@ export class GapiDriveFilesClient implements DriveFilesClient {
     if (!text) {
       return {
         result: undefined,
-        etag: response.headers.get('etag') ?? undefined,
       }
     }
     return {
       result: JSON.parse(text),
-      etag: response.headers.get('etag') ?? undefined,
     }
   }
 
@@ -982,99 +979,85 @@ export class GapiDriveFilesClient implements DriveFilesClient {
     }>
   }
 
-  async getVersionMetadataWithEtag(
+  /** Read v3 metadata; browser sync does not depend on an exposed ETag. */
+  async readVersionMetadata(
     fileId: string,
     resourceKey?: string
   ): Promise<{
     metadata: DriveVersionMetadata | null
-    etag?: string
   }> {
-    // Drive v3 returns the ETag as an HTTP response header, but Google does
-    // not expose that header to cross-origin browser JavaScript. Drive v2
-    // exposes the same file validator in its JSON body, which lets browser
-    // clients keep using a real If-Match precondition instead of weakening
-    // the operation-log CAS.
     const response = await this.request(
       'GET',
-      `/drive/v2/files/${encodeURIComponent(fileId)}`,
+      `/drive/v3/files/${encodeURIComponent(fileId)}`,
       {
-        params: {
-          supportsAllDrives: true,
-          fields: DRIVE_V2_VERSION_FIELDS,
-        },
+        params: { supportsAllDrives: true, fields: VERSION_FIELDS },
         headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
     )
-    return normalizeDriveV2VersionResponse(response)
+    return {
+      metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
+    }
   }
 
-  /** CAS one public property without changing media or unrelated properties. */
-  async setPublicPropertyIfMatch(
+  /** Update a public property. Callers recheck ownership; this is not a lock. */
+  async setPublicProperty(
     fileId: string,
     key: string,
     value: string | null,
-    etag: string,
     resourceKey?: string
   ): Promise<boolean> {
-    try {
-      await this.request(
-        'PATCH',
-        `/drive/v3/files/${encodeURIComponent(fileId)}`,
-        {
-          params: { supportsAllDrives: true },
-          body: JSON.stringify({ properties: { [key]: value } }),
-          headers: {
-            ...driveResourceKeyHeaders({ id: fileId, resourceKey }),
-            'If-Match': etag,
-          },
-        }
-      )
-      return true
-    } catch (error) {
-      if (error instanceof DrivePreconditionFailedError) return false
-      throw error
-    }
+    await this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(fileId)}`,
+      {
+        params: { supportsAllDrives: true },
+        body: JSON.stringify({ properties: { [key]: value } }),
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
+      }
+    )
+    return true
   }
 
-  async setContentIfMatch(
+  /** Return metadata from this upload response, never from a later file read. */
+  async uploadContent(
     fileId: string,
     content: string,
     mimeType: string,
-    etag: string,
     resourceKey?: string,
     placement?: DerivedCopyPlacement
-  ): Promise<boolean> {
-    const upload = conditionalUpload(content, mimeType, placement)
-    try {
-      // Read the validator from Drive v2 because its JSON body exposes the
-      // ETag to browser JavaScript, but write through Drive v3. The v2 upload
-      // endpoint omits Access-Control-Allow-Origin from its actual response,
-      // so a successful preflight still ends as `TypeError: Failed to fetch`
-      // in browsers. Send the v2 file ETag back as the If-Match validator for
-      // the same file through Drive's current v3 media-update endpoint.
-      await this.request(
-        'PATCH',
-        `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
-        {
-          params: {
-            ...upload.params,
-            supportsAllDrives: true,
-          },
-          body: upload.body,
-          contentType: upload.contentType,
-          headers: {
-            ...driveResourceKeyHeaders({ id: fileId, resourceKey }),
-            'If-Match': etag,
-          },
-        }
-      )
-      return true
-    } catch (error) {
-      if (error instanceof DrivePreconditionFailedError) {
-        return false
+  ): Promise<DriveVersionMetadata> {
+    const upload = contentUpload(content, mimeType, placement)
+    const response = await this.request(
+      'PATCH',
+      `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
+      {
+        params: {
+          ...upload.params,
+          supportsAllDrives: true,
+          fields: VERSION_FIELDS,
+        },
+        body: upload.body,
+        contentType: upload.contentType,
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
-      throw error
-    }
+    )
+    return (response.result as DriveVersionMetadata | undefined) ?? {}
+  }
+
+  /** Pin a blob revision before downloading it through the supported v3 API. */
+  async keepRevision(
+    fileId: string,
+    revisionId: string,
+    resourceKey?: string
+  ): Promise<void> {
+    await this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(fileId)}/revisions/${encodeURIComponent(revisionId)}`,
+      {
+        body: JSON.stringify({ keepForever: true }),
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
+      }
+    )
   }
 
   list(
@@ -1278,7 +1261,7 @@ class FetchDriveFilesClient implements DriveFilesClient {
       expectText?: boolean
       headers?: Record<string, string>
     } = {}
-  ): Promise<{ body?: string; result?: unknown; etag?: string }> {
+  ): Promise<{ body?: string; result?: unknown }> {
     const response = await fetch(this.buildUrl(path, options.params), {
       method,
       headers: {
@@ -1309,7 +1292,6 @@ class FetchDriveFilesClient implements DriveFilesClient {
     if (options.expectText) {
       return {
         body: await response.text(),
-        etag: response.headers.get('etag') ?? undefined,
       }
     }
 
@@ -1317,12 +1299,10 @@ class FetchDriveFilesClient implements DriveFilesClient {
     if (!text) {
       return {
         result: undefined,
-        etag: response.headers.get('etag') ?? undefined,
       }
     }
     return {
       result: JSON.parse(text),
-      etag: response.headers.get('etag') ?? undefined,
     }
   }
 
@@ -1482,106 +1462,85 @@ class FetchDriveFilesClient implements DriveFilesClient {
     )
   }
 
-  async getVersionMetadataWithEtag(
+  /** Read v3 metadata; browser sync does not depend on an exposed ETag. */
+  async readVersionMetadata(
     fileId: string,
     resourceKey?: string
   ): Promise<{
     metadata: DriveVersionMetadata | null
-    etag?: string
   }> {
-    // Fake/test servers expose the v3 ETag header through CORS, so preserve
-    // their existing v3 contract instead of requiring them to emulate v2.
-    if (!new URL(this.baseUrl).hostname.endsWith('.googleapis.com')) {
-      const response = await this.request(
-        'GET',
-        `/drive/v3/files/${encodeURIComponent(fileId)}`,
-        {
-          params: {
-            supportsAllDrives: true,
-            fields: VERSION_FIELDS,
-            resourceKey,
-          },
-        }
-      )
-      return {
-        metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
-        etag: response.etag,
-      }
-    }
-
-    // Match the GAPI transport's v2 metadata request. Google does not expose
-    // the v3 ETag response header to cross-origin browser JavaScript, while v2
-    // includes the validator in the JSON body.
     const response = await this.request(
       'GET',
-      `/drive/v2/files/${encodeURIComponent(fileId)}`,
+      `/drive/v3/files/${encodeURIComponent(fileId)}`,
       {
-        params: {
-          supportsAllDrives: true,
-          fields: DRIVE_V2_VERSION_FIELDS,
-        },
+        params: { supportsAllDrives: true, fields: VERSION_FIELDS },
         headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
     )
-    return normalizeDriveV2VersionResponse(response)
+    return {
+      metadata: (response.result as DriveVersionMetadata | undefined) ?? null,
+    }
   }
 
-  /** Use the same source-file CAS contract as the browser transport. */
-  async setPublicPropertyIfMatch(
+  /** Update a public property. Callers recheck ownership; this is not a lock. */
+  async setPublicProperty(
     fileId: string,
     key: string,
     value: string | null,
-    etag: string,
     resourceKey?: string
   ): Promise<boolean> {
-    try {
-      await this.request(
-        'PATCH',
-        `/drive/v3/files/${encodeURIComponent(fileId)}`,
-        {
-          params: { supportsAllDrives: true, resourceKey },
-          body: JSON.stringify({ properties: { [key]: value } }),
-          headers: { 'If-Match': etag },
-        }
-      )
-      return true
-    } catch (error) {
-      if (error instanceof DrivePreconditionFailedError) return false
-      throw error
-    }
+    await this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(fileId)}`,
+      {
+        params: { supportsAllDrives: true },
+        body: JSON.stringify({ properties: { [key]: value } }),
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
+      }
+    )
+    return true
   }
 
-  async setContentIfMatch(
+  /** Return metadata from this upload response, never from a later file read. */
+  async uploadContent(
     fileId: string,
     content: string,
     mimeType: string,
-    etag: string,
     resourceKey?: string,
     placement?: DerivedCopyPlacement
-  ): Promise<boolean> {
-    const upload = conditionalUpload(content, mimeType, placement)
-    try {
-      await this.request(
-        'PATCH',
-        `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
-        {
-          params: {
-            ...upload.params,
-            supportsAllDrives: true,
-            resourceKey,
-          },
-          body: upload.body,
-          contentType: upload.contentType,
-          headers: { 'If-Match': etag },
-        }
-      )
-      return true
-    } catch (error) {
-      if (error instanceof DrivePreconditionFailedError) {
-        return false
+  ): Promise<DriveVersionMetadata> {
+    const upload = contentUpload(content, mimeType, placement)
+    const response = await this.request(
+      'PATCH',
+      `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
+      {
+        params: {
+          ...upload.params,
+          supportsAllDrives: true,
+          fields: VERSION_FIELDS,
+        },
+        body: upload.body,
+        contentType: upload.contentType,
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
       }
-      throw error
-    }
+    )
+    return (response.result as DriveVersionMetadata | undefined) ?? {}
+  }
+
+  /** Pin a blob revision before downloading it through the supported v3 API. */
+  async keepRevision(
+    fileId: string,
+    revisionId: string,
+    resourceKey?: string
+  ): Promise<void> {
+    await this.request(
+      'PATCH',
+      `/drive/v3/files/${encodeURIComponent(fileId)}/revisions/${encodeURIComponent(revisionId)}`,
+      {
+        body: JSON.stringify({ keepForever: true }),
+        headers: driveResourceKeyHeaders({ id: fileId, resourceKey }),
+      }
+    )
   }
 
   list(
@@ -1982,40 +1941,6 @@ export interface DriveVersionMetadata {
   headRevisionId?: string
   version?: string
   appProperties?: Record<string, string>
-}
-
-type DriveV2VersionMetadata = Omit<DriveVersionMetadata, 'properties'> & {
-  etag?: string
-  properties?: {
-    key: string
-    value: string
-    visibility: string
-  }[]
-}
-
-/** Normalize Drive v2's public-property array and browser-visible JSON ETag. */
-function normalizeDriveV2VersionResponse(response: {
-  result?: unknown
-  etag?: string
-}): {
-  metadata: DriveVersionMetadata | null
-  etag?: string
-} {
-  const metadata =
-    (response.result as DriveV2VersionMetadata | undefined) ?? null
-  return {
-    metadata: metadata
-      ? {
-          ...metadata,
-          properties: Object.fromEntries(
-            (metadata.properties ?? [])
-              .filter((property) => property.visibility === 'PUBLIC')
-              .map((property) => [property.key, property.value])
-          ),
-        }
-      : null,
-    etag: metadata?.etag ?? response.etag,
-  }
 }
 
 export interface DriveRevision {
@@ -2594,34 +2519,23 @@ export class DriveNotebookStore {
     const { id, resourceKey } = parseDriveItem(uri)
     const { metadata } = await (
       await this.getFilesClient()
-    ).getVersionMetadataWithEtag(id, resourceKey)
+    ).readVersionMetadata(id, resourceKey)
     return metadata?.properties?.[DERIVED_COPY_PROPERTY]
   }
 
-  /** Compare-and-set the source property; media edits also invalidate its ETag. */
-  async compareAndSetDerivedCopyClaim(
+  /** Client-side property check and readback; competing writers can still race. */
+  async updateDerivedCopyClaimAfterCheck(
     uri: string,
     expected: string | undefined,
     next: string | null
   ): Promise<boolean> {
     const { id, resourceKey } = parseDriveItem(uri)
     const client = await this.getFilesClient()
-    const { metadata, etag } = await client.getVersionMetadataWithEtag(
-      id,
-      resourceKey
-    )
-    if (metadata?.properties?.[DERIVED_COPY_PROPERTY] !== expected) return false
-    if (!etag)
-      throw new Error(
-        'Drive did not expose a validator for Colab copy coordination.'
-      )
-    return client.setPublicPropertyIfMatch(
-      id,
-      DERIVED_COPY_PROPERTY,
-      next,
-      etag,
-      resourceKey
-    )
+    const { metadata } = await client.readVersionMetadata(id, resourceKey)
+    if (!metadata || metadata.properties?.[DERIVED_COPY_PROPERTY] !== expected)
+      return false
+    await client.setPublicProperty(id, DERIVED_COPY_PROPERTY, next, resourceKey)
+    return (await this.getDerivedCopyClaim(uri)) === (next ?? undefined)
   }
 
   /** A source property alone never authorizes overwriting an unrelated file. */
@@ -3643,55 +3557,75 @@ export class DriveNotebookStore {
   }
 
   /**
-   * Replace file content only while Drive still exposes the exact revision
-   * previously inspected by the caller. The metadata recheck closes the gap
-   * before the request, and If-Match closes the gap during the media upload.
+   * Recheck the observed v3 version immediately before uploading. This is a
+   * client-side preflight, not an atomic condition: .runme callers reconcile
+   * revision history afterward; snapshot callers retain conflict handling.
    */
-  async saveContentIfVersion(
+  async saveContentAfterVersionCheck(
     uri: string,
     content: string,
     mimeType: string,
     expected: { checksum?: string; revisionId?: string; version?: string },
     placement?: DerivedCopyPlacement
-  ): Promise<boolean> {
+  ): Promise<DriveVersionMetadata | false> {
     const { id, type, resourceKey } = parseDriveItem(uri)
     if (type !== NotebookStoreItemType.File) {
       throw new Error(
-        'DriveNotebookStore.saveContentIfVersion expects a file URI'
+        'DriveNotebookStore.saveContentAfterVersionCheck expects a file URI'
       )
     }
     const client = await this.getFilesClient()
-    const { metadata, etag } = await client.getVersionMetadataWithEtag(
-      id,
-      resourceKey
-    )
-    const actualChecksum = metadata?.md5Checksum ?? ''
-    const expectedChecksum = expected.checksum ?? ''
+    const { metadata } = await client.readVersionMetadata(id, resourceKey)
     if (
-      actualChecksum !== expectedChecksum ||
+      !metadata ||
+      (metadata.md5Checksum ?? '') !== (expected.checksum ?? '') ||
       (expected.revisionId !== undefined &&
-        metadata?.headRevisionId !== expected.revisionId) ||
-      (expected.version !== undefined && metadata?.version !== expected.version)
-    ) {
+        metadata.headRevisionId !== expected.revisionId) ||
+      (expected.version !== undefined && metadata.version !== expected.version)
+    )
       return false
-    }
-    if (!etag) {
-      // Refuse an unconditional repair if the transport did not expose the
-      // validator needed to protect a collaborator's concurrent edit.
-      return false
-    }
-    const saved = await client.setContentIfMatch(
+    const receipt = await client.uploadContent(
       id,
       content,
       mimeType,
-      etag,
       resourceKey,
       placement
     )
-    if (saved) {
-      this.ipynbState.delete(uri)
+    this.ipynbState.delete(uri)
+    return receipt
+  }
+
+  /**
+   * Google only supports downloading retained blob revisions. Retention is
+   * permanent and capped at 200 per file; never delete history to free slots.
+   * Failures propagate so reconciliation remains pending with local data safe.
+   */
+  async loadRevisionForRecovery(
+    uri: string,
+    revision: DriveRevision
+  ): Promise<string> {
+    if (!revision.id) throw new Error('Drive revision is missing its ID')
+    const { id, resourceKey } = parseDriveItem(uri)
+    appLogger.info('Recovering intervening Drive revision', {
+      attrs: {
+        scope: 'storage.drive.sync',
+        code: 'DRIVE_REVISION_RECOVERY',
+        fileId: id,
+        revisionId: revision.id,
+      },
+    })
+    if (!revision.keepForever) {
+      try {
+        await (
+          await this.getFilesClient()
+        ).keepRevision(id, revision.id, resourceKey)
+      } catch (error) {
+        throw new Error(
+          `Cannot retain Drive revision ${revision.id} for recovery. Check edit permission and the 200 retained-revision limit. Local operations remain pending. ${String(error)}`
+        )
+      }
     }
-    return saved
+    return this.loadRevisionContent(uri, revision.id)
   }
 
   async loadContent(uri: string): Promise<string> {

--- a/app/src/storage/driveRevisionRecovery.ts
+++ b/app/src/storage/driveRevisionRecovery.ts
@@ -1,0 +1,158 @@
+import md5 from 'md5'
+
+import { parseDriveItem } from './drive'
+import type {
+  DriveNotebookStore,
+  DriveRevision,
+  DriveVersionMetadata,
+} from './drive'
+
+/** IDs are opaque. Persist sets rather than inferring order or version increments. */
+export interface DriveRecoveryCheckpoint {
+  fileId: string
+  knownRevisionIds: string[]
+  pendingRevisionIds: string[]
+  /** The observed head must remain available while an upload is reconciled. */
+  anchorRevisionId: string
+}
+
+interface Snapshot {
+  content: string
+  version: DriveVersionMetadata | null
+}
+
+/**
+ * Tracks revisions whose operations have reached the durable local journal.
+ * The checkpoint is written before uploads/downloads and acknowledged only
+ * after OPFS append completes, so reloads and unknown upload outcomes retry
+ * recovery without forgetting overwritten collaborator revisions.
+ */
+export class DriveRevisionRecovery {
+  constructor(
+    private readonly drive: Pick<
+      DriveNotebookStore,
+      'getVersionMetadata' | 'listRevisions' | 'loadRevisionForRecovery'
+    >,
+    private readonly uri: string,
+    private checkpoint: DriveRecoveryCheckpoint | undefined,
+    private readonly persist: (
+      checkpoint: DriveRecoveryCheckpoint
+    ) => Promise<void>
+  ) {
+    if (checkpoint?.fileId !== parseDriveItem(uri).id)
+      this.checkpoint = undefined
+  }
+
+  /** Establish the history boundary before the first sync attempt reads media. */
+  async initialize(): Promise<boolean> {
+    if (this.checkpoint) return true
+    const before = await this.drive.getVersionMetadata(this.uri)
+    const revisions = await this.drive.listRevisions(this.uri)
+    const after = await this.drive.getVersionMetadata(this.uri)
+    const head = after?.headRevisionId
+    if (!head)
+      throw new Error(
+        'Drive recovery requires a head revision ID; local operations remain pending.'
+      )
+    if (before?.headRevisionId !== head || before?.version !== after?.version)
+      return false
+    this.requireRevisions(revisions, [head])
+    // Older history predates this replica's recovery boundary. The current
+    // head is deliberately excluded: it must be read even if overwritten next.
+    await this.save({
+      fileId: parseDriveItem(this.uri).id,
+      knownRevisionIds: revisions.flatMap((revision) =>
+        revision.id && revision.id !== head ? [revision.id] : []
+      ),
+      pendingRevisionIds: [head],
+      anchorRevisionId: head,
+    })
+    return true
+  }
+
+  /** Discover every page, including intervening writes hidden behind our head. */
+  async collect(
+    snapshot: Snapshot
+  ): Promise<{ revisions: DriveRevision[]; contents: string[] }> {
+    if (!this.checkpoint)
+      throw new Error('Drive revision recovery is not initialized')
+    const revisions = await this.drive.listRevisions(this.uri)
+    const head = snapshot.version?.headRevisionId
+    if (!head)
+      throw new Error(
+        'Drive recovery requires a head revision ID; local operations remain pending.'
+      )
+    this.requireRevisions(revisions, [
+      this.checkpoint.anchorRevisionId,
+      ...this.checkpoint.pendingRevisionIds,
+      head,
+    ])
+    const known = new Set(this.checkpoint.knownRevisionIds)
+    const pending = revisions.filter(
+      (revision) => revision.id && !known.has(revision.id)
+    )
+    await this.save({
+      ...this.checkpoint,
+      pendingRevisionIds: pending.map((revision) => revision.id!),
+    })
+    const contents: string[] = []
+    for (const revision of pending) {
+      const content =
+        revision.id === head
+          ? snapshot.content
+          : await this.drive.loadRevisionForRecovery(this.uri, revision)
+      if (revision.md5Checksum && md5(content) !== revision.md5Checksum) {
+        throw new Error(
+          `Drive recovery checksum mismatch for revision ${revision.id}; local operations remain pending.`
+        )
+      }
+      // Zero-byte creation revisions have no operations to recover.
+      if (content !== '') contents.push(content)
+    }
+    return { revisions, contents }
+  }
+
+  /** Call only after every collected operation has been appended to OPFS. */
+  async acknowledge(revisions: DriveRevision[], head: string): Promise<void> {
+    await this.save({
+      fileId: parseDriveItem(this.uri).id,
+      knownRevisionIds: revisions.flatMap((revision) =>
+        revision.id ? [revision.id] : []
+      ),
+      pendingRevisionIds: [],
+      anchorRevisionId: head,
+    })
+  }
+
+  /** An upload receipt identifies our write; a later metadata read does not. */
+  async uploaded(receipt: DriveVersionMetadata): Promise<void> {
+    if (!this.checkpoint || !receipt.headRevisionId) return
+    await this.save({
+      ...this.checkpoint,
+      knownRevisionIds: [
+        ...new Set([
+          ...this.checkpoint.knownRevisionIds,
+          receipt.headRevisionId,
+        ]),
+      ],
+      // Keep the pre-upload anchor until history has been inspected again.
+    })
+  }
+
+  private requireRevisions(
+    revisions: DriveRevision[],
+    required: string[]
+  ): void {
+    const available = new Set(revisions.map((revision) => revision.id))
+    const missing = required.find((id) => !available.has(id))
+    if (missing)
+      throw new Error(
+        `Drive revision ${missing} is no longer available for recovery. Local operations remain pending; restore the missing history or reconcile a saved copy.`
+      )
+  }
+
+  private async save(checkpoint: DriveRecoveryCheckpoint): Promise<void> {
+    await this.persist(checkpoint)
+    this.checkpoint = checkpoint
+  }
+}

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -140,12 +140,47 @@ function createTestStore(
   localStore.driveStore = driveStore
   if (driveStore && typeof driveStore === 'object') {
     const drive = driveStore as any
+    // Existing local-store unit fixtures retain every metadata revision they
+    // expose. Race-specific fixtures below provide explicit historical bytes.
+    if (drive.getVersionMetadata && !drive.listRevisions) {
+      const revisions = new Map<string, any>()
+      const bytes = new Map<string, string>()
+      const getVersion = drive.getVersionMetadata
+      drive.getVersionMetadata = vi.fn(async (...args: any[]) => {
+        const version = await getVersion(...args)
+        if (version?.headRevisionId)
+          revisions.set(version.headRevisionId, {
+            id: version.headRevisionId,
+            md5Checksum: version.md5Checksum,
+          })
+        return version
+      })
+      if (drive.loadContent) {
+        const load = drive.loadContent
+        drive.loadContent = vi.fn(async (...args: any[]) => {
+          const content = await load(...args)
+          bytes.set(md5(content), content)
+          return content
+        })
+      }
+      drive.listRevisions = vi.fn(async () => [...revisions.values()])
+      drive.loadRevisionForRecovery ??= vi.fn(
+        async (_uri: string, revision: any) => {
+          const content = bytes.get(revision.md5Checksum)
+          if (content === undefined)
+            throw new Error(
+              `Test fixture missing historical bytes for ${revision.id}`
+            )
+          return content
+        }
+      )
+    }
     drive.waitForCreateOperation ??= drive.findByCreateOperation
     drive.canUsePreGeneratedFileId ??= vi.fn(async () => false)
     drive.createContent ??= drive.create
     const claims = new Map<string, string>()
     drive.getDerivedCopyClaim ??= vi.fn(async (uri: string) => claims.get(uri))
-    drive.compareAndSetDerivedCopyClaim ??= vi.fn(
+    drive.updateDerivedCopyClaimAfterCheck ??= vi.fn(
       async (
         uri: string,
         expected: string | undefined,
@@ -160,7 +195,7 @@ function createTestStore(
     drive.getDerivedCopyTarget ??= vi.fn(
       async (uri: string) => drive.getMetadataIfExists?.(uri) ?? null
     )
-    if (drive.saveContent && !drive.saveContentIfVersion) {
+    if (drive.saveContent && !drive.saveContentAfterVersionCheck) {
       drive.getVersionMetadata ??= vi.fn(async () => ({
         md5Checksum: 'copy-checksum',
         version: '1',
@@ -172,7 +207,7 @@ function createTestStore(
           ? '{}'
           : ''
       )
-      drive.saveContentIfVersion = vi.fn(
+      drive.saveContentAfterVersionCheck = vi.fn(
         async (uri: string, content: string, mime: string) => {
           await drive.saveContent(uri, content, mime)
           return true
@@ -221,8 +256,8 @@ function notebookJson(value: string): string {
 describe('LocalNotebooks operation-log storage', () => {
   it('clears only the recorded unconfirmed claim before an explicit retry', async () => {
     const source = 'https://drive.google.com/file/d/source/view'
-    const compareAndSetDerivedCopyClaim = vi.fn(async () => false)
-    const store = createTestStore({ compareAndSetDerivedCopyClaim })
+    const updateDerivedCopyClaimAfterCheck = vi.fn(async () => false)
+    const store = createTestStore({ updateDerivedCopyClaimAfterCheck })
     const sync = vi.spyOn(store, 'syncIpynbFile').mockResolvedValue()
     await store.files.put({
       id: 'local://file/recover',
@@ -236,7 +271,7 @@ describe('LocalNotebooks operation-log storage', () => {
       ipynbExportError: 'unconfirmed',
     })
     await store.retryUnconfirmedIpynbCreation('local://file/recover')
-    expect(compareAndSetDerivedCopyClaim).toHaveBeenCalledWith(
+    expect(updateDerivedCopyClaimAfterCheck).toHaveBeenCalledWith(
       source,
       'p:old',
       null
@@ -589,7 +624,7 @@ describe('LocalNotebooks operation-log storage', () => {
         loadContent: vi.fn(async (uri: string) =>
           uri === copy ? content : upstream
         ),
-        saveContentIfVersion: vi.fn(
+        saveContentAfterVersionCheck: vi.fn(
           async (
             _uri: string,
             bytes: string,
@@ -768,7 +803,7 @@ describe('LocalNotebooks operation-log storage', () => {
 
     await store.reconcileDriveNotebook(uri)
 
-    expect(driveStore.loadContent).toHaveBeenCalledTimes(2)
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(3)
     expect(await store.loadContent(uri)).toBe(latestDocument)
     expect(await store.files.get(uri)).toMatchObject({
       md5Checksum: md5(latestDocument),
@@ -1204,7 +1239,7 @@ describe('LocalNotebooks operation-log storage', () => {
       getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
       getVersionMetadata: vi.fn(async () => remoteVersion),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           content: string,
@@ -1272,7 +1307,7 @@ describe('LocalNotebooks operation-log storage', () => {
         )
       )
     ).toEqual(new Set([root.op_id, alice.op_id, bob.op_id]))
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(1)
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledTimes(1)
     expect((await store.files.get('local://file/shared'))?.doc).toBe('')
     expect(await store.files.get('local://file/shared')).toMatchObject({
       md5Checksum: md5(localAfter),
@@ -1301,7 +1336,7 @@ describe('LocalNotebooks operation-log storage', () => {
       getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
       getVersionMetadata: vi.fn(async () => remoteVersion),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           content: string,
@@ -1348,7 +1383,7 @@ describe('LocalNotebooks operation-log storage', () => {
     await store.reconcileDriveNotebook('local://file/empty-drive')
 
     expect(remoteDocument).toBe(localDocument)
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledOnce()
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledOnce()
     expect(await store.files.get('local://file/empty-drive')).toMatchObject({
       lastRemoteChecksum: md5(localDocument),
       lastUpstreamVersion: {
@@ -1369,7 +1404,7 @@ describe('LocalNotebooks operation-log storage', () => {
     const driveStore = {
       getVersionMetadata: vi.fn(async () => remoteVersion),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           content: string,
@@ -1441,7 +1476,7 @@ describe('LocalNotebooks operation-log storage', () => {
     const driveStore = {
       getVersionMetadata: vi.fn(async () => remoteVersion),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(),
+      saveContentAfterVersionCheck: vi.fn(),
     }
     const operationLogStorage = new MemoryOperationLogStorage()
     const local = await operationLogStorage.initialize(
@@ -1465,7 +1500,7 @@ describe('LocalNotebooks operation-log storage', () => {
     await expect(store.reconcileDriveNotebook(uri)).rejects.toThrow(
       'Operation log must end with LF'
     )
-    expect(driveStore.saveContentIfVersion).not.toHaveBeenCalled()
+    expect(driveStore.saveContentAfterVersionCheck).not.toHaveBeenCalled()
   })
 
   it('rejects stale bytes, then accepts a newer self-consistent Drive snapshot', async () => {
@@ -1513,6 +1548,7 @@ describe('LocalNotebooks operation-log storage', () => {
       getVersionMetadata: vi.fn(async () => remoteVersion),
       loadContent: vi.fn(async () => {
         loadCount += 1
+        if (loadCount > 2) return remoteDocument
         const downloaded = remoteDocument
         const operations =
           loadCount === 1
@@ -1528,7 +1564,7 @@ describe('LocalNotebooks operation-log storage', () => {
         }
         return loadCount === 1 ? downloaded : remoteDocument
       }),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           content: string,
@@ -1554,6 +1590,15 @@ describe('LocalNotebooks operation-log storage', () => {
         }
       ),
     }
+    Object.assign(driveStore, {
+      loadRevisionForRecovery: vi.fn(
+        async (_uri: string, revision: { id?: string }) =>
+          serializeOperationLog(
+            header,
+            revision.id === 'revision-1' ? [] : [remoteOperation]
+          )
+      ),
+    })
     const operationLogStorage = new MemoryOperationLogStorage()
     const local = await operationLogStorage.initialize(
       'local://file/drive-race',
@@ -1580,8 +1625,8 @@ describe('LocalNotebooks operation-log storage', () => {
       remoteOperation.op_id,
       laterRemoteOperation.op_id,
     ])
-    expect(driveStore.loadContent).toHaveBeenCalledTimes(2)
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(1)
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(3)
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledTimes(1)
     expect(
       new Set(
         parseOperationLog(remoteDocument).operations.map(
@@ -1603,7 +1648,7 @@ describe('LocalNotebooks operation-log storage', () => {
     })
   })
 
-  it('merges every competing operation through the eighth Drive CAS attempt', async () => {
+  it('merges every competing operation through the eighth Drive preflight attempt', async () => {
     const header: NotebookLogHeader = {
       record_type: 'runme.notebook',
       format_version: 1,
@@ -1644,7 +1689,7 @@ describe('LocalNotebooks operation-log storage', () => {
       getMetadata: vi.fn(async () => ({ name: 'shared.runme' })),
       getVersionMetadata: vi.fn(async () => remoteVersion),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           content: string,
@@ -1710,8 +1755,8 @@ describe('LocalNotebooks operation-log storage', () => {
       localOperation.op_id,
       ...competingOperations.map((operation) => operation.op_id),
     ])
-    expect(driveStore.loadContent).toHaveBeenCalledTimes(8)
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(8)
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(9)
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledTimes(8)
     expect(
       new Set(
         parseOperationLog(remoteDocument).operations.map(
@@ -1728,7 +1773,7 @@ describe('LocalNotebooks operation-log storage', () => {
     ).toEqual(expectedOperationIds)
   })
 
-  it('reports contention after all eight Drive CAS attempts are exhausted', async () => {
+  it('reports contention after all eight Drive preflight attempts are exhausted', async () => {
     const header: NotebookLogHeader = {
       record_type: 'runme.notebook',
       format_version: 1,
@@ -1755,7 +1800,7 @@ describe('LocalNotebooks operation-log storage', () => {
         version: String(revision),
       })),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(async () => {
+      saveContentAfterVersionCheck: vi.fn(async () => {
         revision += 1
         return false
       }),
@@ -1784,8 +1829,8 @@ describe('LocalNotebooks operation-log storage', () => {
       'Drive operation log changed during 8 merge attempts for local://file/drive-exhaustion'
     )
 
-    expect(driveStore.loadContent).toHaveBeenCalledTimes(8)
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledTimes(8)
+    expect(driveStore.loadContent).toHaveBeenCalledTimes(9)
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledTimes(8)
   })
 
   it('unions concurrent local and filesystem operation logs as raw bytes', async () => {
@@ -1963,7 +2008,7 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
     })
   })
 
-  it('initializes a trusted zero-byte .runme snapshot through Drive CAS', async () => {
+  it('initializes a trusted zero-byte .runme snapshot through Drive preflight', async () => {
     const remoteUri = 'https://drive.google.com/file/d/empty-trusted/view'
     let remoteDocument = ''
     let version = {
@@ -1974,7 +2019,7 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
     const driveStore = {
       getVersionMetadata: vi.fn(async () => version),
       loadContent: vi.fn(async () => remoteDocument),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           content: string,
@@ -2033,7 +2078,7 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
     const driveStore = {
       getVersionMetadata: vi.fn(async () => emptyVersion),
       loadContent: vi.fn(async () => ''),
-      saveContentIfVersion: vi.fn(async () => false),
+      saveContentAfterVersionCheck: vi.fn(async () => false),
     }
     const store = createTestStore(driveStore)
 
@@ -2047,7 +2092,7 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
       })
     ).rejects.toBeInstanceOf(DriveSnapshotChangedError)
 
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledWith(
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledWith(
       remoteUri,
       expect.stringMatching(/\n$/),
       'application/vnd.runme.notebook+jsonl',
@@ -2073,7 +2118,7 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
     const driveStore = {
       getVersionMetadata: vi.fn(async () => ({ version: remoteVersion })),
       loadContent: vi.fn(async () => ''),
-      saveContentIfVersion: vi.fn(
+      saveContentAfterVersionCheck: vi.fn(
         async (
           _uri: string,
           _content: string,
@@ -2093,7 +2138,7 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
       })
     ).rejects.toBeInstanceOf(DriveSnapshotChangedError)
 
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledWith(
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledWith(
       remoteUri,
       expect.stringMatching(/\n$/),
       'application/vnd.runme.notebook+jsonl',
@@ -2101,6 +2146,261 @@ describe('LocalNotebooks trusted Drive snapshot import', () => {
     )
     const [record] = await store.files.toArray()
     expect(record?.operationLogRef).toBeUndefined()
+  })
+})
+
+/** In-memory unit fixture; browser integration uses the Go fake Drive service. */
+async function createRecoveryFixture() {
+  const header: NotebookLogHeader = {
+    record_type: 'runme.notebook',
+    format_version: 1,
+    notebook_id: 'notebook_recovery',
+    created_by: 'actor_seed',
+    created_at: '2026-09-05T00:00:00Z',
+  }
+  const operation = (actor: string) =>
+    createRunmeOperation({
+      actorId: `actor_${actor}`,
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'notebook.update',
+      payload: { frontmatter: { [actor]: 'true' }, metadata: {} },
+    })
+  const a = operation('alice'),
+    b = operation('bob'),
+    c = operation('carol')
+  const document = (ops: (typeof a)[]) => serializeOperationLog(header, ops)
+  const history = new Map<string, string>([['root-opaque', document([])]])
+  let head = 'root-opaque',
+    generation = 1
+  let beforeUpload: (() => Promise<void>) | undefined
+  let afterUpload: (() => Promise<void>) | undefined
+  const write = (id: string, content: string) => {
+    history.set(id, content)
+    head = id
+    generation += 7
+  }
+  const metadata = () => ({
+    headRevisionId: head,
+    version: String(generation),
+    md5Checksum: md5(history.get(head)!),
+  })
+  const drive = {
+    getVersionMetadata: vi.fn(async () => metadata()),
+    loadContent: vi.fn(async () => history.get(head)!),
+    // Deliberately reverse order; revision IDs and versions have no arithmetic relationship.
+    listRevisions: vi.fn(async () =>
+      [...history]
+        .reverse()
+        .map(([id, content]) => ({ id, md5Checksum: md5(content) }))
+    ),
+    loadRevisionForRecovery: vi.fn(
+      async (_uri: string, revision: { id?: string }) => {
+        const content = history.get(revision.id!)
+        if (content === undefined) throw new Error('missing revision')
+        return content
+      }
+    ),
+    saveContentAfterVersionCheck: vi.fn(
+      async (
+        _uri: string,
+        content: string,
+        _mime: string,
+        expected: { checksum?: string; version?: string }
+      ) => {
+        if (
+          expected.checksum !== metadata().md5Checksum ||
+          expected.version !== metadata().version
+        )
+          return false
+        const before = beforeUpload
+        beforeUpload = undefined
+        await before?.()
+        write(`our-${generation}-opaque`, content)
+        const receipt = metadata()
+        const after = afterUpload
+        afterUpload = undefined
+        await after?.()
+        return receipt
+      }
+    ),
+  }
+  const uri = 'local://file/recovery'
+  const operationLogStorage = new MemoryOperationLogStorage()
+  const local = await operationLogStorage.initialize(uri, document([a]))
+  const store = createTestStore(drive, { operationLogStorage })
+  await store.files.put({
+    id: uri,
+    name: 'recovery.runme',
+    remoteId: 'https://drive.google.com/file/d/recovery/view',
+    lastRemoteChecksum: '',
+    lastSynced: '',
+    doc: '',
+    md5Checksum: local.checksum,
+    operationLogRef: local.ref,
+  })
+  return {
+    store,
+    drive,
+    uri,
+    local,
+    operationLogStorage,
+    a,
+    b,
+    c,
+    document,
+    history,
+    write,
+    head: () => head,
+    metadataOnly: () => {
+      generation += 19
+    },
+    beforeUpload: (callback: () => Promise<void>) => {
+      beforeUpload = callback
+    },
+    afterUpload: (callback: () => Promise<void>) => {
+      afterUpload = callback
+    },
+    ids: (text: string) =>
+      parseOperationLog(text)
+        .operations.map((op) => op.op_id)
+        .sort(),
+  }
+}
+
+describe('Drive v3 operation-log revision recovery', () => {
+  it('recovers multiple overwritten revisions even when head matches our upload', async () => {
+    const f = await createRecoveryFixture()
+    f.beforeUpload(async () => {
+      f.write('z-hidden', f.document([f.b]))
+      f.metadataOnly()
+      f.write('a-hidden', f.document([f.c]))
+    })
+    await f.store.reconcileDriveNotebook(f.uri)
+    const expected = [f.a.op_id, f.b.op_id, f.c.op_id].sort()
+    expect(f.ids(f.history.get(f.head())!)).toEqual(expected)
+    expect(f.ids(await f.store.loadContent(f.uri))).toEqual(expected)
+    expect(
+      f.drive.loadRevisionForRecovery.mock.calls
+        .map((call) => call[1].id)
+        .sort()
+    ).toEqual(['a-hidden', 'z-hidden'])
+    expect(f.drive.saveContentAfterVersionCheck).toHaveBeenCalledTimes(2)
+    expect((await f.store.files.get(f.uri))?.lastSyncError).toBeUndefined()
+  })
+
+  it('merges a write after our upload without treating its metadata as our receipt', async () => {
+    const f = await createRecoveryFixture()
+    f.afterUpload(async () => {
+      f.write('late-writer', f.document([f.b]))
+    })
+    await f.store.reconcileDriveNotebook(f.uri)
+    expect(f.ids(f.history.get(f.head())!)).toEqual(
+      [f.a.op_id, f.b.op_id].sort()
+    )
+    expect(f.drive.saveContentAfterVersionCheck).toHaveBeenCalledTimes(2)
+  })
+
+  it('resumes persisted recovery after a pin failure and a local-store reload', async () => {
+    const f = await createRecoveryFixture()
+    f.beforeUpload(async () => {
+      f.write('hidden', f.document([f.b]))
+    })
+    f.drive.loadRevisionForRecovery.mockRejectedValueOnce(
+      new Error('200 retained-revision limit')
+    )
+    await expect(f.store.reconcileDriveNotebook(f.uri)).rejects.toThrow(
+      '200 retained-revision limit'
+    )
+    expect(await f.store.files.get(f.uri)).toMatchObject({
+      lastSynced: '',
+      driveRecoveryCheckpoint: { pendingRevisionIds: ['hidden'] },
+    })
+    const reloaded = createTestStore(f.drive, {
+      files: f.store.files as any,
+      operationLogStorage: f.operationLogStorage,
+    })
+    await reloaded.reconcileDriveNotebook(f.uri)
+    expect(f.ids(f.history.get(f.head())!)).toEqual(
+      [f.a.op_id, f.b.op_id].sort()
+    )
+    expect((await reloaded.files.get(f.uri))?.lastSyncError).toBeUndefined()
+  })
+
+  it('reconciles an upload with an unknown outcome before retrying the write', async () => {
+    const f = await createRecoveryFixture()
+    f.beforeUpload(async () => {
+      f.write('hidden', f.document([f.b]))
+    })
+    f.afterUpload(async () => {
+      throw new Error('upload response lost')
+    })
+    await expect(f.store.reconcileDriveNotebook(f.uri)).rejects.toThrow(
+      'upload response lost'
+    )
+    const reloaded = createTestStore(f.drive, {
+      files: f.store.files as any,
+      operationLogStorage: f.operationLogStorage,
+    })
+    await reloaded.reconcileDriveNotebook(f.uri)
+    expect(f.ids(f.history.get(f.head())!)).toEqual(
+      [f.a.op_id, f.b.op_id].sort()
+    )
+    expect(f.drive.saveContentAfterVersionCheck).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps an observed but purged revision pending across retries', async () => {
+    const f = await createRecoveryFixture()
+    f.beforeUpload(async () => {
+      f.write('hidden', f.document([f.b]))
+    })
+    f.drive.loadRevisionForRecovery.mockRejectedValueOnce(
+      new Error('download denied')
+    )
+    await expect(f.store.reconcileDriveNotebook(f.uri)).rejects.toThrow(
+      'download denied'
+    )
+    f.history.delete('hidden')
+    await expect(f.store.reconcileDriveNotebook(f.uri)).rejects.toThrow(
+      'hidden is no longer available'
+    )
+    expect((await f.store.files.get(f.uri))?.lastSynced).toBe('')
+    expect(f.drive.saveContentAfterVersionCheck).toHaveBeenCalledTimes(1)
+    expect(f.ids(await f.store.loadContent(f.uri))).toContain(f.a.op_id)
+  })
+
+  it('does not acknowledge a concurrent local append as synced during a download-only merge', async () => {
+    const f = await createRecoveryFixture()
+    f.write('collaborator', f.document([f.a, f.b]))
+    const append = f.operationLogStorage.append.bind(f.operationLogStorage)
+    vi.spyOn(f.operationLogStorage, 'append').mockImplementationOnce(
+      async (ref, records, options) => {
+        await append(ref, JSON.stringify(f.c) + '\n')
+        return append(ref, records, options)
+      }
+    )
+    await f.store.reconcileDriveNotebook(f.uri)
+    expect(f.ids(f.history.get(f.head())!)).toEqual(
+      [f.a.op_id, f.b.op_id, f.c.op_id].sort()
+    )
+  })
+
+  it('retains local edits appended while an upload is in flight', async () => {
+    const f = await createRecoveryFixture()
+    f.afterUpload(async () => {
+      await f.operationLogStorage.append(
+        f.local.ref,
+        JSON.stringify(f.b) + '\n'
+      )
+    })
+    await f.store.reconcileDriveNotebook(f.uri)
+    expect(f.ids(f.history.get(f.head())!)).toEqual(
+      [f.a.op_id, f.b.op_id].sort()
+    )
+    expect(f.ids(await f.store.loadContent(f.uri))).toEqual(
+      [f.a.op_id, f.b.op_id].sort()
+    )
   })
 })
 
@@ -5207,15 +5507,17 @@ describe('LocalNotebooks legacy notebook conversion', () => {
         remoteUri: conversionRemoteUri,
         parents: [parentRemoteUri],
       })),
-      saveContentIfVersion: vi.fn(async (_uri: string, content: string) => {
-        remoteContent = content
-        remoteVersion = {
-          md5Checksum: md5(content),
-          headRevisionId: 'conversion-revision-2',
-          version: '2',
+      saveContentAfterVersionCheck: vi.fn(
+        async (_uri: string, content: string) => {
+          remoteContent = content
+          remoteVersion = {
+            md5Checksum: md5(content),
+            headRevisionId: 'conversion-revision-2',
+            version: '2',
+          }
+          return true
         }
-        return true
-      }),
+      ),
     }
     const store = createTestStore(driveStore, { operationLogStorage })
     const conversionSnapshot = await operationLogStorage.initialize(
@@ -5295,7 +5597,7 @@ describe('LocalNotebooks legacy notebook conversion', () => {
         materializeOperationLog(uploadedAfter.operations)
       ).cells[0]?.value
     ).toBe('echo after post create failure')
-    expect(driveStore.saveContentIfVersion).toHaveBeenCalledOnce()
+    expect(driveStore.saveContentAfterVersionCheck).toHaveBeenCalledOnce()
     expect((await store.load(conversionUri)).cells[0]?.value).toBe(
       'echo after post create failure'
     )

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -61,6 +61,10 @@ import {
   parseDriveItem,
 } from './drive'
 import {
+  type DriveRecoveryCheckpoint,
+  DriveRevisionRecovery,
+} from './driveRevisionRecovery'
+import {
   type DriveSyncCoordinator,
   browserDriveSyncCoordinator,
 } from './driveSyncCoordinator'
@@ -99,7 +103,7 @@ const NOTEBOOK_MIME_TYPE = 'application/json'
 // let authoritative listings remove files that were moved or trashed elsewhere.
 const PROVISIONAL_DRIVE_CHILD_TTL_MS = 60_000
 
-// A collaborator can win several Drive compare-and-swap races in a row while
+// A collaborator can write several Drive revisions in a row while
 // both sessions are actively editing. Each attempt performs network I/O, so a
 // larger bounded budget improves convergence without creating a tight loop.
 const DRIVE_OPERATION_LOG_MERGE_ATTEMPTS = 8
@@ -169,6 +173,8 @@ export interface LocalFileRecord {
   ipynbPreservation?: IpynbPreservationState
   /** Authoritative .runme document location. IndexedDB never stores its bytes. */
   operationLogRef?: OperationLogRef
+  /** Durable history boundary and unfinished .runme recovery work (no media bytes). */
+  driveRecoveryCheckpoint?: DriveRecoveryCheckpoint
 }
 
 export interface UpstreamVersion {
@@ -534,7 +540,7 @@ export class LocalNotebooks extends Dexie {
       // Preserve the validated trust boundary: claim exactly the Drive
       // revision checked above rather than starting an unconstrained refresh.
       const initialDocument = createInitialNotebookFile(record.name)
-      const saved = await this.driveStore.saveContentIfVersion(
+      const saved = await this.driveStore.saveContentAfterVersionCheck(
         remoteUri,
         initialDocument,
         RUNME_OPERATION_LOG_MIME_TYPE,
@@ -3541,8 +3547,8 @@ export class LocalNotebooks extends Dexie {
           ipynbExportPendingClaim: undefined,
         })
         // Capture the target version BEFORE reading inputs. Metadata and media
-        // publish atomically with If-Match, so a delayed profile cannot undo a
-        // newer profile's placement or contents. Never retry stale bytes.
+        // publish together after a client-side version recheck. The read/write
+        // gap can still race; never retry known-stale bytes.
         const targetVersion = await driveStore.getVersionMetadata(target.uri)
         if (!targetVersion)
           throw new Error('Colab copy disappeared; retry sync.')
@@ -3600,7 +3606,7 @@ export class LocalNotebooks extends Dexie {
         )
         if (latestNotebook.metadata[AUTO_IPYNB_KEY] !== 'true') return
         const generatedAt = new Date().toISOString()
-        const published = await driveStore.saveContentIfVersion(
+        const published = await driveStore.saveContentAfterVersionCheck(
           target.uri,
           encodeDerivedIpynb(latestNotebook, {
             version: 1,
@@ -3676,7 +3682,7 @@ export class LocalNotebooks extends Dexie {
       if (!record?.ipynbExportPendingClaim || !isDriveUri(record.remoteId))
         return
       const drive = appState.driveNotebookStore ?? this.driveStore
-      await drive.compareAndSetDerivedCopyClaim(
+      await drive.updateDerivedCopyClaimAfterCheck(
         record.remoteId,
         record.ipynbExportPendingClaim,
         null
@@ -4350,85 +4356,68 @@ export class LocalNotebooks extends Dexie {
     return { content, version: after }
   }
 
-  /** Merge a raw .runme operation set with Drive using bounded CAS retries. */
+  /** Merge a raw .runme operation set with Drive using bounded client-side reconciliation. */
   private async syncOperationLogDrive(
     localUri: string,
     record: LocalFileRecord
   ): Promise<void> {
     if (!record.operationLogRef) {
-      // An empty Drive file has no operation-log identity yet. Generate one
-      // seed once, then claim the empty revision with CAS so concurrent
-      // initializers cannot create competing notebook IDs.
-      const initialDocument = createInitialNotebookFile(record.name)
+      // Persist the seed before any upload, so a failed initial write does not
+      // invent a second notebook identity on retry or lose its recovery state.
+      let snapshot = null
       for (
         let attempt = 0;
         attempt < DRIVE_OPERATION_LOG_MERGE_ATTEMPTS;
         attempt += 1
       ) {
-        const snapshot = await this.loadConsistentDriveOperationLogSnapshot(
+        snapshot = await this.loadConsistentDriveOperationLogSnapshot(
           record.remoteId
         )
-        if (!snapshot) continue
-
-        let remoteContent = snapshot.content
-        let remoteVersion = snapshot.version
-        if (remoteContent === '') {
-          appLogger.info('Initializing zero-byte Drive operation log', {
-            attrs: {
-              scope: 'storage.drive.sync',
-              code: 'DRIVE_OPERATION_LOG_INITIALIZE_EMPTY',
-              localUri,
-              remoteUri: record.remoteId,
-              source: 'new-mirror',
-            },
-          })
-          const saved = await this.driveStore.saveContentIfVersion(
-            record.remoteId,
-            initialDocument,
-            RUNME_OPERATION_LOG_MIME_TYPE,
-            {
-              checksum: snapshot.version?.md5Checksum,
-              revisionId: snapshot.version?.headRevisionId,
-              version: snapshot.version?.version,
-            }
-          )
-          if (!saved) continue
-          remoteContent = initialDocument
-          remoteVersion = await this.driveStore.getVersionMetadata(
-            record.remoteId
-          )
-        }
-
-        const remote = parseOperationLog(remoteContent)
-        const stored = await this.operationLogStorage.initialize(
-          localUri,
-          serializeOperationLog(remote.header, remote.operations, {
-            canonicalOrder: true,
-          })
-        )
-        const version = driveMetadataToUpstreamVersion(remoteVersion)
-        await this.files.update(localUri, {
-          doc: '',
-          operationLogRef: stored.ref,
-          md5Checksum: stored.checksum,
-          lastRemoteChecksum: version.checksum ?? md5(remoteContent),
-          lastUpstreamVersion: version,
-          lastSynced: nowIsoString(),
-          lastSyncError: undefined,
-        })
-        return
+        if (snapshot) break
       }
-      throw new Error(
-        `Drive operation log changed during ${DRIVE_OPERATION_LOG_MERGE_ATTEMPTS} merge attempts for ${localUri}`
+      if (!snapshot)
+        throw new Error(
+          `Drive operation log changed during ${DRIVE_OPERATION_LOG_MERGE_ATTEMPTS} merge attempts for ${localUri}`
+        )
+      const remote = parseOperationLog(
+        snapshot.content || createInitialNotebookFile(record.name)
       )
+      const stored = await this.operationLogStorage.initialize(
+        localUri,
+        serializeOperationLog(remote.header, remote.operations, {
+          canonicalOrder: true,
+        })
+      )
+      await this.files.update(localUri, {
+        doc: '',
+        operationLogRef: stored.ref,
+        md5Checksum: stored.checksum,
+      })
+      record = { ...record, operationLogRef: stored.ref }
     }
 
+    const recovery = new DriveRevisionRecovery(
+      this.driveStore,
+      record.remoteId,
+      record.driveRecoveryCheckpoint,
+      async (checkpoint) => {
+        await this.files.update(localUri, {
+          driveRecoveryCheckpoint: checkpoint,
+        })
+      }
+    )
     for (
       let attempt = 0;
-      attempt < DRIVE_OPERATION_LOG_MERGE_ATTEMPTS;
+      attempt <= DRIVE_OPERATION_LOG_MERGE_ATTEMPTS;
       attempt += 1
     ) {
-      const local = await this.operationLogStorage.read(record.operationLogRef)
+      if (attempt > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(25 * 2 ** (attempt - 1), 200))
+        )
+      }
+      if (!(await recovery.initialize())) continue
+      const local = await this.operationLogStorage.read(record.operationLogRef!)
       const snapshot = await this.loadConsistentDriveOperationLogSnapshot(
         record.remoteId
       )
@@ -4437,7 +4426,7 @@ export class LocalNotebooks extends Dexie {
 
       const localLog = parseOperationLog(local.document)
       // A zero-byte Drive file is an uninitialized upstream, not a malformed
-      // operation log. Use the local header as its identity and force a CAS
+      // operation log. Use the local header as its identity and force an
       // upload below. Non-empty malformed content remains a hard error.
       const remoteWasEmpty = remoteContent === ''
       const remoteLog: ParsedOperationLog = remoteWasEmpty
@@ -4459,10 +4448,23 @@ export class LocalNotebooks extends Dexie {
           `Cannot merge different operation-log notebooks for ${localUri}`
         )
       }
-      const mergedOperations = mergeOperationSets(
+      const history = await recovery.collect(snapshot)
+      let mergedOperations = mergeOperationSets(
         localLog.operations,
         remoteLog.operations
       )
+      for (const content of history.contents) {
+        const historical = parseOperationLog(content)
+        if (historical.header.notebook_id !== localLog.header.notebook_id) {
+          throw new Error(
+            `Cannot recover a different operation-log notebook for ${localUri}; local operations remain pending.`
+          )
+        }
+        mergedOperations = mergeOperationSets(
+          mergedOperations,
+          historical.operations
+        )
+      }
       const localIds = new Set(
         localLog.operations.map((operation) => operation.op_id)
       )
@@ -4474,20 +4476,34 @@ export class LocalNotebooks extends Dexie {
       )
       let stored = local
       if (missingLocally.length > 0) {
-        try {
-          stored = await this.operationLogStorage.append(
-            local.ref,
-            `${missingLocally
-              .map((operation) =>
-                canonicalJson(operation as unknown as JsonValue)
-              )
-              .join('\n')}\n`,
-            { validate: (document) => void parseOperationLog(document) }
-          )
-        } catch {
-          continue
-        }
+        stored = await this.operationLogStorage.append(
+          local.ref,
+          `${missingLocally
+            .map((operation) =>
+              canonicalJson(operation as unknown as JsonValue)
+            )
+            .join('\n')}\n`,
+          { validate: (document) => void parseOperationLog(document) }
+        )
       }
+
+      await recovery.acknowledge(
+        history.revisions,
+        snapshot.version!.headRevisionId!
+      )
+
+      // append() may include another local writer's edits that arrived after
+      // our read. Do not acknowledge those bytes as synced without uploading
+      // their operations; re-read the durable journal on the next pass.
+      const mergedIds = new Set(
+        mergedOperations.map((operation) => operation.op_id)
+      )
+      if (
+        parseOperationLog(stored.document).operations.some(
+          (operation) => !mergedIds.has(operation.op_id)
+        )
+      )
+        continue
 
       const mergedDocument = serializeOperationLog(
         localLog.header,
@@ -4498,7 +4514,9 @@ export class LocalNotebooks extends Dexie {
         remoteWasEmpty ||
         mergedOperations.some((operation) => !remoteIds.has(operation.op_id))
       ) {
-        const saved = await this.driveStore.saveContentIfVersion(
+        // Reserve the last pass for verification after the eighth upload.
+        if (attempt === DRIVE_OPERATION_LOG_MERGE_ATTEMPTS) break
+        const saved = await this.driveStore.saveContentAfterVersionCheck(
           record.remoteId,
           mergedDocument,
           RUNME_OPERATION_LOG_MIME_TYPE,
@@ -4509,10 +4527,16 @@ export class LocalNotebooks extends Dexie {
           }
         )
         if (!saved) continue
+        await recovery.uploaded(saved)
+        // Always inspect history after a write, even when head equals our
+        // upload: another writer may have been overwritten in the read/write gap.
+        continue
       }
-      const version = driveMetadataToUpstreamVersion(
-        await this.driveStore.getVersionMetadata(record.remoteId)
+      const finalMetadata = await this.driveStore.getVersionMetadata(
+        record.remoteId
       )
+      if (!sameDriveVersion(snapshot.version, finalMetadata)) continue
+      const version = driveMetadataToUpstreamVersion(finalMetadata)
       const latestLocal = await this.operationLogStorage.read(local.ref)
       await this.files.update(localUri, {
         doc: '',

--- a/app/test/browser/run-cuj-scenarios.ts
+++ b/app/test/browser/run-cuj-scenarios.ts
@@ -79,6 +79,7 @@ function fetchWithTimeout(
 }
 
 const SCENARIO_DRIVERS = [
+  join(SCRIPT_DIR, "test-scenario-drive-revision-recovery.ts"),
   join(SCRIPT_DIR, "test-scenario-html-cell.ts"),
   join(SCRIPT_DIR, "test-scenario-hello-world.ts"),
   join(SCRIPT_DIR, "test-scenario-open-shared-drive-link.ts"),

--- a/app/test/browser/test-scenario-drive-revision-recovery.ts
+++ b/app/test/browser/test-scenario-drive-revision-recovery.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// This browser integration scenario exercises real IndexedDB, OPFS and Web
+// Locks through production storage modules served by Vite. The Go fake owns
+// the deterministic network race; no backend is implemented in this driver.
+const frontend = process.env.CUJ_FRONTEND_URL ?? 'http://localhost:5173'
+const fakeDrive = process.env.CUJ_FAKE_DRIVE_URL ?? 'http://127.0.0.1:9090'
+const base = dirname(fileURLToPath(import.meta.url)).replace(
+  /[/\\]\.generated$/,
+  ''
+)
+const output = join(base, 'test-output')
+const runId = `recovery-${Date.now()}`
+const sessions = [`${runId}-a`, `${runId}-b`]
+mkdirSync(output, { recursive: true })
+
+/** Execute the same public storage code in each isolated browser profile. */
+function browser(session: string, ...args: string[]): string {
+  return execFileSync('agent-browser', ['--session', session, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  }).trim()
+}
+function evaluate(session: string, code: string): any {
+  return JSON.parse(browser(session, 'eval', `(async () => { ${code} })()`))
+}
+const setup = `
+  const { default: LocalNotebooks } = await import('/src/storage/local.ts');
+  const { DriveNotebookStore } = await import('/src/storage/drive.ts');
+  const { setGoogleDriveBaseUrl } = await import('/src/lib/googleDriveRuntime.ts');
+  const { createDefaultOperationLogStorage } = await import('/src/storage/operationLogs.ts');
+  const log = await import('/src/lib/operationLog/index.ts');
+  setGoogleDriveBaseUrl(${JSON.stringify(fakeDrive)});
+  window.recoveryRequests = [];
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (input, init) => {
+    window.recoveryRequests.push({ url: String(input), method: init?.method, ifMatch: new Headers(init?.headers).get('If-Match') });
+    return originalFetch(input, init);
+  };
+  const drive = new DriveNotebookStore(async () => 'fake-access-token');
+  const ops = createDefaultOperationLogStorage();
+  const db = new LocalNotebooks(drive, ${JSON.stringify(runId)}, undefined, undefined, undefined, undefined, ops);
+  window.recovery = { drive, ops, db, log };
+`
+const assertions: Record<string, unknown> = {}
+try {
+  for (const session of sessions) {
+    browser(session, 'open', frontend)
+    evaluate(session, setup + `return true;`)
+  }
+  const fixture = evaluate(
+    sessions[0]!,
+    `
+    const { drive, log } = window.recovery;
+    const header = { record_type: 'runme.notebook', format_version: 1, notebook_id: '${runId}', created_by: 'actor_seed', created_at: '2026-09-05T00:00:00Z' };
+    const make = actor => log.createRunmeOperation({ actorId: actor, actorSequence: 1, dependencies: [], knownOperations: [], kind: 'notebook.update', payload: { frontmatter: { [actor]: 'true' }, metadata: {} } });
+    const alice = make('actor_alice'), bob = make('actor_bob');
+    const empty = log.serializeOperationLog(header, []);
+    const item = await drive.createContent('https://drive.google.com/drive/folders/shared-folder-123', '${runId}.runme', empty, 'application/vnd.runme.notebook+jsonl');
+    return { remoteUri: item.uri, alice: log.serializeOperationLog(header, [alice]), bob: log.serializeOperationLog(header, [bob]), expected: [alice.op_id, bob.op_id].sort() };
+  `
+  )
+  for (let index = 0; index < sessions.length; index++) {
+    evaluate(
+      sessions[index]!,
+      `
+      const { db, ops } = window.recovery;
+      const localUri = 'local://file/${runId}';
+      const stored = await ops.initialize(localUri, ${JSON.stringify(index === 0 ? fixture.alice : fixture.bob)});
+      await db.files.put({ id: localUri, name: '${runId}.runme', remoteId: ${JSON.stringify(fixture.remoteUri)}, lastRemoteChecksum: '', lastSynced: '', doc: '', md5Checksum: stored.checksum, operationLogRef: stored.ref });
+      return true;
+    `
+    )
+  }
+  // The Go service writes B after A's preflight and before applying A's PATCH.
+  // Therefore A sees its own checksum at head while B exists only in history.
+  evaluate(
+    sessions[0]!,
+    `
+    const fileId = ${JSON.stringify(fixture.remoteUri)}.split('/d/')[1].split('/')[0];
+    const armed = await fetch(${JSON.stringify(fakeDrive + '/__test/intervening-write')}, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ fileId, content: ${JSON.stringify(fixture.bob)} }) });
+    if (!armed.ok) throw new Error('Failed to arm the intervening write');
+    await window.recovery.db.reconcileDriveNotebook('local://file/${runId}');
+    return true;
+  `
+  )
+  for (const session of sessions) {
+    assertions[session] = evaluate(
+      session,
+      `
+      const { db, drive, log } = window.recovery;
+      await db.reconcileDriveNotebook('local://file/${runId}');
+      const ids = text => log.parseOperationLog(text).operations.map(op => op.op_id).sort();
+      const local = ids(await db.loadContent('local://file/${runId}'));
+      const remote = ids(await drive.loadContent(${JSON.stringify(fixture.remoteUri)}));
+      const expected = ${JSON.stringify(fixture.expected)};
+      if (JSON.stringify(local) !== JSON.stringify(expected) || JSON.stringify(remote) !== JSON.stringify(expected)) throw new Error('Operations did not converge');
+      const requests = window.recoveryRequests;
+      if (requests.some(r => r.url.includes('/drive/v2/') || r.ifMatch)) throw new Error('Unexpected v2 or If-Match dependency');
+      return { local, remote, requests, checkpoint: (await db.files.get('local://file/${runId}')).driveRecoveryCheckpoint };
+    `
+    )
+    browser(session, 'reload')
+    evaluate(
+      session,
+      setup +
+        `
+      const ids = log.parseOperationLog(await db.loadContent('local://file/${runId}')).operations.map(op => op.op_id).sort();
+      if (JSON.stringify(ids) !== ${JSON.stringify(JSON.stringify(fixture.expected))}) throw new Error('Reload lost operations');
+      return true;
+    `
+    )
+  }
+  const first = assertions[sessions[0]!] as {
+    requests: { url: string; method: string }[]
+  }
+  if (
+    !first.requests.some(
+      (r) => r.url.includes('/revisions/') && r.method === 'PATCH'
+    )
+  )
+    throw new Error('Scenario never retained a historical revision')
+  writeFileSync(
+    join(output, 'scenario-drive-revision-recovery-assertions.json'),
+    JSON.stringify({ passed: true, assertions }, null, 2)
+  )
+  console.log(
+    '[PASS] Two isolated browser journals converged after an overwritten revision and retained operations across reload; v3 only.'
+  )
+} catch (error) {
+  writeFileSync(
+    join(output, 'scenario-drive-revision-recovery-assertions.json'),
+    JSON.stringify({ passed: false, error: String(error), assertions }, null, 2)
+  )
+  throw error
+} finally {
+  for (const session of sessions) {
+    try {
+      browser(session, 'close')
+    } catch {
+      /* Keep the original assertion failure. */
+    }
+  }
+}

--- a/docs-dev/CUJs/automatic-colab-copy.md
+++ b/docs-dev/CUJs/automatic-colab-copy.md
@@ -17,13 +17,15 @@
    completes, properties reports the copy error, and a later successful sync
    retries the export.
 8. Open the same source in independent browser profiles and trigger concurrent
-   exports. Verify the shared source property selects one copy identity.
+   exports. Verify profiles adopt an observed shared copy identity and recheck
+   claims before creation. The public property is client-side coordination,
+   not an atomic lock; simultaneous independent creation can still race.
 9. Simulate a Shared Drive create whose response is lost. Verify subsequent
    sync waits for confirmation. If no file was created, use the warning-gated
    recovery action in properties and verify export can resume.
 10. Pause one profile during discovery or upload. In another profile, move and
     rename the source, add content, and finish exporting. Resume the old profile;
-    verify it cannot revert the copy's name, folder, or newer content. A rejected
+    verify its preflight detects the newer copy version. A rejected
     version check queues fresh work; a mirror missing previously exported
     operations reports that the source must be synced first.
 
@@ -32,7 +34,9 @@ Automated coverage: `derivedIpynb.test.ts`, `derivedNotebookModel.test.ts`,
 cases in `storage/local.test.ts`. The slow-upload test holds a real promise
 pending while another journal save commits and is read back from storage.
 `storage/derivedCopy.test.ts` exercises independent clients with only shared
-remote CAS state (no shared local lock), and `storage/drive.test.ts` verifies
-the conditional property update for both browser and token transports.
+shared remote claim state (no shared local lock), and `storage/drive.test.ts` verifies
+the v3 property check, write, and readback for both browser and token transports.
 Out-of-order profile tests verify content and placement together. Both transports
-are checked for atomic multipart updates with If-Match and HTTP 412 rejection.
+are checked for multipart updates after a client-side version preflight without
+ETags or If-Match. A write between the final preflight and upload can still
+race; these tests do not assert a server-side lock.

--- a/docs-dev/CUJs/runme-operation-log-concurrency.md
+++ b/docs-dev/CUJs/runme-operation-log-concurrency.md
@@ -49,3 +49,30 @@ shared Go fake Drive service. It must observe the Drive revision before and
 after local Refresh to prove Refresh performs no upstream I/O, and it must be
 registered in `app/test/browser/run-cuj-scenarios.ts`; unit tests alone are not
 sufficient because the scenario must exercise browser OPFS and Web Locks.
+
+## Intervening revision recovery
+
+9. Pause A after its v3 version preflight. Write B's different operation as R1,
+   then let A upload R2. R2 must initially contain only A's operations, so a
+   head-only check would miss B's overwritten write.
+10. Verify A lists all revision pages, retains and reads R1, appends B's
+    operation to OPFS, and uploads a union. Sync B and verify both journals and
+    Drive contain both operations. Reload each isolated browser profile and
+    verify the same operation IDs remain durable.
+11. Reject a revision retention/download request, then reload and retry. Verify
+    the checkpoint retains the unfinished revision, local edits survive, and
+    sync does not report success. Also test an upload whose response is lost.
+
+`test-scenario-drive-revision-recovery.ts` is registered in the scenario runner.
+It exercises step 9–10 through production storage modules in two isolated
+browsers, real OPFS/IndexedDB/Web Locks, and the Go fake's one-shot intervening
+write. Its JSON artifact records local/remote operation IDs, checkpoints, and
+network requests proving historical retention and v3-only access. This storage
+scenario does not claim to automate the UI/comment steps above. Failure/reload,
+late-writer, metadata-only version changes, and local-append races have separate
+regression cases in `storage/local.test.ts`; transport pagination and retention
+are tested in `storage/drive.test.ts` and the Go fake tests.
+
+Recovery is best-effort, not an atomic compare-and-swap. Revision IDs are opaque,
+File.version can change without a content revision, retained revisions are
+limited to 200, and unavailable observed history must leave sync pending.

--- a/docs/05-google-drive-integration.md
+++ b/docs/05-google-drive-integration.md
@@ -32,6 +32,40 @@ Benefits:
 - sync can resume after auth or connectivity recovery,
 - the UI can surface pending or error states explicitly.
 
+## Concurrent edits and sync
+
+Runme uses Google Drive API v3. Before replacing notebook content, the client
+checks the upstream version or checksum it read. This check and the upload are
+separate requests; they do not provide an atomic write condition.
+
+- `.json` and `.ipynb` notebooks keep the existing checksum check and conflict
+  workflow. They do not automatically merge concurrent snapshots.
+- `.runme` notebooks merge operations into the local journal, recheck Drive,
+  upload, then inspect all pages of revision history. If another writer saved
+  between our check and upload, its overwritten revision can contain operations
+  missing from the current head. Runme reads that revision, merges its operations
+  locally, and uploads the union. It also checks for writes after its upload.
+
+Recovery progress is stored locally and resumes after an error or reload. Sync
+reports success only after the observed history is reconciled and the head is
+rechecked. Retries are bounded; active contention can leave sync pending.
+
+Google permits downloading historical blob revisions only after they are
+marked `keepForever`. Runme retains only revisions it needs to download for
+recovery. Retained revisions count toward storage and Drive limits them to 200
+per file; Runme never deletes history to free slots. If retention or download
+fails, check edit permission and the retention limit. Local operations remain
+safe and sync reports the error. Missing history requires restoring a saved
+revision or reconciling another replica before retrying.
+
+This is best-effort convergence. Drive can purge or omit revisions, and a
+client cannot detect a write that disappears before it ever observes the
+revision. Recovery starts at the current head when a local replica first
+establishes its history checkpoint; it does not repair all older lost writes.
+
+See Google's [file update reference](https://developers.google.com/workspace/drive/api/reference/rest/v3/files/update)
+and [revision retention guide](https://developers.google.com/workspace/drive/api/guides/manage-revisions).
+
 ## Common user actions
 
 - authenticate Drive access,

--- a/testing/fake-drive-server.go
+++ b/testing/fake-drive-server.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -55,16 +56,28 @@ type driveCapabilities struct {
 	CanDownload bool `json:"canDownload"`
 }
 
+// driveRevision keeps media separately so historical downloads never read head.
+type driveRevision struct {
+	ID          string `json:"id"`
+	MD5Checksum string `json:"md5Checksum"`
+	KeepForever bool   `json:"keepForever"`
+	Content     string `json:"-"`
+}
+
 type driveStore struct {
-	mu      sync.Mutex
-	files   map[string]*driveFile
-	counter int
+	revisions   map[string][]*driveRevision
+	intervening map[string]string
+	mu          sync.Mutex
+	files       map[string]*driveFile
+	counter     int
 }
 
 func newDriveStore() *driveStore {
 	store := &driveStore{
-		files:   map[string]*driveFile{},
-		counter: 1,
+		files:       map[string]*driveFile{},
+		revisions:   map[string][]*driveRevision{},
+		intervening: map[string]string{},
+		counter:     1,
 	}
 
 	store.files[seedFolderID] = &driveFile{
@@ -101,7 +114,14 @@ func (s *driveStore) refreshChecksum(id string) {
 	}
 	sum := md5.Sum([]byte(file.Content))
 	file.MD5Checksum = hex.EncodeToString(sum[:])
-	file.HeadRev = fmt.Sprintf("rev-%d", file.Version)
+	if file.MimeType != driveFolderMime {
+		for _, revision := range s.revisions[id] {
+			if revision.ID == file.HeadRev {
+				return
+			}
+		}
+		s.revisions[id] = append(s.revisions[id], &driveRevision{ID: file.HeadRev, MD5Checksum: file.MD5Checksum, Content: file.Content})
+	}
 }
 
 func (s *driveStore) nextIDLocked() string {
@@ -179,25 +199,95 @@ func (s *driveStore) updateMetadata(id string, resource map[string]any, addParen
 	return cloneFile(file), true
 }
 
-func (s *driveStore) setContentIfMatch(id, content, expectedETag string) (*driveFile, bool, bool) {
+// Uploads deliberately ignore If-Match: tests must exercise client reconciliation.
+func (s *driveStore) setContent(id, content string) (*driveFile, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	file := s.files[id]
 	if file == nil {
-		return nil, false, false
+		return nil, false
 	}
-	if expectedETag != "" && expectedETag != driveFileETag(file) {
-		return cloneFile(file), true, false
+	write := func(bytes string) {
+		file.Content = bytes
+		file.Version += 7 // File.version is not a content-revision counter.
+		file.HeadRev = fmt.Sprintf("opaque-content-%d", file.Version)
+		s.refreshChecksum(id)
 	}
-	file.Content = content
-	file.Version++
-	s.refreshChecksum(id)
-	return cloneFile(file), true, true
+	if intervening, ok := s.intervening[id]; ok {
+		delete(s.intervening, id)
+		write(intervening)
+	}
+	write(content)
+	return cloneFile(file), true
 }
 
-func driveFileETag(file *driveFile) string {
-	return fmt.Sprintf("\"version-%d\"", file.Version)
+// Revision media follows the documented retained-blob download contract.
+func (s *driveStore) serveRevisions(w http.ResponseWriter, r *http.Request, id, revisionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	revisions, exists := s.revisions[id]
+	if !exists {
+		http.NotFound(w, r)
+		return
+	}
+	if revisionID == "" && r.Method == http.MethodGet {
+		offset, _ := strconv.Atoi(r.URL.Query().Get("pageToken"))
+		if offset < 0 || offset > len(revisions) {
+			http.Error(w, "invalid page", 400)
+			return
+		}
+		end := offset + 2
+		if end > len(revisions) {
+			end = len(revisions)
+		}
+		result := map[string]any{"revisions": revisions[offset:end]}
+		if end < len(revisions) {
+			result["nextPageToken"] = strconv.Itoa(end)
+		}
+		writeJSON(w, result)
+		return
+	}
+	for _, revision := range revisions {
+		if revision.ID != revisionID {
+			continue
+		}
+		switch r.Method {
+		case http.MethodPatch:
+			var request struct {
+				KeepForever bool `json:"keepForever"`
+			}
+			if json.NewDecoder(r.Body).Decode(&request) != nil || !request.KeepForever {
+				http.Error(w, "only permanent retention is supported", 400)
+				return
+			}
+			count := 0
+			for _, entry := range revisions {
+				if entry.KeepForever {
+					count++
+				}
+			}
+			if !revision.KeepForever && count >= 200 {
+				http.Error(w, "200 retained-revision limit", 403)
+				return
+			}
+			revision.KeepForever = true
+			writeJSON(w, revision)
+		case http.MethodGet:
+			if r.URL.Query().Get("alt") == "media" {
+				if !revision.KeepForever {
+					http.Error(w, "revision must be retained", 403)
+					return
+				}
+				_, _ = w.Write([]byte(revision.Content))
+			} else {
+				writeJSON(w, revision)
+			}
+		default:
+			http.Error(w, "method not allowed", 405)
+		}
+		return
+	}
+	http.NotFound(w, r)
 }
 
 func (s *driveStore) get(id string) (*driveFile, bool) {
@@ -349,6 +439,32 @@ func newDriveHandler(store *driveStore) http.Handler {
 			"expires_in":   3600,
 		})
 	})
+	// A one-shot test fault creates B's revision immediately before A's upload.
+	mux.HandleFunc("/__test/intervening-write", func(w http.ResponseWriter, r *http.Request) {
+		if allowCORS(w, r) {
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", 405)
+			return
+		}
+		var request struct {
+			FileID  string `json:"fileId"`
+			Content string `json:"content"`
+		}
+		if json.NewDecoder(r.Body).Decode(&request) != nil {
+			http.Error(w, "invalid request", 400)
+			return
+		}
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		if store.files[request.FileID] == nil {
+			http.NotFound(w, r)
+			return
+		}
+		store.intervening[request.FileID] = request.Content
+		writeJSON(w, map[string]bool{"armed": true})
+	})
 	mux.HandleFunc("/drive/v3/files/generateIds", func(w http.ResponseWriter, r *http.Request) {
 		if allowCORS(w, r) {
 			return
@@ -391,6 +507,16 @@ func newDriveHandler(store *driveStore) http.Handler {
 			return
 		}
 		id := strings.TrimPrefix(r.URL.Path, "/drive/v3/files/")
+		parts := strings.Split(id, "/")
+		if len(parts) >= 2 && parts[1] == "revisions" {
+			revisionID := ""
+			if len(parts) == 3 {
+				revisionID = parts[2]
+			}
+			store.serveRevisions(w, r, parts[0], revisionID)
+			return
+		}
+
 		if id == "" {
 			http.NotFound(w, r)
 			return
@@ -405,11 +531,9 @@ func newDriveHandler(store *driveStore) http.Handler {
 			}
 			if r.URL.Query().Get("alt") == "media" {
 				w.Header().Set("Content-Type", "application/octet-stream")
-				w.Header().Set("ETag", driveFileETag(file))
 				_, _ = w.Write([]byte(file.Content))
 				return
 			}
-			w.Header().Set("ETag", driveFileETag(file))
 			writeJSON(w, file)
 		case http.MethodPatch:
 			var resource map[string]any
@@ -444,20 +568,11 @@ func newDriveHandler(store *driveStore) http.Handler {
 			http.Error(w, "failed to read body", http.StatusBadRequest)
 			return
 		}
-		file, ok, matched := store.setContentIfMatch(
-			id,
-			string(body),
-			r.Header.Get("If-Match"),
-		)
+		file, ok := store.setContent(id, string(body))
 		if !ok {
 			http.NotFound(w, r)
 			return
 		}
-		if !matched {
-			http.Error(w, "precondition failed", http.StatusPreconditionFailed)
-			return
-		}
-		w.Header().Set("ETag", driveFileETag(file))
 		writeJSON(w, file)
 	})
 

--- a/testing/fake-drive-server_test.go
+++ b/testing/fake-drive-server_test.go
@@ -73,71 +73,91 @@ func TestGeneratedIDCreateAndOperationSearch(t *testing.T) {
 	}
 }
 
-func TestConditionalContentUploadUsesVersionedETag(t *testing.T) {
-	server := httptest.NewServer(newDriveHandler(newDriveStore()))
+func TestV3RecoveryRetainsInterveningRevisionWithoutETag(t *testing.T) {
+	store := newDriveStore()
+	store.intervening[seedFileID] = "collaborator content"
+	server := httptest.NewServer(newDriveHandler(store))
 	defer server.Close()
-
-	response, err := http.Get(server.URL + "/drive/v3/files/" + seedFileID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	etag := response.Header.Get("ETag")
-	response.Body.Close()
-	if etag == "" {
-		t.Fatal("metadata response did not expose an ETag")
-	}
-
-	request, err := http.NewRequest(
-		http.MethodPatch,
-		server.URL+"/upload/drive/v3/files/"+seedFileID+"?uploadType=media",
-		bytes.NewBufferString("updated content"),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	request.Header.Set("If-Match", "\"stale-version\"")
-	response, err = http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	response.Body.Close()
-	if response.StatusCode != http.StatusPreconditionFailed {
-		t.Fatalf("stale upload returned %s", response.Status)
-	}
-
-	request, err = http.NewRequest(
-		http.MethodPatch,
-		server.URL+"/upload/drive/v3/files/"+seedFileID+"?uploadType=media",
-		bytes.NewBufferString("updated content"),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	request.Header.Set("If-Match", etag)
-	response, err = http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("matching upload returned %s", response.Status)
-	}
-	if response.Header.Get("ETag") == etag {
-		t.Fatal("successful upload did not advance the ETag")
-	}
-
-	response, err = http.Get(
-		server.URL + "/drive/v3/files/" + seedFileID + "?alt=media",
-	)
+	request, _ := http.NewRequest(http.MethodPatch, server.URL+"/upload/drive/v3/files/"+seedFileID, bytes.NewBufferString("our content"))
+	request.Header.Set("If-Match", "unsupported-stale-condition")
+	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer response.Body.Close()
-	content, err := io.ReadAll(response.Body)
+	if response.StatusCode != 200 || response.Header.Get("ETag") != "" {
+		t.Fatalf("unexpected upload: %s", response.Status)
+	}
+	var receipt driveFile
+	if err := json.NewDecoder(response.Body).Decode(&receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.HeadRev != store.files[seedFileID].HeadRev {
+		t.Fatal("upload receipt did not identify own revision")
+	}
+	response, err = http.Get(server.URL + "/drive/v3/files/" + seedFileID + "/revisions")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != "updated content" {
-		t.Fatalf("unexpected stored content %q", content)
+	var page struct {
+		Revisions     []driveRevision `json:"revisions"`
+		NextPageToken string          `json:"nextPageToken"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if len(page.Revisions) != 2 || page.NextPageToken == "" {
+		t.Fatalf("expected paginated history: %#v", page)
+	}
+	revisionURL := server.URL + "/drive/v3/files/" + seedFileID + "/revisions/" + page.Revisions[1].ID
+	response, _ = http.Get(revisionURL + "?alt=media")
+	if response.StatusCode != 403 {
+		t.Fatal("unpinned download was accepted")
+	}
+	response.Body.Close()
+	request, _ = http.NewRequest(http.MethodPatch, revisionURL, bytes.NewBufferString(`{"keepForever":true}`))
+	response, _ = http.DefaultClient.Do(request)
+	if response.StatusCode != 200 {
+		t.Fatal("pin failed")
+	}
+	response.Body.Close()
+	response, _ = http.Get(revisionURL + "?alt=media")
+	content, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if string(content) != "collaborator content" {
+		t.Fatalf("lost intervening revision: %q", content)
+	}
+	response, _ = http.Get(server.URL + "/drive/v3/files/" + seedFileID + "/revisions?pageToken=" + page.NextPageToken)
+	if err := json.NewDecoder(response.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if len(page.Revisions) != 1 || page.Revisions[0].ID != receipt.HeadRev {
+		t.Fatal("second page did not contain our head")
+	}
+}
+
+func TestMetadataDoesNotCreateContentRevisionAndRetentionLimit(t *testing.T) {
+	store := newDriveStore()
+	before, _ := store.get(seedFileID)
+	after, _ := store.updateMetadata(seedFileID, map[string]any{"name": "renamed.runme"}, "", "")
+	if after.HeadRev != before.HeadRev || after.Version <= before.Version {
+		t.Fatal("metadata update changed content revision or failed to increment version")
+	}
+	for i := 0; i < 200; i++ {
+		file, _ := store.setContent(seedFileID, "bytes")
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPatch, "/", bytes.NewBufferString(`{"keepForever":true}`))
+		store.serveRevisions(recorder, request, seedFileID, file.HeadRev)
+		if recorder.Code != 200 {
+			t.Fatalf("pin %d failed", i)
+		}
+	}
+	file, _ := store.setContent(seedFileID, "overflow")
+	recorder := httptest.NewRecorder()
+	store.serveRevisions(recorder, httptest.NewRequest(http.MethodPatch, "/", bytes.NewBufferString(`{"keepForever":true}`)), seedFileID, file.HeadRev)
+	if recorder.Code != 403 {
+		t.Fatal("retention limit was not enforced")
 	}
 }


### PR DESCRIPTION
A `.runme` upload can overwrite a collaborator's intervening revision even when the current Drive checksum matches our own upload. Sync now uses Drive v3 client-side checks and recovers operations from revision history before reporting success. This removes the v2 ETag lookup and reliance on `If-Match`.

## Changes

- Persist a per-file recovery checkpoint in IndexedDB before uploads; append recovered operations to OPFS before acknowledging revisions. Resume after failed downloads, unknown upload outcomes, and reloads.
- Read all revision pages after uploading, including when head is our own write. Retain/download unseen historical blob revisions, merge their operations, and upload the union with bounded retries. Use opaque revision IDs and the upload response's own metadata.
- Preserve `.json`/`.ipynb` checksum conflict behavior. Rename and migrate the creation-repair and Colab helpers to v3 preflight checks; recheck Colab claims after preparing content and after property updates.
- Update user documentation, CUJs, and the Go fake. Register a browser regression using two isolated profiles, real IndexedDB/OPFS/Web Locks, and a deterministic intervening write.

This provides best-effort convergence, not an atomic Drive write condition. Recovery begins when a replica establishes its checkpoint; it cannot detect history Drive purges before observation. Historical downloads require permanent retention, limited to 200 revisions per file. Missing history, permission errors, and retention-limit failures leave local operations safe and sync pending; no history is automatically deleted. Colab property coordination also retains a read/write race.

## Validation

- `runme run build test` — passed (full build and 7 console tests).
- `pnpm -C app test --run` — 1,264 tests passed across 117 files.
- `go test testing/fake-drive-server.go testing/fake-drive-server_test.go` — passed (with a writable local Go cache).
- `pnpm -C app run cuj:build` — passed.
- `test-scenario-drive-revision-recovery.ts` — passed locally in two isolated headless Chromium profiles. Reviewed its JSON artifact: both local journals and Drive contain both operation IDs after recovery/reload; requests include paginated revision reads and retention, with no v2/If-Match requests. CI uploads `scenario-drive-revision-recovery-assertions.json` with the CUJ artifacts.
- Full app typecheck still reports existing errors. Compared diagnostic files/codes/counts against the base checkout; no added categories/counts and no diagnostics in the changed production storage files.

Fixes #366
