### PR TITLE
Automatically upgrade V1 notebooks to V2 on save

### DIFF
--- a/app/src/lib/operationLog/codec.ts
+++ b/app/src/lib/operationLog/codec.ts
@@ -206,6 +206,20 @@ export function validateLamportValues(operations: RunmeOperation[]): void {
   }
 }
 
+/** V2 accepts V1 operations unchanged. Promote only the header so existing
+ * notebook identity, operation IDs, revision boundaries and comments survive.
+ * Call under the storage writer lock when saving an existing document.
+ */
+export function upgradeOperationLogToV2(document: string): string {
+  const { header } = parseOperationLog(document)
+  if (header.format_version === 2) return document
+  const upgraded =
+    canonicalJson({ ...header, format_version: 2 } as unknown as JsonValue) +
+    document.slice(document.indexOf('\n'))
+  parseOperationLog(upgraded)
+  return upgraded
+}
+
 export function serializeOperationLog(
   header: NotebookLogHeader,
   operations: RunmeOperation[],

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -28,6 +28,7 @@ import {
 } from '../lib/operationLog'
 import * as actorIdentity from '../lib/operationLog/actorIdentity'
 import { cellDecisionFor } from '../lib/operationLog/cellReview'
+import { upgradeOperationLogToV2 } from '../lib/operationLog/codec'
 import { decideComparisonCell } from '../lib/operationLog/comparisonFeedback'
 import { buildComparisons } from '../lib/operationLog/comparisons'
 import '../lib/operationLog/legacyReviews'
@@ -1025,6 +1026,131 @@ describe('LocalNotebooks operation-log storage', () => {
     ).resolves.toEqual(third)
     actor.mockRestore()
   })
+
+  it('upgrades V1 atomically on save, preserving identity, history and legacy threads', async () => {
+    const actor = vi
+      .spyOn(actorIdentity, 'getNotebookActorId')
+      .mockResolvedValue('upgrade_writer')
+    const operationLogStorage = new MemoryOperationLogStorage()
+    const store = createTestStore({}, { operationLogStorage })
+    const uri = 'local://file/v1-autosave'
+    const header: NotebookLogHeader = {
+      record_type: 'runme.notebook',
+      format_version: 1,
+      notebook_id: 'preserve-identity',
+      created_by: 'seed',
+      created_at: '2026-09-09T00:00:00Z',
+    }
+    const legacy = createRunmeOperation({
+      actorId: 'seed',
+      actorSequence: 1,
+      dependencies: [],
+      knownOperations: [],
+      kind: 'comment.add',
+      payload: {
+        comment_id: 'legacy-comment',
+        thread_id: 'legacy-comment',
+        author: { principal_id: 'seed', display_name: 'User' },
+        body: { format: 'text/markdown', value: 'Keep this discussion' },
+        annotation: { motivation: 'commenting', targets: [] },
+      },
+    })
+    const document = serializeOperationLog(header, [legacy])
+    const stored = await operationLogStorage.initialize(uri, document)
+    await store.files.put({
+      id: uri,
+      name: 'old.runme',
+      remoteId: '',
+      doc: '',
+      lastRemoteChecksum: '',
+      lastSynced: '',
+      md5Checksum: stored.checksum,
+      operationLogRef: stored.ref,
+    })
+    const first = await store.createOperationLogSaveStore(uri)
+    const second = await store.createOperationLogSaveStore(uri)
+    const notebook = await store.loadOperationLogSnapshot(uri)
+    // A no-op save still persists and advertises the new header.
+    await first.save(uri, notebook)
+    expect(await store.loadContent(uri)).toBe(upgradeOperationLogToV2(document))
+    expect((await store.files.get(uri))?.md5Checksum).not.toBe(stored.checksum)
+    const version = await store.checkpointNotebookRevision(uri)
+    await Promise.all([
+      second.save(uri, notebook),
+      store.addAnchoredComment(uri, {
+        content: 'New discussion',
+        anchors: [{ kind: 'notebook', version }],
+      }),
+    ])
+    await store.replyToOperationLogComment(uri, 'legacy-comment', 'Still works')
+    await store.setOperationLogCommentResolved(uri, 'legacy-comment', true)
+    const parsed = parseOperationLog(await store.loadContent(uri))
+    expect(parsed.header).toEqual({ ...header, format_version: 2 })
+    expect(parsed.operations[0]).toEqual(legacy)
+    expect(await store.listOperationLogComments(uri)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'legacy-comment',
+          resolved: true,
+          replies: [expect.objectContaining({ content: 'Still works' })],
+        }),
+        expect.objectContaining({ content: 'New discussion' }),
+      ])
+    )
+    actor.mockRestore()
+  })
+
+  it('upgrades a V1 file directly when creating its first revision record', async () => {
+    const actor = vi
+      .spyOn(actorIdentity, 'getNotebookActorId')
+      .mockResolvedValue('revision_writer')
+    const f = await createRecoveryFixture()
+    await expect(
+      f.store.checkpointNotebookRevision(f.uri, {
+        snapshot_heads: ['missing:1'],
+      })
+    ).rejects.toThrow()
+    expect(await f.store.loadContent(f.uri)).toBe(f.local.document)
+    const version = await f.store.checkpointNotebookRevision(f.uri)
+    const parsed = parseOperationLog(await f.store.loadContent(f.uri))
+    expect(parsed.header.format_version).toBe(2)
+    expect(parsed.operations[0]).toEqual(f.a)
+    expect(parsed.operations.at(-1)?.op_id).toBe(version.revision_id)
+    actor.mockRestore()
+  })
+
+  it.each(['local', 'upstream'])(
+    'synchronizes a header-only filesystem upgrade from %s',
+    async (side) => {
+      const f = await createRecoveryFixture()
+      let upstream = f.document([f.a])
+      if (side === 'upstream') upstream = upgradeOperationLogToV2(upstream)
+      else
+        await f.operationLogStorage.replace(
+          f.local.ref,
+          upgradeOperationLogToV2(upstream)
+        )
+      const filesystemStore = {
+        loadContent: vi.fn(async () => upstream),
+        saveContent: vi.fn(async (_uri: string, content: string) => {
+          upstream = content
+        }),
+      }
+      f.store.setFilesystemStore(filesystemStore as never)
+      await f.store.files.update(f.uri, {
+        remoteId: 'fs://workspace/test/file/shared.runme',
+      })
+      await f.store.sync(f.uri)
+      expect(parseOperationLog(upstream).header.format_version).toBe(2)
+      expect(
+        parseOperationLog(await f.store.loadContent(f.uri)).header
+          .format_version
+      ).toBe(2)
+      expect(filesystemStore.saveContent).toHaveBeenCalledTimes(
+        side === 'local' ? 1 : 0
+      )
+    }
+  )
 
   it('allocates unique actor sequences for concurrent editor and comment writes', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
@@ -3031,8 +3157,39 @@ async function createRecoveryFixture(formatVersion: 1 | 2 = 1) {
 }
 
 describe('Drive v3 operation-log revision recovery', () => {
+  it('uploads a header-only V2 upgrade and does not downgrade after a V1 writer syncs', async () => {
+    const f = await createRecoveryFixture()
+    f.write('same-ops', f.document([f.a]))
+    await f.operationLogStorage.replace(
+      f.local.ref,
+      upgradeOperationLogToV2(f.document([f.a]))
+    )
+    await f.store.reconcileDriveNotebook(f.uri)
+    expect(
+      parseOperationLog(f.history.get(f.head())!).header.format_version
+    ).toBe(2)
+    f.write('old-tab', f.document([f.a, f.b]))
+    await f.store.reconcileDriveNotebook(f.uri)
+    expect(
+      parseOperationLog(f.history.get(f.head())!).header.format_version
+    ).toBe(2)
+    expect(f.ids(f.history.get(f.head())!)).toEqual(
+      [f.a.op_id, f.b.op_id].sort()
+    )
+  })
+
+  it('promotes a local V1 header when upstream is V2 with identical operations', async () => {
+    const f = await createRecoveryFixture()
+    f.write('upgraded', upgradeOperationLogToV2(f.document([f.a])))
+    await f.store.reconcileDriveNotebook(f.uri)
+    expect(
+      parseOperationLog(await f.store.loadContent(f.uri)).header.format_version
+    ).toBe(2)
+    expect(f.drive.saveContentAfterVersionCheck).not.toHaveBeenCalled()
+  })
+
   it('preserves first-class V2 records recovered from an overwritten revision', async () => {
-    const f = await createRecoveryFixture(2)
+    const f = await createRecoveryFixture()
     const revision = projectRecord({
       record_type: 'runme.revision',
       format_version: 2,
@@ -3047,7 +3204,11 @@ describe('Drive v3 operation-log revision recovery', () => {
       author: { displayName: 'Reviewer', kind: 'human' },
     })
     f.beforeUpload(async () => {
-      f.write('hidden-review', f.document([f.a, revision]))
+      const header = parseOperationLog(f.document([])).header
+      f.write(
+        'hidden-review',
+        serializeOperationLog({ ...header, format_version: 2 }, [f.a, revision])
+      )
     })
     await f.store.reconcileDriveNotebook(f.uri)
     const local = await f.store.loadContent(f.uri)

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1152,6 +1152,32 @@ describe('LocalNotebooks operation-log storage', () => {
     }
   )
 
+  it('uploads edits arriving during a filesystem header upgrade before acknowledging them', async () => {
+    const f = await createRecoveryFixture()
+    let upstream = upgradeOperationLogToV2(f.document([f.a]))
+    f.store.setFilesystemStore({
+      loadContent: async () => upstream,
+      saveContent: async (_uri: string, content: string) => {
+        upstream = content
+      },
+    } as never)
+    await f.store.files.update(f.uri, {
+      remoteId: 'fs://workspace/test/file/shared.runme',
+    })
+    const append = f.operationLogStorage.appendTransaction.bind(
+      f.operationLogStorage
+    )
+    vi.spyOn(f.operationLogStorage, 'appendTransaction').mockImplementationOnce(
+      async (ref, createRecords, options) => {
+        await append(ref, () => JSON.stringify(f.c) + '\n')
+        return append(ref, createRecords, options)
+      }
+    )
+    await f.store.sync(f.uri)
+    expect(f.ids(upstream)).toEqual([f.a.op_id, f.c.op_id].sort())
+    expect(f.ids(await f.store.loadContent(f.uri))).toEqual(f.ids(upstream))
+  })
+
   it('allocates unique actor sequences for concurrent editor and comment writes', async () => {
     const operationLogStorage = new MemoryOperationLogStorage()
     const store = createTestStore({}, { operationLogStorage })

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -5211,22 +5211,22 @@ export class LocalNotebooks extends Dexie {
       const mergedIds = new Set(
         mergedOperations.map((operation) => operation.op_id)
       )
+      const persistedLog = parseOperationLog(stored.document)
       if (
-        parseOperationLog(stored.document).operations.some(
+        persistedLog.operations.some(
           (operation) => !mergedIds.has(operation.op_id)
         )
       )
         continue
 
       const mergedDocument = serializeOperationLog(
-        parseOperationLog(stored.document).header,
+        persistedLog.header,
         mergedOperations,
         { canonicalOrder: true }
       )
       if (
         remoteWasEmpty ||
-        remoteLog.header.format_version <
-          parseOperationLog(stored.document).header.format_version ||
+        remoteLog.header.format_version < persistedLog.header.format_version ||
         mergedOperations.some((operation) => !remoteIds.has(operation.op_id))
       ) {
         // Reserve the last pass for verification after the eighth upload.
@@ -5498,15 +5498,19 @@ export class LocalNotebooks extends Dexie {
         }
       )
     }
+    // The locked upgrade/append may also observe another tab's edits. Upload
+    // the exact durable snapshot we acknowledge, not the earlier operation set.
+    const persistedLog = parseOperationLog(stored.document)
     const mergedDocument = serializeOperationLog(
-      parseOperationLog(stored.document).header,
-      mergedOperations,
+      persistedLog.header,
+      persistedLog.operations,
       { canonicalOrder: true }
     )
     if (
-      upstreamLog.header.format_version <
-        parseOperationLog(stored.document).header.format_version ||
-      mergedOperations.some((operation) => !upstreamIds.has(operation.op_id))
+      upstreamLog.header.format_version < persistedLog.header.format_version ||
+      persistedLog.operations.some(
+        (operation) => !upstreamIds.has(operation.op_id)
+      )
     ) {
       await upstreamStore.saveContent(record.remoteId, mergedDocument)
     }

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -46,7 +46,10 @@ import {
 import { sourceAnchorsFromLegacy } from '../lib/operationLog/anchorConversion'
 import { cellDecisionFor } from '../lib/operationLog/cellReview'
 import { cellStateKey } from '../lib/operationLog/cellReviewIdentity'
-import { encodeOperation } from '../lib/operationLog/codec'
+import {
+  encodeOperation,
+  upgradeOperationLogToV2,
+} from '../lib/operationLog/codec'
 import {
   type ComparisonSelection,
   buildComparisons,
@@ -1429,6 +1432,7 @@ export class LocalNotebooks extends Dexie {
         const next = cloneNotebook(notebook)
         const operation = queue.then(async () => {
           let created: RunmeOperation[] = []
+          let upgraded = false
           const stored = await this.operationLogStorage.appendTransaction(
             record.operationLogRef!,
             async (currentDocument) => {
@@ -1450,9 +1454,16 @@ export class LocalNotebooks extends Dexie {
                 ? ''
                 : `${created.map((item) => encodeOperation(item)).join('\n')}\n`
             },
-            { validate: (document) => void parseOperationLog(document) }
+            {
+              prepareDocument: (document) => {
+                const prepared = upgradeOperationLogToV2(document)
+                upgraded = prepared !== document
+                return prepared
+              },
+              validate: (document) => void parseOperationLog(document),
+            }
           )
-          if (created.length === 0) {
+          if (created.length === 0 && !upgraded) {
             previous = next
             return
           }
@@ -1651,7 +1662,12 @@ export class LocalNotebooks extends Dexie {
     const actorId = options.actorId ?? (await getNotebookActorId(uri))
     const author = normalizeAttribution(options.author, true)
     const { parsed } = await this.readMaterializedOperationLog(uri)
-    if (parsed.header.format_version === 2) {
+    // Header promotion preserves legacy thread IDs (which are not operation
+    // IDs). Replies to those threads must keep the legacy record shape.
+    if (
+      parsed.operations.find((op) => op.op_id === parent.operation_id)?.kind ===
+      'comment.record'
+    ) {
       await this.appendFirstClassRecord(uri, (_operations, envelope) => {
         const { kind: _kind, payload: _payload, ...causal } = envelope
         return {
@@ -1670,7 +1686,9 @@ export class LocalNotebooks extends Dexie {
       )!
     }
     if (options.anchors)
-      throw new Error('Version-bound reply anchors require a V2 notebook')
+      throw new Error(
+        'Version-bound reply anchors require a native V2 comment thread'
+      )
     const payload: CommentReplyPayload = {
       comment_id: crypto.randomUUID(),
       thread_id: parent.thread_id,
@@ -1767,7 +1785,7 @@ export class LocalNotebooks extends Dexie {
   }
 
   /** Append first-class entities under the same lock that allocates actor IDs.
-   * Existing V1 files are never silently rewritten; migration creates a copy.
+   * Promote V1 headers atomically with the write, preserving all existing records.
    */
   private async appendFirstClassRecord(
     uri: string,
@@ -1786,10 +1804,6 @@ export class LocalNotebooks extends Dexie {
         file.operationLogRef,
         (document) => {
           const parsed = parseOperationLog(document)
-          if (parsed.header.format_version !== 2)
-            throw new Error(
-              'This notebook uses format V1. Create an explicit V2 migration copy before adding revision/comment records.'
-            )
           if (
             captureReviewRevision(parsed.operations).length !==
             parsed.operations.length
@@ -1811,7 +1825,10 @@ export class LocalNotebooks extends Dexie {
           written = candidate
           return line
         },
-        { validate: (document) => void parseOperationLog(document) }
+        {
+          prepareDocument: upgradeOperationLogToV2,
+          validate: (document) => void parseOperationLog(document),
+        }
       )
       await this.files.update(uri, {
         doc: '',
@@ -2053,10 +2070,6 @@ export class LocalNotebooks extends Dexie {
         record.operationLogRef,
         async (document) => {
           const parsed = parseOperationLog(document)
-          if (parsed.header.format_version !== 2)
-            throw new Error(
-              'Create a V2 migration copy before recording decisions'
-            )
           if (
             captureReviewRevision(parsed.operations).length !==
             parsed.operations.length
@@ -2275,6 +2288,7 @@ export class LocalNotebooks extends Dexie {
           return appended
         },
         {
+          prepareDocument: upgradeOperationLogToV2,
           validate: (document) => {
             const parsed = parseOperationLog(document)
             materializeOperationLog(parsed.operations)
@@ -2343,7 +2357,10 @@ export class LocalNotebooks extends Dexie {
           mutationCreated = true
           return `${encodeOperation(operation)}\n`
         },
-        { validate: (document) => void parseOperationLog(document) }
+        {
+          prepareDocument: upgradeOperationLogToV2,
+          validate: (document) => void parseOperationLog(document),
+        }
       )
       await this.files.update(uri, {
         doc: '',
@@ -2506,6 +2523,7 @@ export class LocalNotebooks extends Dexie {
 
     const format = detectNotebookFileFormat(record.name)
     if (format === 'runme-operation-log') {
+      content = upgradeOperationLogToV2(content)
       const decoded = decodeNotebookFile(content, record.name)
       if (!decoded.operationLog) {
         throw new Error(`Expected operation-log content for ${record.name}`)
@@ -5123,12 +5141,20 @@ export class LocalNotebooks extends Dexie {
         )
       }
       const history = await recovery.collect(snapshot)
+      let formatVersion = Math.max(
+        localLog.header.format_version,
+        remoteLog.header.format_version
+      )
       let mergedOperations = mergeOperationSets(
         localLog.operations,
         remoteLog.operations
       )
       for (const content of history.contents) {
         const historical = parseOperationLog(content)
+        formatVersion = Math.max(
+          formatVersion,
+          historical.header.format_version
+        )
         if (historical.header.notebook_id !== localLog.header.notebook_id) {
           throw new Error(
             `Cannot recover a different operation-log notebook for ${localUri}; local operations remain pending.`
@@ -5157,7 +5183,20 @@ export class LocalNotebooks extends Dexie {
           `${missingLocally
             .map((operation) => encodeOperation(operation))
             .join('\n')}\n`,
-          { validate: (document) => void parseOperationLog(document) }
+          {
+            prepareDocument:
+              formatVersion === 2 ? upgradeOperationLogToV2 : undefined,
+            validate: (document) => void parseOperationLog(document),
+          }
+        )
+      } else if (localLog.header.format_version < formatVersion) {
+        stored = await this.operationLogStorage.appendTransaction(
+          local.ref,
+          () => '',
+          {
+            prepareDocument: upgradeOperationLogToV2,
+            validate: (document) => void parseOperationLog(document),
+          }
         )
       }
 
@@ -5180,12 +5219,14 @@ export class LocalNotebooks extends Dexie {
         continue
 
       const mergedDocument = serializeOperationLog(
-        localLog.header,
+        parseOperationLog(stored.document).header,
         mergedOperations,
         { canonicalOrder: true }
       )
       if (
         remoteWasEmpty ||
+        remoteLog.header.format_version <
+          parseOperationLog(stored.document).header.format_version ||
         mergedOperations.some((operation) => !remoteIds.has(operation.op_id))
       ) {
         // Reserve the last pass for verification after the eighth upload.
@@ -5430,6 +5471,10 @@ export class LocalNotebooks extends Dexie {
     const missingLocally = mergedOperations.filter(
       (operation) => !localIds.has(operation.op_id)
     )
+    const formatVersion = Math.max(
+      localLog.header.format_version,
+      upstreamLog.header.format_version
+    )
     let stored = local
     if (missingLocally.length > 0) {
       stored = await this.operationLogStorage.append(
@@ -5437,15 +5482,30 @@ export class LocalNotebooks extends Dexie {
         `${missingLocally
           .map((operation) => encodeOperation(operation))
           .join('\n')}\n`,
-        { validate: (document) => void parseOperationLog(document) }
+        {
+          prepareDocument:
+            formatVersion === 2 ? upgradeOperationLogToV2 : undefined,
+          validate: (document) => void parseOperationLog(document),
+        }
+      )
+    } else if (localLog.header.format_version < formatVersion) {
+      stored = await this.operationLogStorage.appendTransaction(
+        local.ref,
+        () => '',
+        {
+          prepareDocument: upgradeOperationLogToV2,
+          validate: (document) => void parseOperationLog(document),
+        }
       )
     }
     const mergedDocument = serializeOperationLog(
-      localLog.header,
+      parseOperationLog(stored.document).header,
       mergedOperations,
       { canonicalOrder: true }
     )
     if (
+      upstreamLog.header.format_version <
+        parseOperationLog(stored.document).header.format_version ||
       mergedOperations.some((operation) => !upstreamIds.has(operation.op_id))
     ) {
       await upstreamStore.saveContent(record.remoteId, mergedDocument)

--- a/app/src/storage/operationLogs.test.ts
+++ b/app/src/storage/operationLogs.test.ts
@@ -1,10 +1,11 @@
 /// <reference types="vitest" />
 // @vitest-environment node
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   MemoryOperationLogStorage,
   type OperationLogCoordinator,
+  OpfsOperationLogStorage,
   operationLogPath,
 } from './operationLogs'
 
@@ -103,3 +104,112 @@ describe('operation-log storage', () => {
     ).rejects.toThrow('changed before replacement')
   })
 })
+
+describe.each(['memory', 'opfs'])(
+  'atomic upgrades in %s storage',
+  (backend) => {
+    afterEach(() => vi.unstubAllGlobals())
+
+    function storage() {
+      if (backend === 'memory') return new MemoryOperationLogStorage()
+      // Model OPFS close-to-commit semantics, including keepExistingData and seek.
+      let committed = ''
+      const handle = {
+        getFile: async () => ({
+          size: new TextEncoder().encode(committed).length,
+          text: async () => committed,
+        }),
+        createWritable: async (options?: { keepExistingData?: boolean }) => {
+          let pending = options?.keepExistingData ? committed : ''
+          let offset = 0
+          return {
+            seek: async (position: number) => {
+              offset = position
+            },
+            write: async (value: string) => {
+              pending = pending.slice(0, offset) + value
+            },
+            close: async () => {
+              committed = pending
+            },
+          }
+        },
+      }
+      const directory = {
+        getDirectoryHandle: async () => directory,
+        getFileHandle: async () => handle,
+      }
+      vi.stubGlobal('navigator', {
+        storage: { getDirectory: async () => directory },
+      })
+      return new OpfsOperationLogStorage(coordinator())
+    }
+
+    const prepareDocument = (document: string) =>
+      document.replace('"version":1', '"version":2')
+
+    it('upgrades and appends under one lock, retaining concurrent writers', async () => {
+      const s = storage()
+      const initial = await s.initialize(
+        'local://file/upgrade',
+        '{"version":1}\n'
+      )
+      await Promise.all([
+        s.appendTransaction(
+          initial.ref,
+          (current) => {
+            expect(current).toContain('"version":2')
+            return '{"a":1}\n'
+          },
+          { prepareDocument }
+        ),
+        s.append(initial.ref, '{"b":1}\n', { prepareDocument }),
+      ])
+      expect((await s.read(initial.ref)).document).toBe(
+        '{"version":2}\n{"a":1}\n{"b":1}\n'
+      )
+    })
+
+    it('commits a header-only upgrade idempotently', async () => {
+      const s = storage()
+      const initial = await s.initialize(
+        'local://file/upgrade',
+        '{"version":1}\n'
+      )
+      const first = await s.appendTransaction(initial.ref, () => '', {
+        prepareDocument,
+      })
+      const second = await s.appendTransaction(initial.ref, () => '', {
+        prepareDocument,
+      })
+      expect(first.document).toBe('{"version":2}\n')
+      expect(second).toEqual(first)
+    })
+
+    it('does not commit the header when record creation or validation fails', async () => {
+      const s = storage()
+      const initial = await s.initialize(
+        'local://file/upgrade',
+        '{"version":1}\n'
+      )
+      await expect(
+        s.appendTransaction(
+          initial.ref,
+          () => {
+            throw new Error('invalid record')
+          },
+          { prepareDocument }
+        )
+      ).rejects.toThrow('invalid record')
+      await expect(
+        s.append(initial.ref, '{"bad":1}\n', {
+          prepareDocument,
+          validate: () => {
+            throw new Error('invalid log')
+          },
+        })
+      ).rejects.toThrow('invalid log')
+      expect(await s.read(initial.ref)).toEqual(initial)
+    })
+  }
+)

--- a/app/src/storage/operationLogs.ts
+++ b/app/src/storage/operationLogs.ts
@@ -12,6 +12,14 @@ export interface OperationLogSnapshot {
   checksum: string
 }
 
+export interface OperationLogAppendOptions {
+  validate?: (document: string) => void
+  /** Transform the current document under the writer lock, before appending.
+   * Validation and record creation must succeed before any bytes are written.
+   */
+  prepareDocument?: (document: string) => string
+}
+
 export interface OperationLogStorage {
   supportsConcurrentWriters(): boolean
   initialize(
@@ -22,12 +30,12 @@ export interface OperationLogStorage {
   append(
     ref: OperationLogRef,
     records: string,
-    options?: { validate?: (document: string) => void }
+    options?: OperationLogAppendOptions
   ): Promise<OperationLogSnapshot>
   appendTransaction(
     ref: OperationLogRef,
     createRecords: (currentDocument: string) => string | Promise<string>,
-    options?: { validate?: (document: string) => void }
+    options?: OperationLogAppendOptions
   ): Promise<OperationLogSnapshot>
   replace(
     ref: OperationLogRef,
@@ -219,38 +227,34 @@ export class OpfsOperationLogStorage implements OperationLogStorage {
   async append(
     ref: OperationLogRef,
     records: string,
-    options: { validate?: (document: string) => void } = {}
+    options: OperationLogAppendOptions = {}
   ): Promise<OperationLogSnapshot> {
     validateFraming(records, 'Appended operation-log records')
-    return this.coordinator.runExclusive(ref.path, async () => {
-      const handle = await getHandle(ref)
-      const file = await handle.getFile()
-      const current = await file.text()
-      options.validate?.(`${current}${records}`)
-      const writable = await handle.createWritable({ keepExistingData: true })
-      await writable.seek(file.size)
-      await writable.write(records)
-      await writable.close()
-      return this.readUnchecked(ref)
-    })
+    return this.appendTransaction(ref, () => records, options)
   }
 
   async appendTransaction(
     ref: OperationLogRef,
     createRecords: (currentDocument: string) => string | Promise<string>,
-    options: { validate?: (document: string) => void } = {}
+    options: OperationLogAppendOptions = {}
   ): Promise<OperationLogSnapshot> {
     return this.coordinator.runExclusive(ref.path, async () => {
       const handle = await getHandle(ref)
       const file = await handle.getFile()
-      const current = await file.text()
+      const original = await file.text()
+      const current = options.prepareDocument?.(original) ?? original
       const records = await createRecords(current)
-      if (!records) return snapshot(ref, current)
-      validateFraming(records, 'Appended operation-log records')
-      options.validate?.(`${current}${records}`)
-      const writable = await handle.createWritable({ keepExistingData: true })
-      await writable.seek(file.size)
-      await writable.write(records)
+      const document = `${current}${records}`
+      if (document === original) return snapshot(ref, original)
+      if (records) validateFraming(records, 'Appended operation-log records')
+      validateFraming(document, 'Updated operation log')
+      options.validate?.(document)
+      const rewritten = current !== original
+      const writable = await handle.createWritable({
+        keepExistingData: !rewritten,
+      })
+      if (!rewritten) await writable.seek(file.size)
+      await writable.write(rewritten ? document : records)
       await writable.close()
       return this.readUnchecked(ref)
     })
@@ -330,35 +334,28 @@ export class MemoryOperationLogStorage implements OperationLogStorage {
   async append(
     ref: OperationLogRef,
     records: string,
-    options: { validate?: (document: string) => void } = {}
+    options: OperationLogAppendOptions = {}
   ): Promise<OperationLogSnapshot> {
     validateFraming(records, 'Appended operation-log records')
-    return this.coordinator.runExclusive(ref.path, async () => {
-      const current = this.documents.get(ref.path)
-      if (current === undefined) {
-        throw new Error(`Operation log not found: ${ref.path}`)
-      }
-      const document = `${current}${records}`
-      options.validate?.(document)
-      this.documents.set(ref.path, document)
-      return snapshot(ref, document)
-    })
+    return this.appendTransaction(ref, () => records, options)
   }
 
   async appendTransaction(
     ref: OperationLogRef,
     createRecords: (currentDocument: string) => string | Promise<string>,
-    options: { validate?: (document: string) => void } = {}
+    options: OperationLogAppendOptions = {}
   ): Promise<OperationLogSnapshot> {
     return this.coordinator.runExclusive(ref.path, async () => {
-      const current = this.documents.get(ref.path)
-      if (current === undefined) {
+      const original = this.documents.get(ref.path)
+      if (original === undefined) {
         throw new Error(`Operation log not found: ${ref.path}`)
       }
+      const current = options.prepareDocument?.(original) ?? original
       const records = await createRecords(current)
-      if (!records) return snapshot(ref, current)
-      validateFraming(records, 'Appended operation-log records')
       const document = `${current}${records}`
+      if (document === original) return snapshot(ref, original)
+      if (records) validateFraming(records, 'Appended operation-log records')
+      validateFraming(document, 'Updated operation log')
       options.validate?.(document)
       this.documents.set(ref.path, document)
       return snapshot(ref, document)

--- a/docs/19-notebook-review-rounds.md
+++ b/docs/19-notebook-review-rounds.md
@@ -201,12 +201,22 @@ adds a newline; IME composition does not submit. New editor comments capture
 the displayed committed snapshot at composition time, rejecting intervening
 changes during persistence. Replies may add historical anchors while retaining
 the original conversation and comparison. `.runme` comment API calls require an
-explicit notebook target. These native locations require V2 anchors; legacy
-notebooks remain readable and are never migrated automatically.
+explicit notebook target. These native locations use V2 anchors.
 
 The old `reviews` runtime namespace and Review writers are removed. A read-only
-V1 decoder remains so existing notebooks can still be opened. V1 files are not
-silently upgraded or rewritten. To opt in:
+V1 decoder remains so existing notebooks can still be opened. Saving a V1
+notebook, creating a revision, or writing a comment upgrades its header to V2
+under the same OPFS writer lock as the new records. The notebook identity,
+existing operation IDs, and legacy comments are preserved. Even a save without
+content changes persists the header upgrade. Opening a notebook alone does not
+upgrade it. Drive and filesystem sync propagate the newer header, including
+when both replicas contain identical operation sets. Old V1-only app builds
+must be refreshed before editing an upgraded file.
+
+Header promotion does not convert legacy comment anchors. Existing threads keep
+their legacy reply records; new native comments use version-bound V2 records.
+To explicitly convert legacy labels, comments and assessments in an untouched
+V1 notebook into native V2 records in a separate copy:
 
 ```javascript
 const migration = await revisions.migrate({


### PR DESCRIPTION
## Summary
Fixes #370.

- Upgrade V1 headers atomically with saves and revision/comment writes while preserving notebook identity and existing operation bytes.
- Preserve legacy thread replies/resolution after upgrading.
- Propagate header-only upgrades and recovered V2 records through Drive/filesystem sync without downgrading.
- Upload the full persisted filesystem snapshot, including edits arriving during header promotion, before acknowledging it as synced.
- Keep opening/reading V1 notebooks non-mutating; retain explicit migration-copy support.

## Validation
- runme run build test: passed after final production changes.
- Full app suite: 1,405 tests across 135 files passed on rerun. One unrelated comment-UI test failed transiently in the first run, then passed in isolation and the full rerun.
- Storage suite: 151 passed; includes memory and simulated OPFS transaction/failure/concurrency coverage, Drive recovery, filesystem upgrade propagation, and the concurrent-append regression.
- No live user notebook was mutated for testing.

## Review
- Repository-guided review found and fixed filesystem sync acknowledging a concurrent append without uploading it. Regression test demonstrated the failure before the fix.
- Reviewed identity/history preservation, old thread IDs, header-only propagation, stale writers, failed writes, and recovery of V2 records.
- Automated DCO finding resolved with GitHub commit-API evidence: both commits already have Signed-off-by trailers.
- Requested final-head review; required CI gates must pass before merge.