### PR TITLE
Expose loaded app version to sandbox agents

### DIFF
--- a/app/src/lib/notebookData.test.ts
+++ b/app/src/lib/notebookData.test.ts
@@ -154,6 +154,9 @@ vi.mock("./runtime/sandboxJsKernel", () => ({
           ])) as { cell?: { languageId?: string } };
           this.hooks.onStdout?.(`${result.cell?.languageId ?? ""}\n`);
         }
+        if (source.includes("app.getVersion")) {
+          this.hooks.onStdout?.(`${JSON.stringify(await this.bridge.call("app.getVersion", []))}\n`);
+        }
         if (source.includes("app.getSessionID")) {
           const sessionId = await this.bridge.call("app.getSessionID", []);
           this.hooks.onStdout?.(`${String(sessionId)}\n`);
@@ -1371,6 +1374,43 @@ describe("NotebookData.runCodeCell", () => {
         RunmeMetadataKey.ExitCode
       ],
     ).toBe("130");
+  });
+
+  it("exposes loaded build metadata inside sandbox notebook cells", async () => {
+    window.history.replaceState(null, "", "/?session=notebook-session-id");
+    const cell = create(parser_pb.CellSchema, {
+      refId: "cell-appkernel-session-sandbox",
+      kind: parser_pb.CellKind.CODE,
+      languageId: "javascript",
+      outputs: [],
+      metadata: {
+        [RunmeMetadataKey.RunnerName]: APPKERNEL_SANDBOX_RUNNER_NAME,
+      },
+      value: "console.log(await app.getVersion());",
+    });
+    const notebook = create(parser_pb.NotebookSchema, { cells: [cell] });
+    const model = new NotebookData({
+      notebook,
+      uri: "nb://test",
+      name: "sandbox-session.runme.md",
+      notebookStore: null,
+      loaded: true,
+    });
+
+    model.runCodeCell(cell);
+    await waitForCondition(() => {
+      const snap = model.getCellSnapshot(cell.refId);
+      return snap?.metadata?.[RunmeMetadataKey.ExitCode] === "0";
+    });
+
+    const updated = model.getCellSnapshot(cell.refId);
+    const stdoutText = (updated?.outputs ?? [])
+      .flatMap((o) => o.items)
+      .filter((i) => i.mime === MimeType.VSCodeNotebookStdOut)
+      .map((i) => new TextDecoder().decode(i.data))
+      .join("");
+    const { getRunmeVersionInfo } = await import("./versionInfo");
+    expect(JSON.parse(stdoutText)).toEqual(getRunmeVersionInfo());
   });
 
   it("exposes the fresh Runme session id inside sandbox appkernel javascript cells", async () => {

--- a/app/src/lib/notebookData.ts
+++ b/app/src/lib/notebookData.ts
@@ -1471,6 +1471,8 @@ export class NotebookData {
           cellCount: notebook.getNotebook().cells.length,
         }
       }
+      case 'app.getVersion':
+        return appGlobals.app.getVersion()
       case 'app.getSessionId':
         return getClaimedSessionId()
       case 'app.getSessionID':

--- a/app/src/lib/runtime/aiAgentInstructions.ts
+++ b/app/src/lib/runtime/aiAgentInstructions.ts
@@ -187,6 +187,8 @@ console.log(await app.getSessionID())
 
 Continue only when the printed value matches the selected tab's \`session\` query parameter. If they differ, do not mutate a notebook in that tab.
 
+To identify the app build loaded in that tab, use \`console.log(await app.getVersion())\`. It returns buildDate, webRepo, webBranch, webCommit, and bucket; unavailable values are null.
+
 ## Open or focus notebooks deliberately
 
 - Treat a supplied Runme gateway URL, Google Drive URL, or Markdown-linked notebook URL as a direct notebook reference. Pass it directly to \`notebooks.open(reference)\` for background work or \`notebooks.show(reference)\` for a visible-open request; do not search for the notebook by name.

--- a/app/src/lib/runtime/appJsGlobals.ts
+++ b/app/src/lib/runtime/appJsGlobals.ts
@@ -81,6 +81,7 @@ import {
   showTourStep,
 } from '../tourGuide'
 import { type PanelKey, tourUiController } from '../tourUiController'
+import { getRunmeVersionInfo } from '../versionInfo'
 import { appState } from './AppState'
 import type {
   AppKernelNetworkApi,
@@ -1689,6 +1690,7 @@ export function createAppJsGlobals({
       oidc: oidcConfigManager,
     },
     app: {
+      getVersion: getRunmeVersionInfo,
       getSessionId: () => getClaimedSessionId(),
       getSessionID: () => getClaimedSessionId(),
       getDefaultConfigUrl: () => getDefaultAppConfigUrl(),
@@ -1785,6 +1787,7 @@ export function createAppJsGlobals({
         '  credentials     - Shorthand for Google and OIDC credential managers',
         '',
         'High-value commands:',
+        '  await app.getVersion()',
         '  await app.getSessionId()',
         '  await app.getSessionID()',
         '  tour.show({ target: "left-nav.google-drive", message: "Click here to connect Google Drive." })',

--- a/app/src/lib/runtime/codeModeExecutor.test.ts
+++ b/app/src/lib/runtime/codeModeExecutor.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { parser_pb } from '../../runme/client'
 import { appLogger } from '../logging/runtime'
 import { __resetTabIdForTests, getClaimedSessionId } from '../tabIdentity'
+import { getRunmeVersionInfo } from '../versionInfo'
 import { appState } from './AppState'
 import {
   createCodeModeExecutor,
@@ -26,6 +27,44 @@ const createNotebook = () => {
 }
 
 describe('codeModeExecutor', () => {
+  it('reports the app version in browser mode without an open notebook', async () => {
+    const executor = createCodeModeExecutor({
+      mode: 'browser',
+      resolveNotebook: () => null,
+    })
+    const result = await executor.execute({
+      source: 'webmcp',
+      code: 'console.log(JSON.stringify(await app.getVersion()))',
+    })
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.output)).toEqual(getRunmeVersionInfo())
+  })
+
+  it('dispatches sandbox version requests without an open notebook', async () => {
+    let version: unknown
+    vi.spyOn(SandboxJSKernel.prototype, 'run').mockImplementation(
+      async function (this: SandboxJSKernel) {
+        const bridge = (
+          this as unknown as {
+            bridge: {
+              call: (method: string, args: unknown[]) => Promise<unknown>
+            }
+          }
+        ).bridge
+        version = await bridge.call('app.getVersion', [])
+      }
+    )
+    const executor = createCodeModeExecutor({
+      mode: 'sandbox',
+      resolveNotebook: () => null,
+    })
+    await executor.execute({
+      source: 'webmcp',
+      code: 'console.log(await app.getVersion())',
+    })
+    expect(version).toEqual(getRunmeVersionInfo())
+  })
+
   afterEach(() => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()

--- a/app/src/lib/runtime/codeModeExecutor.ts
+++ b/app/src/lib/runtime/codeModeExecutor.ts
@@ -428,6 +428,8 @@ async function handleSandboxAppKernelBridgeCall({
         cellCount: notebook.getNotebook().cells.length,
       }
     }
+    case 'app.getVersion':
+      return globals.app.getVersion()
     case 'app.getSessionId':
       return getClaimedSessionId()
     case 'app.getSessionID':

--- a/app/src/lib/runtime/sandboxJsKernel.test.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.test.ts
@@ -574,6 +574,13 @@ class TestableSandboxJSKernel extends SandboxJSKernel {
 }
 
 describe('SandboxJSKernel', () => {
+  it('exposes app.getVersion in sandbox helpers, discovery, and the allowlist', () => {
+    const srcDoc = buildSandboxSrcDoc({ enableOpfs: false, enableNet: false })
+    expect(srcDoc).toContain('getVersion: () => hostCall("app.getVersion", [])')
+    expect(srcDoc).toContain('await app.getVersion() (loaded app build metadata)')
+    expect(CODE_MODE_SANDBOX_ALLOWED_METHODS).toContain('app.getVersion')
+  })
+
   it('passes the top-level embed helper into the dynamic runner', () => {
     const srcDoc = buildSandboxSrcDoc({
       enableOpfs: true,

--- a/app/src/lib/runtime/sandboxJsKernel.ts
+++ b/app/src/lib/runtime/sandboxJsKernel.ts
@@ -91,6 +91,7 @@ const DEFAULT_SANDBOX_ALLOWED_METHODS = [
   'notebookDiff.restoreDeletedCell',
   'notebookDiff.restoreAllDeletedCells',
   'notebookDiff.help',
+  'app.getVersion',
   'app.getSessionId',
   'app.getSessionID',
   'app.startGoogleDriveOAuth',
@@ -460,6 +461,7 @@ export function buildSandboxSrcDoc(options: {
           help: () => hostCall("notebookDiff.help", []),
         };
         const app = {
+          getVersion: () => hostCall("app.getVersion", []),
           getSessionId: () => hostCall("app.getSessionId", []),
           getSessionID: () => hostCall("app.getSessionID", []),
           startGoogleDriveOAuth: (options) => hostCall("app.startGoogleDriveOAuth", [options]),
@@ -576,6 +578,7 @@ export function buildSandboxSrcDoc(options: {
           consoleProxy.log("- notebookDiff.listConflictCells({ target?, localUri? })");
           consoleProxy.log("- notebookDiff.restoreDeletedCell({ target?, localUri?, refId?, rowId? })");
           consoleProxy.log("- notebookDiff.restoreAllDeletedCells({ target?, localUri? })");
+          consoleProxy.log("- await app.getVersion() (loaded app build metadata)");
           consoleProxy.log("- await app.getSessionId()");
           consoleProxy.log("- await app.getSessionID()");
           consoleProxy.log("- await app.startGoogleDriveOAuth({ mode?, prompt? })");

--- a/app/src/lib/versionInfo.test.ts
+++ b/app/src/lib/versionInfo.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   formatRunmeVersionYaml,
@@ -7,6 +7,31 @@ import {
 } from './versionInfo'
 
 describe('versionInfo', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('reports loaded build metadata and isolates callers from mutation', async () => {
+    vi.stubEnv('VITE_RUNME_VERSION_BUILD_DATE', '2026-09-11T22:01:42Z')
+    vi.stubEnv('VITE_RUNME_VERSION_WEB_REPO', 'runmedev/web')
+    vi.stubEnv('VITE_RUNME_VERSION_WEB_BRANCH', 'main')
+    vi.stubEnv('VITE_RUNME_VERSION_WEB_COMMIT', '805b4bc')
+    vi.stubEnv('VITE_RUNME_VERSION_BUCKET', 'gs://runme-hosted')
+    vi.resetModules()
+    const { getRunmeVersionInfo } = await import('./versionInfo')
+    const expected = {
+      buildDate: '2026-09-11T22:01:42Z',
+      webRepo: 'runmedev/web',
+      webBranch: 'main',
+      webCommit: '805b4bc',
+      bucket: 'gs://runme-hosted',
+    }
+    const version = getRunmeVersionInfo()
+    expect(version).toEqual(expected)
+    version.webCommit = 'changed-by-caller'
+    // A later deployment/config change must not identify this already loaded bundle.
+    vi.stubEnv('VITE_RUNME_VERSION_WEB_COMMIT', 'new-deployment')
+    expect(getRunmeVersionInfo()).toEqual(expected)
+  })
+
   it('normalizes build env into version.yaml fields', () => {
     const info = normalizeRunmeVersionInfo({
       VITE_RUNME_VERSION_BUILD_DATE: ' 2026-06-03T12:00:00Z ',

--- a/app/src/lib/versionInfo.ts
+++ b/app/src/lib/versionInfo.ts
@@ -32,6 +32,14 @@ export function normalizeRunmeVersionInfo(
 
 export const runmeVersionInfo = normalizeRunmeVersionInfo(import.meta.env)
 
+/** Return a fresh snapshot of the loaded app bundle's build metadata.
+ * Never fetch a deployment manifest: a running tab may still use an older build.
+ * Unknown fields remain null, matching the Version Information window.
+ */
+export function getRunmeVersionInfo(): RunmeVersionInfo {
+  return { ...runmeVersionInfo }
+}
+
 export function hasRunmeVersionInfo(info: RunmeVersionInfo): boolean {
   return VERSION_YAML_KEYS.some((key) => Boolean(info[key]))
 }

--- a/app/test/browser/test-scenario-appkernel-javascript.ts
+++ b/app/test/browser/test-scenario-appkernel-javascript.ts
@@ -304,6 +304,36 @@ runWithRetry(`agent-browser record restart ${MOVIE_PATH}`);
 run("agent-browser wait 3500");
 run(`agent-browser screenshot ${join(OUTPUT_DIR, "scenario-appkernel-javascript-01-initial.png")}`);
 
+// Exercise the real sandbox iframe and host bridge used by WebMCP, without
+// requiring an open notebook, credentials, or a runner connection.
+try {
+  const source = `(async () => {
+    const { createCodeModeExecutor } = await import('/src/lib/runtime/codeModeExecutor.ts');
+    const { runmeVersionInfo } = await import('/src/lib/versionInfo.ts');
+    const versions = {};
+    for (const mode of ['sandbox', 'browser']) {
+      const executor = createCodeModeExecutor({ mode, resolveNotebook: () => null });
+      const result = await executor.execute({
+        source: 'webmcp',
+        code: 'const v = await app.getVersion(); v.webCommit = "caller-change"; console.log(JSON.stringify(await app.getVersion()));',
+      });
+      if (result.exitCode !== 0) throw new Error(result.output);
+      versions[mode] = JSON.parse(result.output);
+      if (JSON.stringify(versions[mode]) !== JSON.stringify(runmeVersionInfo)) {
+        throw new Error(mode + ' returned metadata different from the loaded bundle');
+      }
+    }
+    return JSON.stringify({ expected: runmeVersionInfo, versions });
+  })()`;
+  const raw = runOrThrow(`agent-browser eval ${shellQuote(source)}`).trim();
+  const parsed = JSON.parse(raw);
+  const result = typeof parsed === "string" ? JSON.parse(parsed) : parsed;
+  writeArtifact("scenario-appkernel-version.json", JSON.stringify(result, null, 2));
+  pass("Sandbox and browser getVersion report loaded build metadata without a notebook and resist caller mutation");
+} catch (error) {
+  fail(`App version probe: ${String(error)}`);
+}
+
 // Clear runner config so AppKernel execution proves it is not using a remote websocket runner.
 run(
   `agent-browser eval "(async () => {

--- a/app/test/browser/test-scenario-appkernel-javascript.ts
+++ b/app/test/browser/test-scenario-appkernel-javascript.ts
@@ -272,6 +272,7 @@ function parseAgentEvalString(raw: string): string {
 
 mkdirSync(OUTPUT_DIR, { recursive: true });
 for (const file of [
+  "scenario-appkernel-version.json",
   "scenario-appkernel-javascript-01-initial.png",
   "scenario-appkernel-javascript-02-after-seed.txt",
   "scenario-appkernel-javascript-03-opened.txt",
@@ -310,6 +311,7 @@ try {
   const source = `(async () => {
     const { createCodeModeExecutor } = await import('/src/lib/runtime/codeModeExecutor.ts');
     const { runmeVersionInfo } = await import('/src/lib/versionInfo.ts');
+    const expected = JSON.stringify(runmeVersionInfo);
     const versions = {};
     for (const mode of ['sandbox', 'browser']) {
       const executor = createCodeModeExecutor({ mode, resolveNotebook: () => null });
@@ -319,11 +321,14 @@ try {
       });
       if (result.exitCode !== 0) throw new Error(result.output);
       versions[mode] = JSON.parse(result.output);
-      if (JSON.stringify(versions[mode]) !== JSON.stringify(runmeVersionInfo)) {
+      if (JSON.stringify(versions[mode]) !== expected) {
         throw new Error(mode + ' returned metadata different from the loaded bundle');
       }
     }
-    return JSON.stringify({ expected: runmeVersionInfo, versions });
+    if (JSON.stringify(runmeVersionInfo) !== expected) {
+      throw new Error('Caller mutation changed the loaded bundle metadata');
+    }
+    return JSON.stringify({ expected: JSON.parse(expected), versions });
   })()`;
   const raw = runOrThrow(`agent-browser eval ${shellQuote(source)}`).trim();
   const parsed = JSON.parse(raw);

--- a/docs-dev/CUJs/appkernel-javascript-notebook.md
+++ b/docs-dev/CUJs/appkernel-javascript-notebook.md
@@ -163,3 +163,14 @@ transport.
 
 - `docs-dev/design/20260224_appkernel.md`
 - `docs-dev/design/20260224_drive.md`
+
+## Loaded app version API
+
+Before notebook execution, the browser driver runs `app.getVersion()` through
+both the real sandbox iframe and browser executor with no selected notebook.
+The result must match the loaded bundle’s `runmeVersionInfo`, including nulls
+in unversioned builds. Mutating one result must not change later results.
+`scenario-appkernel-version.json` records the expected and returned metadata.
+The version unit tests separately cover populated build fields and normalization.
+This API must not fetch deployment manifests: an already-open tab may run an
+older bundle than the latest deployment.

--- a/docs/11-webmcp-external-control.md
+++ b/docs/11-webmcp-external-control.md
@@ -495,3 +495,16 @@ The reread stays inside the `NOTEBOOK_UPDATE_FAILED` branch where `error` is in
 scope. Do not assume the whole update rolled back. `notebooks.update` reports
 which operations were applied; it does not make multi-operation updates fully
 transactional.
+
+## Inspect the running app version
+
+Use `ExecuteCode` with sandbox JavaScript to identify the build in the connected tab:
+
+```js
+console.log(await app.getVersion())
+```
+
+This returns `{ buildDate, webRepo, webBranch, webCommit, bucket }` from the
+loaded app bundle. Values are strings, or `null` if the build omitted them.
+No notebook or authentication is required. It does not fetch deployment metadata,
+so an older open tab correctly reports its own build until reloaded.

--- a/docs/13-app-console-reference.md
+++ b/docs/13-app-console-reference.md
@@ -327,6 +327,20 @@ corpora, shared-drive, ordering, pagination, spaces, and fields parameters.
 Include `id` and `mimeType` in `fields` when the returned file should have a
 Runme-ready `uri`. Continue with `result.nextPageToken` when it is present.
 
+App version (available in sandbox code, browser JS, and WebMCP `ExecuteCode`):
+
+```js
+const version = await app.getVersion()
+console.log(version)
+// { buildDate, webRepo, webBranch, webCommit, bucket }
+```
+
+The result identifies the app bundle currently loaded in this tab, using the
+same metadata as the Version Information window. Each field is a string or
+`null` when unavailable (for example, in an unversioned local build). It does
+not fetch the latest deployment or report the runner/backend version. The
+returned object is a copy; modifying it does not change the app's metadata.
+
 App config:
 
 ```js


### PR DESCRIPTION
Agents could only inspect Runme's build metadata through the Version Information UI. Add `await app.getVersion()` to sandbox and browser JavaScript, including WebMCP ExecuteCode and sandbox notebook cells.

The method returns `{ buildDate, webRepo, webBranch, webCommit, bucket }` from the same metadata embedded in the loaded app bundle. Missing fields are `null`. It returns a fresh object and never fetches a deployment manifest, so an older open tab reports its own build. No open notebook, authentication, or runner is required.

Validation:
- All 1,462 app tests pass, covering version values, caller mutation, and both sandbox host dispatch paths.
- Required Runme build/test tasks pass. Type-checking retains the existing 128 diagnostics with none added.
- Manually verified WebMCP ExecuteCode against the local production build: returned repository/commit match the Version Information UI, unavailable fields are null, and caller mutation does not alter later results.
- The AppKernel browser CUJ now calls the real sandbox iframe and browser executor without a notebook and records expected/returned metadata in `scenario-appkernel-version.json`.
- Updated sandbox help, agent instructions, and user-facing API documentation.

Final review and CI:
- Addressed both review findings in 4dd4624; follow-up Codex review found no further issues.
- All 12 browser scenarios pass on the final commit, including 16 AppKernel assertions. Inspected the version artifact: sandbox and browser results match the loaded build metadata.
- [Browser CI artifacts](https://storage.googleapis.com/runme-dev-assets/cuj-runs/runmedev-web/34707870343/1/index.html).
