### PR TITLE
Add a whole-notebook comment button beside Review suggestions

### DIFF
--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -106,6 +106,7 @@ const contextMocks = vi.hoisted(() => ({
     listOperationLogComments?: ReturnType<typeof vi.fn>
     addOperationLogComment?: ReturnType<typeof vi.fn>
     bindOperationLogCommentAnchors?: ReturnType<typeof vi.fn>
+    checkpointNotebookRevision?: ReturnType<typeof vi.fn>
     addAnchoredComment?: ReturnType<typeof vi.fn>
     replyToOperationLogComment?: ReturnType<typeof vi.fn>
     setOperationLogCommentResolved?: ReturnType<typeof vi.fn>
@@ -585,6 +586,88 @@ describe('Actions tabs', () => {
     expect(contextMocks.closeWorkspaceDocument).not.toHaveBeenCalled()
     expect(contextMocks.setCurrentDoc).toHaveBeenCalledWith(uri)
   })
+
+  it.each([false, true])(
+    'starts a whole-notebook comment with readOnly=%s',
+    async (readOnly) => {
+      const uri = 'local://file/document-comments'
+      const checkpointNotebookRevision = vi.fn(async () => ({
+        kind: 'revision',
+        revision_id: 'original',
+      }))
+      const addAnchoredComment = vi.fn(async () => undefined)
+      const notebook = create(parser_pb.NotebookSchema, { cells: [] })
+      let heads = ['original-head']
+      contextMocks.currentDoc = uri
+      contextMocks.workspaceDocuments = [
+        { uri, title: 'document.runme', state: 'loaded', readOnly },
+      ]
+      contextMocks.notebookSnapshots.set(uri, {
+        uri,
+        loaded: true,
+        notebook,
+        readOnly,
+      })
+      contextMocks.getNotebookData.mockReturnValue({
+        getNotebook: () => notebook,
+        getObservedOperationHeads: () => heads,
+        flushPendingPersist: vi.fn(async () => undefined),
+        appendCell: vi.fn(),
+      })
+      contextMocks.notebookStore = {
+        getMetadata: vi.fn(async () => ({})),
+        getSyncState: vi.fn(async () => null),
+        rename: vi.fn(),
+        subscribeSync: vi.fn(() => () => {}),
+        listOperationLogComments: vi.fn(async () => []),
+        checkpointNotebookRevision,
+        addAnchoredComment,
+      }
+      commentsPanelMocks.commentsPanelOpen = true
+      render(<Actions />)
+      const button = await screen.findByRole('button', {
+        name: 'Comment on notebook',
+      })
+      expect((button as HTMLButtonElement).disabled).toBe(readOnly)
+      fireEvent.click(button)
+      if (readOnly) {
+        expect(checkpointNotebookRevision).not.toHaveBeenCalled()
+        return
+      }
+      await waitFor(() =>
+        expect(checkpointNotebookRevision).toHaveBeenCalledWith(uri, {
+          snapshot_heads: ['original-head'],
+        })
+      )
+      expect(screen.getByText('New comment on notebook')).toBeTruthy()
+      const input = screen.getByRole('textbox', { name: 'New comment' })
+      fireEvent.change(input, { target: { value: 'Whole document feedback' } })
+      // Repeated clicks cannot replace the in-progress draft.
+      fireEvent.click(button)
+      expect((input as HTMLTextAreaElement).value).toBe(
+        'Whole document feedback'
+      )
+      heads = ['later-edit']
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Comment', exact: true })
+      )
+      await waitFor(() =>
+        expect(addAnchoredComment).toHaveBeenCalledWith(
+          uri,
+          expect.objectContaining({
+            content: 'Whole document feedback',
+            anchors: [
+              {
+                kind: 'notebook',
+                version: { kind: 'revision', revision_id: 'original' },
+              },
+            ],
+          })
+        )
+      )
+      expect(checkpointNotebookRevision).toHaveBeenCalledTimes(1)
+    }
+  )
 
   it('keeps the complete .runme comment lifecycle in the operation log', async () => {
     const uri = 'local://file/comments.runme'

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -649,7 +649,7 @@ describe('Actions tabs', () => {
       )
       heads = ['later-edit']
       fireEvent.click(
-        screen.getByRole('button', { name: 'Comment', exact: true })
+        screen.getByRole('button', { name: 'Comment' })
       )
       await waitFor(() =>
         expect(addAnchoredComment).toHaveBeenCalledWith(

--- a/app/src/components/Actions/Actions.test.tsx
+++ b/app/src/components/Actions/Actions.test.tsx
@@ -648,9 +648,7 @@ describe('Actions tabs', () => {
         'Whole document feedback'
       )
       heads = ['later-edit']
-      fireEvent.click(
-        screen.getByRole('button', { name: 'Comment' })
-      )
+      fireEvent.click(screen.getByRole('button', { name: 'Comment' }))
       await waitFor(() =>
         expect(addAnchoredComment).toHaveBeenCalledWith(
           uri,
@@ -668,6 +666,74 @@ describe('Actions tabs', () => {
       expect(checkpointNotebookRevision).toHaveBeenCalledTimes(1)
     }
   )
+
+  it('allows legacy Drive cell comments when notebook edits are read-only', async () => {
+    const uri = 'local://file/legacy-comment'
+    const remoteUri = 'https://drive.google.com/file/d/legacy-comment/view'
+    const cell = create(parser_pb.CellSchema, {
+      refId: 'legacy-cell',
+      kind: parser_pb.CellKind.MARKUP,
+      languageId: 'markdown',
+      value: 'Read-only notebook content',
+    })
+    const stub = new StubCellData(cell)
+    const localComments = {
+      list: vi.fn(async () => []),
+      listPendingRecords: vi.fn(async () => []),
+      subscribe: vi.fn(() => () => {}),
+      getDraft: vi.fn(async () => null),
+      saveDraft: vi.fn(async () => undefined),
+      deleteDraft: vi.fn(async () => undefined),
+      saveDesiredComment: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => undefined),
+    }
+    appState.setLocalComments(localComments as never)
+    appState.setDriveNotebookStore({
+      listComments: vi.fn(async () => []),
+    } as never)
+    contextMocks.notebookStore = {
+      getMetadata: vi.fn(async () => ({ remoteUri })),
+      getSyncState: vi.fn(async () => ({
+        status: 'synced',
+        localUri: uri,
+        remoteId: remoteUri,
+      })),
+      rename: vi.fn(),
+      subscribeSync: vi.fn(() => () => {}),
+    }
+    contextMocks.currentDoc = uri
+    contextMocks.workspaceDocuments = [
+      { uri, title: 'legacy.ipynb', state: 'loaded', readOnly: true },
+    ]
+    contextMocks.notebookSnapshots.set(uri, {
+      uri,
+      loaded: true,
+      readOnly: true,
+      notebook: create(parser_pb.NotebookSchema, { cells: [cell] }),
+    })
+    contextMocks.getNotebookData.mockReturnValue({
+      getCell: () => stub,
+      getNotebook: () => ({ cells: [cell] }),
+    })
+    commentsPanelMocks.commentsPanelOpen = true
+    render(<Actions />)
+    const button = await screen.findByRole('button', { name: 'Add comment' })
+    await waitFor(() =>
+      expect((button as HTMLButtonElement).disabled).toBe(false)
+    )
+    fireEvent.click(button)
+    const input = await screen.findByRole('textbox', { name: 'New comment' })
+    fireEvent.change(input, { target: { value: 'Drive feedback' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }))
+    await waitFor(() =>
+      expect(localComments.saveDesiredComment).toHaveBeenCalledWith({
+        notebookUri: uri,
+        remoteUri,
+        content: 'Drive feedback',
+        target: { type: 'cell', cellId: 'legacy-cell' },
+      })
+    )
+  })
 
   it('keeps the complete .runme comment lifecycle in the operation log', async () => {
     const uri = 'local://file/comments.runme'

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -3183,7 +3183,7 @@ function NotebookTabContent({
   )
   const startCommentDraft = useCallback(
     (target: CommentDraftTarget) => {
-      if (readOnly || commentsBusy) return
+      if ((operationLogComments && readOnly) || commentsBusy) return
       if (target.type === 'document') {
         if (!operationLogComments || !notebookData || !store) return
         // Freeze the whole-document target when the composer opens, so later
@@ -3356,7 +3356,8 @@ function NotebookTabContent({
 
   const handleCreateComment = useCallback(
     async (target: CommentDraftTarget, content: string) => {
-      if (readOnly) throw new Error('This notebook is read-only.')
+      if (operationLogComments && readOnly)
+        throw new Error('This notebook is read-only.')
       if (operationLogComments && store) {
         setCommentsBusy(true)
         try {

--- a/app/src/components/Actions/Actions.tsx
+++ b/app/src/components/Actions/Actions.tsx
@@ -3183,7 +3183,29 @@ function NotebookTabContent({
   )
   const startCommentDraft = useCallback(
     (target: CommentDraftTarget) => {
-      if (operationLogComments && notebookData && store) {
+      if (readOnly || commentsBusy) return
+      if (target.type === 'document') {
+        if (!operationLogComments || !notebookData || !store) return
+        // Freeze the whole-document target when the composer opens, so later
+        // edits cannot silently move the comment to a different revision.
+        const binding = captureCommentSnapshot(notebookData).then(
+          async (heads): Promise<Anchor[]> => [
+            {
+              kind: 'notebook',
+              version: await store.checkpointNotebookRevision(docUri, {
+                snapshot_heads: heads,
+              }),
+            },
+          ]
+        )
+        draftAnchors.current.set(
+          target,
+          binding.then(
+            (anchors) => ({ anchors }),
+            (error) => ({ error })
+          )
+        )
+      } else if (operationLogComments && notebookData && store) {
         // Capture source and mapping synchronously, before the flush yields to
         // another edit or a remote sync. The store verifies that same source
         // against the captured causal revision before creating typed anchors.
@@ -3255,10 +3277,11 @@ function NotebookTabContent({
       openCommentsPanel()
       setDraftTarget(target)
       setDraftContent('')
-      focusCommentCell(
-        target.cellId,
-        target.type === 'cell-source' ? 'editor' : undefined
-      )
+      if (target.type !== 'document')
+        focusCommentCell(
+          target.cellId,
+          target.type === 'cell-source' ? 'editor' : undefined
+        )
       setActiveCommentRange(
         target.type === 'cell-text'
           ? { cellId: target.cellId, ...target.selectors[0] }
@@ -3281,6 +3304,8 @@ function NotebookTabContent({
     },
     [
       commentsRemoteUri,
+      commentsBusy,
+      readOnly,
       docUri,
       focusCommentCell,
       openCommentsPanel,
@@ -3331,6 +3356,7 @@ function NotebookTabContent({
 
   const handleCreateComment = useCallback(
     async (target: CommentDraftTarget, content: string) => {
+      if (readOnly) throw new Error('This notebook is read-only.')
       if (operationLogComments && store) {
         setCommentsBusy(true)
         try {
@@ -3413,6 +3439,7 @@ function NotebookTabContent({
     },
     [
       cellDatas,
+      readOnly,
       getCommentAuthor,
       notebookData,
       commentsRemoteUri,
@@ -3908,7 +3935,22 @@ function NotebookTabContent({
             </div>
           ) : null}
           {entry.operationLog && store && (
-            <div className="mb-3 flex justify-end">
+            <div
+              id="notebook-comment-review-actions"
+              className="mb-3 flex items-center justify-end gap-2"
+            >
+              {operationLogComments && (
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-nb-sm text-nb-text-muted hover:bg-nb-accent-muted hover:text-nb-accent disabled:opacity-40"
+                  aria-label="Comment on notebook"
+                  title="Comment on notebook"
+                  disabled={readOnly || commentsBusy || Boolean(draftTarget)}
+                  onClick={() => startCommentDraft({ type: 'document' })}
+                >
+                  <ChatBubbleLeftIcon className="h-5 w-5" />
+                </button>
+              )}
               <Button size="1" variant="soft" onClick={openSuggestionView}>
                 Review suggestions
               </Button>

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -66,7 +66,7 @@ describe('NotebookCommentsPanel', () => {
       target: { value: 'Document feedback' },
     })
     fireEvent.click(
-      screen.getByRole('button', { name: 'Comment', exact: true })
+      screen.getByRole('button', { name: 'Comment' })
     )
     await waitFor(() =>
       expect(onCreateComment).toHaveBeenCalledWith(target, 'Document feedback')

--- a/app/src/components/NotebookCommentsPanel.test.tsx
+++ b/app/src/components/NotebookCommentsPanel.test.tsx
@@ -50,6 +50,30 @@ function renderPanel(overrides = {}) {
 }
 
 describe('NotebookCommentsPanel', () => {
+  it('composes a document comment without a cell target or selected text', async () => {
+    const target = { type: 'document' as const }
+    const onCreateComment = vi.fn(async () => undefined)
+    const onSelectTarget = vi.fn()
+    renderPanel({
+      storage: 'runme-operation-log',
+      draftTarget: target,
+      onCreateComment,
+      onSelectTarget,
+    })
+    expect(screen.getByText('New comment on notebook')).toBeTruthy()
+    expect(document.querySelector('blockquote')).toBeNull()
+    fireEvent.change(screen.getByRole('textbox', { name: 'New comment' }), {
+      target: { value: 'Document feedback' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Comment', exact: true })
+    )
+    await waitFor(() =>
+      expect(onCreateComment).toHaveBeenCalledWith(target, 'Document feedback')
+    )
+    expect(onSelectTarget).not.toHaveBeenCalled()
+  })
+
   it('keeps one native conversation with all historical locations and Enter-to-send', async () => {
     const anchor = {
       kind: 'cell',

--- a/app/src/components/NotebookCommentsPanel.tsx
+++ b/app/src/components/NotebookCommentsPanel.tsx
@@ -480,9 +480,12 @@ export function NotebookCommentsPanel({
                     >
                       <label className="block text-xs font-medium text-nb-text-muted">
                         New comment on{' '}
-                        {cellLabels.get(item.draftTarget.cellId) ?? 'cell'}
+                        {item.draftTarget.type === 'document'
+                          ? 'notebook'
+                          : (cellLabels.get(item.draftTarget.cellId) ?? 'cell')}
                       </label>
-                      {item.draftTarget.type !== 'cell' && (
+                      {(item.draftTarget.type === 'cell-source' ||
+                        item.draftTarget.type === 'cell-text') && (
                         <blockquote
                           className={`mt-2 border-l-2 border-nb-accent pl-2 text-xs text-nb-text-muted${
                             item.draftTarget.type === 'cell-source'
@@ -499,6 +502,7 @@ export function NotebookCommentsPanel({
                         </blockquote>
                       )}
                       <textarea
+                        aria-label="New comment"
                         className="mt-2 h-24 w-full resize-none rounded-nb-sm border border-nb-border bg-white p-2 text-sm text-nb-text outline-none focus:border-nb-accent"
                         value={draft}
                         disabled={busy}
@@ -891,6 +895,21 @@ function sortCommentPanelItems(
 
   if (!draftTarget) {
     return items
+  }
+
+  // Document drafts have no cell target and stay visible above cell threads.
+  if (draftTarget.type === 'document') {
+    return [
+      {
+        type: 'thread',
+        key: 'document-draft',
+        cellId: null,
+        orphaned: false,
+        threads: [],
+        draftTarget,
+      },
+      ...items,
+    ]
   }
 
   const draftKey =

--- a/app/src/lib/notebookComments.ts
+++ b/app/src/lib/notebookComments.ts
@@ -63,6 +63,7 @@ export type SourceSelectionDraft = {
 }
 
 export type CommentDraftTarget =
+  | { type: 'document' }
   | SourceSelectionDraft
   | { type: 'cell'; cellId: string }
   | RenderedMarkdownSelectionDraft

--- a/app/src/storage/localComments.ts
+++ b/app/src/storage/localComments.ts
@@ -362,8 +362,13 @@ export class LocalComments extends Dexie {
   async saveDesiredComment(
     input: SaveDesiredCommentInput
   ): Promise<DesiredCommentRecord> {
-    if (input.target.type === 'cell-source') {
-      throw new Error('Source selection comments require a .runme notebook.')
+    if (
+      input.target.type === 'cell-source' ||
+      input.target.type === 'document'
+    ) {
+      throw new Error(
+        'Source selection and whole-document comments require a .runme notebook.'
+      )
     }
     await this.draftWriteTails.get(input.notebookUri)?.catch(() => undefined)
     const timestamp = nowIsoString()

--- a/app/test/browser/test-scenario-editor-range-comments.ts
+++ b/app/test/browser/test-scenario-editor-range-comments.ts
@@ -360,6 +360,60 @@ try {
     'screenshot',
     join(output, 'scenario-editor-range-comments-rendered.png')
   )
+  // Whole-document feedback uses the same composer but has no cell/range target.
+  const documentButton = inputPage.getByRole('button', {
+    name: 'Comment on notebook',
+    exact: true,
+  })
+  await documentButton.click()
+  await inputPage
+    .getByText('New comment on notebook', { exact: true })
+    .waitFor({ state: 'visible' })
+  check(
+    'Document comment button is left of Review suggestions',
+    await evaluate(`
+    const toolbar = document.getElementById('notebook-comment-review-actions');
+    const buttons = [...toolbar.querySelectorAll('button')];
+    return buttons[0].getAttribute('aria-label') === 'Comment on notebook' &&
+      buttons[1].textContent.includes('Review suggestions') &&
+      buttons[0].getBoundingClientRect().right <= buttons[1].getBoundingClientRect().left;
+  `)
+  )
+  check(
+    'Whole-document composer has no selected-text quote',
+    (await inputPage
+      .locator('[data-comment-panel-item="draft"] blockquote')
+      .count()) === 0
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-whole-document-comment-draft.png')
+  )
+  await submit('Whole notebook feedback')
+  await inputPage.reload()
+  await inputPage
+    .getByText('Whole notebook feedback', { exact: true })
+    .waitFor({ state: 'visible' })
+  const documentComment = await evaluate(`
+    const comments = await window.app.localNotebooks.listOperationLogComments(${JSON.stringify(fixture.uri)});
+    const comment = comments.find(c => c.content === 'Whole notebook feedback');
+    return { content: comment.content, view: JSON.parse(comment.anchor).runme };
+  `)
+  check(
+    'Whole-document comment survives reload with only a revision-bound notebook anchor',
+    documentComment.view.anchors.length === 1 &&
+      documentComment.view.anchors[0].kind === 'notebook' &&
+      documentComment.view.anchors[0].version.kind === 'revision' &&
+      !documentComment.view.anchors[0].cell_id
+  )
+  writeFileSync(
+    join(output, 'scenario-whole-document-comment.json'),
+    JSON.stringify(documentComment, null, 2)
+  )
+  browser(
+    'screenshot',
+    join(output, 'scenario-whole-document-comment-saved.png')
+  )
 } catch (error) {
   failed++
   console.log(`[FAIL] ${error}`)

--- a/docs-dev/cujs/editor-range-comments.md
+++ b/docs-dev/cujs/editor-range-comments.md
@@ -61,3 +61,19 @@ the JSON artifact records persisted anchors and the movie shows the walkthrough.
 Unit tests cover live model capture, empty selections, callback replacement and
 action disposal. Store-backed component tests cover all three selection surfaces
 (rendered Markdown, code, Markdown source), pending saves, and later sync edits.
+
+## Whole-document comments
+
+The comment bubble immediately left of **Review suggestions** opens a **New
+comment on notebook** draft in `.runme` notebooks, including empty notebooks.
+It uses a `notebook` anchor bound to the revision visible when the draft opens;
+it must never infer a cell or range from focus or selection. The button is
+disabled for read-only notebooks, while submitting, and while another draft is
+open so a repeated click cannot discard text. Submit also checks writability.
+
+The browser journey verifies button order, the absence of a selected-text quote,
+and a durable notebook anchor after reload. Evidence is in
+`scenario-whole-document-comment-{draft,saved}.png` and
+`scenario-whole-document-comment.json`. Component tests cover empty notebooks,
+read-only gating, draft preservation, and retaining the original revision after
+later edits. Existing cell and range workflows remain covered by the same CUJ.


### PR DESCRIPTION
Whole-notebook comments had no entry point in the editor. Add a comment bubble immediately left of Review suggestions for .runme notebooks. It opens a New comment on notebook draft, including when the notebook has no cells.

The draft binds a typed notebook anchor to the revision visible when composition starts. It never inherits the selected cell or text range, and subsequent edits cannot retarget it. Read-only notebooks disable the action, submission checks writability, and repeated clicks preserve an existing draft.

Validation:
- Focused component/storage tests pass (108 tests), covering empty notebooks, read-only gating, draft preservation, and original-revision binding.
- Required Runme build/test tasks pass.
- Extended the editor comments browser CUJ with button geometry, document-only composer, save/reload anchor assertions, and screenshot/JSON artifacts.

All 1,466 app tests pass. Type-checking retains 128 existing diagnostics with none added.

Final review and CI:
- Addressed the read-only compatibility finding: legacy Drive comments retain their separate commenting path. The new regression test opens and submits a comment in a read-only Drive notebook.
- Follow-up Codex review on 19636b9 found no further issues.
- All 12 browser scenarios pass, including all 18 editor-comment assertions. Inspected the draft screenshot for button placement and the JSON artifact for the durable notebook revision anchor.
- [Browser CI artifacts](https://storage.googleapis.com/runme-dev-assets/cuj-runs/runmedev-web/34717283965/1/index.html).
