### PR TITLE
Recover failed Colab exports after reconnect

### DIFF
--- a/app/src/components/NotebookPropertiesDialog.test.tsx
+++ b/app/src/components/NotebookPropertiesDialog.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   flushPendingPersist: vi.fn(async () => {}),
   getIpynbExportState: vi.fn(async () => ({})),
   retryUnconfirmedIpynbCreation: vi.fn(async () => {}),
+  syncIpynbFile: vi.fn(async () => {}),
 }))
 vi.mock('../contexts/NotebookContext', () => ({
   useNotebookContext: () => ({
@@ -24,6 +25,7 @@ vi.mock('../contexts/NotebookStoreContext', () => ({
     store: {
       getIpynbExportState: mocks.getIpynbExportState,
       retryUnconfirmedIpynbCreation: mocks.retryUnconfirmedIpynbCreation,
+      syncIpynbFile: mocks.syncIpynbFile,
       subscribeSync: () => () => {},
     },
   }),
@@ -32,6 +34,8 @@ vi.mock('../contexts/NotebookStoreContext', () => ({
 describe('Notebook properties', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.getIpynbExportState.mockResolvedValue({})
+    mocks.syncIpynbFile.mockResolvedValue()
     mocks.snapshot = {
       loaded: true,
       readOnly: false,
@@ -84,6 +88,32 @@ describe('Notebook properties', () => {
       true
     )
   })
+  it('retries a failed export without changing the saved notebook', async () => {
+    mocks.snapshot.notebook.metadata[AUTO_IPYNB_KEY] = 'true'
+    mocks.getIpynbExportState.mockResolvedValue({
+      error: 'Unsupported notebook log format_version 2',
+    })
+    mocks.syncIpynbFile.mockRejectedValueOnce(new Error('Drive is offline'))
+    render(
+      <Theme>
+        <NotebookPropertiesDialog uri="local://file/test" onClose={() => {}} />
+      </Theme>
+    )
+    const retry = await screen.findByRole('button', {
+      name: 'Retry Colab export',
+    })
+    expect(
+      screen.queryByText(/Waiting for the next background export/)
+    ).toBeNull()
+    fireEvent.click(retry)
+    await screen.findByText('Export retry failed: Error: Drive is offline')
+    expect(mocks.syncIpynbFile).toHaveBeenCalledWith('local://file/test')
+    expect(mocks.setMetadataProperty).not.toHaveBeenCalled()
+    expect(mocks.flushPendingPersist).not.toHaveBeenCalled()
+    fireEvent.click(retry)
+    await waitFor(() => expect(mocks.syncIpynbFile).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText(/Export retry failed/)).toBeNull()
+  })
   it('requires confirmation before retrying an unconfirmed creation', async () => {
     mocks.snapshot.notebook.metadata[AUTO_IPYNB_KEY] = 'true'
     mocks.getIpynbExportState.mockResolvedValue({ needsCreateRecovery: true })
@@ -96,6 +126,9 @@ describe('Notebook properties', () => {
     const retry = await screen.findByRole('button', {
       name: 'Retry unconfirmed creation',
     })
+    expect(
+      screen.queryByRole('button', { name: 'Retry Colab export' })
+    ).toBeNull()
     fireEvent.click(retry)
     expect(mocks.retryUnconfirmedIpynbCreation).not.toHaveBeenCalled()
     confirm.mockReturnValue(true)

--- a/app/src/components/NotebookPropertiesDialog.tsx
+++ b/app/src/components/NotebookPropertiesDialog.tsx
@@ -24,6 +24,8 @@ export function NotebookPropertiesDialog({
   }>({})
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [retrying, setRetrying] = useState(false)
+  const [retryError, setRetryError] = useState('')
   useEffect(() => {
     let active = true
     const refresh = () => {
@@ -115,6 +117,26 @@ export function NotebookPropertiesDialog({
                   Drive sync.
                 </p>
               )}
+              {enabled && status.error && !status.needsCreateRecovery && (
+                <Button
+                  disabled={retrying || saving || !store || snapshot?.readOnly}
+                  onClick={() => {
+                    if (!store) return
+                    setRetrying(true)
+                    setRetryError('')
+                    // Retry the committed snapshot without modifying the notebook.
+                    void store
+                      .syncIpynbFile(uri)
+                      .catch((err) => setRetryError(String(err)))
+                      .finally(() => setRetrying(false))
+                  }}
+                >
+                  {retrying ? 'Retrying export…' : 'Retry Colab export'}
+                </Button>
+              )}
+              {enabled && status.error && retryError && (
+                <p role="alert">Export retry failed: {retryError}</p>
+              )}
               {enabled && status.needsCreateRecovery && !snapshot?.readOnly && (
                 <Button
                   disabled={saving}
@@ -136,7 +158,7 @@ export function NotebookPropertiesDialog({
                   Retry unconfirmed creation
                 </Button>
               )}
-              {enabled && !status.uri && (
+              {enabled && !status.uri && !status.error && (
                 <p className="text-nb-text-muted">
                   Waiting for the next background export and a Google Drive
                   connection.

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -264,6 +264,59 @@ function notebookJson(value: string): string {
 }
 
 describe('LocalNotebooks operation-log storage', () => {
+  it('retries failed V2 exports on reconnect even when the source is already synced', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({})
+      const exportCopy = vi.spyOn(store, 'syncIpynbFile').mockResolvedValue()
+      const syncSource = vi.fn(async () => {})
+      Object.assign(store, { syncFile: syncSource })
+      const record = {
+        id: 'local://file/saved-export',
+        name: 'source.runme',
+        remoteId: 'https://drive.google.com/file/d/source/view',
+        doc: '',
+        lastSynced: '',
+        md5Checksum: 'saved',
+        lastRemoteChecksum: 'saved',
+        operationLogRef: { path: 'source.runme' },
+        ipynbExportError: 'Error: Unsupported notebook log format_version 2',
+      }
+      await store.files.put(record as any)
+      await store.files.put({
+        ...record,
+        id: 'local://file/claim',
+        ipynbExportPendingClaim: 'pending',
+      } as any)
+      await store.files.put({
+        ...record,
+        id: 'local://file/conflict',
+        conflict: {},
+      } as any)
+      await store.files.put({
+        ...record,
+        id: 'local://file/local',
+        remoteId: '',
+      } as any)
+      await store.files.put({
+        ...record,
+        id: 'local://file/success',
+        ipynbExportError: undefined,
+      } as any)
+      expect(await store.listDriveBackedFilesNeedingSync()).toEqual([])
+      expect(await store.enqueueDriveBackedFilesNeedingSync()).toEqual([
+        record.id,
+      ])
+      expect(exportCopy).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(exportCopy).toHaveBeenCalledTimes(1)
+      expect(exportCopy).toHaveBeenCalledWith(record.id)
+      expect(syncSource).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('clears only the recorded unconfirmed claim before an explicit retry', async () => {
     const source = 'https://drive.google.com/file/d/source/view'
     const updateDerivedCopyClaimAfterCheck = vi.fn(async () => false)
@@ -371,7 +424,19 @@ describe('LocalNotebooks operation-log storage', () => {
         'true'
       )
       expect(drive.saveContent).not.toHaveBeenCalled()
+      // An old client can leave this error persisted after a V2 upgrade.
+      // The current exporter must parse the saved V2 log and clear it on success.
+      expect(
+        parseOperationLog(await store.loadContent(created.uri)).header
+          .format_version
+      ).toBe(2)
+      await store.files.update(created.uri, {
+        ipynbExportError: 'Error: Unsupported notebook log format_version 2',
+      })
       await store.syncIpynbFile(created.uri)
+      expect(
+        (await store.getIpynbExportState(created.uri)).error
+      ).toBeUndefined()
       await store.syncIpynbFile(created.uri)
       expect(drive.create).toHaveBeenCalledTimes(1)
       expect(drive.saveContent).toHaveBeenCalledTimes(2)

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -4074,8 +4074,10 @@ export class LocalNotebooks extends Dexie {
   }
 
   /**
-   * Enqueue sync for every Drive-backed file that appears locally modified.
-   * Returns the list of enqueued local URIs.
+   * Resume source saves and failed exports when Drive becomes available.
+   * Export failures are independent of source dirtiness: a saved notebook can
+   * still need its derived copy retried after an app upgrade or auth recovery.
+   * Returns the list of local URIs queued for either kind of work.
    */
   async enqueueDriveBackedFilesNeedingSync(): Promise<string[]> {
     const pending = await this.listDriveBackedFilesNeedingSync()
@@ -4098,7 +4100,23 @@ export class LocalNotebooks extends Dexie {
       this.enqueueSync(uri)
       this.enqueueMarkdownSync(uri)
     }
-    return pending
+    const failedExports = await this.files
+      .filter(
+        (record) =>
+          isDriveUri(record.remoteId) &&
+          Boolean(record.operationLogRef && record.ipynbExportError) &&
+          !record.conflict &&
+          !record.ipynbExportPendingClaim
+      )
+      .toArray()
+    for (const record of failedExports) {
+      // Unconfirmed creates retain their separate, explicit recovery flow.
+      // syncIpynbFile rechecks the saved option before touching Drive.
+      if (!pending.includes(record.id)) this.enqueueIpynbSync(record.id)
+    }
+    return [
+      ...new Set([...pending, ...failedExports.map((record) => record.id)]),
+    ]
   }
 
   private enqueueSync(uri: string): void {

--- a/app/test/browser/run-cuj-scenarios.ts
+++ b/app/test/browser/run-cuj-scenarios.ts
@@ -79,6 +79,7 @@ function fetchWithTimeout(
 }
 
 const SCENARIO_DRIVERS = [
+  join(SCRIPT_DIR, "test-scenario-colab-export-recovery.ts"),
   join(SCRIPT_DIR, "test-scenario-drive-revision-recovery.ts"),
   join(SCRIPT_DIR, "test-scenario-html-cell.ts"),
   join(SCRIPT_DIR, "test-scenario-hello-world.ts"),

--- a/app/test/browser/test-scenario-colab-export-recovery.ts
+++ b/app/test/browser/test-scenario-colab-export-recovery.ts
@@ -1,0 +1,201 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const frontend = process.env.CUJ_FRONTEND_URL ?? 'http://localhost:5173'
+const fakeDrive = process.env.CUJ_FAKE_DRIVE_URL ?? 'http://127.0.0.1:9090'
+const base = dirname(fileURLToPath(import.meta.url)).replace(
+  /[/\\]\.generated$/,
+  ''
+)
+const output = join(base, 'test-output')
+const name = `colab-recovery-${Date.now()}.runme`
+const session = name.replace('.runme', '')
+const evidence: Record<string, unknown> = {}
+mkdirSync(output, { recursive: true })
+
+/** Use an isolated browser profile and the canonical suite's Go Drive service. */
+function browser(...args: string[]): string {
+  return execFileSync('agent-browser', ['--session', session, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  }).trim()
+}
+
+/** Run production modules in the test browser; no fake backend lives in this driver. */
+function evaluate(code: string): any {
+  return JSON.parse(browser('eval', `(async () => { ${code} })()`))
+}
+
+/** Poll asynchronous persistence rather than assuming that a rendered view is saved. */
+function waitFor(code: string, description: string): void {
+  for (let attempt = 0; attempt < 90; attempt++) {
+    if (evaluate(code)) return
+    browser('wait', '500')
+  }
+  throw new Error(`Timed out: ${description}`)
+}
+
+/** Click the real accessible control, ensuring the UI handler performs the retry. */
+function clickButton(label: string): void {
+  browser('find', 'role', 'button', 'click', '--name', label, '--exact')
+}
+
+let recording = false
+try {
+  browser('open', frontend)
+  browser(
+    'record',
+    'start',
+    join(output, 'scenario-colab-export-recovery-walkthrough.webm')
+  )
+  recording = true
+  waitFor(
+    'return Boolean(window.app?.localNotebooks);',
+    'local store initialization'
+  )
+  const fixture = evaluate(`
+    const { DriveNotebookStore } = await import('/src/storage/drive.ts');
+    const { setGoogleDriveBaseUrl } = await import('/src/lib/googleDriveRuntime.ts');
+    const { LOCAL_FOLDER_URI } = await import('/src/storage/local.ts');
+    const { AUTO_IPYNB_KEY } = await import('/src/lib/derivedNotebook.ts');
+    const { parseOperationLog, serializeOperationLog, createRunmeOperation, causalHeads } = await import('/src/lib/operationLog/index.ts');
+    setGoogleDriveBaseUrl(${JSON.stringify(fakeDrive)});
+    const drive = new DriveNotebookStore(async () => 'fake-drive-access-token');
+    const db = window.app.localNotebooks;
+    if (!await db.folders.get(LOCAL_FOLDER_URI)) await db.folders.put({ id: LOCAL_FOLDER_URI, name: 'Local', remoteId: '', children: [], lastSynced: '' });
+    const file = await db.create(LOCAL_FOLDER_URI, ${JSON.stringify(name)});
+    const notebook = await db.load(file.uri);
+    notebook.metadata[AUTO_IPYNB_KEY] = 'true';
+    const journal = await db.createOperationLogSaveStore(file.uri);
+    await journal.save(file.uri, notebook);
+    const log = parseOperationLog(await db.loadContent(file.uri));
+    if (log.header.format_version !== 2) throw new Error('Expected a V2 fixture');
+    log.operations.push(createRunmeOperation({ actorId: 'browser-fixture', actorSequence: 1, knownOperations: log.operations, dependencies: causalHeads(log.operations), kind: 'cell.create', payload: { cell_id: 'colab-recovery-cell', position: [[1, 'browser-fixture', 1]], cell: { kind: 'code', language_id: 'python', value: 'print("colab recovery")', metadata: {} } } }));
+    const content = serializeOperationLog(log.header, log.operations);
+    await db.saveContent(file.uri, content, 'application/vnd.runme.notebook+jsonl');
+    const source = await drive.createContent('https://drive.google.com/drive/folders/shared-folder-123', file.name, content, 'application/vnd.runme.notebook+jsonl');
+    const record = await db.files.get(file.uri);
+    await db.files.update(file.uri, {
+      remoteId: source.uri, lastRemoteChecksum: record.md5Checksum,
+      ipynbExportError: 'Error: Unsupported notebook log format_version 2',
+    });
+    if ((await db.listDriveBackedFilesNeedingSync()).includes(file.uri)) throw new Error('Fixture source must already be saved');
+    sessionStorage.setItem('runme/openNotebooks', JSON.stringify([{ uri: file.uri, name: file.name, type: 'file', children: [] }]));
+    sessionStorage.setItem('runme/currentDoc', file.uri);
+    localStorage.setItem('googleClientConfig', '{}');
+    localStorage.setItem('runme/google-auth/drive-account', 'viewer@acme.example');
+    localStorage.setItem('runme/google-auth/token', JSON.stringify({ token: 'fake-drive-access-token', expiresAt: Date.now() + 600000 }));
+    return { uri: file.uri, remoteUri: source.uri, content };
+  `)
+  const uri = JSON.stringify(fixture.uri)
+  // Reload drops the old in-memory save timers. Auth initialization must recover
+  // this export even though the source checksum has no unapplied edits.
+  browser('reload')
+  waitFor(
+    `
+    const db = window.app?.localNotebooks;
+    if (!db) return false;
+    const state = await db.getIpynbExportState(${uri});
+    return Boolean(state.uri && state.exportedAt && !state.error);
+  `,
+    'automatic export recovery on Drive reconnect'
+  )
+  const firstExport = evaluate(
+    `return await window.app.localNotebooks.getIpynbExportState(${uri});`
+  )
+  evidence.reconnect = firstExport
+  console.log(
+    '[PASS] Drive reconnect exported a saved V2 notebook and cleared its persisted format-version error.'
+  )
+
+  // Fail through the real network path, then restore connectivity without a
+  // reload so the properties button is solely responsible for the next retry.
+  evaluate(`
+    const { setGoogleDriveBaseUrl } = await import('/src/lib/googleDriveRuntime.ts');
+    const db = window.app.localNotebooks;
+    setGoogleDriveBaseUrl(${JSON.stringify(fakeDrive + '/unavailable')});
+    try { await db.syncIpynbFile(${uri}); } catch {}
+    finally { setGoogleDriveBaseUrl(${JSON.stringify(fakeDrive)}); }
+    if (!(await db.getIpynbExportState(${uri})).error) throw new Error('Expected a real export failure');
+    const tab = [...document.querySelectorAll('[role=tab]')].find(node => node.textContent.includes(${JSON.stringify(name)}));
+    if (!tab) throw new Error('Notebook tab missing');
+    const rect = tab.getBoundingClientRect();
+    tab.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true, button: 2, clientX: rect.left + 20, clientY: rect.top + 10 }));
+    return true;
+  `)
+  clickButton('Notebook properties')
+  waitFor(
+    `return [...document.querySelectorAll('button')].some(node => node.textContent === 'Retry Colab export');`,
+    'retry button'
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-colab-export-recovery-error.png')
+  )
+  if (
+    evaluate(
+      `return document.body.textContent.includes('Waiting for the next background export');`
+    )
+  )
+    throw new Error('Error and waiting messages must not appear together')
+  clickButton('Retry Colab export')
+  waitFor(
+    `
+    const state = await window.app.localNotebooks.getIpynbExportState(${uri});
+    return !state.error && state.exportedAt !== ${JSON.stringify(firstExport.exportedAt)};
+  `,
+    'properties retry completion'
+  )
+  waitFor(
+    `return !document.querySelector('[role=dialog]')?.textContent.includes('could not be updated');`,
+    'properties error clears'
+  )
+  evidence.retry = evaluate(`
+    const db = window.app.localNotebooks;
+    const { appState } = await import('/src/lib/runtime/AppState.ts');
+    const state = await db.getIpynbExportState(${uri});
+    if (state.uri !== ${JSON.stringify(firstExport.uri)}) throw new Error('Retry duplicated the derived copy');
+    if (await db.loadContent(${uri}) !== ${JSON.stringify(fixture.content)}) throw new Error('Retry modified source history');
+    const copy = JSON.parse(await appState.driveNotebookStore.loadContent(state.uri));
+    if (copy.metadata.runme.derivedFrom.uri !== ${JSON.stringify(fixture.remoteUri)}) throw new Error('Derived source identity missing');
+    if (!copy.cells.some(cell => JSON.stringify(cell.source).includes('colab recovery'))) throw new Error('Committed cell source missing from Colab copy');
+    return { state, cells: copy.cells.length, sourceUnchanged: true };
+  `)
+  browser(
+    'screenshot',
+    join(output, 'scenario-colab-export-recovery-success.png')
+  )
+  console.log(
+    '[PASS] Notebook properties retried the real export, cleared its error, reused the copy, and left source history unchanged.'
+  )
+  writeFileSync(
+    join(output, 'scenario-colab-export-recovery-assertions.json'),
+    JSON.stringify({ passed: true, evidence }, null, 2)
+  )
+} catch (error) {
+  try {
+    evidence.storage = evaluate(
+      `return (await window.app.localNotebooks.files.toArray()).map(({ id, name, remoteId, ipynbExportError, ipynbExportUri, ipynbExportPendingClaim }) => ({ id, name, remoteId, ipynbExportError, ipynbExportUri, ipynbExportPendingClaim }));`
+    )
+  } catch {}
+  writeFileSync(
+    join(output, 'scenario-colab-export-recovery-assertions.json'),
+    JSON.stringify({ passed: false, error: String(error), evidence }, null, 2)
+  )
+  try {
+    browser(
+      'screenshot',
+      join(output, 'scenario-colab-export-recovery-failure.png')
+    )
+  } catch {}
+  console.log(`[FAIL] ${String(error)}`)
+  throw error
+} finally {
+  try {
+    if (recording) browser('record', 'stop')
+  } finally {
+    browser('close')
+  }
+}

--- a/docs-dev/cujs/README.md
+++ b/docs-dev/cujs/README.md
@@ -32,6 +32,8 @@ from `docs-dev/cujs/`.
     deterministic convergence,
   - exercise operation-log comment lifecycle and durable reload.
 
+- `colab-export-recovery.md` — retry a failed derived copy after Drive reconnects or from Notebook properties without editing its saved source.
+
 ## How CUJs are executed
 
 - Scripted runner(s) live under `app/test/browser/`.

--- a/docs-dev/cujs/colab-export-recovery.md
+++ b/docs-dev/cujs/colab-export-recovery.md
@@ -1,0 +1,33 @@
+# Recover a failed Colab export
+
+## Goal
+
+A failed generated `.ipynb` copy must recover independently of the saved
+`.runme` source. Upgrading the app or reconnecting Drive must not require a
+meaningless source edit to retry an old export failure.
+
+## Journey
+
+1. Enable automatic Colab export on a Drive-backed V2 `.runme` notebook.
+2. Allow the source to sync, then fail its derived export (for example, lose
+   Drive connectivity). The source remains saved and editable.
+3. Open Notebook properties. Verify the export error appears without the
+   generic waiting-for-export message.
+4. Restore Drive connectivity. Verify the failed export is queued even though
+   the source has no pending edits. An error persisted by an older client,
+   including `Unsupported notebook log format_version 2`, follows this path.
+5. Alternatively, click **Retry Colab export**. Verify the button shows progress,
+   failures remain visible, and another retry is possible.
+6. On success, verify the generated copy contains the latest committed content,
+   the error clears, and the existing copy is reused.
+7. Verify unconfirmed creates retain their separate explicit recovery action;
+   the ordinary retry button must not bypass that flow.
+
+## Regression coverage
+
+`app/src/storage/local.test.ts` covers reconnect eligibility, V2 conversion,
+clearing an old error, and reuse of the derived copy.
+`app/src/components/NotebookPropertiesDialog.test.tsx` covers direct retry,
+retry failure, source immutability during export retry, and unconfirmed-create
+isolation. These are unit regressions; this journey has no dedicated browser
+script yet.

--- a/docs-dev/cujs/colab-export-recovery.md
+++ b/docs-dev/cujs/colab-export-recovery.md
@@ -29,5 +29,11 @@ meaningless source edit to retry an old export failure.
 clearing an old error, and reuse of the derived copy.
 `app/src/components/NotebookPropertiesDialog.test.tsx` covers direct retry,
 retry failure, source immutability during export retry, and unconfirmed-create
-isolation. These are unit regressions; this journey has no dedicated browser
-script yet.
+isolation.
+
+`app/test/browser/test-scenario-colab-export-recovery.ts` is registered in the
+canonical scenario suite. It exercises real IndexedDB, OPFS, Drive reconnect,
+and the Notebook properties retry button against the Go Drive fake. It verifies
+the exported cell content, source identity, copy reuse, and unchanged source
+history, and writes assertions, error/success screenshots, and a walkthrough
+video under `app/test/browser/test-output/`.

--- a/testing/fake-drive-server.go
+++ b/testing/fake-drive-server.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"regexp"
@@ -39,6 +41,7 @@ type driveFile struct {
 	Owners        []driveUser       `json:"owners,omitempty"`
 	Capabilities  driveCapabilities `json:"capabilities"`
 	AppProperties map[string]string `json:"appProperties,omitempty"`
+	Properties    map[string]string `json:"properties,omitempty"`
 	Content       string            `json:"-"`
 	Version       int               `json:"version,string"`
 	HeadRev       string            `json:"headRevisionId"`
@@ -154,6 +157,7 @@ func (s *driveStore) create(resource map[string]any) (*driveFile, bool) {
 		MimeType:      stringValue(resource["mimeType"], notebookJSONMime),
 		Parents:       stringSlice(resource["parents"]),
 		AppProperties: stringMap(resource["appProperties"]),
+		Properties:    stringMap(resource["properties"]),
 		OwnedByMe:     true,
 		Owners:        []driveUser{{DisplayName: "Fake Drive User", EmailAddress: "viewer@acme.example", PermissionID: "viewer-acme-1", Me: true}},
 		Capabilities:  driveCapabilities{CanDownload: true},
@@ -185,6 +189,20 @@ func (s *driveStore) updateMetadata(id string, resource map[string]any, addParen
 	}
 	if appProperties, ok := resource["appProperties"]; ok {
 		file.AppProperties = stringMap(appProperties)
+	}
+	// Drive public properties are patched by key; null removes only that key.
+	// Colab exporters coordinate their source claim through this API.
+	if properties, ok := resource["properties"].(map[string]any); ok {
+		if file.Properties == nil {
+			file.Properties = make(map[string]string)
+		}
+		for key, value := range properties {
+			if value == nil {
+				delete(file.Properties, key)
+			} else if text, ok := value.(string); ok {
+				file.Properties[key] = text
+			}
+		}
 	}
 	if addParents != "" && !containsString(file.Parents, addParents) {
 		file.Parents = append(file.Parents, addParents)
@@ -324,6 +342,10 @@ func cloneFile(file *driveFile) *driveFile {
 	for key, value := range file.AppProperties {
 		appProperties[key] = value
 	}
+	properties := make(map[string]string, len(file.Properties))
+	for key, value := range file.Properties {
+		properties[key] = value
+	}
 	return &driveFile{
 		ID:            file.ID,
 		Name:          file.Name,
@@ -334,6 +356,7 @@ func cloneFile(file *driveFile) *driveFile {
 		Owners:        owners,
 		Capabilities:  file.Capabilities,
 		AppProperties: appProperties,
+		Properties:    properties,
 		Content:       file.Content,
 		Version:       file.Version,
 		HeadRev:       file.HeadRev,
@@ -567,6 +590,36 @@ func newDriveHandler(store *driveStore) http.Handler {
 		if err != nil {
 			http.Error(w, "failed to read body", http.StatusBadRequest)
 			return
+		}
+		// Colab publishes metadata and notebook bytes in one multipart update.
+		// Keep MIME framing out of the saved file, just as Drive does.
+		if r.URL.Query().Get("uploadType") == "multipart" {
+			_, params, parseErr := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if parseErr != nil || params["boundary"] == "" {
+				http.Error(w, "invalid multipart content type", http.StatusBadRequest)
+				return
+			}
+			reader := multipart.NewReader(strings.NewReader(string(body)), params["boundary"])
+			metadataPart, parseErr := reader.NextPart()
+			var resource map[string]any
+			if parseErr != nil || json.NewDecoder(metadataPart).Decode(&resource) != nil {
+				http.Error(w, "invalid multipart metadata", http.StatusBadRequest)
+				return
+			}
+			mediaPart, parseErr := reader.NextPart()
+			if parseErr != nil {
+				http.Error(w, "missing multipart media", http.StatusBadRequest)
+				return
+			}
+			body, parseErr = io.ReadAll(mediaPart)
+			if parseErr != nil {
+				http.Error(w, "invalid multipart media", http.StatusBadRequest)
+				return
+			}
+			if _, ok := store.updateMetadata(id, resource, r.URL.Query().Get("addParents"), r.URL.Query().Get("removeParents")); !ok {
+				http.NotFound(w, r)
+				return
+			}
 		}
 		file, ok := store.setContent(id, string(body))
 		if !ok {

--- a/testing/fake-drive-server_test.go
+++ b/testing/fake-drive-server_test.go
@@ -10,6 +10,76 @@ import (
 	"testing"
 )
 
+func TestPublicPropertiesPatchReadbackAndRemoval(t *testing.T) {
+	server := httptest.NewServer(newDriveHandler(newDriveStore()))
+	defer server.Close()
+	for _, patch := range []string{
+		`{"properties":{"unrelated":"keep","runmeColabCopy":"pending"}}`,
+		`{"properties":{"runmeColabCopy":"confirmed"}}`,
+		`{"properties":{"runmeColabCopy":null}}`,
+	} {
+		request, err := http.NewRequest(http.MethodPatch, server.URL+"/drive/v3/files/"+seedFileID, bytes.NewBufferString(patch))
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("patch returned %s", response.Status)
+		}
+		response, err = http.Get(server.URL + "/drive/v3/files/" + seedFileID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var file driveFile
+		if err := json.NewDecoder(response.Body).Decode(&file); err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		var resource struct {
+			Properties map[string]*string `json:"properties"`
+		}
+		if err := json.Unmarshal([]byte(patch), &resource); err != nil {
+			t.Fatal(err)
+		}
+		expected := ""
+		if value := resource.Properties["runmeColabCopy"]; value != nil {
+			expected = *value
+		}
+		if file.Properties["runmeColabCopy"] != expected || file.Properties["unrelated"] != "keep" {
+			t.Fatalf("unexpected public properties after %s: %#v", patch, file.Properties)
+		}
+	}
+}
+
+func TestMultipartUpdateStoresNotebookBytesAndMetadata(t *testing.T) {
+	store := newDriveStore()
+	server := httptest.NewServer(newDriveHandler(store))
+	defer server.Close()
+	content := `{"nbformat":4,"cells":[]}`
+	body := "--test-boundary\r\nContent-Type: application/json\r\n\r\n{\"name\":\"copy.ipynb\"}\r\n--test-boundary\r\nContent-Type: application/x-ipynb+json\r\n\r\n" + content + "\r\n--test-boundary--\r\n"
+	request, err := http.NewRequest(http.MethodPatch, server.URL+"/upload/drive/v3/files/"+seedFileID+"?uploadType=multipart", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "multipart/related; boundary=test-boundary")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("upload returned %s", response.Status)
+	}
+	file, ok := store.get(seedFileID)
+	if !ok || file.Content != content || file.Name != "copy.ipynb" {
+		t.Fatalf("unexpected saved multipart file: %#v", file)
+	}
+}
+
 func TestGeneratedIDCreateAndOperationSearch(t *testing.T) {
 	server := httptest.NewServer(newDriveHandler(newDriveStore()))
 	defer server.Close()


### PR DESCRIPTION
## Problem

A Colab export error can remain indefinitely after an app upgrade or Drive
reconnect when the `.runme` source is already synced. Reconnect reconciliation
only queued files with source edits, so a persisted error such as `Unsupported
notebook log format_version 2` did not get another export attempt even though
the current parser supports V2.

## Changes

- Queue failed derived exports independently of source dirtiness when Drive
  becomes available. Keep conflicted files and unconfirmed creations out of
  this additional recovery path.
- Add **Retry Colab export** to Notebook properties, with progress and retry
  failure feedback. Retry uses the committed source without editing it.
- Hide the generic waiting message while an export error is present.
- Document the recovery journey and verify existing V2 conversion clears a
  persisted format-version error and reuses the generated copy.
- Register a browser scenario for Drive reconnect and the real properties retry
  flow. Extend the existing Go Drive fake with public-property patch/readback
  and multipart upload handling used by production Colab exports.

This is separate from execution-history recovery in #372. It fixes retry
behavior; it does not change the supported file formats.

## Validation

- 145 storage and Notebook properties tests passed.
- `runme run build test` passed.
- Reviewed against root/app agent guidance and the repository style guide.
- Browser scenario verifies exported content, copy reuse, and unchanged source
  history, with screenshots, assertion JSON, and a walkthrough video.
- Go fake API tests cover public-property update/removal and multipart bytes.
