### PR TITLE
Support source range comments in code and Markdown editors

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^16.0.0",
     "jsdom": "27.4.0",
+    "playwright-core": "1.57.0",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.0.10",
     "typescript": "~5.8.3",

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -914,7 +914,26 @@ describe('Actions tabs', () => {
             name: 'Mock editor selection comment',
           })
         )
-        expect(document.querySelector('blockquote')?.textContent).toBe(source.slice(1))
+        expect(document.querySelector('blockquote')?.textContent).toBe(
+          source.slice(1)
+        )
+        expect(
+          JSON.parse(localStorage.getItem('runme/notebook-active-cells')!)[uri]
+            .focusRole
+        ).toBe('editor')
+        if (surface === 'markdown-source') {
+          const focused = vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+          fireEvent.blur(window)
+          focused.mockReturnValue(true)
+          fireEvent.focus(window)
+          expect(screen.queryByTestId('markdown-rendered')).toBeNull()
+          expect(
+            screen.getByRole('button', {
+              name: 'Mock editor selection comment',
+            })
+          ).toBeTruthy()
+          focused.mockRestore()
+        }
       }
       await waitFor(() => expect(flush).toHaveBeenCalledOnce())
       await waitFor(async () =>

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -174,6 +174,27 @@ const commentsPanelMocks = vi.hoisted(() => ({
 }))
 
 // Minimal mocks for contexts Action consumes
+// Exercise the parent comment flow independently of Monaco's browser runtime.
+// Editor.test.tsx covers the actual Monaco action and UTF-16 selection capture.
+vi.mock('./Editor', () => ({
+  default: ({ value, onCommentSelection }: any) => (
+    <div>
+      {onCommentSelection && (
+        <button
+          onClick={() =>
+            onCommentSelection({
+              source: value,
+              range: { start: 1, end: value.length },
+            })
+          }
+        >
+          Mock editor selection comment
+        </button>
+      )}
+    </div>
+  ),
+}))
+
 vi.mock('../../contexts/OutputContext', () => ({
   useOutput: () => ({
     getRenderer: () => undefined,
@@ -757,231 +778,266 @@ describe('Actions tabs', () => {
     expect(screen.getByText(/Historical source/)).toBeTruthy()
   })
 
-  it('submits a rendered selection through real operation-log persistence after a pending flush and later edit', async () => {
-    const actor = vi
-      .spyOn(actorIdentity, 'getNotebookActorId')
-      .mockResolvedValue('ui-selection-actor')
-    const records = new Map<string, any>()
-    const table = () => ({
-      get: async (id: string) => records.get(id),
-      put: async (record: any) => {
-        records.set(record.id, record)
-        return record.id
-      },
-      update: async (id: string, changes: any) => {
-        records.set(id, { ...records.get(id), ...changes })
-        return 1
-      },
-      filter: (predicate: (record: any) => boolean) => ({
-        toArray: async () => [...records.values()].filter(predicate),
-      }),
-      toArray: async () => [...records.values()],
-    })
-    const store = Object.create(LocalNotebooks.prototype) as LocalNotebooks &
-      any
-    store.files = table()
-    store.folders = table()
-    store.driveStore = {}
-    store.driveSyncCoordinator = {
-      runExclusive: async (_key: string, operation: () => Promise<unknown>) =>
-        operation(),
-    }
-    store.filesystemStore = null
-    store.inFlightSyncs = new Map()
-    store.syncListeners = new Map()
-    store.syncSubjects = new Map()
-    store.markdownSyncSubjects = new Map()
-    store.ipynbSyncSubjects = new Map()
-    store.conflictDocStorage = new MemoryConflictDocStorage()
-    store.revisionDocStorage = new MemoryRevisionDocStorage()
-    store.ipynbShadowStorage = new MemoryIpynbShadowStorage()
-    store.operationLogStorage = new MemoryOperationLogStorage()
-    store.transaction = async (
-      _mode: unknown,
-      _table: unknown,
-      operation: () => Promise<unknown>
-    ) => operation()
-    store.getSyncState = vi.fn(async () => null)
-    store.getMetadata = vi.fn(async () => ({}))
-    store.subscribeSync = vi.fn(() => () => undefined)
-    await store.folders.put({
-      id: LOCAL_FOLDER_URI,
-      name: 'Local',
-      remoteId: '',
-      children: [],
-      lastSynced: '',
-    })
-    const { uri } = await store.create(LOCAL_FOLDER_URI, 'ui-selection.runme')
-    const save = await store.createOperationLogSaveStore(uri)
-    const source = 'Read **the [migration guide](https://example.com)** today.'
-    const cell = create(parser_pb.CellSchema, {
-      refId: 'selected',
-      kind: parser_pb.CellKind.MARKUP,
-      languageId: 'markdown',
-      value: source,
-    })
-    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] })
-    const cellData = new StubCellData(cell)
-    const flush = vi.fn(async () => save.save(uri, notebook))
-    contextMocks.currentDoc = uri
-    contextMocks.openNotebooks = [
-      {
-        uri,
-        requestedUri: uri,
-        name: 'ui-selection.runme',
-        state: 'loaded',
-        operationLog: true,
-      },
-    ]
-    contextMocks.workspaceDocuments = [
-      { uri, title: 'ui-selection.runme', state: 'loaded' },
-    ]
-    contextMocks.notebookSnapshots.set(uri, { uri, loaded: true, notebook })
-    contextMocks.getNotebookData.mockReturnValue({
-      getCell: () => cellData,
-      getNotebook: () => notebook,
-      appendCell: vi.fn(),
-      flushPendingPersist: flush,
-      getObservedOperationHeads: () => save.getObservedOperationHeads(),
-    })
-    contextMocks.notebookStore = store
-    commentsPanelMocks.commentsPanelOpen = true
-    render(<Actions />)
-    await screen.findByTestId('markdown-rendered')
-    const start = screen.getByText('the')
-    const end = screen.getByText('migration guide')
-    const range = document.createRange()
-    range.setStart(start.firstChild!, 0)
-    range.setEnd(end.firstChild!, 'migration guide'.length)
-    Object.defineProperty(range, 'getBoundingClientRect', {
-      value: () => ({
-        top: 10,
-        bottom: 20,
-        left: 10,
-        right: 90,
-        width: 80,
-        height: 10,
-        x: 10,
-        y: 10,
-        toJSON: () => ({}),
-      }),
-    })
-    const selection = window.getSelection()!
-    selection.removeAllRanges()
-    selection.addRange(range)
-    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
-      clientX: 40,
-      clientY: 20,
-    })
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Comment on selected text' })
-    )
-    await waitFor(() => expect(flush).toHaveBeenCalledOnce())
-    await waitFor(async () =>
-      expect(
-        parseOperationLog(await store.loadContent(uri)).operations.some(
-          (op) => op.kind === 'revision.checkpoint'
-        )
-      ).toBe(true)
-    )
-    const other = await store.createOperationLogSaveStore(uri)
-    const changed = create(parser_pb.NotebookSchema, {
-      cells: [
-        create(parser_pb.CellSchema, {
-          refId: 'selected',
-          kind: parser_pb.CellKind.MARKUP,
-          value: 'Changed by sync',
+  it.each(['rendered', 'code', 'markdown-source'])(
+    'submits a %s selection through real operation-log persistence after a pending flush and later edit',
+    async (surface) => {
+      const actor = vi
+        .spyOn(actorIdentity, 'getNotebookActorId')
+        .mockResolvedValue('ui-selection-actor')
+      const records = new Map<string, any>()
+      const table = () => ({
+        get: async (id: string) => records.get(id),
+        put: async (record: any) => {
+          records.set(record.id, record)
+          return record.id
+        },
+        update: async (id: string, changes: any) => {
+          records.set(id, { ...records.get(id), ...changes })
+          return 1
+        },
+        filter: (predicate: (record: any) => boolean) => ({
+          toArray: async () => [...records.values()].filter(predicate),
         }),
-      ],
-    })
-    await other.save(uri, changed)
-    const draft = await screen.findByText('New comment on Cell 1')
-    const article = draft.closest('article') as HTMLElement
-    fireEvent.change(within(article).getByRole('textbox'), {
-      target: { value: 'Clarify this selection' },
-    })
-    fireEvent.click(within(article).getByRole('button', { name: 'Comment' }))
-    await waitFor(async () =>
-      expect((await store.listOperationLogComments(uri)).length).toBe(1)
-    )
-    const [comment] = await store.listOperationLogComments(uri)
-    const view = JSON.parse(comment.anchor!).runme
-    expect(view.anchors.map((a: any) => a.range)).toEqual([
-      { start_index: 7, end_index: 11, unit: 'unicode-code-point' },
-      { start_index: 12, end_index: 27, unit: 'unicode-code-point' },
-    ])
-    expect(view.anchorSources.map((a: any) => a.source)).toEqual([
-      source,
-      source,
-    ])
-    expect(
-      await screen.findByText('Commented revision: the migration guide')
-    ).toBeTruthy()
-    expect((await store.load(uri)).cells[0].value).toBe('Changed by sync')
-    expect(
-      ancestorClosure(
-        parseOperationLog(await store.loadContent(uri)).operations,
-        [view.anchors[0].version.revision_id]
-      ).some((op) => (op.payload as any).cell?.value === 'Changed by sync')
-    ).toBe(false)
-    expect(toastMocks.showToast).not.toHaveBeenCalledWith(
-      expect.objectContaining({ tone: 'error' })
-    )
-    selection.removeAllRanges()
-    // A failed bind must leave the user's typed draft available for retry.
-    vi.spyOn(store, 'bindOperationLogCommentAnchors').mockRejectedValueOnce(
-      new Error('Snapshot unavailable')
-    )
-    const retryRange = document.createRange()
-    const rendered = screen.getByTestId('markdown-rendered')
-    retryRange.setStart(within(rendered).getByText('the').firstChild!, 0)
-    retryRange.setEnd(
-      within(rendered).getByText('migration guide').firstChild!,
-      15
-    )
-    Object.defineProperty(retryRange, 'getBoundingClientRect', {
-      value: () => ({
-        top: 10,
-        bottom: 20,
-        left: 10,
-        right: 90,
-        width: 80,
-        height: 10,
-        x: 10,
-        y: 10,
-        toJSON: () => ({}),
-      }),
-    })
-    selection.addRange(retryRange)
-    fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
-      clientX: 40,
-      clientY: 20,
-    })
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Comment on selected text' })
-    )
-    const retryDraft = await screen.findByText('New comment on Cell 1')
-    const retryArticle = retryDraft.closest('article') as HTMLElement
-    const retryText = within(retryArticle).getByRole(
-      'textbox'
-    ) as HTMLTextAreaElement
-    fireEvent.change(retryText, { target: { value: 'Please keep this draft' } })
-    fireEvent.click(
-      within(retryArticle).getByRole('button', { name: 'Comment' })
-    )
-    await waitFor(() =>
-      expect(toastMocks.showToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tone: 'error',
-          message: expect.stringContaining('Snapshot unavailable'),
+        toArray: async () => [...records.values()],
+      })
+      const store = Object.create(LocalNotebooks.prototype) as LocalNotebooks &
+        any
+      store.files = table()
+      store.folders = table()
+      store.driveStore = {}
+      store.driveSyncCoordinator = {
+        runExclusive: async (_key: string, operation: () => Promise<unknown>) =>
+          operation(),
+      }
+      store.filesystemStore = null
+      store.inFlightSyncs = new Map()
+      store.syncListeners = new Map()
+      store.syncSubjects = new Map()
+      store.markdownSyncSubjects = new Map()
+      store.ipynbSyncSubjects = new Map()
+      store.conflictDocStorage = new MemoryConflictDocStorage()
+      store.revisionDocStorage = new MemoryRevisionDocStorage()
+      store.ipynbShadowStorage = new MemoryIpynbShadowStorage()
+      store.operationLogStorage = new MemoryOperationLogStorage()
+      store.transaction = async (
+        _mode: unknown,
+        _table: unknown,
+        operation: () => Promise<unknown>
+      ) => operation()
+      store.getSyncState = vi.fn(async () => null)
+      store.getMetadata = vi.fn(async () => ({}))
+      store.subscribeSync = vi.fn(() => () => undefined)
+      await store.folders.put({
+        id: LOCAL_FOLDER_URI,
+        name: 'Local',
+        remoteId: '',
+        children: [],
+        lastSynced: '',
+      })
+      const { uri } = await store.create(LOCAL_FOLDER_URI, 'ui-selection.runme')
+      const save = await store.createOperationLogSaveStore(uri)
+      const source =
+        surface === 'rendered'
+          ? 'Read **the [migration guide](https://example.com)** today.'
+          : 'a😀 **first**\nsecond'
+      const cell = create(parser_pb.CellSchema, {
+        refId: 'selected',
+        kind:
+          surface === 'code'
+            ? parser_pb.CellKind.CODE
+            : parser_pb.CellKind.MARKUP,
+        languageId: surface === 'code' ? 'python' : 'markdown',
+        value: source,
+      })
+      const notebook = create(parser_pb.NotebookSchema, { cells: [cell] })
+      const cellData = new StubCellData(cell)
+      const flush = vi.fn(async () => save.save(uri, notebook))
+      contextMocks.currentDoc = uri
+      contextMocks.openNotebooks = [
+        {
+          uri,
+          requestedUri: uri,
+          name: 'ui-selection.runme',
+          state: 'loaded',
+          operationLog: true,
+        },
+      ]
+      contextMocks.workspaceDocuments = [
+        { uri, title: 'ui-selection.runme', state: 'loaded' },
+      ]
+      contextMocks.notebookSnapshots.set(uri, { uri, loaded: true, notebook })
+      contextMocks.getNotebookData.mockReturnValue({
+        getCell: () => cellData,
+        getNotebook: () => notebook,
+        appendCell: vi.fn(),
+        flushPendingPersist: flush,
+        getObservedOperationHeads: () => save.getObservedOperationHeads(),
+      })
+      contextMocks.notebookStore = store
+      commentsPanelMocks.commentsPanelOpen = true
+      render(<Actions />)
+      const selection = window.getSelection()!
+      if (surface === 'rendered') {
+        await screen.findByTestId('markdown-rendered')
+        const start = screen.getByText('the')
+        const end = screen.getByText('migration guide')
+        const range = document.createRange()
+        range.setStart(start.firstChild!, 0)
+        range.setEnd(end.firstChild!, 'migration guide'.length)
+        Object.defineProperty(range, 'getBoundingClientRect', {
+          value: () => ({
+            top: 10,
+            bottom: 20,
+            left: 10,
+            right: 90,
+            width: 80,
+            height: 10,
+            x: 10,
+            y: 10,
+            toJSON: () => ({}),
+          }),
         })
+        selection.removeAllRanges()
+        selection.addRange(range)
+        fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+          clientX: 40,
+          clientY: 20,
+        })
+        fireEvent.click(
+          screen.getByRole('button', { name: 'Comment on selected text' })
+        )
+      } else {
+        if (surface === 'markdown-source')
+          fireEvent.doubleClick(await screen.findByTestId('markdown-rendered'))
+        fireEvent.click(
+          await screen.findByRole('button', {
+            name: 'Mock editor selection comment',
+          })
+        )
+        expect(document.querySelector('blockquote')?.textContent).toBe(source.slice(1))
+      }
+      await waitFor(() => expect(flush).toHaveBeenCalledOnce())
+      await waitFor(async () =>
+        expect(
+          parseOperationLog(await store.loadContent(uri)).operations.some(
+            (op) => op.kind === 'revision.checkpoint'
+          )
+        ).toBe(true)
       )
-    )
-    expect(retryText.value).toBe('Please keep this draft')
-    expect((await store.listOperationLogComments(uri)).length).toBe(1)
-    selection.removeAllRanges()
-    actor.mockRestore()
-  }, 20000)
+      const other = await store.createOperationLogSaveStore(uri)
+      const changed = create(parser_pb.NotebookSchema, {
+        cells: [
+          create(parser_pb.CellSchema, {
+            refId: 'selected',
+            kind: parser_pb.CellKind.MARKUP,
+            value: 'Changed by sync',
+          }),
+        ],
+      })
+      await other.save(uri, changed)
+      const draft = await screen.findByText('New comment on Cell 1')
+      const article = draft.closest('article') as HTMLElement
+      fireEvent.change(within(article).getByRole('textbox'), {
+        target: { value: 'Clarify this selection' },
+      })
+      fireEvent.click(within(article).getByRole('button', { name: 'Comment' }))
+      await waitFor(async () =>
+        expect((await store.listOperationLogComments(uri)).length).toBe(1)
+      )
+      const [comment] = await store.listOperationLogComments(uri)
+      const view = JSON.parse(comment.anchor!).runme
+      if (surface === 'rendered') {
+        expect(view.anchors.map((a: any) => a.range)).toEqual([
+          { start_index: 7, end_index: 11, unit: 'unicode-code-point' },
+          { start_index: 12, end_index: 27, unit: 'unicode-code-point' },
+        ])
+        expect(view.anchorSources.map((a: any) => a.source)).toEqual([
+          source,
+          source,
+        ])
+        expect(
+          await screen.findByText('Commented revision: the migration guide')
+        ).toBeTruthy()
+        expect((await store.load(uri)).cells[0].value).toBe('Changed by sync')
+        expect(
+          ancestorClosure(
+            parseOperationLog(await store.loadContent(uri)).operations,
+            [view.anchors[0].version.revision_id]
+          ).some((op) => (op.payload as any).cell?.value === 'Changed by sync')
+        ).toBe(false)
+        expect(toastMocks.showToast).not.toHaveBeenCalledWith(
+          expect.objectContaining({ tone: 'error' })
+        )
+        selection.removeAllRanges()
+        // A failed bind must leave the user's typed draft available for retry.
+        vi.spyOn(store, 'bindOperationLogCommentAnchors').mockRejectedValueOnce(
+          new Error('Snapshot unavailable')
+        )
+        const retryRange = document.createRange()
+        const rendered = screen.getByTestId('markdown-rendered')
+        retryRange.setStart(within(rendered).getByText('the').firstChild!, 0)
+        retryRange.setEnd(
+          within(rendered).getByText('migration guide').firstChild!,
+          15
+        )
+        Object.defineProperty(retryRange, 'getBoundingClientRect', {
+          value: () => ({
+            top: 10,
+            bottom: 20,
+            left: 10,
+            right: 90,
+            width: 80,
+            height: 10,
+            x: 10,
+            y: 10,
+            toJSON: () => ({}),
+          }),
+        })
+        selection.addRange(retryRange)
+        fireEvent.contextMenu(screen.getByTestId('markdown-rendered'), {
+          clientX: 40,
+          clientY: 20,
+        })
+        fireEvent.click(
+          screen.getByRole('button', { name: 'Comment on selected text' })
+        )
+        const retryDraft = await screen.findByText('New comment on Cell 1')
+        const retryArticle = retryDraft.closest('article') as HTMLElement
+        const retryText = within(retryArticle).getByRole(
+          'textbox'
+        ) as HTMLTextAreaElement
+        fireEvent.change(retryText, {
+          target: { value: 'Please keep this draft' },
+        })
+        fireEvent.click(
+          within(retryArticle).getByRole('button', { name: 'Comment' })
+        )
+        await waitFor(() =>
+          expect(toastMocks.showToast).toHaveBeenCalledWith(
+            expect.objectContaining({
+              tone: 'error',
+              message: expect.stringContaining('Snapshot unavailable'),
+            })
+          )
+        )
+        expect(retryText.value).toBe('Please keep this draft')
+        expect((await store.listOperationLogComments(uri)).length).toBe(1)
+        selection.removeAllRanges()
+      } else {
+        expect(view.anchors.map((a: any) => a.range)).toEqual([
+          {
+            start_index: 1,
+            end_index: Array.from(source).length,
+            unit: 'unicode-code-point',
+          },
+        ])
+        expect(view.anchorSources[0].source).toBe(source)
+        expect(view.quote).toBe(source.slice(1))
+      }
+      actor.mockRestore()
+    },
+    20000
+  )
 
   it('embeds an image selected from the button beside Add cell', async () => {
     const uri = 'local://file/images.json'

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -965,6 +965,13 @@ describe('Actions tabs', () => {
       )
       const [comment] = await store.listOperationLogComments(uri)
       const view = JSON.parse(comment.anchor!).runme
+      expect(
+        view.anchors.every(
+          (anchor: any) =>
+            anchor.selection_surface ===
+            (surface === 'rendered' ? 'rendered-markdown' : 'source')
+        )
+      ).toBe(true)
       if (surface === 'rendered') {
         expect(view.anchors.map((a: any) => a.range)).toEqual([
           { start_index: 7, end_index: 11, unit: 'unicode-code-point' },

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -691,6 +691,7 @@ export function Action({
   onFocusStateChange,
   readOnly = false,
   commentsAvailable = false,
+  sourceCommentsAvailable = false,
   commentCount = 0,
   commentRanges = [],
   commentSourceRanges = [],
@@ -708,6 +709,7 @@ export function Action({
   onFocusStateChange?: (state: NotebookActiveCellState) => void
   readOnly?: boolean
   commentsAvailable?: boolean
+  sourceCommentsAvailable?: boolean
   commentCount?: number
   commentRanges?: readonly RenderedMarkdownCommentRange[]
   commentSourceRanges?: CommentSourceRange[]
@@ -902,6 +904,19 @@ export function Action({
       setContextMenu({ x: event.clientX, y: event.clientY })
     },
     []
+  )
+
+  const handleEditorComment = useCallback(
+    (selection: { source: string; range: { start: number; end: number } }) => {
+      if (!cell?.refId || !sourceCommentsAvailable) return
+      setContextMenu(null)
+      onStartComment?.({
+        type: 'cell-source',
+        cellId: cell.refId,
+        ...selection,
+      })
+    },
+    [cell?.refId, sourceCommentsAvailable, onStartComment]
   )
 
   const handleRenderedSelectionContextMenu = useCallback(
@@ -1690,6 +1705,9 @@ export function Action({
               commentRanges={commentRanges}
               commentSourceRanges={commentSourceRanges}
               onSelectComment={onSelectComment}
+              onCommentSelection={
+                sourceCommentsAvailable ? handleEditorComment : undefined
+              }
               onRenderedSelectionContextMenu={
                 handleRenderedSelectionContextMenu
               }
@@ -1980,6 +1998,9 @@ export function Action({
             <Editor
               commentRanges={commentSourceRanges}
               onSelectComment={onSelectComment}
+              onCommentSelection={
+                sourceCommentsAvailable ? handleEditorComment : undefined
+              }
               key={`editor-${cell.refId}-${selectedLanguage}`}
               id={cell.refId}
               value={cell.value}
@@ -3168,11 +3189,13 @@ function NotebookTabContent({
                 target.selectors[0].start,
                 target.selectors[0].end
               )
-            : undefined
+            : target.type === 'cell-source'
+              ? [target.range]
+              : undefined
         const binding = (async () => {
           if (
             typeof source !== 'string' ||
-            (target.type === 'cell-text' && source !== target.source)
+            (target.type !== 'cell' && source !== target.source)
           )
             throw new Error(
               'The displayed selection changed. Select the text again.'
@@ -3954,6 +3977,7 @@ function NotebookTabContent({
                       onFocusStateChange={(state) => onCellFocus(docUri, state)}
                       readOnly={readOnly}
                       commentsAvailable={Boolean(commentsRemoteUri)}
+                      sourceCommentsAvailable={operationLogComments}
                       commentCount={commentsByCell.get(refId)?.length ?? 0}
                       commentRanges={commentRangesByCell.get(refId) ?? []}
                       commentSourceRanges={sourceRangesByCell.get(refId) ?? []}

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2538,7 +2538,16 @@ function NotebookTabContent({
         target.cellId,
         target.surface === 'source' ? 'editor' : undefined
       )
-      const range = target.range
+      const source =
+        commentCellIdentities.find((cell) => cell.refId === target.cellId)
+          ?.value ?? ''
+      const range = target.sourceRange
+        ? projectSourceCommentRange(
+            source,
+            target.sourceRange.start,
+            target.sourceRange.end
+          )[0]
+        : target.range
       setActiveCommentRange(range ? { cellId: target.cellId, ...range } : null)
 
       const scrollCellIntoView = () => {
@@ -2587,7 +2596,7 @@ function NotebookTabContent({
         scrollCellIntoView()
       }
     },
-    [findCellElement, focusCommentCell]
+    [findCellElement, focusCommentCell, commentCellIdentities]
   )
 
   useEffect(() => {
@@ -3231,6 +3240,8 @@ function NotebookTabContent({
             cellId: target.cellId,
             source,
             ranges,
+            selectionSurface:
+              target.type === 'cell-source' ? 'source' : 'rendered-markdown',
           })
         })()
         draftAnchors.current.set(

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2534,7 +2534,10 @@ function NotebookTabContent({
 
   const selectCommentTarget = useCallback(
     (target: CommentNavigationTarget) => {
-      focusCommentCell(target.cellId)
+      focusCommentCell(
+        target.cellId,
+        target.surface === 'source' ? 'editor' : undefined
+      )
       const range = target.range
       setActiveCommentRange(range ? { cellId: target.cellId, ...range } : null)
 

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -2517,11 +2517,13 @@ function NotebookTabContent({
   }, [])
 
   const focusCommentCell = useCallback(
-    (cellId: string) => {
+    (cellId: string, originatingRole?: CellFocusRole) => {
       const element = findCellElement(cellId)
-      const focusRole = element?.id.startsWith('markdown-action-')
-        ? 'rendered'
-        : 'editor'
+      // Source drafts originate in Monaco even inside a Markdown wrapper.
+      // Preserve that mode when notebook/window focus is restored later.
+      const focusRole =
+        originatingRole ??
+        (element?.id.startsWith('markdown-action-') ? 'rendered' : 'editor')
       const nextState = createNotebookActiveCellState(cellId, focusRole)
       if (nextState) {
         onCellFocus(docUri, nextState)
@@ -3159,7 +3161,7 @@ function NotebookTabContent({
     }
   }, [syncPendingComments])
 
-  // Bind the rendered selection to immutable source while its displayed model
+  // Bind the selection to immutable source while its displayed model
   // and revision are still available. Sending later does not inspect the editor.
   const draftAnchors = useRef(
     new WeakMap<
@@ -3239,7 +3241,10 @@ function NotebookTabContent({
       openCommentsPanel()
       setDraftTarget(target)
       setDraftContent('')
-      focusCommentCell(target.cellId)
+      focusCommentCell(
+        target.cellId,
+        target.type === 'cell-source' ? 'editor' : undefined
+      )
       setActiveCommentRange(
         target.type === 'cell-text'
           ? { cellId: target.cellId, ...target.selectors[0] }

--- a/app/src/components/Actions/Editor.test.tsx
+++ b/app/src/components/Actions/Editor.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Editor from './Editor'
+
+const state = vi.hoisted(() => ({
+  editor: null as any,
+  action: null as any,
+  dispose: vi.fn(),
+}))
+vi.mock('use-resize-observer', () => ({
+  default: () => ({ ref: () => {}, width: 400 }),
+}))
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ onMount }: any) => {
+    React.useEffect(() => {
+      onMount(state.editor, {
+        editor: { defineTheme: vi.fn(), setTheme: vi.fn() },
+        KeyMod: { CtrlCmd: 2048, Alt: 512 },
+        KeyCode: { KeyM: 43 },
+      })
+    }, [])
+    return <div className="monaco-editor" />
+  },
+}))
+
+beforeEach(() => {
+  state.action = null
+  state.dispose.mockReset()
+  const source = 'a😀 first\r\nsecond'
+  state.editor = {
+    getModel: () => ({
+      getValue: () => source,
+      getOffsetAt: ({ lineNumber, column }: any) =>
+        (lineNumber === 1 ? 0 : 11) + column - 1,
+    }),
+    getSelection: () => ({
+      isEmpty: () => false,
+      getStartPosition: () => ({ lineNumber: 1, column: 2 }),
+      getEndPosition: () => ({ lineNumber: 2, column: 7 }),
+    }),
+    addAction: vi.fn((action) => {
+      state.action = action
+      return { dispose: state.dispose }
+    }),
+    onKeyDown: vi.fn(),
+    onDidContentSizeChange: vi.fn(),
+    onDidFocusEditorText: vi.fn(),
+    getContentHeight: () => 120,
+    layout: vi.fn(),
+    getLayoutInfo: () => ({ width: 400 }),
+  }
+})
+const props = {
+  id: 'cell',
+  value: 'stale React source',
+  language: 'python',
+  onChange: vi.fn(),
+  onEnter: vi.fn(),
+}
+
+describe('editor range comments', () => {
+  it.each(['python', 'markdown'])(
+    'captures the current %s source and UTF-16 multiline selection',
+    (language) => {
+      const onCommentSelection = vi.fn()
+      render(
+        <Editor
+          {...props}
+          language={language}
+          onCommentSelection={onCommentSelection}
+        />
+      )
+      expect(state.action.precondition).toBe('editorHasSelection')
+      act(() => state.action.run())
+      expect(onCommentSelection).toHaveBeenCalledWith({
+        source: 'a😀 first\r\nsecond',
+        range: { start: 1, end: 17 },
+      })
+    }
+  )
+  it('ignores an empty selection even when invoked programmatically', () => {
+    const onCommentSelection = vi.fn()
+    render(<Editor {...props} onCommentSelection={onCommentSelection} />)
+    state.editor.getSelection = () => ({ isEmpty: () => true })
+    act(() => state.action.run())
+    expect(onCommentSelection).not.toHaveBeenCalled()
+  })
+  it('registers when comments become available and uses the latest callback', () => {
+    const first = vi.fn(),
+      second = vi.fn()
+    const view = render(<Editor {...props} />)
+    expect(state.editor.addAction).not.toHaveBeenCalled()
+    view.rerender(<Editor {...props} onCommentSelection={first} />)
+    act(() => state.action.run())
+    view.rerender(<Editor {...props} onCommentSelection={second} />)
+    act(() => state.action.run())
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(state.dispose).toHaveBeenCalledTimes(1)
+    view.unmount()
+    expect(state.dispose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/app/src/components/Actions/Editor.tsx
+++ b/app/src/components/Actions/Editor.tsx
@@ -25,6 +25,7 @@ const Editor = memo(
     onMount,
     commentRanges = [],
     onSelectComment,
+    onCommentSelection,
   }: {
     id: string;
     value: string;
@@ -41,12 +42,47 @@ const Editor = memo(
     onMount?: (editor: any, monaco: any) => void;
     commentRanges?: readonly CommentSourceRange[];
     onSelectComment?: (id: string) => void;
+    onCommentSelection?: (selection: {
+      source: string;
+      range: { start: number; end: number };
+    }) => void;
   }) => {
     // Store the latest onEnter in a ref to ensure late binding
     const onEnterRef = useRef(onEnter);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const editorRef = useRef<any>(null);
     const [mountVersion, setMountVersion] = useState(0);
+    const monacoRef = useRef<any>(null);
+
+    // Read Monaco's model/selection synchronously when the action runs. DOM
+    // selections are unrelated to Monaco offsets and disappear on menu focus.
+    useEffect(() => {
+      const editor = editorRef.current;
+      const monaco = monacoRef.current;
+      if (!editor || !monaco || !onCommentSelection) return;
+      const action = editor.addAction({
+        id: "runme.commentSelection",
+        label: "Comment on selection",
+        precondition: "editorHasSelection",
+        contextMenuGroupId: "9_cutcopypaste",
+        contextMenuOrder: 4,
+        keybindings: [
+          monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyM,
+        ],
+        run: () => {
+          const model = editor.getModel();
+          const selection = editor.getSelection();
+          if (!model || !selection || selection.isEmpty()) return;
+          const start = model.getOffsetAt(selection.getStartPosition());
+          const end = model.getOffsetAt(selection.getEndPosition());
+          onCommentSelection({
+            source: model.getValue(),
+            range: { start, end },
+          });
+        },
+      });
+      return () => action.dispose();
+    }, [onCommentSelection, mountVersion]);
     // Monaco uses UTF-16 positions; immutable anchors are converted by the view.
     useEffect(() => {
       const editor = editorRef.current,
@@ -148,6 +184,7 @@ const Editor = memo(
 
     const editorDidMount = (editor: any, monaco: any) => {
       editorRef.current = editor;
+      monacoRef.current = monaco;
       setMountVersion((v) => v + 1);
 
       if (!monaco?.editor) {
@@ -234,6 +271,8 @@ const Editor = memo(
         className="w-full min-w-0 max-w-full"
         style={{ contain: "inline-size" }}
         ref={setContainerRef}
+        // Monaco owns its context menu, including selection and clipboard actions.
+        onContextMenu={(event) => event.stopPropagation()}
       >
         <div className="overflow-hidden">
           <MonacoEditor
@@ -273,17 +312,6 @@ const Editor = memo(
           />
         </div>
       </div>
-    );
-  },
-  (prevProps, nextProps) => {
-    return (
-      prevProps.id === nextProps.id &&
-      prevProps.value === nextProps.value &&
-      prevProps.language === nextProps.language &&
-      prevProps.readOnly === nextProps.readOnly &&
-      prevProps.ariaLabel === nextProps.ariaLabel &&
-      prevProps.autoFocusWhenEmpty === nextProps.autoFocusWhenEmpty &&
-      prevProps.shouldFocus === nextProps.shouldFocus
     );
   }
 );

--- a/app/src/components/Actions/MarkdownCell.test.tsx
+++ b/app/src/components/Actions/MarkdownCell.test.tsx
@@ -138,6 +138,30 @@ describe("MarkdownCell", () => {
     expect(screen.queryByTestId("markdown-rendered")).toBeNull();
   });
 
+  it("opens source when comment navigation changes the role of an already active cell", () => {
+    const cell = create(parser_pb.CellSchema, {
+      refId: "md-comment-navigation",
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: "markdown",
+      value: "first second",
+    });
+    const stub = new StubCellData(cell);
+    const props = {
+      cellData: stub as unknown as CellData,
+      selectedLanguage: "markdown",
+      languageSelectId: "lang-comment-navigation",
+      languageOptions: [{ label: "Markdown", value: "markdown" }],
+      onLanguageChange: () => {},
+      isActiveCell: true,
+      isWindowFocused: true,
+    };
+    const view = render(<MarkdownCell {...props} activeFocusRole="rendered" />);
+    expect(screen.getByTestId("markdown-rendered")).toBeTruthy();
+    view.rerender(<MarkdownCell {...props} activeFocusRole="editor" />);
+    expect(screen.getByTestId("markdown-editor")).toBeTruthy();
+    expect(screen.queryByTestId("markdown-rendered")).toBeNull();
+  });
+
   it("focuses the editor when the window regains focus", async () => {
     const cell = create(parser_pb.CellSchema, {
       refId: "md-focus-editor",

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -280,6 +280,7 @@ const MarkdownCell = memo(
     const projectionRef = useRef<RenderedMarkdownProjection | null>(null)
     const commentHighlightOwnerRef = useRef<object>({})
     const previousShouldOwnFocusRef = useRef(false)
+    const previousFocusRoleRef = useRef(activeFocusRole)
     const [editorFocusIntent, setEditorFocusIntent] = useState(false)
     const [renderedFocusIntent, setRenderedFocusIntent] = useState(false)
 
@@ -334,7 +335,14 @@ const MarkdownCell = memo(
     useEffect(() => {
       const previouslyOwnedFocus = previousShouldOwnFocusRef.current
       previousShouldOwnFocusRef.current = shouldOwnFocus
-      if (!shouldOwnFocus || previouslyOwnedFocus) {
+      const previousRole = previousFocusRoleRef.current
+      previousFocusRoleRef.current = activeFocusRole
+      // Selecting a saved source comment changes the focus role even if this
+      // cell already owns focus. Honor that explicit navigation request.
+      if (
+        !shouldOwnFocus ||
+        (previouslyOwnedFocus && previousRole === activeFocusRole)
+      ) {
         return
       }
       if (

--- a/app/src/components/Actions/MarkdownCell.tsx
+++ b/app/src/components/Actions/MarkdownCell.tsx
@@ -107,10 +107,7 @@ const markdownComponents: Components = {
       )
     }
     return (
-      <code
-        className={`block text-[12.6px] font-mono ${className}`}
-        {...props}
-      >
+      <code className={`block text-[12.6px] font-mono ${className}`} {...props}>
         {children}
       </code>
     )
@@ -197,6 +194,7 @@ interface MarkdownCellProps {
   /** Resolved open-comment ranges to keep visible in rendered Markdown. */
   commentRanges?: readonly RenderedMarkdownCommentRange[]
   commentSourceRanges?: CommentSourceRange[]
+  onCommentSelection?: React.ComponentProps<typeof Editor>['onCommentSelection']
   onSelectComment?: (id: string) => void
   /** Open the cell context menu with a lazily captured rendered selection. */
   onRenderedSelectionContextMenu?: (request: {
@@ -253,6 +251,7 @@ const MarkdownCell = memo(
     commentRanges = [],
     commentSourceRanges = [],
     onSelectComment,
+    onCommentSelection,
     onRenderedSelectionContextMenu,
   }: MarkdownCellProps) => {
     // Subscribe to cell data changes using useSyncExternalStore for tearing-safe reads
@@ -637,6 +636,7 @@ const MarkdownCell = memo(
           >
             <Editor
               commentRanges={commentSourceRanges}
+              onCommentSelection={onCommentSelection}
               onSelectComment={onSelectComment}
               id={`md-editor-${cell.refId}`}
               value={value}
@@ -694,6 +694,7 @@ const MarkdownCell = memo(
       prevProps.readOnly === nextProps.readOnly &&
       sameCommentRanges(prevProps.commentRanges, nextProps.commentRanges) &&
       prevProps.commentSourceRanges === nextProps.commentSourceRanges &&
+      prevProps.onCommentSelection === nextProps.onCommentSelection &&
       prevProps.onSelectComment === nextProps.onSelectComment &&
       prevProps.onRenderedSelectionContextMenu ===
         nextProps.onRenderedSelectionContextMenu

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -98,67 +98,78 @@ describe('NotebookCommentsPanel', () => {
     )
     expect(onReply).toHaveBeenCalledTimes(1)
   })
-  it('activates only the selected saved source range and navigates to its editor', () => {
-    const source = 'first second'
-    const threads = toCellCommentThreads(
-      [0, 1].map((index) => {
-        const anchor = {
-          kind: 'cell',
-          cell_id: 'cell-1',
-          surface: 'source',
-          selection_surface: 'source',
-          version: { kind: 'operation', op_id: 'old:1' },
-          range: {
-            start_index: index === 0 ? 0 : 6,
-            end_index: index === 0 ? 5 : 12,
-            unit: 'unicode-code-point',
-          },
-        }
-        return {
-          id: `range-${index}`,
-          content: `Source range ${index}`,
-          anchor: JSON.stringify({
-            runme: {
-              version: 1,
-              type: 'cell',
-              cellId: 'cell-1',
-              anchorSources: [{ anchor, source }],
+  it.each([false, true])(
+    'activates only the selected saved source range and navigates to its editor (legacy comparison: %s)',
+    (comparison) => {
+      const source = 'first second'
+      const threads = toCellCommentThreads(
+        [0, 1].map((index) => {
+          const anchor = {
+            kind: 'cell',
+            cell_id: 'cell-1',
+            surface: 'source',
+            selection_surface: comparison ? undefined : 'source',
+            version: { kind: 'operation', op_id: 'old:1' },
+            range: {
+              start_index: index === 0 ? 0 : 6,
+              end_index: index === 0 ? 5 : 12,
+              unit: 'unicode-code-point',
             },
-          }),
-        }
-      }),
-      [{ refId: 'cell-1', value: source }]
-    )
-    const onSelectTarget = vi.fn()
-    renderPanel({
-      storage: 'runme-operation-log',
-      threads,
-      activeCellId: 'cell-1',
-      cellLabels: new Map([['cell-1', 'Cell 1']]),
-      onSelectTarget,
-    })
-    expect(
-      document.querySelectorAll('article[aria-current="true"]')
-    ).toHaveLength(1)
-    expect(
-      screen.getAllByPlaceholderText('Reply or add others with @')
-    ).toHaveLength(1)
-    const second = screen.getByText('Source range 1').closest('article')!
-    fireEvent.click(second)
-    expect(
-      document.querySelectorAll('article[aria-current="true"]')
-    ).toHaveLength(1)
-    expect(second.getAttribute('aria-current')).toBe('true')
-    expect(onSelectTarget).toHaveBeenLastCalledWith({
-      cellId: 'cell-1',
-      surface: 'source',
-    })
-    fireEvent.click(within(second).getByRole('button', { name: /Located/ }))
-    expect(onSelectTarget).toHaveBeenLastCalledWith({
-      cellId: 'cell-1',
-      surface: 'source',
-    })
-  })
+          }
+          return {
+            id: `range-${index}`,
+            content: `Source range ${index}`,
+            anchor: JSON.stringify({
+              runme: {
+                version: 1,
+                type: 'cell',
+                cellId: 'cell-1',
+                anchorSources: [{ anchor, source }],
+                ...(comparison
+                  ? {
+                      comparison: {
+                        start: anchor.version,
+                        end: anchor.version,
+                      },
+                    }
+                  : {}),
+              },
+            }),
+          }
+        }),
+        [{ refId: 'cell-1', value: source }]
+      )
+      const onSelectTarget = vi.fn()
+      renderPanel({
+        storage: 'runme-operation-log',
+        threads,
+        activeCellId: 'cell-1',
+        cellLabels: new Map([['cell-1', 'Cell 1']]),
+        onSelectTarget,
+      })
+      expect(
+        document.querySelectorAll('article[aria-current="true"]')
+      ).toHaveLength(1)
+      expect(
+        screen.getAllByPlaceholderText('Reply or add others with @')
+      ).toHaveLength(1)
+      const second = screen.getByText('Source range 1').closest('article')!
+      fireEvent.click(second)
+      expect(
+        document.querySelectorAll('article[aria-current="true"]')
+      ).toHaveLength(1)
+      expect(second.getAttribute('aria-current')).toBe('true')
+      expect(onSelectTarget).toHaveBeenLastCalledWith({
+        cellId: 'cell-1',
+        surface: 'source',
+      })
+      fireEvent.click(within(second).getByRole('button', { name: /Located/ }))
+      expect(onSelectTarget).toHaveBeenLastCalledWith({
+        cellId: 'cell-1',
+        surface: 'source',
+      })
+    }
+  )
 
   it.each([undefined, 'rendered-markdown'])(
     'keeps saved rendered selections on their rendered surface (%s)',

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -98,6 +98,67 @@ describe('NotebookCommentsPanel', () => {
     )
     expect(onReply).toHaveBeenCalledTimes(1)
   })
+  it('activates only the selected saved source range and navigates to its editor', () => {
+    const source = 'first second'
+    const threads = toCellCommentThreads(
+      [0, 1].map((index) => {
+        const anchor = {
+          kind: 'cell',
+          cell_id: 'cell-1',
+          surface: 'source',
+          version: { kind: 'operation', op_id: 'old:1' },
+          range: {
+            start_index: index === 0 ? 0 : 6,
+            end_index: index === 0 ? 5 : 12,
+            unit: 'unicode-code-point',
+          },
+        }
+        return {
+          id: `range-${index}`,
+          content: `Source range ${index}`,
+          anchor: JSON.stringify({
+            runme: {
+              version: 1,
+              type: 'cell',
+              cellId: 'cell-1',
+              anchorSources: [{ anchor, source }],
+            },
+          }),
+        }
+      }),
+      [{ refId: 'cell-1', value: source }]
+    )
+    const onSelectTarget = vi.fn()
+    renderPanel({
+      storage: 'runme-operation-log',
+      threads,
+      activeCellId: 'cell-1',
+      cellLabels: new Map([['cell-1', 'Cell 1']]),
+      onSelectTarget,
+    })
+    expect(
+      document.querySelectorAll('article[aria-current="true"]')
+    ).toHaveLength(1)
+    expect(
+      screen.getAllByPlaceholderText('Reply or add others with @')
+    ).toHaveLength(1)
+    const second = screen.getByText('Source range 1').closest('article')!
+    fireEvent.click(second)
+    expect(
+      document.querySelectorAll('article[aria-current="true"]')
+    ).toHaveLength(1)
+    expect(second.getAttribute('aria-current')).toBe('true')
+    expect(onSelectTarget).toHaveBeenLastCalledWith({
+      cellId: 'cell-1',
+      surface: 'source',
+    })
+    fireEvent.click(within(second).getByRole('button', { name: /Located/ }))
+    expect(onSelectTarget).toHaveBeenLastCalledWith({
+      cellId: 'cell-1',
+      surface: 'source',
+    })
+  })
+
   it('describes where comments are stored for each notebook format', () => {
     const view = renderPanel({ storage: 'runme-operation-log' })
 

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -106,6 +106,7 @@ describe('NotebookCommentsPanel', () => {
           kind: 'cell',
           cell_id: 'cell-1',
           surface: 'source',
+          selection_surface: 'source',
           version: { kind: 'operation', op_id: 'old:1' },
           range: {
             start_index: index === 0 ? 0 : 6,
@@ -158,6 +159,56 @@ describe('NotebookCommentsPanel', () => {
       surface: 'source',
     })
   })
+
+  it.each([undefined, 'rendered-markdown'])(
+    'keeps saved rendered selections on their rendered surface (%s)',
+    (selectionSurface) => {
+      const source = '# Before **selected** after'
+      const anchor = {
+        kind: 'cell',
+        cell_id: 'cell-1',
+        surface: 'source',
+        selection_surface: selectionSurface,
+        version: { kind: 'revision', revision_id: 'revision-1' },
+        range: { start_index: 11, end_index: 19, unit: 'unicode-code-point' },
+      }
+      const threads = toCellCommentThreads(
+        [
+          {
+            id: 'rendered-range',
+            content: 'Rendered selection',
+            anchor: JSON.stringify({
+              runme: {
+                version: 1,
+                type: 'cell',
+                cellId: 'cell-1',
+                diffTarget: {
+                  cellId: 'cell-1',
+                  side: 'head',
+                  quote: 'selected',
+                  sourceRange: { start: 11, end: 19, unit: 'utf-16' },
+                },
+                anchorSources: [{ anchor, source }],
+              },
+            }),
+          },
+        ],
+        [{ refId: 'cell-1', value: source }]
+      )
+      const onSelectTarget = vi.fn()
+      renderPanel({
+        threads,
+        onSelectTarget,
+        cellLabels: new Map([['cell-1', 'Cell 1']]),
+      })
+      const card = screen.getByText('Rendered selection').closest('article')!
+      const expected = { cellId: 'cell-1', sourceRange: { start: 11, end: 19 } }
+      fireEvent.click(card)
+      expect(onSelectTarget).toHaveBeenLastCalledWith(expected)
+      fireEvent.click(within(card).getByRole('button', { name: /Located/ }))
+      expect(onSelectTarget).toHaveBeenLastCalledWith(expected)
+    }
+  )
 
   it('describes where comments are stored for each notebook format', () => {
     const view = renderPanel({ storage: 'runme-operation-log' })

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { commentAttributionLabel } from '../lib/commentAttribution'
 import { CommentAnchorLocations } from './CommentAnchorLocations'
-import { isLocated } from '../lib/commentAnchorMapping'
+import { isLocated, type LocatedAnchor } from '../lib/commentAnchorMapping'
 
 import type {
   CellCommentThread,
@@ -419,13 +419,7 @@ export function NotebookCommentsPanel({
                       onSelect={(entry) => {
                         if (entry.anchor.kind === 'cell') {
                           setActiveThreadKey(item.key)
-                          onSelectTarget({
-                            cellId: entry.anchor.cell_id,
-                            ...(entry.anchor.surface === 'source' &&
-                            entry.anchor.range
-                              ? { surface: 'source' as const }
-                              : {}),
-                          })
+                          onSelectTarget(navigationTargetForLocation(entry)!)
                         }
                       }}
                     />
@@ -1000,22 +994,43 @@ function isSourceRangeThread(thread: CellCommentThread): boolean {
   )
 }
 
+/** Older V2 selections originated in rendered Markdown. Only an explicit UI
+ * origin opens Monaco; the anchor's source surface describes storage coordinates.
+ */
+function navigationTargetForLocation(
+  entry: LocatedAnchor
+): CommentNavigationTarget | null {
+  if (entry.anchor.kind !== 'cell') return null
+  const cellId = entry.anchor.cell_id
+  if (entry.anchor.selection_surface === 'source')
+    return { cellId, surface: 'source' }
+  return {
+    cellId,
+    ...('start' in entry.location
+      ? {
+          sourceRange: { start: entry.location.start, end: entry.location.end },
+        }
+      : {}),
+  }
+}
+
 function navigationTargetForItem(
   item: CommentsPanelItem
 ): CommentNavigationTarget | null {
   if (!item.cellId || item.orphaned) {
     return null
   }
-  if (
-    item.draftTarget?.type === 'cell-source' ||
-    item.threads.some(isSourceRangeThread)
-  ) {
+  if (item.draftTarget?.type === 'cell-source') {
     return { cellId: item.cellId, surface: 'source' }
   }
   if (item.draftTarget?.type === 'cell-text') {
     const { start, end } = item.draftTarget.selectors[0]
     return { cellId: item.cellId, range: { start, end } }
   }
+  const located = item.threads.flatMap((thread) => thread.locations ?? [])
+  const primary =
+    located.find((entry) => isLocated(entry.location)) ?? located[0]
+  if (primary) return navigationTargetForLocation(primary)
   const rangeThread = item.threads.find(
     (thread) =>
       thread.anchor?.type === 'cell-text' &&

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -347,7 +347,9 @@ export function NotebookCommentsPanel({
                 item.draftTarget?.type === 'cell-text' ||
                   item.draftTarget?.type === 'cell-source' ||
                   item.threads.some(
-                    (thread) => thread.anchor?.type === 'cell-text'
+                    (thread) =>
+                      thread.anchor?.type === 'cell-text' ||
+                      isSourceRangeThread(thread)
                   )
               )
               const isActiveThread =
@@ -415,8 +417,16 @@ export function NotebookCommentsPanel({
                       key={thread.comment.id}
                       locations={thread.locations ?? []}
                       onSelect={(entry) => {
-                        if (entry.anchor.kind === 'cell')
-                          onSelectTarget({ cellId: entry.anchor.cell_id })
+                        if (entry.anchor.kind === 'cell') {
+                          setActiveThreadKey(item.key)
+                          onSelectTarget({
+                            cellId: entry.anchor.cell_id,
+                            ...(entry.anchor.surface === 'source' &&
+                            entry.anchor.range
+                              ? { surface: 'source' as const }
+                              : {}),
+                          })
+                        }
                       }}
                     />
                   ))}
@@ -977,11 +987,30 @@ function getThreadKey(thread: CellCommentThread): string {
   )
 }
 
+/** V2 comments retain a cell-shaped compatibility anchor around typed ranges. */
+function isSourceRangeThread(thread: CellCommentThread): boolean {
+  return Boolean(
+    thread.anchor?.diffTarget?.sourceRange ||
+      thread.locations?.some(
+        (entry) =>
+          entry.anchor.kind === 'cell' &&
+          entry.anchor.surface === 'source' &&
+          entry.anchor.range
+      )
+  )
+}
+
 function navigationTargetForItem(
   item: CommentsPanelItem
 ): CommentNavigationTarget | null {
   if (!item.cellId || item.orphaned) {
     return null
+  }
+  if (
+    item.draftTarget?.type === 'cell-source' ||
+    item.threads.some(isSourceRangeThread)
+  ) {
+    return { cellId: item.cellId, surface: 'source' }
   }
   if (item.draftTarget?.type === 'cell-text') {
     const { start, end } = item.draftTarget.selectors[0]

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -345,6 +345,7 @@ export function NotebookCommentsPanel({
               )
               const isRangeItem = Boolean(
                 item.draftTarget?.type === 'cell-text' ||
+                  item.draftTarget?.type === 'cell-source' ||
                   item.threads.some(
                     (thread) => thread.anchor?.type === 'cell-text'
                   )
@@ -477,9 +478,14 @@ export function NotebookCommentsPanel({
                         New comment on{' '}
                         {cellLabels.get(item.draftTarget.cellId) ?? 'cell'}
                       </label>
-                      {item.draftTarget.type === 'cell-text' && (
+                      {item.draftTarget.type !== 'cell' && (
                         <blockquote className="mt-2 border-l-2 border-nb-accent pl-2 text-xs text-nb-text-muted">
-                          {item.draftTarget.selectors[1].exact}
+                          {item.draftTarget.type === 'cell-source'
+                            ? item.draftTarget.source.slice(
+                                item.draftTarget.range.start,
+                                item.draftTarget.range.end
+                              )
+                            : item.draftTarget.selectors[1].exact}
                         </blockquote>
                       )}
                       <textarea
@@ -880,7 +886,9 @@ function sortCommentPanelItems(
   const draftKey =
     draftTarget.type === 'cell'
       ? getCellThreadKey(draftTarget.cellId)
-      : `draft:${draftTarget.cellId}:${draftTarget.selectors[0].start}:${draftTarget.selectors[0].end}`
+      : draftTarget.type === 'cell-source'
+        ? `source-draft:${draftTarget.cellId}:${draftTarget.range.start}:${draftTarget.range.end}`
+        : `draft:${draftTarget.cellId}:${draftTarget.selectors[0].start}:${draftTarget.selectors[0].end}`
   const existingItem =
     draftTarget.type === 'cell' ? itemsByCell.get(draftKey) : undefined
   if (existingItem) {

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -479,7 +479,13 @@ export function NotebookCommentsPanel({
                         {cellLabels.get(item.draftTarget.cellId) ?? 'cell'}
                       </label>
                       {item.draftTarget.type !== 'cell' && (
-                        <blockquote className="mt-2 border-l-2 border-nb-accent pl-2 text-xs text-nb-text-muted">
+                        <blockquote
+                          className={`mt-2 border-l-2 border-nb-accent pl-2 text-xs text-nb-text-muted${
+                            item.draftTarget.type === 'cell-source'
+                              ? ' whitespace-pre-wrap break-words'
+                              : ''
+                          }`}
+                        >
                           {item.draftTarget.type === 'cell-source'
                             ? item.draftTarget.source.slice(
                                 item.draftTarget.range.start,

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -984,7 +984,7 @@ function getThreadKey(thread: CellCommentThread): string {
 /** V2 comments retain a cell-shaped compatibility anchor around typed ranges. */
 function isSourceRangeThread(thread: CellCommentThread): boolean {
   return Boolean(
-    thread.anchor?.diffTarget?.sourceRange ||
+    (thread.anchor?.type === 'cell' && thread.anchor.diffTarget?.sourceRange) ||
       thread.locations?.some(
         (entry) =>
           entry.anchor.kind === 'cell' &&

--- a/app/src/lib/commentAnchorMapping.test.ts
+++ b/app/src/lib/commentAnchorMapping.test.ts
@@ -68,6 +68,31 @@ describe('historical comment display mapping', () => {
       status: 'unavailable',
     })
   })
+  it('derives the source origin for old comparison ranges without duplicating locations', () => {
+    const anchor = {
+      kind: 'cell',
+      cell_id: 'cell',
+      surface: 'source',
+      version: { kind: 'operation', op_id: 'a:1' },
+      range: { start_index: 0, end_index: 2, unit: 'unicode-code-point' },
+    }
+    const encoded = JSON.stringify({
+      runme: {
+        comparison: { start: anchor.version, end: anchor.version },
+        anchorSources: [{ anchor, source: '**syntax**' }],
+      },
+    })
+    const comment = { anchor: encoded, replies: [{ anchor: encoded }] }
+    expect(historicalAnchors(comment)).toEqual([
+      {
+        anchor: { ...anchor, selection_surface: 'source' },
+        source: '**syntax**',
+      },
+    ])
+    expect(comment.anchor).toBe(encoded)
+    expect(anchor).not.toHaveProperty('selection_surface')
+  })
+
   it('resolves all root and reply anchors independently on both sides, without mutation', () => {
     const anchor = {
       kind: 'cell',

--- a/app/src/lib/commentAnchorMapping.ts
+++ b/app/src/lib/commentAnchorMapping.ts
@@ -295,12 +295,14 @@ export function mapSourceRange(
 /** Read only transient materialization metadata; it is never a serialized quote. */
 export function historicalAnchors(comment: DriveComment): HistoricalAnchor[] {
   const result: HistoricalAnchor[] = []
+  const seen = new Set<string>()
   for (const message of [
     comment,
     ...(comment.replies ?? []).filter((r) => !r.deleted),
   ]) {
     try {
-      const sources = JSON.parse(message.anchor ?? '{}').runme?.anchorSources
+      const projection = JSON.parse(message.anchor ?? '{}').runme
+      const sources = projection?.anchorSources
       if (Array.isArray(sources))
         for (const entry of sources) {
           if (
@@ -311,11 +313,22 @@ export function historicalAnchors(comment: DriveComment): HistoricalAnchor[] {
               ? typeof entry.anchor.version.op_id === 'string'
               : entry.anchor.version?.kind === 'revision' &&
                 typeof entry.anchor.version.revision_id === 'string') &&
-            !result.some(
-              (x) => JSON.stringify(x.anchor) === JSON.stringify(entry.anchor)
+            !seen.has(JSON.stringify(entry.anchor))
+          ) {
+            seen.add(JSON.stringify(entry.anchor))
+            // Comparisons select source even in older records without a UI hint.
+            // Derive this only in the read projection; never rewrite history.
+            result.push(
+              projection.comparison &&
+                entry.anchor.range &&
+                !entry.anchor.selection_surface
+                ? {
+                    ...entry,
+                    anchor: { ...entry.anchor, selection_surface: 'source' },
+                  }
+                : entry
             )
-          )
-            result.push(entry)
+          }
         }
     } catch {
       /* Legacy anchors have no historical-source projection. */

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -69,6 +69,8 @@ export type CommentDraftTarget =
 
 export type CommentNavigationTarget = {
   cellId: string
+  /** Source anchors open Monaco; range below remains a rendered-text range. */
+  surface?: 'source'
   range?: TextRange
 }
 

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -72,6 +72,8 @@ export type CommentNavigationTarget = {
   /** Source anchors open Monaco; range below remains a rendered-text range. */
   surface?: 'source'
   range?: TextRange
+  /** Located source code points to project into the rendered view at navigation. */
+  sourceRange?: TextRange
 }
 
 export type CommentCellIdentity = {

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -54,7 +54,16 @@ export type CellTextCommentAnchor = {
 
 export type CommentAnchor = CellCommentAnchor | CellTextCommentAnchor
 
+/** Transient Monaco selection; offsets are UTF-16 until bound to immutable source. */
+export type SourceSelectionDraft = {
+  type: 'cell-source'
+  cellId: string
+  source: string
+  range: TextRange
+}
+
 export type CommentDraftTarget =
+  | SourceSelectionDraft
   | { type: 'cell'; cellId: string }
   | RenderedMarkdownSelectionDraft
 

--- a/app/src/lib/operationLog/comparisonFeedback.test.ts
+++ b/app/src/lib/operationLog/comparisonFeedback.test.ts
@@ -125,6 +125,7 @@ describe('direct comparison feedback', () => {
           kind: 'cell',
           cell_id: 'c',
           version: { kind: 'revision', revision_id: 'end' },
+          selection_surface: 'source',
           range: { start_index: 6, end_index: 11, unit: 'unicode-code-point' },
         },
       ],

--- a/app/src/lib/operationLog/comparisonFeedback.ts
+++ b/app/src/lib/operationLog/comparisonFeedback.ts
@@ -173,6 +173,7 @@ export async function commentOnComparison(
           surface: 'source',
           ...(input.sourceRange
             ? {
+                selection_surface: 'source',
                 range: codePointRange(
                   source!,
                   input.sourceRange.start,

--- a/app/src/lib/operationLog/recordValidation.ts
+++ b/app/src/lib/operationLog/recordValidation.ts
@@ -112,6 +112,12 @@ export function validateAnchor(value: any): asserts value is Anchor {
     value.surface !== 'source'
   )
     throw new Error('Invalid cell anchor')
+  if (
+    value.selection_surface !== undefined &&
+    value.selection_surface !== 'source' &&
+    value.selection_surface !== 'rendered-markdown'
+  )
+    throw new Error('Invalid selection surface')
   if (value.range) {
     const r = value.range
     if (

--- a/app/src/lib/operationLog/records.ts
+++ b/app/src/lib/operationLog/records.ts
@@ -52,6 +52,8 @@ export type Anchor =
       cell_id: string
       version: VersionRef
       surface: 'source'
+      /** UI origin only; anchor coordinates always refer to immutable source. */
+      selection_surface?: 'source' | 'rendered-markdown'
       range?: SourceRange
     }
 

--- a/app/src/storage/local.test.ts
+++ b/app/src/storage/local.test.ts
@@ -1466,6 +1466,7 @@ describe('LocalNotebooks operation-log storage', () => {
       cellId: 'selected',
       source,
       ranges,
+      selectionSurface: 'rendered-markdown',
     })
     notebook.cells[0].value = 'Remote edit replaces the selected words'
     await save.save(uri, notebook)
@@ -1479,6 +1480,11 @@ describe('LocalNotebooks operation-log storage', () => {
     )
     const view = JSON.parse(comment.anchor!).runme
     expect(view.anchors).toEqual(anchors)
+    expect(
+      view.anchors.every(
+        (anchor: any) => anchor.selection_surface === 'rendered-markdown'
+      )
+    ).toBe(true)
     expect(view.anchorSources).toEqual(
       anchors.map((anchor) => ({ anchor, source }))
     )

--- a/app/src/storage/local.ts
+++ b/app/src/storage/local.ts
@@ -1929,6 +1929,7 @@ export class LocalNotebooks extends Dexie {
       cellId: string
       source: string
       ranges?: { start: number; end: number }[]
+      selectionSurface?: 'source' | 'rendered-markdown'
     }
   ): Promise<Anchor[]> {
     const { parsed } = await this.readMaterializedOperationLog(uri)
@@ -1954,6 +1955,9 @@ export class LocalNotebooks extends Dexie {
       version,
       surface: 'source',
       ...(range ? { range } : {}),
+      ...(range && input.selectionSurface
+        ? { selection_surface: input.selectionSurface }
+        : {}),
     }))
     const updated = (await this.readMaterializedOperationLog(uri)).parsed
       .operations

--- a/app/src/storage/localComments.ts
+++ b/app/src/storage/localComments.ts
@@ -362,6 +362,9 @@ export class LocalComments extends Dexie {
   async saveDesiredComment(
     input: SaveDesiredCommentInput
   ): Promise<DesiredCommentRecord> {
+    if (input.target.type === 'cell-source') {
+      throw new Error('Source selection comments require a .runme notebook.')
+    }
     await this.draftWriteTails.get(input.notebookUri)?.catch(() => undefined)
     const timestamp = nowIsoString()
     const record: DesiredCommentRecord = {

--- a/app/test/browser/run-cuj-scenarios.ts
+++ b/app/test/browser/run-cuj-scenarios.ts
@@ -79,6 +79,7 @@ function fetchWithTimeout(
 }
 
 const SCENARIO_DRIVERS = [
+  join(SCRIPT_DIR, "test-scenario-editor-range-comments.ts"),
   join(SCRIPT_DIR, "test-scenario-colab-export-recovery.ts"),
   join(SCRIPT_DIR, "test-scenario-horizontal-rendering.ts"),
   join(SCRIPT_DIR, "test-scenario-drive-revision-recovery.ts"),

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -1,0 +1,226 @@
+/** CUJ: docs-dev/cujs/editor-range-comments.md.
+ * Exercise real Monaco keyboard/menu events and durable operation-log anchors.
+ * No runner, credentials, or fake service is needed.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const dir = here.endsWith('/.generated') ? dirname(here) : here
+const output = join(dir, 'test-output')
+const session =
+  process.env.AGENT_BROWSER_SESSION?.trim() || `editor-comments-${Date.now()}`
+const profile = process.env.AGENT_BROWSER_PROFILE?.trim()
+const headed = process.env.AGENT_BROWSER_HEADED?.toLowerCase() === 'true'
+const keepOpen = process.env.AGENT_BROWSER_KEEP_OPEN?.toLowerCase() === 'true'
+const movie = join(output, 'scenario-editor-range-comments.webm')
+const sources = [
+  '# 😀 first\nprint(123)',
+  '# Markdown source\n\n😀 **first**\nsecond',
+]
+mkdirSync(output, { recursive: true })
+let passed = 0
+let failed = 0
+
+/** Preserve argument boundaries and the orchestrator's browser configuration. */
+function browser(...args: string[]): string {
+  const options = ['--session', session]
+  if (profile) options.push('--profile', profile)
+  if (headed) options.push('--headed')
+  return execFileSync('agent-browser', [...options, ...args], {
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 4 * 1024 * 1024,
+  }).trim()
+}
+
+/** Evaluate setup and storage assertions; interactions below use real input. */
+function evaluate(code: string): any {
+  let result = JSON.parse(browser('eval', `(async () => { ${code} })()`))
+  if (typeof result === 'string') result = JSON.parse(result)
+  return result
+}
+
+/** Count every assertion so the suite can reject a partial walkthrough. */
+function check(name: string, ok: boolean) {
+  if (ok) passed++
+  else throw new Error(name)
+  console.log(`[PASS] ${name}`)
+}
+
+/** Save the actual draft through the visible comments panel. */
+function submit(content: string) {
+  browser(
+    'fill',
+    '[aria-label="Notebook comments"] textarea:not([placeholder])',
+    content
+  )
+  browser('find', 'role', 'button', 'click', '--name', 'Comment', '--exact')
+  browser(
+    'wait',
+    '--fn',
+    `!document.querySelector('[aria-label="Notebook comments"] textarea:not([placeholder])')`
+  )
+}
+
+try {
+  browser('open', process.env.CUJ_FRONTEND_URL ?? 'http://localhost:5173')
+  browser('record', 'start', movie)
+  browser('wait', '--fn', 'Boolean(window.app?.localNotebooks)')
+  const fixture = evaluate(`
+    const db = window.app.localNotebooks;
+    const { LOCAL_FOLDER_URI } = await import('/src/storage/local.ts');
+    const { parseOperationLog, serializeOperationLog, createRunmeOperation, causalHeads } = await import('/src/lib/operationLog/index.ts');
+    if (!await db.folders.get(LOCAL_FOLDER_URI)) await db.folders.put({id:LOCAL_FOLDER_URI,name:'Local',remoteId:'',children:[],lastSynced:''});
+    const file = await db.create(LOCAL_FOLDER_URI, 'editor-range-comments.runme');
+    const notebook = await db.load(file.uri);
+    await (await db.createOperationLogSaveStore(file.uri)).save(file.uri, notebook);
+    const log = parseOperationLog(await db.loadContent(file.uri));
+    for (const [index,value] of ${JSON.stringify(sources)}.entries()) {
+      log.operations.push(createRunmeOperation({actorId:'editor-range-fixture',actorSequence:index+1,
+        knownOperations:log.operations,dependencies:causalHeads(log.operations),kind:'cell.create',
+        payload:{cell_id:'editor-range-'+index,position:[[index+1,'editor-range-fixture',index+1]],
+          cell:{kind:index === 0 ? 'code' : 'markup',language_id:index === 0 ? 'python' : 'markdown',value,metadata:{}}}}));
+    }
+    await db.saveContent(file.uri, serializeOperationLog(log.header,log.operations), 'application/vnd.runme.notebook+jsonl');
+    sessionStorage.setItem('runme/openNotebooks', JSON.stringify([{uri:file.uri,name:file.name,type:'file',children:[]}]));
+    sessionStorage.setItem('runme/currentDoc', file.uri);
+    return {uri:file.uri};
+  `)
+  browser('reload')
+  const codeInput = '#code-action-editor-range-0 textarea'
+  const markdownInput = '#markdown-action-editor-range-1 textarea'
+  browser('wait', codeInput)
+  // From offset one through the end, crossing a surrogate pair and a newline.
+  browser('focus', codeInput)
+  for (const key of [
+    'ControlOrMeta+a',
+    'ArrowLeft',
+    'ArrowRight',
+    'Shift+ArrowDown',
+    'Shift+End',
+    'Shift+F10',
+  ])
+    browser('press', key)
+  browser('wait', '[aria-label="Comment on selection"]')
+  check('Monaco context menu offers Comment on selection', true)
+  browser(
+    'screenshot',
+    join(output, 'scenario-editor-range-comments-code-menu.png')
+  )
+  browser('click', '[aria-label="Comment on selection"]')
+  browser('wait', '[aria-label="Notebook comments"] blockquote')
+  check(
+    'Code draft contains only the selected multiline source',
+    evaluate(
+      `return document.querySelector('[aria-label="Notebook comments"] blockquote').textContent === ${JSON.stringify(sources[0].slice(1))};`
+    )
+  )
+  submit('Code selection comment')
+
+  browser('dblclick', '#markdown-rendered-editor-range-1')
+  browser('wait', markdownInput)
+  browser('focus', markdownInput)
+  for (const key of [
+    'ControlOrMeta+a',
+    'ArrowLeft',
+    'ArrowDown',
+    'ArrowDown',
+    'Shift+ArrowDown',
+    'Shift+End',
+    'ControlOrMeta+Alt+m',
+  ])
+    browser('press', key)
+  browser(
+    'wait',
+    '[aria-label="Notebook comments"] textarea:not([placeholder])'
+  )
+  check(
+    'Markdown shortcut captures source including formatting markers',
+    evaluate(
+      `return [...document.querySelectorAll('[aria-label="Notebook comments"] blockquote')].at(-1).textContent === ${JSON.stringify('😀 **first**\nsecond')};`
+    )
+  )
+  // The draft must retain the immutable revision even when the editor changes.
+  browser('focus', markdownInput)
+  browser('press', 'ControlOrMeta+a')
+  browser('type', markdownInput, '# Changed after opening comment draft')
+  submit('Markdown selection comment')
+  browser(
+    'wait',
+    '--fn',
+    `document.body.textContent.includes('Outdated anchor')`
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-editor-range-comments-saved.png')
+  )
+
+  browser('reload')
+  browser('wait', codeInput)
+  browser(
+    'wait',
+    '--fn',
+    `document.body.textContent.includes('Markdown selection comment')`
+  )
+  const persisted = evaluate(`
+    const db = window.app.localNotebooks;
+    const comments = await db.listOperationLogComments(${JSON.stringify(fixture.uri)});
+    return comments.map(comment => ({content:comment.content,view:JSON.parse(comment.anchor).runme}));
+  `)
+  writeFileSync(
+    join(output, 'scenario-editor-range-comments-anchors.json'),
+    JSON.stringify(persisted, null, 2)
+  )
+  check('Both comments survive reload', persisted.length === 2)
+  for (const [index, content] of [
+    'Code selection comment',
+    'Markdown selection comment',
+  ].entries()) {
+    const view = persisted.find((entry: any) => entry.content === content)?.view
+    const anchor = view?.anchors?.[0]
+    const start = index === 0 ? 1 : sources[1].indexOf('😀')
+    check(
+      `${content}: immutable Unicode source range`,
+      anchor?.kind === 'cell' &&
+        anchor.surface === 'source' &&
+        anchor.range?.unit === 'unicode-code-point' &&
+        anchor.range.start_index === start &&
+        anchor.range.end_index === Array.from(sources[index]).length &&
+        view.anchorSources[0].source === sources[index]
+    )
+  }
+  check(
+    'Later Markdown edit does not retarget the comment',
+    evaluate(
+      `return document.body.textContent.includes('Changed after opening comment draft') && document.body.textContent.includes('Outdated anchor');`
+    )
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-editor-range-comments-reloaded.png')
+  )
+} catch (error) {
+  failed++
+  console.log(`[FAIL] ${error}`)
+} finally {
+  try {
+    browser('record', 'stop')
+  } catch (error) {
+    failed++
+    console.log(`[FAIL] Recording: ${error}`)
+  }
+  if (!keepOpen)
+    try {
+      browser('close')
+    } catch {
+      /* Preserve the test result. */
+    }
+}
+console.log(`Movie: ${movie}`)
+console.log(
+  `Assertions: ${passed + failed}, Passed: ${passed}, Failed: ${failed}`
+)
+process.exitCode = failed ? 1 : 0

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -6,6 +6,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { type Browser, type Page, chromium } from 'playwright-core'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const dir = here.endsWith('/.generated') ? dirname(here) : here
@@ -23,17 +24,25 @@ const sources = [
 mkdirSync(output, { recursive: true })
 let passed = 0
 let failed = 0
+let inputBrowser: Browser | undefined
+let inputPage: Page
 
 /** Preserve argument boundaries and the orchestrator's browser configuration. */
 function browser(...args: string[]): string {
   const options = ['--session', session]
   if (profile) options.push('--profile', profile)
   if (headed) options.push('--headed')
-  return execFileSync('agent-browser', [...options, ...args], {
-    encoding: 'utf8',
-    timeout: 30000,
-    maxBuffer: 4 * 1024 * 1024,
-  }).trim()
+  try {
+    return execFileSync('agent-browser', [...options, ...args], {
+      encoding: 'utf8',
+      timeout: 30000,
+      maxBuffer: 4 * 1024 * 1024,
+    }).trim()
+  } catch (error) {
+    throw new Error(
+      `agent-browser ${args[0]} ${args[0] === 'eval' ? '(script)' : args.slice(1).join(' ')}: ${error}`
+    )
+  }
 }
 
 /** Evaluate setup and storage assertions; interactions below use real input. */
@@ -93,6 +102,18 @@ try {
   const codeInput = '#code-action-editor-range-0 textarea'
   const markdownInput = '#markdown-action-editor-range-1 textarea'
   browser('wait', codeInput)
+  // The pinned agent-browser native CLI treats chord strings as a single key.
+  // Attach Playwright only for real keyboard input; retain the suite's existing
+  // browser session, recorder, setup, snapshots, and artifacts.
+  const endpoint = JSON.parse(browser('get', 'cdp-url', '--json')).data.cdpUrl
+  inputBrowser = await chromium.connectOverCDP(endpoint)
+  const activeUrl = browser('get', 'url')
+  const activePage = inputBrowser
+    .contexts()
+    .flatMap((context) => context.pages())
+    .find((page) => page.url() === activeUrl)
+  if (!activePage) throw new Error('Cannot find the recorded browser page')
+  inputPage = activePage
   // From offset one through the end, crossing a surrogate pair and a newline.
   browser('focus', codeInput)
   for (const key of [
@@ -103,7 +124,7 @@ try {
     'Shift+End',
     'Shift+F10',
   ])
-    browser('press', key)
+    await inputPage.keyboard.press(key)
   browser('wait', '[aria-label="Comment on selection"]')
   check('Monaco context menu offers Comment on selection', true)
   browser(
@@ -117,6 +138,14 @@ try {
     evaluate(
       `return document.querySelector('[aria-label="Notebook comments"] blockquote').textContent === ${JSON.stringify(sources[0].slice(1))};`
     )
+  )
+  check(
+    'Code draft visibly preserves source line breaks',
+    evaluate(`
+    const quote = document.querySelector('[aria-label="Notebook comments"] blockquote');
+    const style = getComputedStyle(quote);
+    return style.whiteSpace === 'pre-wrap' && quote.getBoundingClientRect().height >= 2 * parseFloat(style.lineHeight);
+  `)
   )
   submit('Code selection comment')
 
@@ -132,7 +161,7 @@ try {
     'Shift+End',
     'ControlOrMeta+Alt+m',
   ])
-    browser('press', key)
+    await inputPage.keyboard.press(key)
   browser(
     'wait',
     '[aria-label="Notebook comments"] textarea:not([placeholder])'
@@ -143,10 +172,40 @@ try {
       `return [...document.querySelectorAll('[aria-label="Notebook comments"] blockquote')].at(-1).textContent === ${JSON.stringify('😀 **first**\nsecond')};`
     )
   )
+  check(
+    'Markdown draft preserves editor focus role',
+    evaluate(`
+    return JSON.parse(localStorage.getItem('runme/notebook-active-cells'))[${JSON.stringify(fixture.uri)}].focusRole === 'editor';
+  `)
+  )
+  browser('find', 'role', 'button', 'click', '--name', 'Open Logs', '--exact')
+  browser(
+    'find',
+    'role',
+    'tab',
+    'click',
+    '--name',
+    'editor-range-comments.runme',
+    '--exact'
+  )
+  browser('wait', markdownInput)
+  check('Returning to the notebook restores Markdown source editing', true)
+  check(
+    'Markdown draft visibly preserves source line breaks',
+    evaluate(`
+    const quote = [...document.querySelectorAll('[aria-label="Notebook comments"] blockquote')].at(-1);
+    const style = getComputedStyle(quote);
+    return style.whiteSpace === 'pre-wrap' && quote.getBoundingClientRect().height >= 2 * parseFloat(style.lineHeight);
+  `)
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-editor-range-comments-markdown-draft.png')
+  )
   // The draft must retain the immutable revision even when the editor changes.
   browser('focus', markdownInput)
-  browser('press', 'ControlOrMeta+a')
-  browser('type', markdownInput, '# Changed after opening comment draft')
+  await inputPage.keyboard.press('ControlOrMeta+a')
+  await inputPage.keyboard.insertText('# Changed after opening comment draft')
   submit('Markdown selection comment')
   browser(
     'wait',
@@ -212,6 +271,7 @@ try {
     failed++
     console.log(`[FAIL] Recording: ${error}`)
   }
+  await inputBrowser?.close()
   if (!keepOpen)
     try {
       browser('close')

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -217,6 +217,24 @@ try {
     join(output, 'scenario-editor-range-comments-saved.png')
   )
 
+  // Add another range on the same Markdown cell, this time on current source.
+  // The old range remains outdated; selecting either card must not activate both.
+  browser('focus', markdownInput)
+  for (const key of [
+    'ControlOrMeta+a',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowRight',
+    'Shift+End',
+    'ControlOrMeta+Alt+m',
+  ])
+    await inputPage.keyboard.press(key)
+  browser(
+    'wait',
+    '[aria-label="Notebook comments"] textarea:not([placeholder])'
+  )
+  submit('Current Markdown selection comment')
+
   browser('reload')
   browser('wait', codeInput)
   browser(
@@ -227,13 +245,13 @@ try {
   const persisted = evaluate(`
     const db = window.app.localNotebooks;
     const comments = await db.listOperationLogComments(${JSON.stringify(fixture.uri)});
-    return comments.map(comment => ({content:comment.content,view:JSON.parse(comment.anchor).runme}));
+    return comments.map(comment => ({id:comment.id,content:comment.content,view:JSON.parse(comment.anchor).runme}));
   `)
   writeFileSync(
     join(output, 'scenario-editor-range-comments-anchors.json'),
     JSON.stringify(persisted, null, 2)
   )
-  check('Both comments survive reload', persisted.length === 2)
+  check('All three source comments survive reload', persisted.length === 3)
   for (const [index, content] of [
     'Code selection comment',
     'Markdown selection comment',
@@ -251,6 +269,31 @@ try {
         view.anchorSources[0].source === sources[index]
     )
   }
+  const current = persisted.find(
+    (entry: any) => entry.content === 'Current Markdown selection comment'
+  )
+  // Explicitly render the already-active Markdown cell before navigating back
+  // through the persisted comment card, as a reader does after reopening.
+  browser('focus', markdownInput)
+  await inputPage.keyboard.press('Escape')
+  browser('wait', '#markdown-rendered-editor-range-1')
+  browser('click', `#editor-comment-${current.id}`)
+  browser('wait', markdownInput)
+  browser(
+    'wait',
+    '#markdown-action-editor-range-1 .runme-source-comment-underline'
+  )
+  check(
+    'Saved Markdown range navigation opens its decorated source editor',
+    true
+  )
+  check(
+    'Only the selected saved range is active',
+    evaluate(`
+    const active = [...document.querySelectorAll('[aria-label="Notebook comments"] article[aria-current="true"]')];
+    return active.length === 1 && active[0].id === ${JSON.stringify('editor-comment-' + current.id)};
+  `)
+  )
   check(
     'Later Markdown edit does not retarget the comment',
     evaluate(

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -45,11 +45,9 @@ function browser(...args: string[]): string {
   }
 }
 
-/** Evaluate setup and storage assertions; interactions below use real input. */
-function evaluate(code: string): any {
-  let result = JSON.parse(browser('eval', `(async () => { ${code} })()`))
-  if (typeof result === 'string') result = JSON.parse(result)
-  return result
+/** Inspect setup/storage directly, while UI actions use real browser events. */
+async function evaluate(code: string): Promise<any> {
+  return inputPage.evaluate(`(async () => { ${code} })()`)
 }
 
 /** Count every assertion so the suite can reject a partial walkthrough. */
@@ -60,25 +58,33 @@ function check(name: string, ok: boolean) {
 }
 
 /** Save the actual draft through the visible comments panel. */
-function submit(content: string) {
-  browser(
-    'fill',
-    '[aria-label="Notebook comments"] textarea:not([placeholder])',
-    content
+async function submit(content: string) {
+  const draft = inputPage.locator(
+    '[aria-label="Notebook comments"] textarea:not([placeholder])'
   )
-  browser('find', 'role', 'button', 'click', '--name', 'Comment', '--exact')
-  browser(
-    'wait',
-    '--fn',
-    `!document.querySelector('[aria-label="Notebook comments"] textarea:not([placeholder])')`
-  )
+  await draft.fill(content)
+  await inputPage.getByRole('button', { name: 'Comment', exact: true }).click()
+  await draft.waitFor({ state: 'hidden' })
 }
 
 try {
   browser('open', process.env.CUJ_FRONTEND_URL ?? 'http://localhost:5173')
   browser('record', 'start', movie)
   browser('wait', '--fn', 'Boolean(window.app?.localNotebooks)')
-  const fixture = evaluate(`
+  // The pinned agent-browser native CLI treats chord strings as a single key.
+  // Use Playwright for UI events and accessible locators, while retaining
+  // the suite's existing browser session, recorder, and artifacts.
+  const endpoint = JSON.parse(browser('get', 'cdp-url', '--json')).data.cdpUrl
+  inputBrowser = await chromium.connectOverCDP(endpoint)
+  const activeUrl = browser('get', 'url')
+  const activePage = inputBrowser
+    .contexts()
+    .flatMap((context) => context.pages())
+    .find((page) => page.url() === activeUrl)
+  if (!activePage) throw new Error('Cannot find the recorded browser page')
+  inputPage = activePage
+  inputPage.setDefaultTimeout(15000)
+  const fixture = await evaluate(`
     const db = window.app.localNotebooks;
     const { LOCAL_FOLDER_URI } = await import('/src/storage/local.ts');
     const { parseOperationLog, serializeOperationLog, createRunmeOperation, causalHeads } = await import('/src/lib/operationLog/index.ts');
@@ -98,24 +104,12 @@ try {
     sessionStorage.setItem('runme/currentDoc', file.uri);
     return {uri:file.uri};
   `)
-  browser('reload')
+  await inputPage.reload()
   const codeInput = '#code-action-editor-range-0 textarea'
   const markdownInput = '#markdown-action-editor-range-1 textarea'
-  browser('wait', codeInput)
-  // The pinned agent-browser native CLI treats chord strings as a single key.
-  // Attach Playwright only for real keyboard input; retain the suite's existing
-  // browser session, recorder, setup, snapshots, and artifacts.
-  const endpoint = JSON.parse(browser('get', 'cdp-url', '--json')).data.cdpUrl
-  inputBrowser = await chromium.connectOverCDP(endpoint)
-  const activeUrl = browser('get', 'url')
-  const activePage = inputBrowser
-    .contexts()
-    .flatMap((context) => context.pages())
-    .find((page) => page.url() === activeUrl)
-  if (!activePage) throw new Error('Cannot find the recorded browser page')
-  inputPage = activePage
+  await inputPage.locator(codeInput).first().waitFor({ state: 'visible' })
   // From offset one through the end, crossing a surrogate pair and a newline.
-  browser('focus', codeInput)
+  await inputPage.locator(codeInput).focus()
   for (const key of [
     'ControlOrMeta+a',
     'ArrowLeft',
@@ -125,33 +119,39 @@ try {
     'Shift+F10',
   ])
     await inputPage.keyboard.press(key)
-  browser('wait', '[aria-label="Comment on selection"]')
+  const menu = inputPage.getByRole('menuitem', {
+    name: /^Comment on selection/,
+  })
+  await menu.waitFor({ state: 'visible' })
   check('Monaco context menu offers Comment on selection', true)
   browser(
     'screenshot',
     join(output, 'scenario-editor-range-comments-code-menu.png')
   )
-  browser('click', '[aria-label="Comment on selection"]')
-  browser('wait', '[aria-label="Notebook comments"] blockquote')
+  await menu.click()
+  await inputPage
+    .locator('[aria-label="Notebook comments"] blockquote')
+    .first()
+    .waitFor({ state: 'visible' })
   check(
     'Code draft contains only the selected multiline source',
-    evaluate(
+    await evaluate(
       `return document.querySelector('[aria-label="Notebook comments"] blockquote').textContent === ${JSON.stringify(sources[0].slice(1))};`
     )
   )
   check(
     'Code draft visibly preserves source line breaks',
-    evaluate(`
+    await evaluate(`
     const quote = document.querySelector('[aria-label="Notebook comments"] blockquote');
     const style = getComputedStyle(quote);
     return style.whiteSpace === 'pre-wrap' && quote.getBoundingClientRect().height >= 2 * parseFloat(style.lineHeight);
   `)
   )
-  submit('Code selection comment')
+  await submit('Code selection comment')
 
-  browser('dblclick', '#markdown-rendered-editor-range-1')
-  browser('wait', markdownInput)
-  browser('focus', markdownInput)
+  await inputPage.locator('#markdown-rendered-editor-range-1').dblclick()
+  await inputPage.locator(markdownInput).first().waitFor({ state: 'visible' })
+  await inputPage.locator(markdownInput).focus()
   for (const key of [
     'ControlOrMeta+a',
     'ArrowLeft',
@@ -162,37 +162,33 @@ try {
     'ControlOrMeta+Alt+m',
   ])
     await inputPage.keyboard.press(key)
-  browser(
-    'wait',
-    '[aria-label="Notebook comments"] textarea:not([placeholder])'
-  )
+  await inputPage
+    .locator('[aria-label="Notebook comments"] textarea:not([placeholder])')
+    .first()
+    .waitFor({ state: 'visible' })
   check(
     'Markdown shortcut captures source including formatting markers',
-    evaluate(
+    await evaluate(
       `return [...document.querySelectorAll('[aria-label="Notebook comments"] blockquote')].at(-1).textContent === ${JSON.stringify('😀 **first**\nsecond')};`
     )
   )
   check(
     'Markdown draft preserves editor focus role',
-    evaluate(`
+    await evaluate(`
     return JSON.parse(localStorage.getItem('runme/notebook-active-cells'))[${JSON.stringify(fixture.uri)}].focusRole === 'editor';
   `)
   )
-  browser('find', 'role', 'button', 'click', '--name', 'Open Logs', '--exact')
-  browser(
-    'find',
-    'role',
-    'tab',
-    'click',
-    '--name',
-    'editor-range-comments.runme',
-    '--exact'
-  )
-  browser('wait', markdownInput)
+  await inputPage
+    .getByRole('button', { name: 'Open Logs', exact: true })
+    .click()
+  await inputPage
+    .getByRole('tab', { name: 'editor-range-comments.runme', exact: true })
+    .click()
+  await inputPage.locator(markdownInput).first().waitFor({ state: 'visible' })
   check('Returning to the notebook restores Markdown source editing', true)
   check(
     'Markdown draft visibly preserves source line breaks',
-    evaluate(`
+    await evaluate(`
     const quote = [...document.querySelectorAll('[aria-label="Notebook comments"] blockquote')].at(-1);
     const style = getComputedStyle(quote);
     return style.whiteSpace === 'pre-wrap' && quote.getBoundingClientRect().height >= 2 * parseFloat(style.lineHeight);
@@ -203,13 +199,11 @@ try {
     join(output, 'scenario-editor-range-comments-markdown-draft.png')
   )
   // The draft must retain the immutable revision even when the editor changes.
-  browser('focus', markdownInput)
+  await inputPage.locator(markdownInput).focus()
   await inputPage.keyboard.press('ControlOrMeta+a')
   await inputPage.keyboard.insertText('# Changed after opening comment draft')
-  submit('Markdown selection comment')
-  browser(
-    'wait',
-    '--fn',
+  await submit('Markdown selection comment')
+  await inputPage.waitForFunction(
     `document.body.textContent.includes('Outdated anchor')`
   )
   browser(
@@ -219,7 +213,7 @@ try {
 
   // Add another range on the same Markdown cell, this time on current source.
   // The old range remains outdated; selecting either card must not activate both.
-  browser('focus', markdownInput)
+  await inputPage.locator(markdownInput).focus()
   for (const key of [
     'ControlOrMeta+a',
     'ArrowLeft',
@@ -229,20 +223,18 @@ try {
     'ControlOrMeta+Alt+m',
   ])
     await inputPage.keyboard.press(key)
-  browser(
-    'wait',
-    '[aria-label="Notebook comments"] textarea:not([placeholder])'
-  )
-  submit('Current Markdown selection comment')
+  await inputPage
+    .locator('[aria-label="Notebook comments"] textarea:not([placeholder])')
+    .first()
+    .waitFor({ state: 'visible' })
+  await submit('Current Markdown selection comment')
 
-  browser('reload')
-  browser('wait', codeInput)
-  browser(
-    'wait',
-    '--fn',
+  await inputPage.reload()
+  await inputPage.locator(codeInput).first().waitFor({ state: 'visible' })
+  await inputPage.waitForFunction(
     `document.body.textContent.includes('Markdown selection comment')`
   )
-  const persisted = evaluate(`
+  const persisted = await evaluate(`
     const db = window.app.localNotebooks;
     const comments = await db.listOperationLogComments(${JSON.stringify(fixture.uri)});
     return comments.map(comment => ({id:comment.id,content:comment.content,view:JSON.parse(comment.anchor).runme}));
@@ -274,29 +266,32 @@ try {
   )
   // Explicitly render the already-active Markdown cell before navigating back
   // through the persisted comment card, as a reader does after reopening.
-  browser('focus', markdownInput)
+  await inputPage.locator(markdownInput).focus()
   await inputPage.keyboard.press('Escape')
-  browser('wait', '#markdown-rendered-editor-range-1')
-  browser('click', `#editor-comment-${current.id}`)
-  browser('wait', markdownInput)
-  browser(
-    'wait',
-    '#markdown-action-editor-range-1 .runme-source-comment-underline'
-  )
+  await inputPage
+    .locator('#markdown-rendered-editor-range-1')
+    .first()
+    .waitFor({ state: 'visible' })
+  await inputPage.locator(`#editor-comment-${current.id}`).click()
+  await inputPage.locator(markdownInput).first().waitFor({ state: 'visible' })
+  await inputPage
+    .locator('#markdown-action-editor-range-1 .runme-source-comment-underline')
+    .first()
+    .waitFor({ state: 'visible' })
   check(
     'Saved Markdown range navigation opens its decorated source editor',
     true
   )
   check(
     'Only the selected saved range is active',
-    evaluate(`
+    await evaluate(`
     const active = [...document.querySelectorAll('[aria-label="Notebook comments"] article[aria-current="true"]')];
     return active.length === 1 && active[0].id === ${JSON.stringify('editor-comment-' + current.id)};
   `)
   )
   check(
     'Later Markdown edit does not retarget the comment',
-    evaluate(
+    await evaluate(
       `return document.body.textContent.includes('Changed after opening comment draft') && document.body.textContent.includes('Outdated anchor');`
     )
   )
@@ -307,6 +302,11 @@ try {
 } catch (error) {
   failed++
   console.log(`[FAIL] ${error}`)
+  if (inputPage)
+    writeFileSync(
+      join(output, 'scenario-editor-range-comments-failure.html'),
+      await inputPage.content().catch(() => 'Page unavailable')
+    )
 } finally {
   try {
     browser('record', 'stop')

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -255,6 +255,7 @@ try {
       `${content}: immutable Unicode source range`,
       anchor?.kind === 'cell' &&
         anchor.surface === 'source' &&
+        anchor.selection_surface === 'source' &&
         anchor.range?.unit === 'unicode-code-point' &&
         anchor.range.start_index === start &&
         anchor.range.end_index === Array.from(sources[index]).length &&
@@ -272,7 +273,9 @@ try {
     .locator('#markdown-rendered-editor-range-1')
     .first()
     .waitFor({ state: 'visible' })
-  await inputPage.locator(`#editor-comment-${current.id}`).click()
+  await inputPage
+    .getByText('Current Markdown selection comment', { exact: true })
+    .click()
   await inputPage.locator(markdownInput).first().waitFor({ state: 'visible' })
   await inputPage
     .locator('#markdown-action-editor-range-1 .runme-source-comment-underline')
@@ -298,6 +301,57 @@ try {
   browser(
     'screenshot',
     join(output, 'scenario-editor-range-comments-reloaded.png')
+  )
+  // Preserve rendered-origin navigation too: source coordinates alone do not
+  // identify which view the reader used when creating a comment.
+  await inputPage.locator(markdownInput).focus()
+  await inputPage.keyboard.press('Escape')
+  const rendered = inputPage.locator('#markdown-rendered-editor-range-1')
+  await rendered.waitFor({ state: 'visible' })
+  const heading = rendered.locator('h1')
+  const box = await heading.evaluate((element) => {
+    const range = document.createRange()
+    range.selectNodeContents(element)
+    const rect = range.getBoundingClientRect()
+    return { x: rect.x, y: rect.y + rect.height / 2, width: rect.width }
+  })
+  await inputPage.mouse.move(box.x + 1, box.y)
+  await inputPage.mouse.down()
+  await inputPage.mouse.move(box.x + box.width - 1, box.y, { steps: 12 })
+  await inputPage.mouse.up()
+  await heading.click({ button: 'right' })
+  await inputPage
+    .getByRole('button', { name: 'Comment on selected text', exact: true })
+    .click()
+  await submit('Rendered heading selection comment')
+  await inputPage.reload()
+  await inputPage
+    .getByText('Rendered heading selection comment', { exact: true })
+    .waitFor({ state: 'visible' })
+  await rendered.dblclick()
+  await inputPage.locator(markdownInput).first().waitFor({ state: 'visible' })
+  await inputPage
+    .getByText('Rendered heading selection comment', { exact: true })
+    .click()
+  await rendered.waitFor({ state: 'visible' })
+  check(
+    'Saved rendered selection returns to rendered Markdown from its editor',
+    true
+  )
+  check(
+    'Rendered navigation highlights the selected projected text',
+    await evaluate(`
+    const root = document.querySelector('#markdown-rendered-editor-range-1');
+    const active = [...(CSS.highlights?.get('runme-comment-range-active') ?? [])];
+    const fallback = [...root.querySelectorAll('[data-runme-comment-highlight=active]')];
+    return [...active.map(range => range.toString()), ...fallback.map(el => el.textContent)]
+      .includes('Changed after opening comment draft') &&
+      !document.querySelector('#markdown-action-editor-range-1 .monaco-editor');
+  `)
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-editor-range-comments-rendered.png')
   )
 } catch (error) {
   failed++

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -311,7 +311,14 @@ try {
   const heading = rendered.locator('h1')
   const box = await heading.evaluate((element) => {
     const range = document.createRange()
-    range.selectNodeContents(element)
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+    let text = walker.nextNode()
+    while (text && !text.textContent?.includes('Changed'))
+      text = walker.nextNode()
+    if (!text) throw new Error('Rendered heading text is missing')
+    const start = text.textContent!.indexOf('Changed')
+    range.setStart(text, start)
+    range.setEnd(text, start + 'Changed'.length)
     const rect = range.getBoundingClientRect()
     return { x: rect.x, y: rect.y + rect.height / 2, width: rect.width }
   })
@@ -319,7 +326,7 @@ try {
   await inputPage.mouse.down()
   await inputPage.mouse.move(box.x + box.width - 1, box.y, { steps: 12 })
   await inputPage.mouse.up()
-  await heading.click({ button: 'right' })
+  await inputPage.mouse.click(box.x + box.width / 2, box.y, { button: 'right' })
   await inputPage
     .getByRole('button', { name: 'Comment on selected text', exact: true })
     .click()
@@ -345,7 +352,7 @@ try {
     const active = [...(CSS.highlights?.get('runme-comment-range-active') ?? [])];
     const fallback = [...root.querySelectorAll('[data-runme-comment-highlight=active]')];
     return [...active.map(range => range.toString()), ...fallback.map(el => el.textContent)]
-      .includes('Changed after opening comment draft') &&
+      .includes('Changed') &&
       !document.querySelector('#markdown-action-editor-range-1 .monaco-editor');
   `)
   )

--- a/docs-dev/cujs/README.md
+++ b/docs-dev/cujs/README.md
@@ -38,6 +38,8 @@ from `docs-dev/cujs/`.
 - `colab-export-recovery.md` — retry a failed derived copy after Drive reconnects or from Notebook properties without editing its saved source.
 - execution-output-recovery.md — open, edit, save, reload, and rerun notebooks with conflicting execution results; retain history and replace ambiguous output with a cell-level diagnostic.
 
+- `editor-range-comments.md` — select code or Markdown source in Monaco, create a revision-bound comment, edit after capture, and verify durable anchors after reload.
+
 ## How CUJs are executed
 
 - Scripted runner(s) live under `app/test/browser/`.

--- a/docs-dev/cujs/editor-range-comments.md
+++ b/docs-dev/cujs/editor-range-comments.md
@@ -1,0 +1,48 @@
+# Comment on a source range in Monaco
+
+## User journey
+
+In a `.runme` notebook, select part of a code cell or a Markdown cell in edit
+mode. Right-click and choose **Comment on selection**, or press
+**Ctrl+Alt+M** (**Cmd+Option+M** on macOS). The comments panel shows the selected
+source. Enter a comment and submit it. Empty selections do not offer this action.
+
+The existing cell comment button continues to comment on the whole cell.
+Rendered Markdown keeps its existing selection menu. Legacy JSON/ipynb files use
+their existing comment flow; this source-range action requires `.runme` revision
+history.
+
+## Design decisions that prevent regressions
+
+- Monaco owns selection coordinates. Read its current model and normalized
+  selection synchronously when the action runs; a browser DOM selection cannot
+  represent editor source reliably and may disappear when a menu takes focus.
+- Monaco offsets use UTF-16. Pass them to the existing operation-log anchor
+  binder, which validates source boundaries and converts them to Unicode code
+  points. Never persist Monaco offsets directly: emoji otherwise shift ranges.
+- Flush pending notebook edits and bind to immutable cell source when the draft
+  opens. Submission uses that bound revision. Later edits or syncs may mark the
+  anchor outdated, but must not move it to different text or reject a valid
+  previously captured revision.
+- Selected source is transient draft data for display/validation. The durable
+  comment stores the revision and source range; historical context is resolved
+  from that revision, not from a captured quote or a checksum of current text.
+- Register/dispose the Monaco action with its current callback and comment
+  availability. Memoization must not retain a stale cell callback or hide newly
+  available comments. Keep Monaco's context menu from also opening the outer
+  cell menu.
+
+## Automated evidence
+
+`app/test/browser/test-scenario-editor-range-comments.ts` is registered in the
+canonical CUJ suite. It creates a local `.runme` fixture and uses real keyboard
+input to select multiline ranges containing emoji. It submits a code comment
+through Monaco's menu and a Markdown source comment through the shortcut, edits
+Markdown after draft capture, and reloads the page. Assertions verify exact
+selected excerpts, immutable Unicode ranges, original source, and both persisted
+comments. Screenshots cover the menu, submitted comments, and reloaded notebook;
+the JSON artifact records persisted anchors and the movie shows the walkthrough.
+
+Unit tests cover live model capture, empty selections, callback replacement and
+action disposal. Store-backed component tests cover all three selection surfaces
+(rendered Markdown, code, Markdown source), pending saves, and later sync edits.

--- a/docs-dev/cujs/editor-range-comments.md
+++ b/docs-dev/cujs/editor-range-comments.md
@@ -27,6 +27,10 @@ history.
 - Selected source is transient draft data for display/validation. The durable
   comment stores the revision and source range; historical context is resolved
   from that revision, not from a captured quote or a checksum of current text.
+- Preserve source draft whitespace so newlines and indentation remain visible.
+  Verify browser geometry and computed whitespace, not only `textContent`.
+- Source drafts retain the `editor` focus role even in a Markdown wrapper.
+  Switching tabs or restoring window focus must return to source editing.
 - Register/dispose the Monaco action with its current callback and comment
   availability. Memoization must not retain a stale cell callback or hide newly
   available comments. Keep Monaco's context menu from also opening the outer

--- a/docs-dev/cujs/editor-range-comments.md
+++ b/docs-dev/cujs/editor-range-comments.md
@@ -29,6 +29,12 @@ history.
   from that revision, not from a captured quote or a checksum of current text.
 - Preserve source draft whitespace so newlines and indentation remain visible.
   Verify browser geometry and computed whitespace, not only `textContent`.
+- Store the optional `selection_surface` with typed anchors to preserve the UI
+  origin across reloads. `surface: source` always describes storage coordinates;
+  it must not be used to infer editor versus rendered navigation. Older V2
+  comments lack this hint and keep rendered navigation. Project mapped source
+  ranges into the current rendered text for scrolling; never use source offsets
+  directly as rendered offsets.
 - Persisted source ranges navigate to Monaco and activate only their own thread.
   A compatibility anchor shaped like a whole-cell comment still contains a typed
   source range; inspect those historical locations when grouping/activating cards.

--- a/docs-dev/cujs/editor-range-comments.md
+++ b/docs-dev/cujs/editor-range-comments.md
@@ -32,7 +32,9 @@ history.
 - Store the optional `selection_surface` with typed anchors to preserve the UI
   origin across reloads. `surface: source` always describes storage coordinates;
   it must not be used to infer editor versus rendered navigation. Older V2
-  comments lack this hint and keep rendered navigation. Project mapped source
+  comments lack this hint and keep rendered navigation, except comparison
+  comments: their comparison context identifies a source selection. New diff
+  comments explicitly store the source hint. Project mapped source
   ranges into the current rendered text for scrolling; never use source offsets
   directly as rendered offsets.
 - Persisted source ranges navigate to Monaco and activate only their own thread.

--- a/docs-dev/cujs/editor-range-comments.md
+++ b/docs-dev/cujs/editor-range-comments.md
@@ -29,6 +29,9 @@ history.
   from that revision, not from a captured quote or a checksum of current text.
 - Preserve source draft whitespace so newlines and indentation remain visible.
   Verify browser geometry and computed whitespace, not only `textContent`.
+- Persisted source ranges navigate to Monaco and activate only their own thread.
+  A compatibility anchor shaped like a whole-cell comment still contains a typed
+  source range; inspect those historical locations when grouping/activating cards.
 - Source drafts retain the `editor` focus role even in a Markdown wrapper.
   Switching tabs or restoring window focus must return to source editing.
 - Register/dispose the Monaco action with its current callback and comment

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
       jsdom:
         specifier: 27.4.0
         version: 27.4.0
+      playwright-core:
+        specifier: 1.57.0
+        version: 1.57.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -4688,6 +4691,11 @@ packages:
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
+    hasBin: true
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: ">=18"}
     hasBin: true
 
   pretty-format@27.5.1:
@@ -10112,6 +10120,8 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  playwright-core@1.57.0: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
## Summary

Code cells and Markdown cells in edit mode had no way to comment on selected source. Add **Comment on selection** to Monaco's context menu and **Ctrl+Alt+M** (**Cmd+Option+M** on macOS) for `.runme` notebooks.

Capture the current Monaco model and UTF-16 selection at invocation, then use the existing immutable revision binder to persist Unicode source ranges. Show the selected source with preserved whitespace in the draft. Saved source-range comments reopen Monaco and activate only the selected thread. Edits or syncs after capture preserve the original anchor. Keep editor callbacks current and prevent Monaco's menu from also opening the outer cell menu.

## Validation

- `SHELL=/bin/bash runme run build test` passed.
- All 1,447 app tests passed with `pnpm -C app exec vitest run --maxWorkers=4 --minWorkers=1`, including multiline/Unicode ranges, pending saves, and edits after capture.
- Type checking produces the same 128 existing diagnostics as an isolated `origin/main` worktree; no added diagnostics.
- Exercised both modes in the local browser; saved comments survived reload, and a Markdown edit after capture correctly left the comment on its original revision.
- Added a canonical browser CUJ with menu/shortcut interactions, persisted-anchor assertions, screenshots, and video.
- Design decisions and CUJ documented in `docs-dev/cujs/editor-range-comments.md`.

The source selection action requires `.runme` revision history; existing whole-cell and rendered Markdown comment paths remain available as before.

Saved selections retain their originating view: source selections reopen Monaco; rendered selections navigate to their rendered highlight. This is persisted as an optional anchor hint, preserving existing V2 comment behavior and source navigation for both old and new diff comments.
