### PR TITLE
Bind selected-text comments to immutable notebook revisions

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -20,6 +20,14 @@ import {
 import { driveLinkCoordinator } from '../../lib/driveLinkCoordinator'
 import { appState } from '../../lib/runtime/AppState'
 import { createCellCommentAnchor } from '../../lib/notebookComments'
+import * as actorIdentity from '../../lib/operationLog/actorIdentity'
+import { parseOperationLog } from '../../lib/operationLog'
+import { ancestorClosure } from '../../lib/operationLog/versions'
+import LocalNotebooks, { LOCAL_FOLDER_URI } from '../../storage/local'
+import { MemoryOperationLogStorage } from '../../storage/operationLogs'
+import { MemoryConflictDocStorage } from '../../storage/conflictDocs'
+import { MemoryRevisionDocStorage } from '../../storage/revisionDocs'
+import { MemoryIpynbShadowStorage } from '../../storage/ipynbShadows'
 
 import { parser_pb, RunmeMetadataKey } from '../../runme/client'
 import type { CellData } from '../../lib/notebookData'
@@ -97,6 +105,8 @@ const contextMocks = vi.hoisted(() => ({
     subscribeSync: ReturnType<typeof vi.fn>
     listOperationLogComments?: ReturnType<typeof vi.fn>
     addOperationLogComment?: ReturnType<typeof vi.fn>
+    bindOperationLogCommentAnchors?: ReturnType<typeof vi.fn>
+    addAnchoredComment?: ReturnType<typeof vi.fn>
     replyToOperationLogComment?: ReturnType<typeof vi.fn>
     setOperationLogCommentResolved?: ReturnType<typeof vi.fn>
   },
@@ -596,7 +606,15 @@ describe('Actions tabs', () => {
       rename: vi.fn(),
       subscribeSync: vi.fn(() => () => undefined),
       listOperationLogComments: vi.fn(async () => comments),
-      addOperationLogComment: vi.fn(async () => comments[0]),
+      bindOperationLogCommentAnchors: vi.fn(async (_uri, input) => [
+        {
+          kind: 'cell',
+          cell_id: input.cellId,
+          surface: 'source',
+          version: { kind: 'revision', revision_id: 'captured-revision' },
+        },
+      ]),
+      addAnchoredComment: vi.fn(async () => comments[0]),
       replyToOperationLogComment: vi.fn(async () => comments[0]),
       setOperationLogCommentResolved: vi.fn(async () => comments[0]),
     }
@@ -697,11 +715,11 @@ describe('Actions tabs', () => {
       within(draftArticle).getByRole('button', { name: 'Comment' })
     )
     await waitFor(() => {
-      expect(store.addOperationLogComment).toHaveBeenCalledWith(
+      expect(store.addAnchoredComment).toHaveBeenCalledWith(
         uri,
         expect.objectContaining({
           content: 'New operation-log comment',
-          anchor: expect.stringContaining('cell-new'),
+          anchors: [expect.objectContaining({ cell_id: 'cell-new' })],
         })
       )
     })
@@ -738,6 +756,232 @@ describe('Actions tabs', () => {
     expect(await screen.findByText('Feedback from diff')).toBeTruthy()
     expect(screen.getByText(/Historical source/)).toBeTruthy()
   })
+
+  it('submits a rendered selection through real operation-log persistence after a pending flush and later edit', async () => {
+    const actor = vi
+      .spyOn(actorIdentity, 'getNotebookActorId')
+      .mockResolvedValue('ui-selection-actor')
+    const records = new Map<string, any>()
+    const table = () => ({
+      get: async (id: string) => records.get(id),
+      put: async (record: any) => {
+        records.set(record.id, record)
+        return record.id
+      },
+      update: async (id: string, changes: any) => {
+        records.set(id, { ...records.get(id), ...changes })
+        return 1
+      },
+      filter: (predicate: (record: any) => boolean) => ({
+        toArray: async () => [...records.values()].filter(predicate),
+      }),
+      toArray: async () => [...records.values()],
+    })
+    const store = Object.create(LocalNotebooks.prototype) as LocalNotebooks &
+      any
+    store.files = table()
+    store.folders = table()
+    store.driveStore = {}
+    store.driveSyncCoordinator = {
+      runExclusive: async (_key: string, operation: () => Promise<unknown>) =>
+        operation(),
+    }
+    store.filesystemStore = null
+    store.inFlightSyncs = new Map()
+    store.syncListeners = new Map()
+    store.syncSubjects = new Map()
+    store.markdownSyncSubjects = new Map()
+    store.ipynbSyncSubjects = new Map()
+    store.conflictDocStorage = new MemoryConflictDocStorage()
+    store.revisionDocStorage = new MemoryRevisionDocStorage()
+    store.ipynbShadowStorage = new MemoryIpynbShadowStorage()
+    store.operationLogStorage = new MemoryOperationLogStorage()
+    store.transaction = async (
+      _mode: unknown,
+      _table: unknown,
+      operation: () => Promise<unknown>
+    ) => operation()
+    store.getSyncState = vi.fn(async () => null)
+    store.getMetadata = vi.fn(async () => ({}))
+    store.subscribeSync = vi.fn(() => () => undefined)
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    const { uri } = await store.create(LOCAL_FOLDER_URI, 'ui-selection.runme')
+    const save = await store.createOperationLogSaveStore(uri)
+    const source = 'Read **the [migration guide](https://example.com)** today.'
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'selected',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      value: source,
+    })
+    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] })
+    const cellData = new StubCellData(cell)
+    const flush = vi.fn(async () => save.save(uri, notebook))
+    contextMocks.currentDoc = uri
+    contextMocks.openNotebooks = [
+      {
+        uri,
+        requestedUri: uri,
+        name: 'ui-selection.runme',
+        state: 'loaded',
+        operationLog: true,
+      },
+    ]
+    contextMocks.workspaceDocuments = [
+      { uri, title: 'ui-selection.runme', state: 'loaded' },
+    ]
+    contextMocks.notebookSnapshots.set(uri, { uri, loaded: true, notebook })
+    contextMocks.getNotebookData.mockReturnValue({
+      getCell: () => cellData,
+      getNotebook: () => notebook,
+      appendCell: vi.fn(),
+      flushPendingPersist: flush,
+      getObservedOperationHeads: () => save.getObservedOperationHeads(),
+    })
+    contextMocks.notebookStore = store
+    commentsPanelMocks.commentsPanelOpen = true
+    render(<Actions />)
+    await screen.findByTestId('markdown-rendered')
+    const start = screen.getByText('the')
+    const end = screen.getByText('migration guide')
+    const range = document.createRange()
+    range.setStart(start.firstChild!, 0)
+    range.setEnd(end.firstChild!, 'migration guide'.length)
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      value: () => ({
+        top: 10,
+        bottom: 20,
+        left: 10,
+        right: 90,
+        width: 80,
+        height: 10,
+        x: 10,
+        y: 10,
+        toJSON: () => ({}),
+      }),
+    })
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+      clientX: 40,
+      clientY: 20,
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Comment on selected text' })
+    )
+    await waitFor(() => expect(flush).toHaveBeenCalledOnce())
+    await waitFor(async () =>
+      expect(
+        parseOperationLog(await store.loadContent(uri)).operations.some(
+          (op) => op.kind === 'revision.checkpoint'
+        )
+      ).toBe(true)
+    )
+    const other = await store.createOperationLogSaveStore(uri)
+    const changed = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'selected',
+          kind: parser_pb.CellKind.MARKUP,
+          value: 'Changed by sync',
+        }),
+      ],
+    })
+    await other.save(uri, changed)
+    const draft = await screen.findByText('New comment on Cell 1')
+    const article = draft.closest('article') as HTMLElement
+    fireEvent.change(within(article).getByRole('textbox'), {
+      target: { value: 'Clarify this selection' },
+    })
+    fireEvent.click(within(article).getByRole('button', { name: 'Comment' }))
+    await waitFor(async () =>
+      expect((await store.listOperationLogComments(uri)).length).toBe(1)
+    )
+    const [comment] = await store.listOperationLogComments(uri)
+    const view = JSON.parse(comment.anchor!).runme
+    expect(view.anchors.map((a: any) => a.range)).toEqual([
+      { start_index: 7, end_index: 11, unit: 'unicode-code-point' },
+      { start_index: 12, end_index: 27, unit: 'unicode-code-point' },
+    ])
+    expect(view.anchorSources.map((a: any) => a.source)).toEqual([
+      source,
+      source,
+    ])
+    expect(
+      await screen.findByText('Commented revision: the migration guide')
+    ).toBeTruthy()
+    expect((await store.load(uri)).cells[0].value).toBe('Changed by sync')
+    expect(
+      ancestorClosure(
+        parseOperationLog(await store.loadContent(uri)).operations,
+        [view.anchors[0].version.revision_id]
+      ).some((op) => (op.payload as any).cell?.value === 'Changed by sync')
+    ).toBe(false)
+    expect(toastMocks.showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tone: 'error' })
+    )
+    selection.removeAllRanges()
+    // A failed bind must leave the user's typed draft available for retry.
+    vi.spyOn(store, 'bindOperationLogCommentAnchors').mockRejectedValueOnce(
+      new Error('Snapshot unavailable')
+    )
+    const retryRange = document.createRange()
+    const rendered = screen.getByTestId('markdown-rendered')
+    retryRange.setStart(within(rendered).getByText('the').firstChild!, 0)
+    retryRange.setEnd(
+      within(rendered).getByText('migration guide').firstChild!,
+      15
+    )
+    Object.defineProperty(retryRange, 'getBoundingClientRect', {
+      value: () => ({
+        top: 10,
+        bottom: 20,
+        left: 10,
+        right: 90,
+        width: 80,
+        height: 10,
+        x: 10,
+        y: 10,
+        toJSON: () => ({}),
+      }),
+    })
+    selection.addRange(retryRange)
+    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+      clientX: 40,
+      clientY: 20,
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Comment on selected text' })
+    )
+    const retryDraft = await screen.findByText('New comment on Cell 1')
+    const retryArticle = retryDraft.closest('article') as HTMLElement
+    const retryText = within(retryArticle).getByRole(
+      'textbox'
+    ) as HTMLTextAreaElement
+    fireEvent.change(retryText, { target: { value: 'Please keep this draft' } })
+    fireEvent.click(
+      within(retryArticle).getByRole('button', { name: 'Comment' })
+    )
+    await waitFor(() =>
+      expect(toastMocks.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tone: 'error',
+          message: expect.stringContaining('Snapshot unavailable'),
+        })
+      )
+    )
+    expect(retryText.value).toBe('Please keep this draft')
+    expect((await store.listOperationLogComments(uri)).length).toBe(1)
+    selection.removeAllRanges()
+    actor.mockRestore()
+  }, 20000)
 
   it('embeds an image selected from the button beside Add cell', async () => {
     const uri = 'local://file/images.json'

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -129,7 +129,6 @@ import { appState } from '../../lib/runtime/AppState'
 import {
   createCellCommentAnchor,
   createCellTextCommentAnchor,
-  createPendingCellTextCommentAnchor,
   groupCommentsByCell,
   toCellCommentThreads,
   type CommentDraftTarget,
@@ -138,8 +137,11 @@ import {
 import {
   buildRenderedMarkdownProjection,
   scrollRenderedMarkdownRangeIntoView,
+  sliceByCodePoint,
+  sourceRangesForProjectionRange,
   type RenderedMarkdownSelectionDraft,
 } from '../../lib/markdown/renderedMarkdownProjection'
+import type { Anchor } from '../../lib/operationLog/records'
 import type { RenderedMarkdownCommentRange } from '../../lib/markdown/renderedMarkdownCommentHighlights'
 import DriveLinkStatusTab from '../DriveLinkStatusTab'
 import DriveSyncStatusTab from '../DriveSyncStatusTab'
@@ -3136,23 +3138,81 @@ function NotebookTabContent({
     }
   }, [syncPendingComments])
 
-  // A draft retains its selection-time snapshot even if edits arrive before Send.
-  const draftSnapshots = useRef(
+  // Bind the rendered selection to immutable source while its displayed model
+  // and revision are still available. Sending later does not inspect the editor.
+  const draftAnchors = useRef(
     new WeakMap<
       CommentDraftTarget,
-      Promise<{ heads?: string[]; error?: unknown }>
+      Promise<{ anchors?: Anchor[]; error?: unknown }>
     >()
   )
   const startCommentDraft = useCallback(
     (target: CommentDraftTarget) => {
-      if (operationLogComments && notebookData)
-        draftSnapshots.current.set(
+      if (operationLogComments && notebookData && store) {
+        // Capture source and mapping synchronously, before the flush yields to
+        // another edit or a remote sync. The store verifies that same source
+        // against the captured causal revision before creating typed anchors.
+        const visible = notebookData
+          .getNotebook()
+          .cells.find((cell) => cell.refId === target.cellId)
+        const source = visible?.value
+        const projection =
+          target.type === 'cell-text'
+            ? buildRenderedMarkdownProjection(target.source)
+            : undefined
+        const ranges =
+          target.type === 'cell-text' && projection
+            ? sourceRangesForProjectionRange(
+                projection,
+                target.source,
+                target.selectors[0].start,
+                target.selectors[0].end
+              )
+            : undefined
+        const binding = (async () => {
+          if (
+            typeof source !== 'string' ||
+            (target.type === 'cell-text' && source !== target.source)
+          )
+            throw new Error(
+              'The displayed selection changed. Select the text again.'
+            )
+          if (target.type === 'cell-text') {
+            const [position, quote] = target.selectors
+            if (
+              projection?.text !== target.projection.text ||
+              !Number.isSafeInteger(position.start) ||
+              !Number.isSafeInteger(position.end) ||
+              position.start < 0 ||
+              position.end > Array.from(projection.text).length ||
+              position.end <= position.start ||
+              sliceByCodePoint(
+                target.projection.text,
+                position.start,
+                position.end
+              ) !== quote.exact ||
+              !ranges?.length
+            )
+              throw new Error(
+                'The rendered selection changed. Select the text again.'
+              )
+          }
+          const heads = await captureCommentSnapshot(notebookData)
+          return store.bindOperationLogCommentAnchors(docUri, {
+            snapshot_heads: heads,
+            cellId: target.cellId,
+            source,
+            ranges,
+          })
+        })()
+        draftAnchors.current.set(
           target,
-          captureCommentSnapshot(notebookData).then(
-            (heads) => ({ heads }),
+          binding.then(
+            (anchors) => ({ anchors }),
             (error) => ({ error })
           )
         )
+      }
       openCommentsPanel()
       setDraftTarget(target)
       setDraftContent('')
@@ -3184,6 +3244,7 @@ function NotebookTabContent({
       openCommentsPanel,
       operationLogComments,
       notebookData,
+      store,
     ]
   )
 
@@ -3231,23 +3292,17 @@ function NotebookTabContent({
       if (operationLogComments && store) {
         setCommentsBusy(true)
         try {
-          const captured = await draftSnapshots.current.get(target)
-          if (captured?.error) throw captured.error
-          const heads = captured
-            ? captured.heads
-            : notebookData
-              ? await captureCommentSnapshot(notebookData)
-              : undefined
-          const commentId = crypto.randomUUID()
-          const anchor =
-            target.type === 'cell'
-              ? createCellCommentAnchor(target.cellId, commentId)
-              : createPendingCellTextCommentAnchor(target, commentId)
-          await store.addOperationLogComment(docUri, {
+          const bound = draftAnchors.current.get(target)
+          if (!bound)
+            throw new Error(
+              'The comment selection is unavailable. Select it again.'
+            )
+          const { anchors, error } = await bound
+          if (error) throw error
+          if (!anchors) throw new Error('The comment selection is unavailable.')
+          await store.addAnchoredComment(docUri, {
             content,
-            anchor,
-            commentId,
-            snapshot_heads: heads,
+            anchors,
             author: await getCommentAuthor(),
           })
           setDraftTarget(null)

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -659,6 +659,29 @@ function CommentMessage({
   separated: boolean
 }) {
   const { comment } = thread
+  // Historical sources in the read projection are derived from each anchor's
+  // immutable revision. Join each selected fragment without bridging Markdown
+  // syntax between discontiguous source ranges.
+  const firstRange = thread.locations?.find(
+    ({ anchor }) => anchor.kind === 'cell' && anchor.range
+  )
+  const selectedQuote = thread.locations
+    ?.flatMap(({ anchor, source }) =>
+      firstRange?.anchor.kind === 'cell' &&
+      anchor.kind === 'cell' &&
+      anchor.range &&
+      anchor.cell_id === firstRange.anchor.cell_id &&
+      JSON.stringify(anchor.version) ===
+        JSON.stringify(firstRange.anchor.version) &&
+      source !== undefined
+        ? [
+            Array.from(source)
+              .slice(anchor.range.start_index, anchor.range.end_index)
+              .join(''),
+          ]
+        : []
+    )
+    .join('')
   return (
     <div
       className={separated ? 'border-t border-nb-border pt-3' : ''}
@@ -708,6 +731,11 @@ function CommentMessage({
             {thread.location?.status === 'outdated' && ' (outdated context)'}
           </blockquote>
         )}
+      {selectedQuote && (
+        <blockquote className="mb-2 border-l-2 border-nb-accent pl-2 text-xs text-nb-text-muted">
+          Commented revision: {selectedQuote}
+        </blockquote>
+      )}
       {thread.anchor?.type === 'cell-text' && (
         <div className="mb-2 rounded-nb-sm bg-nb-surface-2 px-2 py-1.5">
           <blockquote className="border-l-2 border-nb-accent pl-2 text-xs text-nb-text-muted">

--- a/app/src/lib/operationLog/versions.ts
+++ b/app/src/lib/operationLog/versions.ts
@@ -305,6 +305,18 @@ export function codePointRange(source: string, start: number, end: number) {
   }
   if (!boundaries.has(start) || !boundaries.has(end))
     throw new Error('Range splits a surrogate pair')
+  const Segmenter = Intl.Segmenter
+  if (!Segmenter) throw new Error('Grapheme validation is unavailable')
+  const graphemeBoundaries = new Set<number>([0])
+  let graphemeOffset = 0
+  for (const { segment } of new Segmenter(undefined, {
+    granularity: 'grapheme',
+  }).segment(source)) {
+    graphemeOffset += segment.length
+    graphemeBoundaries.add(graphemeOffset)
+  }
+  if (!graphemeBoundaries.has(start) || !graphemeBoundaries.has(end))
+    throw new Error('Range splits a grapheme')
   return {
     start_index: Array.from(source.slice(0, start)).length,
     end_index: Array.from(source.slice(0, end)).length,

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -11,6 +11,10 @@ import {
 } from '../lib/googleDriveRuntime'
 import { IPYNB_MIME_TYPE } from '../lib/ipynb'
 import { appLogger } from '../lib/logging/runtime'
+import {
+  buildRenderedMarkdownProjection,
+  sourceRangesForProjectionRange,
+} from '../lib/markdown/renderedMarkdownProjection'
 import { createCellCommentAnchor } from '../lib/notebookComments'
 import {
   RUNME_OPERATION_LOG_MIME_TYPE,
@@ -1422,6 +1426,143 @@ describe('LocalNotebooks operation-log storage', () => {
         (op) => (op.payload as any).cell?.value === 'Unseen change in B'
       )
     ).toBe(false)
+    actor.mockRestore()
+  })
+
+  it('persists discontiguous rendered Markdown source anchors at the captured revision', async () => {
+    const actor = vi
+      .spyOn(actorIdentity, 'getNotebookActorId')
+      .mockResolvedValue('selection-actor')
+    const store = createTestStore({})
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    const { uri } = await store.create(LOCAL_FOLDER_URI, 'selected.runme')
+    const save = await store.createOperationLogSaveStore(uri)
+    const source =
+      'Read **the [migration guide](https://example.com)** today 😀👍🏽.'
+    const notebook = create(parser_pb.NotebookSchema, {
+      cells: [
+        create(parser_pb.CellSchema, {
+          refId: 'selected',
+          kind: parser_pb.CellKind.MARKUP,
+          value: source,
+        }),
+      ],
+    })
+    await save.save(uri, notebook)
+    const projection = buildRenderedMarkdownProjection(source)
+    const ranges = sourceRangesForProjectionRange(projection, source, 5, 24)
+    expect(ranges).toEqual([
+      { start: 7, end: 11 },
+      { start: 12, end: 27 },
+    ])
+    const anchors = await store.bindOperationLogCommentAnchors(uri, {
+      snapshot_heads: save.getObservedOperationHeads(),
+      cellId: 'selected',
+      source,
+      ranges,
+    })
+    notebook.cells[0].value = 'Remote edit replaces the selected words'
+    await save.save(uri, notebook)
+    const comment = await store.addAnchoredComment(uri, {
+      content: 'Clarify this link',
+      anchors,
+    })
+    const reloaded = await store.listOperationLogComments(uri)
+    expect(reloaded.find((item) => item.id === comment.id)?.content).toBe(
+      'Clarify this link'
+    )
+    const view = JSON.parse(comment.anchor!).runme
+    expect(view.anchors).toEqual(anchors)
+    expect(view.anchorSources).toEqual(
+      anchors.map((anchor) => ({ anchor, source }))
+    )
+    expect(view.quote).toBe('the ')
+    const records = parseOperationLog(
+      await store.loadContent(uri)
+    ).operations.filter((op) => op.kind === 'comment.record')
+    expect(JSON.stringify(records)).not.toContain('migration guide')
+    expect((await store.load(uri)).cells[0].value).toBe(notebook.cells[0].value)
+    actor.mockRestore()
+  })
+
+  it('rejects a stale displayed selection and invalid Unicode source ranges before binding', async () => {
+    const actor = vi
+      .spyOn(actorIdentity, 'getNotebookActorId')
+      .mockResolvedValue('unicode-actor')
+    const store = createTestStore({})
+    await store.folders.put({
+      id: LOCAL_FOLDER_URI,
+      name: 'Local',
+      remoteId: '',
+      children: [],
+      lastSynced: '',
+    })
+    const { uri } = await store.create(LOCAL_FOLDER_URI, 'unicode.runme')
+    const save = await store.createOperationLogSaveStore(uri)
+    const source = 'A😀👍🏽B'
+    await save.save(
+      uri,
+      create(parser_pb.NotebookSchema, {
+        cells: [
+          create(parser_pb.CellSchema, {
+            refId: 'unicode',
+            kind: parser_pb.CellKind.MARKUP,
+            value: source,
+          }),
+        ],
+      })
+    )
+    const heads = save.getObservedOperationHeads()
+    await expect(
+      store.bindOperationLogCommentAnchors(uri, {
+        snapshot_heads: heads,
+        cellId: 'unicode',
+        source: 'other',
+        ranges: [{ start: 1, end: 3 }],
+      })
+    ).rejects.toThrow('does not match')
+    await expect(
+      store.bindOperationLogCommentAnchors(uri, {
+        snapshot_heads: heads,
+        cellId: 'unicode',
+        source,
+        ranges: [{ start: 2, end: 3 }],
+      })
+    ).rejects.toThrow('surrogate pair')
+    await expect(
+      store.bindOperationLogCommentAnchors(uri, {
+        snapshot_heads: heads,
+        cellId: 'unicode',
+        source,
+        ranges: [{ start: 3, end: 5 }],
+      })
+    ).rejects.toThrow('grapheme')
+    expect(
+      parseOperationLog(await store.loadContent(uri)).operations.some(
+        (operation) => operation.kind === 'revision.checkpoint'
+      )
+    ).toBe(false)
+    const anchors = await store.bindOperationLogCommentAnchors(uri, {
+      snapshot_heads: heads,
+      cellId: 'unicode',
+      source,
+      ranges: [
+        { start: 1, end: 3 },
+        { start: 3, end: 7 },
+      ],
+    })
+    expect(
+      anchors.map((anchor) => anchor.kind === 'cell' && anchor.range)
+    ).toEqual([
+      { start_index: 1, end_index: 2, unit: 'unicode-code-point' },
+      { start_index: 2, end_index: 4, unit: 'unicode-code-point' },
+    ])
     actor.mockRestore()
   })
 

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -73,7 +73,12 @@ import {
   buildNotebookRevisions,
   notebookRevisionForVersion,
 } from '../lib/operationLog/revisions'
-import { ancestorClosure, snapshotHeads } from '../lib/operationLog/versions'
+import {
+  ancestorClosure,
+  anchorSource,
+  codePointRange,
+  snapshotHeads,
+} from '../lib/operationLog/versions'
 import { captureCommittedRevision as captureReviewRevision } from '../lib/operationLog/versions'
 import { appState } from '../lib/runtime/AppState'
 import { RunmeMetadataKey, parser_pb } from '../runme/client'
@@ -1911,6 +1916,49 @@ export class LocalNotebooks extends Dexie {
       }
     )
     return { kind: 'revision' as const, revision_id: op.op_id }
+  }
+
+  /** Bind a displayed cell selection to historical source before composition can
+   * outlive subsequent edits. The source is used only to verify the visible
+   * snapshot; the saved anchors contain a revision and source offsets alone.
+   */
+  async bindOperationLogCommentAnchors(
+    uri: string,
+    input: {
+      snapshot_heads: string[]
+      cellId: string
+      source: string
+      ranges?: { start: number; end: number }[]
+    }
+  ): Promise<Anchor[]> {
+    const { parsed } = await this.readMaterializedOperationLog(uri)
+    const visible = ancestorClosure(parsed.operations, input.snapshot_heads)
+    const cell = materializeOperationLog(visible).notebook.cells.find(
+      (candidate) => candidate.cell_id === input.cellId
+    )
+    if (!cell || cell.value !== input.source)
+      throw new Error(
+        'The displayed cell does not match its captured revision. Select the text again.'
+      )
+    if (input.ranges && !input.ranges.length)
+      throw new Error('Rendered selection has no source mapping')
+    const ranges = input.ranges?.map(({ start, end }) =>
+      codePointRange(cell.value, start, end)
+    )
+    const version = await this.checkpointNotebookRevision(uri, {
+      snapshot_heads: input.snapshot_heads,
+    })
+    const anchors: Anchor[] = (ranges ?? [undefined]).map((range) => ({
+      kind: 'cell',
+      cell_id: input.cellId,
+      version,
+      surface: 'source',
+      ...(range ? { range } : {}),
+    }))
+    const updated = (await this.readMaterializedOperationLog(uri)).parsed
+      .operations
+    for (const anchor of anchors) anchorSource(updated, anchor)
+    return anchors
   }
 
   /** Explicit conversion exports a local copy and never changes the source/Drive file. */


### PR DESCRIPTION
## Summary

Fixes selected rendered Markdown comments in `.runme` notebooks failing with `Captured source has changed`.

The composer now captures the displayed cell and revision while flushing pending edits, maps the rendered selection to each exact source range, and binds typed anchors to a checkpoint of that immutable revision. Submission writes those anchors directly. Later edits and sync do not change the draft's target. Legacy Drive and compatibility conversion paths remain available.

The comments panel derives the complete selected quote from historical source ranges. Unicode ranges are checked against surrogate and grapheme boundaries before creating a checkpoint.

## Verification

- `runme run build test`
- `pnpm -C app exec vitest run --testTimeout=20000 --reporter=dot` (1,433 tests)
- Focused UI and storage tests (237 tests), including a real UI submission into the memory operation log, pending persistence, a later edit, reload, discontiguous Markdown, Unicode, and preservation of typed draft text after a failed bind.
- `pnpm -C app exec tsc --noEmit -p tsconfig.json`
- Prettier check and `git diff --check`
