### PR TITLE
Add JSON copy buttons to log entries

### DIFF
--- a/app/src/components/Logs/LogsPane.test.tsx
+++ b/app/src/components/Logs/LogsPane.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LogEvent } from '../../lib/logging/runtime'
+import LogsPane from './LogsPane'
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  subscribe: vi.fn(),
+  writeText: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('../../lib/logging/runtime', () => ({
+  loggingRuntime: { list: mocks.list, subscribe: mocks.subscribe },
+}))
+
+vi.mock('../../lib/toast', () => ({ showToast: mocks.showToast }))
+
+const entries: LogEvent[] = [
+  {
+    id: 'info-entry',
+    ts: '2026-09-09T17:13:24.123Z',
+    level: 'info',
+    message: 'Drive resync reconciliation completed',
+    attrs: { scope: 'storage.drive.sync', enqueuedCount: 3 },
+  },
+  {
+    id: 'error-entry',
+    ts: '2026-09-09T17:14:25.456Z',
+    level: 'error',
+    message: 'Sync failed: "retry"\nMore details',
+    attrs: {
+      scope: 'storage.drive.sync',
+      code: 'DRIVE_SYNC_FAILED',
+      details: { retryable: true, attempts: [1, 2], cause: null },
+    },
+  },
+]
+
+describe('LogsPane structured copying', () => {
+  beforeEach(() => {
+    mocks.list.mockReturnValue(entries)
+    mocks.subscribe.mockReturnValue(() => {})
+    mocks.writeText.mockReset().mockResolvedValue(undefined)
+    mocks.showToast.mockReset()
+    vi.stubGlobal('navigator', { clipboard: { writeText: mocks.writeText } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('copies only the chosen entry, including its full timestamp and nested attributes', async () => {
+    render(<LogsPane />)
+    const rows = screen.getAllByRole('listitem')
+    expect(screen.getAllByRole('button', { name: 'Copy log entry as JSON' })).toHaveLength(2)
+
+    fireEvent.click(within(rows[1]).getByRole('button', { name: 'Copy log entry as JSON' }))
+
+    await waitFor(() => expect(mocks.showToast).toHaveBeenCalledWith({
+      message: 'Log entry copied as JSON', tone: 'success',
+    }))
+    expect(mocks.writeText).toHaveBeenCalledOnce()
+    const copied = mocks.writeText.mock.calls[0][0]
+    expect(JSON.parse(copied)).toEqual(entries[1])
+    expect(copied).toContain('\n  "id": "error-entry"')
+    expect(copied).not.toContain(entries[0].message)
+  })
+
+  it('copies an informational entry without optional attributes', async () => {
+    const { attrs: _attrs, ...entry } = entries[0]
+    mocks.list.mockReturnValue([entry])
+    render(<LogsPane />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy log entry as JSON' }))
+
+    await waitFor(() => expect(mocks.showToast).toHaveBeenCalledWith(expect.objectContaining({ tone: 'success' })))
+    expect(JSON.parse(mocks.writeText.mock.calls[0][0])).toEqual(entry)
+  })
+
+  it('reports success only after the clipboard write finishes', async () => {
+    let resolveWrite!: () => void
+    mocks.writeText.mockReturnValue(new Promise<void>(resolve => { resolveWrite = resolve }))
+    render(<LogsPane />)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Copy log entry as JSON' })[0])
+    expect(mocks.showToast).not.toHaveBeenCalled()
+    await act(async () => resolveWrite())
+    expect(mocks.showToast).toHaveBeenCalledWith(expect.objectContaining({ tone: 'success' }))
+  })
+
+  it.each(['denied', 'unavailable'])('reports a %s clipboard without claiming success', async mode => {
+    if (mode === 'denied') {
+      mocks.writeText.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'))
+    } else {
+      vi.stubGlobal('navigator', {})
+    }
+    render(<LogsPane />)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Copy log entry as JSON' })[0])
+
+    await waitFor(() => expect(mocks.showToast).toHaveBeenCalledWith({
+      message: 'Failed to copy log entry to clipboard', tone: 'error',
+    }))
+    expect(mocks.showToast).toHaveBeenCalledOnce()
+  })
+})

--- a/app/src/components/Logs/LogsPane.tsx
+++ b/app/src/components/Logs/LogsPane.tsx
@@ -1,9 +1,20 @@
 import { useEffect, useState } from "react";
 
 import { loggingRuntime, type LogEvent, type LogLevel } from "../../lib/logging/runtime";
+import { showToast } from "../../lib/toast";
 
 const DEFAULT_LEVEL: LogLevel = "debug";
 const DEFAULT_LIMIT = 200;
+
+/** Copy the complete record, preserving its ISO timestamp and nested attributes. */
+async function copyLogEntry(event: LogEvent): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(event, null, 2));
+    showToast({ message: "Log entry copied as JSON", tone: "success" });
+  } catch {
+    showToast({ message: "Failed to copy log entry to clipboard", tone: "error" });
+  }
+}
 
 /**
  * Renders a compact JSON string for log attributes. This keeps the pane simple
@@ -83,6 +94,15 @@ export default function LogsPane() {
                   <div id={`logs-pane-event-meta-${event.id}`} className="flex flex-wrap items-center gap-2">
                     <span className="text-slate-400">{new Date(event.ts).toLocaleTimeString()}</span>
                     <span className="rounded bg-slate-700/80 px-1 py-0.5 uppercase">{event.level}</span>
+                    <button
+                      type="button"
+                      aria-label="Copy log entry as JSON"
+                      title="Copy this log entry as JSON"
+                      className="ml-auto shrink-0 rounded border border-white/20 px-2 py-0.5 text-slate-300 hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300"
+                      onClick={() => void copyLogEntry(event)}
+                    >
+                      Copy JSON
+                    </button>
                   </div>
                   <div id={`logs-pane-event-message-${event.id}`} className="mt-1 text-slate-100">
                     {event.message}


### PR DESCRIPTION
Add a **Copy JSON** button to each entry in the Logs view so an individual error or other log record can be shared without selecting truncated text.

The button copies the complete event as indented JSON: `id`, the original ISO timestamp in `ts`, `level`, `message`, and any nested `attrs`. Success is reported after the clipboard write completes; denied or unavailable clipboard access produces an error toast.

Validation:
- `runme run build test` passed.
- Log pane and logging runtime suites passed: 11 tests covering the selected record, full timestamp, nested attributes, absent attributes, asynchronous completion, and clipboard failures.
- Chromium verification passed with the real clipboard at 900px and 380px viewport widths (Explorer collapsed for the narrow layout), including complete nested metadata despite truncated display text.
