### PR TITLE
Preserve saved OAuth scopes across refreshes

### DIFF
--- a/app/src/auth/oauthSettingsPersistence.test.ts
+++ b/app/src/auth/oauthSettingsPersistence.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Exercise real manager storage failures, including retry and module recreation.
+describe('OAuth settings persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it.each(['oidcConfig', 'googleClientConfig'])(
+    'does not commit a failed %s write to memory and supports retry',
+    async (storageKey) => {
+      const { oidcConfigManager } = await import('./oidcConfig')
+      const { googleClientManager } = await import('../lib/googleClientManager')
+      oidcConfigManager.setConfig({
+        discoveryUrl:
+          'https://accounts.google.com/.well-known/openid-configuration',
+        clientId: 'runme-client',
+        scope: 'openid',
+      })
+      googleClientManager.setOAuthClient({
+        clientId: 'old.apps.googleusercontent.com',
+      })
+      const read = () =>
+        storageKey === 'oidcConfig'
+          ? oidcConfigManager.getScope()
+          : googleClientManager.getOAuthClient().clientId
+      const save = () =>
+        storageKey === 'oidcConfig'
+          ? oidcConfigManager.setConfig(
+              { scope: 'openid email' },
+              { requirePersistence: true }
+            )
+          : googleClientManager.setOAuthClient(
+              { clientId: 'new.apps.googleusercontent.com' },
+              { requirePersistence: true }
+            )
+      const before = read()
+      const storedBefore = localStorage.getItem(storageKey)
+      const setItem = Storage.prototype.setItem
+      const spy = vi
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(function (this: Storage, key, value) {
+          if (key === storageKey)
+            throw new DOMException('Quota exceeded', 'QuotaExceededError')
+          setItem.call(this, key, value)
+        })
+      expect(save).toThrow(/Could not save/)
+      expect(read()).toBe(before)
+      expect(localStorage.getItem(storageKey)).toBe(storedBefore)
+      // The small precedence flag would succeed despite the failed config write.
+      localStorage.setItem('runme/app-config/prefer-local', 'false')
+      spy.mockRestore()
+      save()
+      const expected = read()
+      expect(expected).not.toBe(before)
+      vi.resetModules()
+      if (storageKey === 'oidcConfig') {
+        expect(
+          (await import('./oidcConfig')).oidcConfigManager.getScope()
+        ).toBe(expected)
+      } else {
+        expect(
+          (
+            await import('../lib/googleClientManager')
+          ).googleClientManager.getOAuthClient().clientId
+        ).toBe(expected)
+      }
+    }
+  )
+})

--- a/app/src/auth/oidcConfig.ts
+++ b/app/src/auth/oidcConfig.ts
@@ -70,7 +70,10 @@ export class OidcConfigManager {
     return this.config.scope;
   }
 
-  setConfig(config: Partial<OidcConfig>): OidcConfig {
+  setConfig(
+    config: Partial<OidcConfig>,
+    options: { requirePersistence?: boolean } = {},
+  ): OidcConfig {
     const extraAuthParams = config.extraAuthParams
       ? this.sanitizeExtraAuthParams(config.extraAuthParams)
       : undefined;
@@ -78,12 +81,14 @@ export class OidcConfigManager {
       extraAuthParams && Object.keys(extraAuthParams).length > 0
         ? extraAuthParams
         : undefined;
-    this.config = {
+    const nextConfig = {
       ...this.config,
       ...config,
       extraAuthParams: normalizedExtraAuthParams ?? this.config.extraAuthParams,
     };
-    this.persistConfig(this.config);
+    if (options.requirePersistence) this.assertRequired(nextConfig);
+    this.persistConfig(nextConfig, options.requirePersistence);
+    this.config = nextConfig;
     this.assertRequired(this.config);
     return this.config;
   }
@@ -190,11 +195,12 @@ export class OidcConfigManager {
     }
   }
 
-  private persistConfig(config: OidcConfig): void {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return;
-    }
+  private persistConfig(config: OidcConfig, requirePersistence = false): void {
     try {
+      if (typeof window === "undefined" || !window.localStorage) {
+        if (requirePersistence) throw new Error("Browser storage is unavailable");
+        return;
+      }
       window.localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -207,6 +213,11 @@ export class OidcConfigManager {
         }),
       );
     } catch (error) {
+      if (requirePersistence) {
+        throw new Error(
+          "Could not save Runme OAuth settings. Browser storage is unavailable or full.",
+        );
+      }
       console.warn("Failed to persist OIDC config", error);
     }
   }

--- a/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.test.tsx
+++ b/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.test.tsx
@@ -65,6 +65,10 @@ vi.mock('../../auth/oidcConfig', () => ({
 vi.mock('../../lib/toast', () => ({ showToast: mocks.showToast }))
 
 import AuthenticationSettingsPanel from './AuthenticationSettingsPanel'
+import {
+  isLocalConfigPreferredOnLoad,
+  setLocalConfigPreferredOnLoad,
+} from '../../lib/appConfig'
 
 describe('AuthenticationSettingsPanel', () => {
   beforeEach(() => {
@@ -98,6 +102,34 @@ describe('AuthenticationSettingsPanel', () => {
       'value',
       'drive-user@example.com'
     )
+  })
+
+  it('preserves explicitly saved OAuth settings on the next startup', () => {
+    setLocalConfigPreferredOnLoad(false)
+    render(<AuthenticationSettingsPanel />)
+    fireEvent.change(screen.getByLabelText('Runme OAuth scopes'), {
+      target: { value: 'openid email profile' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save authentication settings' })
+    )
+    expect(mocks.setOidcConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'openid email profile' })
+    )
+    expect(isLocalConfigPreferredOnLoad()).toBe(true)
+  })
+
+  it('does not change startup precedence when authentication settings fail validation', () => {
+    setLocalConfigPreferredOnLoad(false)
+    render(<AuthenticationSettingsPanel />)
+    fireEvent.change(screen.getByLabelText('Runme OAuth scopes'), {
+      target: { value: '' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save authentication settings' })
+    )
+    expect(isLocalConfigPreferredOnLoad()).toBe(false)
+    expect(mocks.setOidcConfig).not.toHaveBeenCalled()
   })
 
   it('registers the authentication controls as AI tour targets', () => {

--- a/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.test.tsx
+++ b/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.test.tsx
@@ -114,10 +114,65 @@ describe('AuthenticationSettingsPanel', () => {
       screen.getByRole('button', { name: 'Save authentication settings' })
     )
     expect(mocks.setOidcConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ scope: 'openid email profile' })
+      expect.objectContaining({ scope: 'openid email profile' }),
+      { requirePersistence: true }
     )
     expect(isLocalConfigPreferredOnLoad()).toBe(true)
   })
+
+  it.each(['Sign in to Runme', 'Connect or refresh'])(
+    'keeps deployment precedence for unchanged %s',
+    async (action) => {
+      setLocalConfigPreferredOnLoad(false)
+      render(<AuthenticationSettingsPanel />)
+      fireEvent.click(screen.getByRole('button', { name: action }))
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: action })).toHaveProperty(
+          'disabled',
+          false
+        )
+      )
+      expect(isLocalConfigPreferredOnLoad()).toBe(false)
+    }
+  )
+
+  it('preserves OAuth edits made directly before signing in', async () => {
+    setLocalConfigPreferredOnLoad(false)
+    render(<AuthenticationSettingsPanel />)
+    fireEvent.change(screen.getByLabelText('Runme OAuth scopes'), {
+      target: { value: 'openid email profile' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in to Runme' }))
+    await waitFor(() => expect(mocks.loginWithRedirect).toHaveBeenCalled())
+    expect(isLocalConfigPreferredOnLoad()).toBe(true)
+  })
+
+  it.each(['setOidcConfig', 'setOAuthClient'] as const)(
+    'does not report success or authorize after %s fails to persist',
+    async (setter) => {
+      setLocalConfigPreferredOnLoad(false)
+      render(<AuthenticationSettingsPanel />)
+      const fail = () => {
+        throw new Error('Browser storage is full')
+      }
+      mocks[setter].mockImplementationOnce(fail)
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Save authentication settings' })
+      )
+      expect(screen.getByText('Browser storage is full')).toBeTruthy()
+      expect(mocks.showToast).not.toHaveBeenCalled()
+      expect(isLocalConfigPreferredOnLoad()).toBe(false)
+      mocks[setter].mockImplementationOnce(fail)
+      fireEvent.click(screen.getByRole('button', { name: 'Sign in to Runme' }))
+      expect(mocks.loginWithRedirect).not.toHaveBeenCalled()
+      expect(isLocalConfigPreferredOnLoad()).toBe(false)
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Save authentication settings' })
+      )
+      expect(mocks.showToast).toHaveBeenCalled()
+      expect(isLocalConfigPreferredOnLoad()).toBe(true)
+    }
+  )
 
   it('does not change startup precedence when authentication settings fail validation', () => {
     setLocalConfigPreferredOnLoad(false)
@@ -206,19 +261,25 @@ describe('AuthenticationSettingsPanel', () => {
       driveServiceAccount: '',
     })
     expect(mocks.setDriveAccount).toHaveBeenCalledWith('drive-user@example.com')
-    expect(mocks.setOAuthClient).toHaveBeenCalledWith({
-      clientId: 'drive-client-id.apps.googleusercontent.com',
-      clientSecret: 'drive-client-secret',
-      authFlow: 'pkce',
-      authUxMode: 'new_tab',
-    })
-    expect(mocks.setOidcConfig).toHaveBeenCalledWith({
-      discoveryUrl:
-        'https://accounts.google.com/.well-known/openid-configuration',
-      clientId: 'runme-client-id',
-      clientSecret: 'runme-client-secret',
-      scope: 'openid email',
-    })
+    expect(mocks.setOAuthClient).toHaveBeenCalledWith(
+      {
+        clientId: 'drive-client-id.apps.googleusercontent.com',
+        clientSecret: 'drive-client-secret',
+        authFlow: 'pkce',
+        authUxMode: 'new_tab',
+      },
+      { requirePersistence: true }
+    )
+    expect(mocks.setOidcConfig).toHaveBeenCalledWith(
+      {
+        discoveryUrl:
+          'https://accounts.google.com/.well-known/openid-configuration',
+        clientId: 'runme-client-id',
+        clientSecret: 'runme-client-secret',
+        scope: 'openid email',
+      },
+      { requirePersistence: true }
+    )
   })
 
   it('uses the saved direct-principal settings to connect Google Drive', async () => {

--- a/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.tsx
+++ b/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.tsx
@@ -254,79 +254,97 @@ export default function AuthenticationSettingsPanel() {
     driveHumanIdentityValid &&
     requiredFieldsPresent
 
-  const saveSettings = useCallback((): boolean => {
-    if (!runmeServiceAccountValid || !driveServiceAccountValid) {
-      setErrorMessage('Enter a valid Google service-account identity.')
-      return false
-    }
-    if (!runmeHumanIdentityValid || !driveHumanIdentityValid) {
-      setErrorMessage(
-        'Enter the human identity that is allowed to impersonate the Google service account.'
-      )
-      return false
-    }
-    if (!requiredFieldsPresent) {
-      setErrorMessage(
-        'Enter a Google Web application client ID ending in .apps.googleusercontent.com and all required Runme OAuth fields.'
-      )
-      return false
-    }
-    try {
-      saveAppLoginConfiguration({
-        identitySharing,
-        mode: loginMode,
-        humanAccount,
-        serviceAccount,
-        driveMode: driveLoginMode,
-        driveHumanAccount,
-        driveServiceAccount,
-      })
-      setDriveAccount(effectiveDriveHumanAccount)
-      googleClientManager.setOAuthClient({
-        clientId: driveClientId.trim(),
-        clientSecret: driveClientSecret.trim() || undefined,
-        authFlow: driveAuthFlow,
-        authUxMode: driveAuthUxMode,
-      })
-      oidcConfigManager.setConfig({
-        discoveryUrl: runmeDiscoveryUrl.trim(),
-        clientId: runmeClientId.trim(),
-        clientSecret: runmeClientSecret.trim() || undefined,
-        scope: runmeScope.trim(),
-      })
-      // A successful save is an explicit local override. Production startup
-      // otherwise reapplies deployment defaults and silently erases these edits.
-      setLocalConfigPreferredOnLoad(true)
-      setErrorMessage(null)
-      return true
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : String(error))
-      return false
-    }
-  }, [
-    driveAuthFlow,
-    driveAuthUxMode,
-    driveClientId,
-    driveClientSecret,
-    driveHumanAccount,
-    driveLoginMode,
-    driveServiceAccount,
-    driveServiceAccountValid,
-    driveHumanIdentityValid,
-    effectiveDriveHumanAccount,
-    humanAccount,
-    identitySharing,
-    loginMode,
-    requiredFieldsPresent,
-    runmeClientId,
-    runmeClientSecret,
-    runmeDiscoveryUrl,
-    runmeHumanIdentityValid,
-    runmeScope,
-    serviceAccount,
-    runmeServiceAccountValid,
-    setDriveAccount,
-  ])
+  const saveSettings = useCallback(
+    (explicitSave = false): boolean => {
+      if (!runmeServiceAccountValid || !driveServiceAccountValid) {
+        setErrorMessage('Enter a valid Google service-account identity.')
+        return false
+      }
+      if (!runmeHumanIdentityValid || !driveHumanIdentityValid) {
+        setErrorMessage(
+          'Enter the human identity that is allowed to impersonate the Google service account.'
+        )
+        return false
+      }
+      if (!requiredFieldsPresent) {
+        setErrorMessage(
+          'Enter a Google Web application client ID ending in .apps.googleusercontent.com and all required Runme OAuth fields.'
+        )
+        return false
+      }
+      try {
+        saveAppLoginConfiguration({
+          identitySharing,
+          mode: loginMode,
+          humanAccount,
+          serviceAccount,
+          driveMode: driveLoginMode,
+          driveHumanAccount,
+          driveServiceAccount,
+        })
+        setDriveAccount(effectiveDriveHumanAccount)
+        const driveOAuth = {
+          clientId: driveClientId.trim(),
+          clientSecret: driveClientSecret.trim() || undefined,
+          authFlow: driveAuthFlow,
+          authUxMode: driveAuthUxMode,
+        }
+        const runmeOAuth = {
+          discoveryUrl: runmeDiscoveryUrl.trim(),
+          clientId: runmeClientId.trim(),
+          clientSecret: runmeClientSecret.trim() || undefined,
+          scope: runmeScope.trim(),
+        }
+        const currentDrive = googleClientManager.getOAuthClient()
+        const currentRunme = oidcConfigManager.getConfigForEditing()
+        const oauthChanged =
+          Object.entries(driveOAuth).some(
+            ([key, value]) =>
+              currentDrive[key as keyof typeof driveOAuth] !== value
+          ) ||
+          Object.entries(runmeOAuth).some(
+            ([key, value]) =>
+              currentRunme[key as keyof typeof runmeOAuth] !== value
+          )
+        googleClientManager.setOAuthClient(driveOAuth, {
+          requirePersistence: true,
+        })
+        oidcConfigManager.setConfig(runmeOAuth, { requirePersistence: true })
+        // Preserve deliberate saves and OAuth edits before authorization redirects.
+        // Signing in with unchanged deployment defaults must not pin them locally.
+        if (explicitSave || oauthChanged) setLocalConfigPreferredOnLoad(true)
+        setErrorMessage(null)
+        return true
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : String(error))
+        return false
+      }
+    },
+    [
+      driveAuthFlow,
+      driveAuthUxMode,
+      driveClientId,
+      driveClientSecret,
+      driveHumanAccount,
+      driveLoginMode,
+      driveServiceAccount,
+      driveServiceAccountValid,
+      driveHumanIdentityValid,
+      effectiveDriveHumanAccount,
+      humanAccount,
+      identitySharing,
+      loginMode,
+      requiredFieldsPresent,
+      runmeClientId,
+      runmeClientSecret,
+      runmeDiscoveryUrl,
+      runmeHumanIdentityValid,
+      runmeScope,
+      serviceAccount,
+      runmeServiceAccountValid,
+      setDriveAccount,
+    ]
+  )
 
   const authorizeServiceAccount = useCallback(
     async (
@@ -353,7 +371,7 @@ export default function AuthenticationSettingsPanel() {
 
   const handleSave = useCallback(() => {
     setBusyAction('save')
-    if (saveSettings()) {
+    if (saveSettings(true)) {
       showToast({ message: 'Authentication settings saved', tone: 'success' })
     }
     setBusyAction(null)

--- a/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.tsx
+++ b/app/src/components/AuthenticationSettings/AuthenticationSettingsPanel.tsx
@@ -22,6 +22,7 @@ import {
   type GoogleDriveAuthUxMode,
 } from '../../lib/googleClientManager'
 import { getGoogleDriveOAuthCallbackUrl } from '../../lib/appBase'
+import { setLocalConfigPreferredOnLoad } from '../../lib/appConfig'
 import { showToast } from '../../lib/toast'
 
 const inputClass =
@@ -293,6 +294,9 @@ export default function AuthenticationSettingsPanel() {
         clientSecret: runmeClientSecret.trim() || undefined,
         scope: runmeScope.trim(),
       })
+      // A successful save is an explicit local override. Production startup
+      // otherwise reapplies deployment defaults and silently erases these edits.
+      setLocalConfigPreferredOnLoad(true)
       setErrorMessage(null)
       return true
     } catch (error) {

--- a/app/src/lib/appConfig.test.ts
+++ b/app/src/lib/appConfig.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import localAppConfigYaml from '../../assets/configs/app-configs.yaml?raw'
 
@@ -13,6 +13,7 @@ async function loadModules() {
 }
 
 describe('appConfig OIDC Google shorthand', () => {
+  afterEach(() => vi.unstubAllGlobals())
   beforeEach(() => {
     window.localStorage.clear()
     window.history.replaceState(null, '', '/index.html')
@@ -374,6 +375,50 @@ describe('appConfig OIDC Google shorthand', () => {
         scopes: ['https://www.googleapis.com/auth/drive.readonly'],
       },
     })
+  })
+
+  it('restores locally saved OAuth settings before deployment preload after a reload', async () => {
+    const original = await loadModules()
+    original.setAppConfigFromYaml(localAppConfigYaml)
+    original.setLocalConfigPreferredOnLoad(false)
+    original.oidcConfigManager.setConfig({ scope: 'openid email profile' })
+    const { googleClientManager } = await import('./googleClientManager')
+    googleClientManager.setOAuthClient({
+      clientId: 'saved.apps.googleusercontent.com',
+      authFlow: 'pkce',
+      authUxMode: 'popup',
+    })
+    original.setLocalConfigPreferredOnLoad(true)
+
+    // Recreate the singleton managers as a real page load does, then run the
+    // actual async startup loader against the deployment's default YAML.
+    const reloaded = await loadModules()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(localAppConfigYaml))
+    )
+    const applied = await reloaded.maybeSetAppConfig()
+    expect(applied?.oidc?.scope).toBe('openid email profile')
+    expect(applied?.googleOAuth).toMatchObject({
+      clientId: 'saved.apps.googleusercontent.com',
+      authFlow: 'pkce',
+      authUxMode: 'popup',
+    })
+    expect(JSON.parse(window.localStorage.getItem('oidcConfig')!).scope).toBe(
+      'openid email profile'
+    )
+
+    // Explicit imports and opting back into deployment defaults remain supported.
+    reloaded.setAppConfigFromYaml(localAppConfigYaml)
+    expect(reloaded.oidcConfigManager.getScope()).not.toBe(
+      'openid email profile'
+    )
+    reloaded.oidcConfigManager.setScope('openid email profile')
+    reloaded.enableAppConfigOverridesOnLoad()
+    await reloaded.maybeSetAppConfig()
+    expect(reloaded.oidcConfigManager.getScope()).not.toBe(
+      'openid email profile'
+    )
   })
 
   it('toggles app-config local precedence on load', async () => {

--- a/app/src/lib/googleClientManager.ts
+++ b/app/src/lib/googleClientManager.ts
@@ -171,7 +171,8 @@ export class GoogleClientManager {
   }
 
   setOAuthClient(
-    config: Partial<GoogleOAuthClientConfig>
+    config: Partial<GoogleOAuthClientConfig>,
+    options: { requirePersistence?: boolean } = {}
   ): GoogleOAuthClientConfig {
     const requestedAuthFlow = config.authFlow
     if (requestedAuthFlow && !isGoogleDriveAuthFlow(requestedAuthFlow)) {
@@ -208,6 +209,7 @@ export class GoogleClientManager {
     } else {
       delete nextOAuthClient.serviceAccount
     }
+    this.persistOAuthClient(nextOAuthClient, options.requirePersistence)
     this.config.oauth = nextOAuthClient
     if (config.clientId !== undefined) {
       this.config.drivePicker = {
@@ -215,7 +217,6 @@ export class GoogleClientManager {
         clientId: config.clientId,
       }
     }
-    this.persistOAuthClient(this.config.oauth)
     return this.config.oauth
   }
 
@@ -463,11 +464,16 @@ export class GoogleClientManager {
     }
   }
 
-  private persistOAuthClient(config: GoogleOAuthClientConfig): void {
-    if (typeof window === 'undefined' || !window.localStorage) {
-      return
-    }
+  private persistOAuthClient(
+    config: GoogleOAuthClientConfig,
+    requirePersistence = false
+  ): void {
     try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        if (requirePersistence)
+          throw new Error('Browser storage is unavailable')
+        return
+      }
       const serviceAccount =
         config.authFlow === 'service_account' && config.serviceAccount
           ? serializeServiceAccountCredentials(config.serviceAccount)
@@ -483,6 +489,10 @@ export class GoogleClientManager {
         })
       )
     } catch (error) {
+      if (requirePersistence)
+        throw new Error(
+          'Could not save Google Drive OAuth settings. Browser storage is unavailable or full.'
+        )
       console.warn('Failed to persist Google OAuth client config', error)
     }
   }

--- a/app/test/browser/run-cuj-scenarios.ts
+++ b/app/test/browser/run-cuj-scenarios.ts
@@ -79,6 +79,7 @@ function fetchWithTimeout(
 }
 
 const SCENARIO_DRIVERS = [
+  join(SCRIPT_DIR, "test-scenario-authentication-settings.ts"),
   join(SCRIPT_DIR, "test-scenario-editor-range-comments.ts"),
   join(SCRIPT_DIR, "test-scenario-colab-export-recovery.ts"),
   join(SCRIPT_DIR, "test-scenario-horizontal-rendering.ts"),

--- a/app/test/browser/test-scenario-authentication-settings.ts
+++ b/app/test/browser/test-scenario-authentication-settings.ts
@@ -84,6 +84,7 @@ try {
       [
         'oidcConfig',
         'googleClientConfig',
+        'runme/google-drive/runtime',
         'runme/app-config/prefer-local',
         'runme/app-login-configuration',
       ].map((key) => [key, localStorage.getItem(key)])

--- a/app/test/browser/test-scenario-authentication-settings.ts
+++ b/app/test/browser/test-scenario-authentication-settings.ts
@@ -40,6 +40,14 @@ function check(message: string, valid: boolean) {
 }
 /** Reopen the same settings panel after a complete page reload. */
 async function showSettings() {
+  // Startup awaits deployment config before mounting React. Wait for the
+  // toolbar before deciding whether the persisted panel is already open.
+  await page!
+    .getByRole('button', {
+      name: 'Toggle Authentication Settings panel',
+      exact: true,
+    })
+    .waitFor({ state: 'visible' })
   const heading = page!.getByRole('heading', {
     name: 'Authentication Settings',
     exact: true,

--- a/app/test/browser/test-scenario-authentication-settings.ts
+++ b/app/test/browser/test-scenario-authentication-settings.ts
@@ -77,7 +77,7 @@ try {
   if (!page) throw new Error('Recorded page not found')
   page.setDefaultTimeout(15000)
   await page.waitForFunction(
-    'Boolean(window.app?.setLocalConfigPreferredOnLoad && window.oidc)'
+    'Boolean(window.oidc?.getScope)'
   )
   saved = await page.evaluate(() =>
     Object.fromEntries(
@@ -90,7 +90,11 @@ try {
       ].map((key) => [key, localStorage.getItem(key)])
     )
   )
-  await page.evaluate('window.app.setLocalConfigPreferredOnLoad(false)')
+  // App mounts replace window.app with debug state. Seed the documented
+  // preference directly instead of relying on that transient global API.
+  await page.evaluate(() =>
+    localStorage.setItem('runme/app-config/prefer-local', 'false')
+  )
   await page.reload()
   await showSettings()
   const scopes = page.getByLabel('Runme OAuth scopes', { exact: true })
@@ -102,7 +106,9 @@ try {
     .click()
   check(
     'Saving authentication settings preserves local startup configuration',
-    await page.evaluate('window.app.isLocalConfigPreferredOnLoad()')
+    await page.evaluate(() =>
+      localStorage.getItem('runme/app-config/prefer-local') === 'true'
+    )
   )
   for (let reload = 1; reload <= 2; reload++) {
     await page.reload()
@@ -121,7 +127,9 @@ try {
     'screenshot',
     join(output, 'scenario-authentication-settings-reloaded.png')
   )
-  await page.evaluate('window.app.enableConfigOverridesOnLoad()')
+  await page.evaluate(() =>
+    localStorage.setItem('runme/app-config/prefer-local', 'false')
+  )
   await page.reload()
   await showSettings()
   check(

--- a/app/test/browser/test-scenario-authentication-settings.ts
+++ b/app/test/browser/test-scenario-authentication-settings.ts
@@ -1,0 +1,156 @@
+/** CUJ: docs-dev/cujs/authentication-settings-persistence.md.
+ * Reproduce production startup precedence even when CI serves Vite development.
+ * No authorization request or real credential is needed for this settings test.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { type Browser, type Page, chromium } from 'playwright-core'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const dir = here.endsWith('/.generated') ? dirname(here) : here
+const output = join(dir, 'test-output')
+const session =
+  process.env.AGENT_BROWSER_SESSION || `auth-settings-${Date.now()}`
+const movie = join(output, 'scenario-authentication-settings.webm')
+let connection: Browser | undefined
+let page: Page | undefined
+let saved: Record<string, string | null> | undefined
+let passed = 0,
+  failed = 0
+mkdirSync(output, { recursive: true })
+
+/** Share the orchestrator's browser, profile, recording, and cleanup conventions. */
+function browser(...args: string[]): string {
+  const flags = ['--session', session]
+  if (process.env.AGENT_BROWSER_PROFILE)
+    flags.push('--profile', process.env.AGENT_BROWSER_PROFILE)
+  if (process.env.AGENT_BROWSER_HEADED === 'true') flags.push('--headed')
+  return execFileSync('agent-browser', [...flags, ...args], {
+    encoding: 'utf8',
+    timeout: 30000,
+  }).trim()
+}
+/** Count checks independently of the workflow's exit status. */
+function check(message: string, valid: boolean) {
+  if (!valid) throw new Error(message)
+  passed++
+  console.log(`[PASS] ${message}`)
+}
+/** Reopen the same settings panel after a complete page reload. */
+async function showSettings() {
+  const heading = page!.getByRole('heading', {
+    name: 'Authentication Settings',
+    exact: true,
+  })
+  if (!(await heading.isVisible()))
+    await page!
+      .getByRole('button', {
+        name: 'Toggle Authentication Settings panel',
+        exact: true,
+      })
+      .click()
+  await page!
+    .getByLabel('Runme OAuth scopes', { exact: true })
+    .waitFor({ state: 'visible' })
+}
+
+try {
+  browser('open', process.env.CUJ_FRONTEND_URL || 'http://localhost:5173')
+  browser('record', 'start', movie)
+  const endpoint = JSON.parse(browser('get', 'cdp-url', '--json')).data.cdpUrl
+  connection = await chromium.connectOverCDP(endpoint)
+  const url = browser('get', 'url')
+  page = connection
+    .contexts()
+    .flatMap((c) => c.pages())
+    .find((p) => p.url() === url)
+  if (!page) throw new Error('Recorded page not found')
+  page.setDefaultTimeout(15000)
+  await page.waitForFunction(
+    'Boolean(window.app?.setLocalConfigPreferredOnLoad && window.oidc)'
+  )
+  saved = await page.evaluate(() =>
+    Object.fromEntries(
+      [
+        'oidcConfig',
+        'googleClientConfig',
+        'runme/app-config/prefer-local',
+        'runme/app-login-configuration',
+      ].map((key) => [key, localStorage.getItem(key)])
+    )
+  )
+  await page.evaluate('window.app.setLocalConfigPreferredOnLoad(false)')
+  await page.reload()
+  await showSettings()
+  const scopes = page.getByLabel('Runme OAuth scopes', { exact: true })
+  const baseline = await scopes.inputValue()
+  const custom = `${baseline} email regression_scope`
+  await scopes.fill(custom)
+  await page
+    .getByRole('button', { name: 'Save authentication settings', exact: true })
+    .click()
+  check(
+    'Saving authentication settings preserves local startup configuration',
+    await page.evaluate('window.app.isLocalConfigPreferredOnLoad()')
+  )
+  for (let reload = 1; reload <= 2; reload++) {
+    await page.reload()
+    await showSettings()
+    check(
+      `Saved email scope survives page reload ${reload}`,
+      (await scopes.inputValue()) === custom
+    )
+    check(
+      `OIDC runtime retains the same scopes after reload ${reload}`,
+      (await page.evaluate('window.oidc.getScope()')) === custom
+    )
+  }
+  await scopes.scrollIntoViewIfNeeded()
+  browser(
+    'screenshot',
+    join(output, 'scenario-authentication-settings-reloaded.png')
+  )
+  await page.evaluate('window.app.enableConfigOverridesOnLoad()')
+  await page.reload()
+  await showSettings()
+  check(
+    'Explicitly restoring deployment defaults still works',
+    (await scopes.inputValue()) === baseline
+  )
+} catch (error) {
+  failed++
+  console.log(`[FAIL] ${String(error)}`)
+} finally {
+  // These keys can contain credentials. Keep the snapshot in memory only and
+  // restore it so this scenario cannot affect subsequent notebook scenarios.
+  if (page && saved)
+    await page
+      .evaluate((values) => {
+        for (const [key, value] of Object.entries(values)) {
+          if (value === null) localStorage.removeItem(key)
+          else localStorage.setItem(key, value)
+        }
+      }, saved)
+      .catch(() => {})
+  try {
+    browser('record', 'stop')
+  } catch (error) {
+    failed++
+    console.log(`[FAIL] Recording: ${String(error)}`)
+  }
+  await connection?.close()
+  if (process.env.AGENT_BROWSER_KEEP_OPEN !== 'true') {
+    try {
+      browser('close')
+    } catch {
+      /* Keep the assertion result. */
+    }
+  }
+}
+console.log(`Movie: ${movie}`)
+console.log(
+  `Assertions: ${passed + failed}, Passed: ${passed}, Failed: ${failed}`
+)
+process.exitCode = failed ? 1 : 0

--- a/app/test/browser/test-scenario-jupyter.ts
+++ b/app/test/browser/test-scenario-jupyter.ts
@@ -819,8 +819,11 @@ if (run(`curl -sf ${FRONTEND_URL}`).status !== 0) {
 
 runWithRetry(agentBrowserCommand(`open ${FRONTEND_URL}`));
 run(agentBrowserCommand("record stop"));
-runWithRetry(agentBrowserCommand(`record restart ${MOVIE_PATH}`));
-run(agentBrowserCommand("wait 3500"));
+// Wait for the initial navigation and React mount before attaching the recorder.
+// Restarting immediately after open produced zero JPEG frames in CI, leaving
+// FFmpeg without stream dimensions even though all notebook assertions passed.
+runWithRetry(agentBrowserCommand('wait --fn "Boolean(window.app?.localNotebooks)"'));
+runWithRetry(agentBrowserCommand(`record start ${MOVIE_PATH}`));
 
 const runnerWsLiteral = `'${BACKEND_WS.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
 const runnerSeed = run(

--- a/docs-dev/cujs/README.md
+++ b/docs-dev/cujs/README.md
@@ -8,6 +8,8 @@ from `docs-dev/cujs/`.
 
 ## Current CUJs
 
+- `authentication-settings-persistence.md` — saved OAuth scopes survive refresh under production config precedence.
+
 - [horizontal-rendering.md](horizontal-rendering.md) — viewport-bounded prose with locally scrolling wide
   tables/code and wrapping outputs; verified at normal and narrow widths.
 

--- a/docs-dev/cujs/authentication-settings-persistence.md
+++ b/docs-dev/cujs/authentication-settings-persistence.md
@@ -1,0 +1,37 @@
+# Authentication settings survive refresh
+
+## Journey
+
+Open Authentication Settings, add `email` to Runme OAuth scopes, and save.
+Refresh twice. The scope field and the OIDC runtime must retain exactly the saved
+value. Saving must not initiate authorization.
+
+## Root cause and design
+
+Production startup normally reapplies deployment YAML to local OAuth settings.
+The settings panel previously saved the clients but did not enable local
+precedence, so the next preload silently replaced the saved scopes. Development
+already defaults to local precedence, hiding the production failure.
+
+A successful settings save now enables the existing local-precedence preference
+**after** both OAuth clients are saved. This preserves OIDC and Google Drive
+configuration on automatic startup. Failed validation does not change precedence.
+Explicit config imports still apply immediately, and
+`app.enableConfigOverridesOnLoad()` restores deployment precedence. This uses the
+existing configuration policy rather than special-casing the `email` scope.
+
+The preference also preserves an existing Drive runtime base URL, as defined by
+the existing policy; agent and runner configuration retain their existing rules.
+Settings are local to this browser and origin. Previously overwritten values
+cannot be recovered automatically: re-enter and save them after the fix arrives.
+
+## Regression evidence
+
+`app/test/browser/test-scenario-authentication-settings.ts` forces production
+precedence before interacting with the real settings UI. It checks two reloads,
+compares the visible scope field with the OIDC runtime, and verifies that explicit
+restoration of deployment defaults still works. It records a screenshot and movie,
+and restores its original storage keys without writing credentials to artifacts.
+
+Component tests cover successful and rejected saves. The startup test recreates
+singleton managers from storage and invokes the actual async YAML preload.

--- a/docs-dev/cujs/authentication-settings-persistence.md
+++ b/docs-dev/cujs/authentication-settings-persistence.md
@@ -13,8 +13,11 @@ The settings panel previously saved the clients but did not enable local
 precedence, so the next preload silently replaced the saved scopes. Development
 already defaults to local precedence, hiding the production failure.
 
-A successful settings save now enables the existing local-precedence preference
-**after** both OAuth clients are saved. This preserves OIDC and Google Drive
+An explicit settings save, or authorization after editing OAuth fields, now enables
+the existing local-precedence preference **after** both OAuth clients are persisted.
+Signing in or connecting with unchanged OAuth fields leaves deployment precedence
+intact. Storage failures are surfaced in the panel and prevent a success toast or
+authorization; a failed write also leaves that manager’s in-memory state unchanged. This preserves OIDC and Google Drive
 configuration on automatic startup. Failed validation does not change precedence.
 Explicit config imports still apply immediately, and
 `app.enableConfigOverridesOnLoad()` restores deployment precedence. This uses the
@@ -33,5 +36,6 @@ compares the visible scope field with the OIDC runtime, and verifies that explic
 restoration of deployment defaults still works. It records a screenshot and movie,
 and restores its original storage keys without writing credentials to artifacts.
 
-Component tests cover successful and rejected saves. The startup test recreates
+Component and manager tests cover successful saves, unchanged and edited sign-ins,
+validation failures, and storage failures followed by a successful retry. The startup test recreates
 singleton managers from storage and invokes the actual async YAML preload.


### PR DESCRIPTION
Saving Authentication Settings persisted OAuth clients, but production startup reapplied deployment YAML and removed user-added scopes such as `email`. Development defaults to local precedence, hiding the failure.

Explicit saves and OAuth edits followed by authorization now enable the existing local-precedence preference after both OAuth clients are persisted. Unchanged sign-in/connect actions leave deployment precedence intact. Invalid saves and storage failures are surfaced without claiming success or changing precedence. Explicit config imports and re-enabling deployment defaults remain supported. Existing Drive runtime URL preservation follows the same policy.

Validation:
- Reproduced on a production build of main: save `email`, refresh, and observe it disappear. Verified the fixed production build retains it across two refreshes.
- All 1,457 app tests pass; required Runme build/test tasks pass. Type-check diagnostics match the existing baseline (128, none added).
- Added UI save/validation/authorization tests, real quota-failure and retry tests, singleton-reload/startup integration coverage, and a browser CUJ that forces production precedence, checks both visible and runtime scopes after two reloads, and restores deployment defaults.

The browser suite also needed a Jupyter recorder startup correction: wait for React mount, then start a fresh recording. Two CI runs produced zero video frames when restarting immediately after navigation, despite passing the notebook assertions. Video assertions remain enabled.

Final validation: all 12 browser scenarios passed on 88d6350, including all six authentication assertions and all 19 Jupyter assertions. Inspected the saved-scope screenshot and repaired Jupyter recording. [CI artifacts](https://storage.googleapis.com/runme-dev-assets/cuj-runs/runmedev-web/34651150240/1/index.html). The final code review reported no major issues.

Previously overwritten values must be entered and saved again after this fix is deployed.
