### PR TITLE
Keep notebooks editable when execution results conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ When you open a follow-up PR that fixes an issue, include an issue-closing refer
 - Use one of GitHub's auto-close keywords with an issue number, for example: `Fixes #123`, `Closes #123`, or `Resolves #123`.
 - Put this in the PR body (not just a comment) so the issue is linked and automatically closed when the PR merges.
 
+## Corrupt notebook recovery
+
+Corrupt notebook files and inconsistent history must degrade gracefully: keep recovered content openable, editable, and saveable. Preserve the original bytes/history, isolate errors to affected content, and verify save/reopen/rerun behavior. Follow the detailed recovery and review requirements in app/AGENTS.md.
+
 ## Architecture
 
 This is a pnpm workspace monorepo with two publishable packages and one app:

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -49,6 +49,14 @@ Here is an example of correct code.
 
 ## Review guidelines for app/
 
+### Graceful recovery from corrupt notebooks
+
+- Corrupt files or inconsistent saved history must not prevent a notebook from opening or make its recovered content read-only. Keep recoverable cells editable and ensure edits can be saved and reopened.
+- Isolate damage to the affected cell, output, or record. Preserve original bytes/history; never silently replace a damaged notebook with an empty one or delete conflicting records to make validation pass.
+- For ambiguous execution results, show a useful error in that cell's outputs. Clear the diagnostic when the cell runs again, and let the new execution supply fresh output. Do not serialize recovery diagnostics as real execution results.
+- Use explicit causal history to reconcile updates. Do not guess the correct output from wall-clock timestamps or arbitrary file order.
+- Review recovery changes with corrupt-input regression tests covering open, edit, save, reopen, and rerun. An error boundary or read-only fallback alone is not recovery.
+
 * Ensure code changes are consistent with the design, practices, and styles defined in `docs-dev/architecture.md`.
 * Ensure that tests are properly updated to verify bug fixes and prevent regressions, including adding new tests where needed.
   * Ensure CUJs as defined in `docs-dev/cujs` are updated if necessary.

--- a/app/src/lib/ipynb.ts
+++ b/app/src/lib/ipynb.ts
@@ -8,6 +8,7 @@ import {
   uniqueCanonicalCellId,
 } from './cellIdentity'
 import { DERIVED_NOTEBOOK_KEY, parseDerivedSource } from './derivedNotebook'
+import { withoutRecoveredOutputs } from './recoveredOutputs'
 
 export const IPYNB_MIME_TYPE = 'application/x-ipynb+json'
 export const IPYNB_RAW_CELL_METADATA_KEY = 'runme.dev/ipynbRawCell'
@@ -559,6 +560,7 @@ export function encodeIpynb(
   shadowText?: string,
   previousState?: Partial<IpynbMergeState>
 ): EncodedIpynb {
+  notebook = withoutRecoveredOutputs(notebook)
   assertCanonicalNotebookCellIds(notebook)
   const shadow = shadowText
     ? validateNotebook(JSON.parse(shadowText))

--- a/app/src/lib/markdown/serializeNotebookToMarkdown.ts
+++ b/app/src/lib/markdown/serializeNotebookToMarkdown.ts
@@ -5,6 +5,7 @@ import {
   linkedResourceMarkdown,
   parseLinkedResource,
 } from '../linkedResource'
+import { isRecoveredOutput } from '../recoveredOutputs'
 
 const IOPUB_MIME_TYPE = 'application/vnd.jupyter.iopub+json'
 
@@ -49,7 +50,9 @@ function serializeCell(cell: parser_pb.Cell): string {
   const body = isAuthoredContentCell(cell)
     ? normalizeContentCell(cell.value)
     : renderFencedBlock(cell.value, normalizeCodeFenceLanguage(cell.languageId))
-  const outputs = serializeCellOutputs(cell.outputs ?? [])
+  const outputs = serializeCellOutputs(
+    (cell.outputs ?? []).filter((output) => !isRecoveredOutput(output))
+  )
   return [body, outputs].filter(Boolean).join('\n\n')
 }
 

--- a/app/src/lib/notebookFormat.ts
+++ b/app/src/lib/notebookFormat.ts
@@ -19,6 +19,7 @@ import {
   parseOperationLog,
   serializeOperationLog,
 } from './operationLog'
+import { withoutRecoveredOutputs } from './recoveredOutputs'
 
 const NOTEBOOK_JSON_WRITE_OPTIONS = {
   emitDefaultValues: true,
@@ -390,7 +391,7 @@ export function decodeNotebookFile(
 export function encodeRunmeNotebook(notebook: parser_pb.Notebook): string {
   return toJsonString(
     parser_pb.NotebookSchema,
-    notebook,
+    withoutRecoveredOutputs(notebook),
     NOTEBOOK_JSON_WRITE_OPTIONS
   )
 }

--- a/app/src/lib/operationLog/editorJournal.ts
+++ b/app/src/lib/operationLog/editorJournal.ts
@@ -5,9 +5,9 @@ import {
   RunmeMetadataKey,
   parser_pb,
 } from '../../runme/client'
+import { isRecoveredOutput } from '../recoveredOutputs'
 import { materializeOperationLog } from './materialize'
 import { causalHeads, createRunmeOperation } from './mutations'
-import { RECOVERED_OUTPUT_KEY } from './notebook'
 import { allocatePositionBetween } from './positions'
 import type {
   JsonValue,
@@ -91,7 +91,7 @@ async function sha256(value: string): Promise<string> {
 function outputJson(cell: parser_pb.Cell): JsonValue[] {
   // Recovery diagnostics belong to the display, never to execution history.
   return cell.outputs
-    .filter((output) => output.metadata?.[RECOVERED_OUTPUT_KEY] !== 'true')
+    .filter((output) => !isRecoveredOutput(output))
     .map((output) => {
       const normalized = create(parser_pb.CellOutputSchema, {
         ...output,
@@ -284,8 +284,10 @@ export async function buildOperationLogDiff({
     if (
       previousCell &&
       !nextRunId &&
-      previousOutputs.length > 0 &&
-      nextOutputs.length === 0
+      // A user clear also removes recovery-only output. Compare the visible
+      // snapshots here, before filtering diagnostics out of saved results.
+      previousCell.outputs.length > 0 &&
+      cell.outputs.length === 0
     ) {
       append('cell.clear_outputs', {
         cell_id: cell.refId,

--- a/app/src/lib/operationLog/editorJournal.ts
+++ b/app/src/lib/operationLog/editorJournal.ts
@@ -7,6 +7,7 @@ import {
 } from '../../runme/client'
 import { materializeOperationLog } from './materialize'
 import { causalHeads, createRunmeOperation } from './mutations'
+import { RECOVERED_OUTPUT_KEY } from './notebook'
 import { allocatePositionBetween } from './positions'
 import type {
   JsonValue,
@@ -88,23 +89,28 @@ async function sha256(value: string): Promise<string> {
 }
 
 function outputJson(cell: parser_pb.Cell): JsonValue[] {
-  return cell.outputs.map((output) => {
-    const normalized = create(parser_pb.CellOutputSchema, {
-      ...output,
-      items: output.items.map((item) =>
-        create(parser_pb.CellOutputItemSchema, {
-          ...item,
-          data:
-            item.data instanceof Uint8Array
-              ? item.data
-              : new Uint8Array(
-                  Object.values(item.data as unknown as Record<string, number>)
-                ),
-        })
-      ),
+  // Recovery diagnostics belong to the display, never to execution history.
+  return cell.outputs
+    .filter((output) => output.metadata?.[RECOVERED_OUTPUT_KEY] !== 'true')
+    .map((output) => {
+      const normalized = create(parser_pb.CellOutputSchema, {
+        ...output,
+        items: output.items.map((item) =>
+          create(parser_pb.CellOutputItemSchema, {
+            ...item,
+            data:
+              item.data instanceof Uint8Array
+                ? item.data
+                : new Uint8Array(
+                    Object.values(
+                      item.data as unknown as Record<string, number>
+                    )
+                  ),
+          })
+        ),
+      })
+      return protobufJson(parser_pb.CellOutputSchema, normalized)
     })
-    return protobufJson(parser_pb.CellOutputSchema, normalized)
-  })
 }
 
 /** Convert one debounced editor snapshot change into append-only operations. */

--- a/app/src/lib/operationLog/editorJournal.ts
+++ b/app/src/lib/operationLog/editorJournal.ts
@@ -274,9 +274,17 @@ export async function buildOperationLogDiff({
     const persistedRunId = cell.metadata?.[RunmeMetadataKey.LastRunID]
     const previousOutputs = previousCell ? outputJson(previousCell) : []
     const nextOutputs = outputJson(cell)
+    // A failed setup attempt has output but no backend run ID. Give a
+    // replacement for recovered output a durable execution identity so reopening
+    // cannot restore the old diagnostic. Unchanged snapshots emit no new run.
+    const replacedRecovery = Boolean(
+      previousCell?.outputs.some(isRecoveredOutput) &&
+        !cell.outputs.some(isRecoveredOutput) &&
+        nextOutputs.length > 0
+    )
     const nextRunId =
       persistedRunId ??
-      (!previousCell && nextOutputs.length > 0
+      ((!previousCell || replacedRecovery) && nextOutputs.length > 0
         ? `${actorId}:imported-execution:${actorSequence}`
         : undefined)
     const outputsChanged =

--- a/app/src/lib/operationLog/executionRecovery.test.ts
+++ b/app/src/lib/operationLog/executionRecovery.test.ts
@@ -8,6 +8,10 @@ import {
   RunmeMetadataKey,
   parser_pb,
 } from '../../runme/client'
+import { encodeDerivedIpynb } from '../derivedIpynb'
+import { encodeIpynb } from '../ipynb'
+import { serializeNotebookToMarkdown } from '../markdown/serializeNotebookToMarkdown'
+import { encodeRunmeNotebook } from '../notebookFormat'
 import { buildOperationLogDiff, cloneNotebook } from './editorJournal'
 import { materializeOperationLog } from './materialize'
 import { causalHeads, createRunmeOperation } from './mutations'
@@ -271,6 +275,59 @@ describe('execution output recovery', () => {
     ;(finish.payload as unknown as ExecutionFinishPayload).outputs =
       null as unknown as JsonValue[]
     expect(outputText(reopen(f.operations))).toContain('completion records')
+  })
+
+  it('keeps user-cleared recovery-only outputs cleared after reopening', async () => {
+    const f = fixture()
+    f.finish('left', [f.start.op_id])
+    f.finish('right', [f.start.op_id])
+    const previous = reopen(f.operations)
+    const next = cloneNotebook(previous)
+    next.cells[0]!.outputs = []
+    delete next.cells[0]!.metadata[RunmeMetadataKey.LastRunID]
+    delete next.cells[0]!.metadata[RunmeMetadataKey.ExecutionState]
+    const changes = await buildOperationLogDiff({
+      previous,
+      next,
+      observedOperations: f.operations,
+      actorId: 'clear',
+      firstActorSequence: 1,
+    })
+    expect(changes.some((op) => op.kind === 'cell.clear_outputs')).toBe(true)
+    f.operations.push(...changes)
+    expect(reopen(f.operations).cells[0]!.outputs).toEqual([])
+    expect(
+      f.operations.filter((op) => op.kind === 'execution.finish')
+    ).toHaveLength(2)
+  })
+
+  it('omits recovery diagnostics from IPYNB, JSON, and Markdown exports without changing the model', () => {
+    const f = fixture()
+    const finish = f.finish('valid sibling')
+    ;(finish.payload as unknown as ExecutionFinishPayload).outputs.push(null)
+    const notebook = reopen(f.operations)
+    expect(outputText(notebook)).toContain('corrupt saved output')
+    const exports = [
+      encodeIpynb(notebook).text,
+      encodeRunmeNotebook(notebook),
+      serializeNotebookToMarkdown(notebook),
+      encodeDerivedIpynb(notebook, {
+        version: 1,
+        uri: 'https://drive.google.com/file/d/source/view',
+        notebookId: 'test',
+        generatedAt: '2026-09-10T00:00:00Z',
+        operationIds: f.operations.map((op) => op.op_id),
+      }),
+    ]
+    for (const exported of exports) {
+      expect(exported).not.toContain('corrupt saved output')
+      expect(exported).not.toContain(RECOVERED_OUTPUT_KEY)
+    }
+    const ipynb = JSON.parse(exports[0]!)
+    expect(ipynb.cells[0].outputs).toHaveLength(1)
+    expect(JSON.stringify(ipynb.cells[0].outputs)).toContain('valid sibling')
+    expect(outputText(notebook)).toContain('corrupt saved output')
+    expect(notebook.cells[0]!.outputs).toHaveLength(2)
   })
 
   it('keeps recovered source editable through save/reopen and never journals the diagnostic', async () => {

--- a/app/src/lib/operationLog/executionRecovery.test.ts
+++ b/app/src/lib/operationLog/executionRecovery.test.ts
@@ -277,6 +277,52 @@ describe('execution output recovery', () => {
     expect(outputText(reopen(f.operations))).toContain('completion records')
   })
 
+  it('persists a failed setup attempt that replaces recovered output without a backend run ID', async () => {
+    const f = fixture()
+    f.finish('left', [f.start.op_id])
+    f.finish('right', [f.start.op_id])
+    const previous = reopen(f.operations)
+    const next = cloneNotebook(previous)
+    delete next.cells[0]!.metadata[RunmeMetadataKey.LastRunID]
+    next.cells[0]!.metadata[RunmeMetadataKey.ExecutionState] =
+      RunmeExecutionState.Completed
+    next.cells[0]!.metadata[RunmeMetadataKey.ExitCode] = '1'
+    next.cells[0]!.outputs = [
+      create(parser_pb.CellOutputSchema, {
+        items: [
+          create(parser_pb.CellOutputItemSchema, {
+            mime: MimeType.VSCodeNotebookStdErr,
+            type: 'Buffer',
+            data: new TextEncoder().encode('Runner backend unavailable'),
+          }),
+        ],
+      }),
+    ]
+    const changes = await buildOperationLogDiff({
+      previous,
+      next,
+      observedOperations: f.operations,
+      actorId: 'failed-rerun',
+      firstActorSequence: 1,
+    })
+    f.operations.push(...changes)
+    expect(outputText(reopen(f.operations))).toBe('Runner backend unavailable')
+    expect(
+      (
+        changes.find((op) => op.kind === 'execution.finish')!
+          .payload as unknown as ExecutionFinishPayload
+      ).status
+    ).toBe('failed')
+    const unchanged = await buildOperationLogDiff({
+      previous: next,
+      next,
+      observedOperations: f.operations,
+      actorId: 'failed-rerun',
+      firstActorSequence: changes.length + 1,
+    })
+    expect(unchanged).toEqual([])
+  })
+
   it('keeps user-cleared recovery-only outputs cleared after reopening', async () => {
     const f = fixture()
     f.finish('left', [f.start.op_id])

--- a/app/src/lib/operationLog/executionRecovery.test.ts
+++ b/app/src/lib/operationLog/executionRecovery.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment node
+import { create, toJson } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import {
+  MimeType,
+  RunmeExecutionState,
+  RunmeMetadataKey,
+  parser_pb,
+} from '../../runme/client'
+import { buildOperationLogDiff, cloneNotebook } from './editorJournal'
+import { materializeOperationLog } from './materialize'
+import { causalHeads, createRunmeOperation } from './mutations'
+import { RECOVERED_OUTPUT_KEY, materializedLogToNotebook } from './notebook'
+import type { ExecutionFinishPayload, JsonValue, RunmeOperation } from './types'
+
+/** Build real causal records, including concurrent completions for the same run. */
+function fixture() {
+  const operations: RunmeOperation[] = []
+  const append = (
+    kind: string,
+    payload: JsonValue,
+    deps = causalHeads(operations)
+  ) => {
+    const op = createRunmeOperation({
+      actorId: `actor_${operations.length}`,
+      actorSequence: 1,
+      knownOperations: operations,
+      dependencies: deps,
+      kind,
+      payload,
+    })
+    operations.push(op)
+    return op
+  }
+  const cell = append('cell.create', {
+    cell_id: 'cell-1',
+    position: [[1, 'seed', 1]],
+    cell: {
+      kind: 'code',
+      language_id: 'javascript',
+      value: 'console.log("hello")',
+      metadata: {
+        [RunmeMetadataKey.LastRunID]: 'run-1',
+        [RunmeMetadataKey.ExecutionState]: RunmeExecutionState.Completed,
+      },
+    },
+  })
+  const start = append('execution.start', {
+    execution_id: 'run-1',
+    cell_id: 'cell-1',
+    source_op_id: cell.op_id,
+    input: {
+      language_id: 'javascript',
+      value: 'console.log("hello")',
+      execution_metadata: {},
+    },
+    input_sha256: 'source-hash',
+    runner: {
+      runner_id: 'browser',
+      runtime: 'javascript',
+      runtime_version: '1',
+      environment_digest: null,
+    },
+    started_at: '2026-09-09T00:00:00Z',
+  })
+  const finish = (text: string, deps?: string[], executionId = 'run-1') =>
+    append(
+      'execution.finish',
+      {
+        execution_id: executionId,
+        status: 'succeeded',
+        outputs: [
+          toJson(
+            parser_pb.CellOutputSchema,
+            create(parser_pb.CellOutputSchema, {
+              items: [
+                create(parser_pb.CellOutputItemSchema, {
+                  mime: MimeType.VSCodeNotebookStdOut,
+                  type: 'Buffer',
+                  data: new TextEncoder().encode(text),
+                }),
+              ],
+            })
+          ) as JsonValue,
+        ],
+        execution_summary: {},
+        finished_at: '2026-09-09T00:00:01Z',
+      },
+      deps
+    )
+  return { operations, append, start, finish }
+}
+
+function reopen(operations: RunmeOperation[]) {
+  return materializedLogToNotebook(materializeOperationLog(operations))
+}
+
+function outputText(notebook: parser_pb.Notebook) {
+  return notebook.cells[0]!.outputs.flatMap((o) =>
+    o.items.map((i) => new TextDecoder().decode(i.data))
+  ).join('')
+}
+
+describe('execution output recovery', () => {
+  it('uses a causally later completion to retain late output, regardless of timestamp', () => {
+    const f = fixture()
+    f.finish('first chunk')
+    f.append('cell.move', { cell_id: 'cell-1', position: [[2, 'seed', 1]] })
+    const later = f.finish('first chunk\nlast chunk')
+    ;(later.payload as unknown as ExecutionFinishPayload).finished_at =
+      '2020-01-01T00:00:00Z'
+    expect(outputText(reopen(f.operations))).toBe('first chunk\nlast chunk')
+  })
+
+  it('accepts identical concurrent results despite different completion timestamps', () => {
+    const f = fixture()
+    f.finish('same', [f.start.op_id])
+    const duplicate = f.finish('same', [f.start.op_id])
+    ;(duplicate.payload as unknown as ExecutionFinishPayload).finished_at =
+      '2030-01-01T00:00:00Z'
+    expect(outputText(reopen(f.operations))).toBe('same')
+  })
+
+  it('shows a deterministic cell-level error for conflicting results without changing history', () => {
+    const f = fixture()
+    f.finish('left', [f.start.op_id])
+    f.finish('right', [f.start.op_id])
+    const original = JSON.stringify(f.operations)
+    const notebook = reopen(f.operations)
+    expect(notebook.cells[0]!.value).toBe('console.log("hello")')
+    expect(outputText(notebook)).toContain(
+      'conflicting or invalid completion records'
+    )
+    expect(outputText(notebook)).toContain('Run this cell again')
+    expect(outputText(reopen([...f.operations].reverse()))).toBe(
+      outputText(notebook)
+    )
+    expect(
+      materializeOperationLog(f.operations).executions[0]!.finish
+    ).toBeUndefined()
+    expect(JSON.stringify(f.operations)).toBe(original)
+  })
+
+  it('does not let a successor on only one branch hide the other conflicting result', () => {
+    const f = fixture()
+    const left = f.finish('left', [f.start.op_id])
+    f.finish('right', [f.start.op_id])
+    f.finish('left updated', [left.op_id])
+    expect(outputText(reopen(f.operations))).toContain('conflicting')
+    f.finish('reconciled')
+    expect(outputText(reopen(f.operations))).toBe('reconciled')
+  })
+
+  it('treats concurrent status or summary disagreement as ambiguous even with the same output', () => {
+    const f = fixture()
+    f.finish('same', [f.start.op_id])
+    const other = f.finish('same', [f.start.op_id])
+    ;(other.payload as unknown as ExecutionFinishPayload).status = 'failed'
+    expect(outputText(reopen(f.operations))).toContain('conflicting')
+    ;(other.payload as unknown as ExecutionFinishPayload).status = 'succeeded'
+    ;(other.payload as unknown as ExecutionFinishPayload).execution_summary = {
+      success: false,
+    }
+    expect(outputText(reopen(f.operations))).toContain('conflicting')
+  })
+
+  it('clears recovered output at the next start and ignores late finishes from the old run', () => {
+    const f = fixture()
+    f.finish('left', [f.start.op_id])
+    f.finish('right', [f.start.op_id])
+    const oldHeads = causalHeads(f.operations)
+    f.append('execution.start', {
+      ...(f.start.payload as object),
+      execution_id: 'run-2',
+    } as JsonValue)
+    expect(reopen(f.operations).cells[0]!.outputs).toEqual([])
+    f.finish('fresh output', undefined, 'run-2')
+    f.finish('late old output', oldHeads)
+    expect(outputText(reopen(f.operations))).toBe('fresh output')
+    f.append('cell.clear_outputs', {
+      cell_id: 'cell-1',
+      reason: 'user-cleared',
+    })
+    expect(reopen(f.operations).cells[0]!.outputs).toEqual([])
+  })
+
+  it.each([null, {}, { items: [{ data: 'not-valid-base64!!!' }] }])(
+    'isolates malformed protobuf output %j to its cell',
+    (badOutput) => {
+      const f = fixture()
+      const finish = f.finish('valid')
+      ;(finish.payload as unknown as ExecutionFinishPayload).outputs = [
+        badOutput as JsonValue,
+      ]
+      // An empty object is a valid empty protobuf output; corrupt values get a diagnostic.
+      const notebook = reopen(f.operations)
+      expect(notebook.cells[0]!.value).toContain('console.log')
+      if (badOutput === null || 'items' in badOutput)
+        expect(outputText(notebook)).toContain('corrupt saved output')
+    }
+  )
+
+  it('opens a malformed outputs collection with a diagnostic instead of throwing', () => {
+    const f = fixture()
+    const finish = f.finish('valid')
+    ;(finish.payload as unknown as ExecutionFinishPayload).outputs =
+      null as unknown as JsonValue[]
+    expect(outputText(reopen(f.operations))).toContain('completion records')
+  })
+
+  it('keeps recovered source editable through save/reopen and never journals the diagnostic', async () => {
+    const f = fixture()
+    f.finish('left', [f.start.op_id])
+    f.finish('right', [f.start.op_id])
+    const previous = reopen(f.operations)
+    expect(previous.cells[0]!.outputs[0]!.metadata[RECOVERED_OUTPUT_KEY]).toBe(
+      'true'
+    )
+    const edited = cloneNotebook(previous)
+    edited.cells[0]!.value = 'console.log("edited")'
+    const changes = await buildOperationLogDiff({
+      previous,
+      next: edited,
+      observedOperations: f.operations,
+      actorId: 'editor',
+      firstActorSequence: 1,
+    })
+    expect(changes.map((op) => op.kind)).toEqual(['cell.update'])
+    expect(JSON.stringify(changes)).not.toContain('conflicting or invalid')
+    f.operations.push(...changes)
+    const saved = reopen(f.operations)
+    expect(saved.cells[0]!.value).toBe('console.log("edited")')
+    expect(outputText(saved)).toContain('conflicting')
+
+    const running = cloneNotebook(saved)
+    running.cells[0]!.metadata[RunmeMetadataKey.LastRunID] = 'rerun'
+    running.cells[0]!.metadata[RunmeMetadataKey.ExecutionState] =
+      RunmeExecutionState.Running
+    running.cells[0]!.outputs = []
+    const rerun = await buildOperationLogDiff({
+      previous: saved,
+      next: running,
+      observedOperations: f.operations,
+      actorId: 'runner',
+      firstActorSequence: 1,
+    })
+    f.operations.push(...rerun)
+    expect(reopen(f.operations).cells[0]!.outputs).toEqual([])
+    f.finish('recovered', undefined, 'rerun')
+    expect(outputText(reopen(f.operations))).toBe('recovered')
+  })
+})

--- a/app/src/lib/operationLog/executionRecovery.test.ts
+++ b/app/src/lib/operationLog/executionRecovery.test.ts
@@ -103,6 +103,70 @@ function outputText(notebook: parser_pb.Notebook) {
 }
 
 describe('execution output recovery', () => {
+  it('preserves the only completed result when another tab concurrently starts a run', () => {
+    const f = fixture()
+    f.append(
+      'execution.start',
+      {
+        ...(f.start.payload as object),
+        execution_id: 'concurrent-run',
+      } as JsonValue,
+      f.start.deps
+    )
+    f.finish('available output', [f.start.op_id])
+    expect(outputText(reopen(f.operations))).toBe('available output')
+    expect(outputText(reopen([...f.operations].reverse()))).toBe(
+      'available output'
+    )
+  })
+
+  it('shows conflicting concurrent runs until a causally later rerun replaces both', () => {
+    const f = fixture()
+    const concurrent = f.append(
+      'execution.start',
+      {
+        ...(f.start.payload as object),
+        execution_id: 'concurrent-run',
+      } as JsonValue,
+      f.start.deps
+    )
+    f.finish('left', [f.start.op_id])
+    f.finish('right', [concurrent.op_id], 'concurrent-run')
+    expect(outputText(reopen(f.operations))).toContain('Concurrent executions')
+    expect(outputText(reopen([...f.operations].reverse()))).toBe(
+      outputText(reopen(f.operations))
+    )
+    f.append('execution.start', {
+      ...(f.start.payload as object),
+      execution_id: 'rerun',
+    } as JsonValue)
+    expect(reopen(f.operations).cells[0]!.outputs).toEqual([])
+    f.finish('fresh output', undefined, 'rerun')
+    expect(outputText(reopen(f.operations))).toBe('fresh output')
+  })
+
+  it('retains valid output siblings when one output fails protobuf decoding', () => {
+    const f = fixture()
+    const finish = f.finish('valid stdout')
+    const payload = finish.payload as unknown as ExecutionFinishPayload
+    payload.outputs = [
+      payload.outputs[0]!,
+      null,
+      { items: [{ mime: 'text/plain', data: 'dmFsaWQgcmlnaHQ=' }] },
+    ]
+    const notebook = reopen(f.operations)
+    expect(notebook.cells[0]!.outputs).toHaveLength(3)
+    expect(
+      new TextDecoder().decode(notebook.cells[0]!.outputs[0]!.items[0]!.data)
+    ).toBe('valid stdout')
+    expect(
+      new TextDecoder().decode(notebook.cells[0]!.outputs[1]!.items[0]!.data)
+    ).toContain('corrupt saved output (item 2)')
+    expect(
+      new TextDecoder().decode(notebook.cells[0]!.outputs[2]!.items[0]!.data)
+    ).toBe('valid right')
+  })
+
   it('uses a causally later completion to retain late output, regardless of timestamp', () => {
     const f = fixture()
     f.finish('first chunk')

--- a/app/src/lib/operationLog/executionRecovery.ts
+++ b/app/src/lib/operationLog/executionRecovery.ts
@@ -7,7 +7,7 @@ export interface ExecutionFinishRecord {
 }
 
 /** Follow dependencies, not timestamps or file order, to identify output updates. */
-function observes(
+export function operationObserves(
   operation: RunmeOperation,
   ancestorId: string,
   operations: Map<string, RunmeOperation>
@@ -32,7 +32,7 @@ export function advanceExecutionFinishes(
 ): ExecutionFinishRecord[] {
   return [
     ...previous.filter(
-      (finish) => !observes(operation, finish.operationId, operations)
+      (finish) => !operationObserves(operation, finish.operationId, operations)
     ),
     {
       payload: operation.payload as unknown as ExecutionFinishPayload,
@@ -46,6 +46,13 @@ export function executionFinishError(
   finishes: ExecutionFinishRecord[]
 ): string | undefined {
   const first = finishes[0]!.payload
+  const executionIds = [
+    ...new Set(finishes.map(({ payload }) => payload.execution_id)),
+  ]
+  const subject =
+    executionIds.length === 1
+      ? `Execution ${first.execution_id} has`
+      : `Concurrent executions ${executionIds.join(', ')} have`
   const result = (payload: ExecutionFinishPayload): JsonValue => ({
     status: payload.status,
     outputs: payload.outputs,
@@ -63,7 +70,7 @@ export function executionFinishError(
           !canonicalJsonEqual(result(first), result(payload))
       )
     ) {
-      return `Execution ${first.execution_id} has conflicting or invalid completion records. Its saved output cannot be determined. Run this cell again to replace this error with new output.`
+      return `${subject} conflicting or invalid completion records. The saved output cannot be determined. Run this cell again to replace this error with new output.`
     }
   } catch {
     return `Execution ${first.execution_id} has invalid saved output. Run this cell again to replace this error with new output.`

--- a/app/src/lib/operationLog/executionRecovery.ts
+++ b/app/src/lib/operationLog/executionRecovery.ts
@@ -1,0 +1,72 @@
+import { canonicalJsonEqual } from './canonicalJson'
+import type { ExecutionFinishPayload, JsonValue, RunmeOperation } from './types'
+
+export interface ExecutionFinishRecord {
+  payload: ExecutionFinishPayload
+  operationId: string
+}
+
+/** Follow dependencies, not timestamps or file order, to identify output updates. */
+function observes(
+  operation: RunmeOperation,
+  ancestorId: string,
+  operations: Map<string, RunmeOperation>
+): boolean {
+  const pending = [...operation.deps]
+  const visited = new Set<string>()
+  while (pending.length) {
+    const id = pending.pop()!
+    if (id === ancestorId) return true
+    if (visited.has(id)) continue
+    visited.add(id)
+    pending.push(...(operations.get(id)?.deps ?? []))
+  }
+  return false
+}
+
+/** Retain concurrent finishes; a causally later finish includes late output. */
+export function advanceExecutionFinishes(
+  previous: ExecutionFinishRecord[],
+  operation: RunmeOperation,
+  operations: Map<string, RunmeOperation>
+): ExecutionFinishRecord[] {
+  return [
+    ...previous.filter(
+      (finish) => !observes(operation, finish.operationId, operations)
+    ),
+    {
+      payload: operation.payload as unknown as ExecutionFinishPayload,
+      operationId: operation.op_id,
+    },
+  ]
+}
+
+/** Concurrent identical results are harmless; conflicting results stay visible as an error. */
+export function executionFinishError(
+  finishes: ExecutionFinishRecord[]
+): string | undefined {
+  const first = finishes[0]!.payload
+  const result = (payload: ExecutionFinishPayload): JsonValue => ({
+    status: payload.status,
+    outputs: payload.outputs,
+    execution_summary: payload.execution_summary,
+  })
+  try {
+    if (
+      finishes.some(
+        ({ payload }) =>
+          !Array.isArray(payload.outputs) ||
+          !['succeeded', 'failed', 'cancelled', 'lost'].includes(
+            payload.status
+          ) ||
+          !payload.execution_summary ||
+          !canonicalJsonEqual(result(first), result(payload))
+      )
+    ) {
+      return `Execution ${first.execution_id} has conflicting or invalid completion records. Its saved output cannot be determined. Run this cell again to replace this error with new output.`
+    }
+  } catch {
+    return `Execution ${first.execution_id} has invalid saved output. Run this cell again to replace this error with new output.`
+  }
+  return undefined
+}

--- a/app/src/lib/operationLog/materialize.ts
+++ b/app/src/lib/operationLog/materialize.ts
@@ -2,6 +2,7 @@ import {
   type ExecutionFinishRecord,
   advanceExecutionFinishes,
   executionFinishError,
+  operationObserves,
 } from './executionRecovery'
 import { committedOperationIds, orderOperationSet } from './order'
 import { comparePositionIds, validatePositionId } from './positions'
@@ -129,8 +130,8 @@ export function materializeOperationLog(
     { payload: ExecutionStartPayload; operationId: string }
   >()
   const executionFinishes = new Map<string, ExecutionFinishRecord[]>()
-  // A late finish from an old run must not overwrite output from a rerun.
-  const activeExecutions = new Map<string, string>()
+  // Keep concurrent starts; only a causally later start supersedes an old run.
+  const activeExecutions = new Map<string, RunmeOperation[]>()
   const comments: MaterializedComment[] = []
   const historicalSources = new Map<string, string>()
   const migratedComments = new Set(
@@ -207,6 +208,30 @@ export function materializeOperationLog(
     const created: CellRegisters = {}
     cells.set(cellId, created)
     return created
+  }
+
+  /** Project all live runs together without letting actor sort order hide results. */
+  const updateExecutionOutputs = (cellId: string, operationId: string) => {
+    const finishes = (activeExecutions.get(cellId) ?? []).flatMap(
+      (start) =>
+        executionFinishes.get(
+          (start.payload as unknown as ExecutionStartPayload).execution_id
+        ) ?? []
+    )
+    const error = finishes.length ? executionFinishError(finishes) : undefined
+    const finish = finishes.at(-1)
+    const start = finish
+      ? executionStarts.get(finish.payload.execution_id)
+      : undefined
+    registersFor(cellId).outputs = {
+      value: {
+        outputs: error ? [] : (finish?.payload.outputs ?? []),
+        error,
+        executionId: finish?.payload.execution_id,
+        sourceOperationId: start?.payload.source_op_id,
+      },
+      operationId,
+    }
   }
 
   for (const operation of ordered.ordered) {
@@ -307,12 +332,13 @@ export function materializeOperationLog(
           payload,
           operationId: operation.op_id,
         })
-        activeExecutions.set(payload.cell_id, payload.execution_id)
-        const registers = registersFor(payload.cell_id)
-        registers.outputs = {
-          value: { outputs: [] },
-          operationId: operation.op_id,
-        }
+        activeExecutions.set(payload.cell_id, [
+          ...(activeExecutions.get(payload.cell_id) ?? []).filter(
+            (start) => !operationObserves(operation, start.op_id, operationById)
+          ),
+          operation,
+        ])
+        updateExecutionOutputs(payload.cell_id, operation.op_id)
         break
       }
       case 'execution.finish': {
@@ -330,19 +356,13 @@ export function materializeOperationLog(
         )
         executionFinishes.set(payload.execution_id, finishes)
         if (
-          activeExecutions.get(start.payload.cell_id) !== payload.execution_id
+          (activeExecutions.get(start.payload.cell_id) ?? []).some(
+            (active) =>
+              (active.payload as unknown as ExecutionStartPayload)
+                .execution_id === payload.execution_id
+          )
         )
-          break
-        const error = executionFinishError(finishes)
-        registersFor(start.payload.cell_id).outputs = {
-          value: {
-            outputs: error ? [] : payload.outputs,
-            error,
-            executionId: payload.execution_id,
-            sourceOperationId: start.payload.source_op_id,
-          },
-          operationId: operation.op_id,
-        }
+          updateExecutionOutputs(start.payload.cell_id, operation.op_id)
         break
       }
       case 'comment.add': {

--- a/app/src/lib/operationLog/materialize.ts
+++ b/app/src/lib/operationLog/materialize.ts
@@ -1,3 +1,8 @@
+import {
+  type ExecutionFinishRecord,
+  advanceExecutionFinishes,
+  executionFinishError,
+} from './executionRecovery'
 import { committedOperationIds, orderOperationSet } from './order'
 import { comparePositionIds, validatePositionId } from './positions'
 import { type CommentRecord, serializedRecord } from './records'
@@ -35,6 +40,7 @@ interface CellRegisters {
     outputs: JsonValue[]
     executionId?: string
     sourceOperationId?: string
+    error?: string
   }>
 }
 
@@ -45,6 +51,7 @@ export interface MaterializedCell extends OperationCell {
   outputs: JsonValue[]
   output_execution_id?: string
   outputs_stale: boolean
+  output_error?: string
 }
 
 export interface MaterializedExecution {
@@ -53,6 +60,7 @@ export interface MaterializedExecution {
   finish?: ExecutionFinishPayload
   start_operation_id: string
   finish_operation_id?: string
+  finish_error?: string
 }
 
 export interface MaterializedComment {
@@ -120,10 +128,9 @@ export function materializeOperationLog(
     string,
     { payload: ExecutionStartPayload; operationId: string }
   >()
-  const executionFinishes = new Map<
-    string,
-    { payload: ExecutionFinishPayload; operationId: string }
-  >()
+  const executionFinishes = new Map<string, ExecutionFinishRecord[]>()
+  // A late finish from an old run must not overwrite output from a rerun.
+  const activeExecutions = new Map<string, string>()
   const comments: MaterializedComment[] = []
   const historicalSources = new Map<string, string>()
   const migratedComments = new Set(
@@ -300,28 +307,37 @@ export function materializeOperationLog(
           payload,
           operationId: operation.op_id,
         })
+        activeExecutions.set(payload.cell_id, payload.execution_id)
+        const registers = registersFor(payload.cell_id)
+        registers.outputs = {
+          value: { outputs: [] },
+          operationId: operation.op_id,
+        }
         break
       }
       case 'execution.finish': {
         const payload = operation.payload as unknown as ExecutionFinishPayload
-        if (executionFinishes.has(payload.execution_id)) {
-          throw new Error(
-            `Execution ${payload.execution_id} has more than one finish`
-          )
-        }
         const start = executionStarts.get(payload.execution_id)
         if (!start) {
           throw new Error(
             `Execution ${payload.execution_id} finished before its start`
           )
         }
-        executionFinishes.set(payload.execution_id, {
-          payload,
-          operationId: operation.op_id,
-        })
+        const finishes = advanceExecutionFinishes(
+          executionFinishes.get(payload.execution_id) ?? [],
+          operation,
+          operationById
+        )
+        executionFinishes.set(payload.execution_id, finishes)
+        if (
+          activeExecutions.get(start.payload.cell_id) !== payload.execution_id
+        )
+          break
+        const error = executionFinishError(finishes)
         registersFor(start.payload.cell_id).outputs = {
           value: {
-            outputs: payload.outputs,
+            outputs: error ? [] : payload.outputs,
+            error,
             executionId: payload.execution_id,
             sourceOperationId: start.payload.source_op_id,
           },
@@ -488,6 +504,7 @@ export function materializeOperationLog(
       outputs: output.outputs,
       output_execution_id: output.executionId,
       outputs_stale: stale,
+      output_error: output.error,
     })
   }
   visibleCells.sort((left, right) => {
@@ -503,13 +520,16 @@ export function materializeOperationLog(
 
   const executions: MaterializedExecution[] = [...executionStarts].map(
     ([executionId, start]) => {
-      const finish = executionFinishes.get(executionId)
+      const finishes = executionFinishes.get(executionId)
+      const error = finishes ? executionFinishError(finishes) : undefined
+      const finish = error ? undefined : finishes?.at(-1)
       return {
         execution_id: executionId,
         start: start.payload,
         finish: finish?.payload,
         start_operation_id: start.operationId,
         finish_operation_id: finish?.operationId,
+        finish_error: error,
       }
     }
   )

--- a/app/src/lib/operationLog/notebook.ts
+++ b/app/src/lib/operationLog/notebook.ts
@@ -1,11 +1,12 @@
 import { create, fromJson } from '@bufbuild/protobuf'
 
 import { MimeType, parser_pb } from '../../runme/client'
+import { RECOVERED_OUTPUT_KEY } from '../recoveredOutputs'
 import { canonicalJson } from './canonicalJson'
 import type { MaterializedOperationLog } from './materialize'
 import type { JsonValue } from './types'
 
-export const RECOVERED_OUTPUT_KEY = 'runme.dev/recovered-output'
+export { RECOVERED_OUTPUT_KEY } from '../recoveredOutputs'
 
 /** A transient stderr output uses the normal renderer and is cleared on execution. */
 function recoveryOutput(message: string): parser_pb.CellOutput {

--- a/app/src/lib/operationLog/notebook.ts
+++ b/app/src/lib/operationLog/notebook.ts
@@ -57,19 +57,17 @@ export function materializedLogToNotebook(
       result.value = cell.value
       result.metadata = stringRecord(cell.metadata)
       // Bad execution output must never prevent access to the editable source.
-      try {
-        result.outputs = cell.output_error
-          ? [recoveryOutput(cell.output_error)]
-          : cell.outputs.map((output) =>
-              fromJson(parser_pb.CellOutputSchema, output)
-            )
-      } catch {
-        result.outputs = [
-          recoveryOutput(
-            'This cell has corrupt saved output. Run this cell again to replace this error with new output.'
-          ),
-        ]
-      }
+      result.outputs = cell.output_error
+        ? [recoveryOutput(cell.output_error)]
+        : cell.outputs.map((output, index) => {
+            try {
+              return fromJson(parser_pb.CellOutputSchema, output)
+            } catch {
+              return recoveryOutput(
+                `This cell has corrupt saved output (item ${index + 1}). Run this cell again to replace this error with new output.`
+              )
+            }
+          })
       return result
     }),
   })

--- a/app/src/lib/operationLog/notebook.ts
+++ b/app/src/lib/operationLog/notebook.ts
@@ -1,9 +1,25 @@
 import { create, fromJson } from '@bufbuild/protobuf'
 
-import { parser_pb } from '../../runme/client'
+import { MimeType, parser_pb } from '../../runme/client'
 import { canonicalJson } from './canonicalJson'
 import type { MaterializedOperationLog } from './materialize'
 import type { JsonValue } from './types'
+
+export const RECOVERED_OUTPUT_KEY = 'runme.dev/recovered-output'
+
+/** A transient stderr output uses the normal renderer and is cleared on execution. */
+function recoveryOutput(message: string): parser_pb.CellOutput {
+  return create(parser_pb.CellOutputSchema, {
+    metadata: { [RECOVERED_OUTPUT_KEY]: 'true' },
+    items: [
+      create(parser_pb.CellOutputItemSchema, {
+        mime: MimeType.VSCodeNotebookStdErr,
+        type: 'Buffer',
+        data: new TextEncoder().encode(message),
+      }),
+    ],
+  })
+}
 
 function stringValue(value: JsonValue): string {
   return typeof value === 'string' ? value : canonicalJson(value)
@@ -40,9 +56,20 @@ export function materializedLogToNotebook(
       result.languageId = cell.language_id
       result.value = cell.value
       result.metadata = stringRecord(cell.metadata)
-      result.outputs = cell.outputs.map((output) =>
-        fromJson(parser_pb.CellOutputSchema, output)
-      )
+      // Bad execution output must never prevent access to the editable source.
+      try {
+        result.outputs = cell.output_error
+          ? [recoveryOutput(cell.output_error)]
+          : cell.outputs.map((output) =>
+              fromJson(parser_pb.CellOutputSchema, output)
+            )
+      } catch {
+        result.outputs = [
+          recoveryOutput(
+            'This cell has corrupt saved output. Run this cell again to replace this error with new output.'
+          ),
+        ]
+      }
       return result
     }),
   })

--- a/app/src/lib/recoveredOutputs.ts
+++ b/app/src/lib/recoveredOutputs.ts
@@ -1,0 +1,20 @@
+import { clone } from '@bufbuild/protobuf'
+
+import { parser_pb } from '../runme/client'
+
+export const RECOVERED_OUTPUT_KEY = 'runme.dev/recovered-output'
+
+/** Identify diagnostics that explain saved corruption but are not execution results. */
+export function isRecoveredOutput(output: parser_pb.CellOutput): boolean {
+  return output.metadata?.[RECOVERED_OUTPUT_KEY] === 'true'
+}
+
+/** Export a copy without transient diagnostics; leave the editable model intact. */
+export function withoutRecoveredOutputs(
+  notebook: parser_pb.Notebook
+): parser_pb.Notebook {
+  const copy = clone(parser_pb.NotebookSchema, notebook)
+  for (const cell of copy.cells)
+    cell.outputs = cell.outputs.filter((output) => !isRecoveredOutput(output))
+  return copy
+}

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -8027,3 +8027,103 @@ describe('LocalNotebooks markdown sidecar sync', () => {
     })
   })
 })
+
+it('opens, edits, saves and reruns a .runme notebook with conflicting execution finishes', async () => {
+  const operationLogStorage = new MemoryOperationLogStorage()
+  const store = createTestStore({}, { operationLogStorage })
+  await store.folders.put({
+    id: LOCAL_FOLDER_URI,
+    name: 'Local Notebooks',
+    remoteId: '',
+    children: [],
+    lastSynced: '',
+  })
+  const file = await store.create(LOCAL_FOLDER_URI, 'recovered.runme')
+  const initialWriter = await store.createOperationLogSaveStore(file.uri, {
+    actorId: 'initial',
+  })
+  const output = (text: string) =>
+    create(parser_pb.CellOutputSchema, {
+      items: [
+        create(parser_pb.CellOutputItemSchema, {
+          mime: MimeType.VSCodeNotebookStdOut,
+          type: 'Buffer',
+          data: new TextEncoder().encode(text),
+        }),
+      ],
+    })
+  const notebook = create(parser_pb.NotebookSchema, {
+    cells: [
+      create(parser_pb.CellSchema, {
+        refId: 'recovery-cell',
+        kind: parser_pb.CellKind.CODE,
+        languageId: 'javascript',
+        value: 'console.log("original")',
+        metadata: {
+          [RunmeMetadataKey.LastRunID]: 'run-1',
+          [RunmeMetadataKey.ExecutionState]: 'completed',
+        },
+        outputs: [output('left')],
+      }),
+    ],
+  })
+  await initialWriter.save(file.uri, notebook)
+  const original = parseOperationLog(await store.loadContent(file.uri))
+  const start = original.operations.find((op) => op.kind === 'execution.start')!
+  const finish = original.operations.find(
+    (op) => op.kind === 'execution.finish'
+  )!
+  const conflict = createRunmeOperation({
+    actorId: 'concurrent',
+    actorSequence: 1,
+    dependencies: [start.op_id],
+    knownOperations: original.operations,
+    kind: 'execution.finish',
+    payload: {
+      ...(finish.payload as object),
+      outputs: [
+        JSON.parse(toJsonString(parser_pb.CellOutputSchema, output('right'))),
+      ],
+    },
+  })
+  const record = (await store.files.get(file.uri))!
+  await operationLogStorage.appendTransaction(
+    record.operationLogRef!,
+    async () => `${JSON.stringify(conflict)}\n`
+  )
+
+  const reopened = await store.load(file.uri)
+  const text = (nb: parser_pb.Notebook) =>
+    nb.cells[0]!.outputs.flatMap((o) =>
+      o.items.map((i) => new TextDecoder().decode(i.data))
+    ).join('')
+  expect(text(reopened)).toContain('conflicting')
+  const writer = await store.createOperationLogSaveStore(file.uri, {
+    actorId: 'recovery-editor',
+  })
+  reopened.cells[0]!.value = 'console.log("edited")'
+  await writer.save(file.uri, reopened)
+  const saved = await store.load(file.uri)
+  expect(saved.cells[0]!.value).toBe('console.log("edited")')
+  expect(text(saved)).toContain('conflicting')
+  const history = parseOperationLog(await store.loadContent(file.uri))
+  expect(history.operations).toEqual(
+    expect.arrayContaining([...original.operations, conflict])
+  )
+  expect(
+    history.operations.filter((op) => op.kind === 'execution.finish')
+  ).toHaveLength(2)
+  expect(JSON.stringify(history.operations)).not.toContain(
+    'conflicting or invalid'
+  )
+
+  saved.cells[0]!.metadata[RunmeMetadataKey.LastRunID] = 'run-2'
+  saved.cells[0]!.metadata[RunmeMetadataKey.ExecutionState] = 'running'
+  saved.cells[0]!.outputs = []
+  await writer.save(file.uri, saved)
+  expect((await store.load(file.uri)).cells[0]!.outputs).toEqual([])
+  saved.cells[0]!.metadata[RunmeMetadataKey.ExecutionState] = 'completed'
+  saved.cells[0]!.outputs = [output('fresh output')]
+  await writer.save(file.uri, saved)
+  expect(text(await store.load(file.uri))).toBe('fresh output')
+})

--- a/docs-dev/cujs/README.md
+++ b/docs-dev/cujs/README.md
@@ -32,6 +32,8 @@ from `docs-dev/cujs/`.
     deterministic convergence,
   - exercise operation-log comment lifecycle and durable reload.
 
+- execution-output-recovery.md — open, edit, save, reload, and rerun notebooks with conflicting execution results; retain history and replace ambiguous output with a cell-level diagnostic.
+
 ## How CUJs are executed
 
 - Scripted runner(s) live under `app/test/browser/`.

--- a/docs-dev/cujs/execution-output-recovery.md
+++ b/docs-dev/cujs/execution-output-recovery.md
@@ -21,6 +21,11 @@ and run the affected cell again.
    reload retains that result. A late finish from the old run cannot restore the
    diagnostic or overwrite the new output.
 
+6. Explicitly clear the recovered outputs and reload. They remain cleared while
+   the original finish records remain in history.
+7. Export to IPYNB, legacy JSON, or Markdown. Display-only diagnostics are omitted;
+   valid sibling outputs remain. Exporting must not change the editable model.
+
 ## Regression coverage
 
 - `app/src/lib/operationLog/executionRecovery.test.ts` exercises causal ordering,

--- a/docs-dev/cujs/execution-output-recovery.md
+++ b/docs-dev/cujs/execution-output-recovery.md
@@ -1,0 +1,34 @@
+# Execution output recovery
+
+## User journey
+
+An existing `.runme` notebook contains multiple completion records for the same
+execution. The user must still be able to open it, edit its cells, save changes,
+and run the affected cell again.
+
+## Acceptance criteria
+
+1. Causally ordered completion records retain the latest result, including late
+   output. Wall-clock timestamps do not determine which result wins.
+2. Concurrent records with identical results display that result. Concurrent
+   records with conflicting results display a diagnostic in the affected cell's
+   outputs. Malformed saved output also produces a cell-level diagnostic.
+3. The notebook opens normally and remains writable. Other cells and source text
+   remain available. The original operation history is preserved.
+4. Edit the affected cell, save, and reload. The edit and diagnostic both remain.
+   The diagnostic must not be appended as a real execution result.
+5. Run the affected cell. The diagnostic clears, the new result appears, and a
+   reload retains that result. A late finish from the old run cannot restore the
+   diagnostic or overwrite the new output.
+
+## Regression coverage
+
+- `app/src/lib/operationLog/executionRecovery.test.ts` exercises causal ordering,
+  concurrent conflicts, malformed output, source edits, and reruns.
+- `app/src/storage/local.test.ts` exercises opening, saving, and reopening the
+  damaged history through the real operation-log storage adapter.
+- For browser verification, create a local JavaScript notebook with two
+  conflicting finishes that both depend on the same start. Open it in the editor,
+  type a source edit, reload, then use the Run button with the browser runner.
+  Verify the rendered diagnostic and replacement output, and capture screenshots
+  under `app/test/browser/test-output/`.


### PR DESCRIPTION
Keep notebooks editable when execution history contains duplicate or conflicting completion records. Previously, a second `execution.finish` aborted reconstruction of the entire notebook, including on the save path.

Replay now keeps causally later completion results (including late output updates), accepts equivalent concurrent results, and shows a cell-level output diagnostic when concurrent results disagree. Concurrent starts remain eligible until causally superseded. Invalid saved output produces an individual diagnostic while valid sibling outputs remain visible. A causally later execution clears the old output, and a delayed finish from an older run cannot overwrite the new result.

Original history is retained. Display-only diagnostics are excluded from the editor journal and IPYNB, legacy JSON, and Markdown exports. Explicitly clearing recovered output persists across reopening without deleting original execution records.

Update the root and app agent instructions to require graceful, editable recovery from corrupt notebooks, with preservation of original history and open/edit/save/reopen/rerun coverage. Document that recovery journey in the CUJs.

Validation:
- `runme run build test` passed.
- All 268 focused operation-log, storage, and export tests passed, including recovery, concurrent runs, valid sibling outputs, persistent clearing, failed setup, export isolation, and save/reopen/rerun regressions.
- Chromium UI verification passed: open the conflicting notebook, type into Monaco, wait for the actual saved log, reload, run with AppKernel, verify the diagnostic disappears and fresh output survives reload.
- TypeScript diagnostics match the base commit (173 diagnostic/output lines; no added diagnostics).
- The broader app suite encountered an existing comment-lifecycle timeout (also reproduced on the unmodified base) and a copy-selection timing failure. Both passed in isolation with a 20-second test timeout; the comment test took 7.4 seconds versus the default 5-second limit.
